### PR TITLE
[Tracer] v1 Schema: Use existing tags for `_dd.peer.service.source`

### DIFF
--- a/docs/span_attribute_schema/v0.md
+++ b/docs/span_attribute_schema/v0.md
@@ -423,6 +423,7 @@ Name | Required |
 component | `Oracle`
 db.name | Yes
 db.type | `oracle`
+out.host | Yes
 span.kind | `client`
 
 ## Process

--- a/docs/span_attribute_schema/v0.md
+++ b/docs/span_attribute_schema/v0.md
@@ -155,6 +155,28 @@ http.status_code | Yes
 http.url | Yes
 span.kind | `client`
 
+## AwsSns
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `sns.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `SNS`
+aws.topic.arn | No
+aws.topic.name | No
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+span.kind | `client`
+
 ## CosmosDb
 ### Span properties
 Name | Required |

--- a/docs/span_attribute_schema/v0.md
+++ b/docs/span_attribute_schema/v0.md
@@ -285,6 +285,7 @@ http-client-handler-type | Yes
 http.method | Yes
 http.status_code | Yes
 http.url | Yes
+out.host | Yes
 span.kind | `client`
 
 ## Kafka
@@ -551,5 +552,6 @@ http-client-handler-type | No
 http.method | Yes
 http.status_code | Yes
 http.url | Yes
+out.host | Yes
 span.kind | `client`
 

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -201,7 +201,7 @@ Type | `elasticsearch`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `network.destination.name`; `peer.service`
+_dd.peer.service.source | `out.host`; `peer.service`
 component | `elasticsearch-net`
 elasticsearch.action | Yes
 elasticsearch.method | Yes

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -157,6 +157,28 @@ http.status_code | Yes
 http.url | Yes
 span.kind | `client`
 
+## AwsSns
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `sns.request`
+Type | `http`
+### Tags
+Name | Required |
+---------|----------------|
+aws.agent | `dotnet-aws-sdk`
+aws.operation | Yes
+aws.region | No
+aws.requestId | Yes
+aws.service | `SNS`
+aws.topic.arn | No
+aws.topic.name | No
+component | `aws-sdk`
+http.method | Yes
+http.status_code | Yes
+http.url | Yes
+span.kind | `client`
+
 ## CosmosDb
 ### Span properties
 Name | Required |

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -11,7 +11,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `AdoNet`
 db.name | No
 db.type | Yes
@@ -166,7 +166,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `CosmosDb`
 cosmosdb.container | No
 db.name | No
@@ -288,12 +288,13 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `network.destination.name`; `peer.service`
+_dd.peer.service.source | `out.host`; `peer.service`
 component | Yes
 http-client-handler-type | Yes
 http.method | Yes
 http.status_code | Yes
 http.url | Yes
+out.host | Yes
 peer.service | Yes
 span.kind | `client`
 
@@ -330,7 +331,7 @@ Type | `mongodb`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `MongoDb`
 db.name | No
 mongodb.collection | No
@@ -365,7 +366,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `MySql`
 db.name | Yes
 db.type | `mysql`
@@ -383,7 +384,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `Npgsql`
 db.name | Yes
 db.type | `postgres`
@@ -415,7 +416,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `Oracle`
 db.name | Yes
 db.type | `oracle`
@@ -524,7 +525,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `Sqlite`
 db.name | No
 db.type | `sqlite`
@@ -542,7 +543,7 @@ Type | `sql`
 Name | Required |
 ---------|----------------|
 _dd.dbm_trace_injected | No
-_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
+_dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `SqlClient`
 db.name | No
 db.type | `sql-server`
@@ -574,12 +575,13 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `network.destination.name`; `peer.service`
+_dd.peer.service.source | `out.host`; `peer.service`
 component | `HttpMessageHandler`; `WebRequest`
 http-client-handler-type | No
 http.method | Yes
 http.status_code | Yes
 http.url | Yes
+out.host | Yes
 peer.service | Yes
 span.kind | `client`
 

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -510,8 +510,8 @@ _dd.peer.service.source | `out.host`; `peer.service`
 component | `ServiceStackRedis`
 out.host | Yes
 out.port | Yes
-redis.raw_command | Yes
 peer.service | Yes
+redis.raw_command | Yes
 span.kind | `client`
 ### Metrics
 Name | Required |
@@ -531,8 +531,8 @@ _dd.peer.service.source | `out.host`; `peer.service`
 component | `StackExchangeRedis`
 out.host | Yes
 out.port | Yes
-redis.raw_command | Yes
 peer.service | Yes
+redis.raw_command | Yes
 span.kind | `client`
 ### Metrics
 Name | Required |

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -11,7 +11,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
 component | `AdoNet`
 db.name | No
 db.type | Yes
@@ -166,7 +166,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
 component | `CosmosDb`
 cosmosdb.container | No
 db.name | No
@@ -365,7 +365,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
 component | `MySql`
 db.name | Yes
 db.type | `mysql`
@@ -383,7 +383,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
 component | `Npgsql`
 db.name | Yes
 db.type | `postgres`
@@ -415,7 +415,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
 component | `Oracle`
 db.name | Yes
 db.type | `oracle`
@@ -524,7 +524,7 @@ Type | `sql`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
 component | `Sqlite`
 db.name | No
 db.type | `sqlite`
@@ -542,7 +542,7 @@ Type | `sql`
 Name | Required |
 ---------|----------------|
 _dd.dbm_trace_injected | No
-_dd.peer.service.source | `db.instance`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `db.instance`; `out.host`; `peer.service`
 component | `SqlClient`
 db.name | No
 db.type | `sql-server`

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -256,7 +256,7 @@ Type | `grpc`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `rpc.service`; `network.destination.name`; `peer.service`
+_dd.peer.service.source | `rpc.service`; `out.host`; `peer.service`
 component | `Grpc`
 grpc.method.kind | Yes
 grpc.method.name | Yes
@@ -442,6 +442,7 @@ _dd.peer.service.source | `db.name`; `out.host`; `peer.service`
 component | `Oracle`
 db.name | Yes
 db.type | `oracle`
+out.host | Yes
 peer.service | Yes
 span.kind | `client`
 

--- a/tracer/build/smoke_test_snapshots/smoke_test_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_snapshots.json
@@ -14,6 +14,7 @@
         "http.method": "GET",
         "http.status_code": "200",
         "http.url": "http://localhost:5000/api/values",
+        "out.host": "localhost",
         "runtime-id": "11c61d09-16bb-477f-87ab-4f81d656c5ca",
         "span.kind": "client",
         "_dd.p.dm": "-0"

--- a/tracer/build/smoke_test_snapshots/smoke_test_snapshots_2_1.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_snapshots_2_1.json
@@ -14,6 +14,7 @@
         "http.method": "GET",
         "http.status_code": "200",
         "http.url": "http://localhost:5000/api/values",
+        "out.host": "localhost",
         "runtime-id": "b34b2bed-9444-4597-87f6-b8202b03b1b8",
         "span.kind": "client",
         "_dd.p.dm": "-0"

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/ElasticsearchTags.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/ElasticsearchTags.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
             {
                 return _peerServiceOverride is not null
                         ? "peer.service"
-                        : "network.destination.name";
+                        : "out.host";
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/MongoDbTags.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/MongoDbTags.cs
@@ -57,8 +57,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
                 return _peerServiceOverride is not null
                         ? "peer.service"
                         : DbName is not null
-                            ? "db.instance"
-                            : "network.destination.name";
+                            ? "db.name"
+                            : "out.host";
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -113,11 +113,7 @@ namespace Datadog.Trace.ClrProfiler
                 if (requestUri is not null)
                 {
                     tags.HttpUrl = HttpRequestUtils.GetUrl(requestUri, tracer.TracerManager.QueryStringManager);
-
-                    if (tags is HttpV1Tags v1Tags)
-                    {
-                        v1Tags.SetHost(HttpRequestUtils.GetNormalizedHost(requestUri.Host));
-                    }
+                    tags.Host = HttpRequestUtils.GetNormalizedHost(requestUri.Host);
                 }
 
                 tags.InstrumentationName = IntegrationRegistry.GetName(integrationId);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -45,6 +45,12 @@ namespace Datadog.Trace.Tagging
 #else
         private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
 #endif
+        // HostBytes = MessagePack.Serialize("out.host");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#else
+        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -56,6 +62,7 @@ namespace Datadog.Trace.Tagging
                 "http.url" => HttpUrl,
                 "http-client-handler-type" => HttpClientHandlerType,
                 "http.status_code" => HttpStatusCode,
+                "out.host" => Host,
                 _ => base.GetTag(key),
             };
         }
@@ -78,6 +85,9 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "http.status_code": 
                     HttpStatusCode = value;
+                    break;
+                case "out.host": 
+                    Host = value;
                     break;
                 case "span.kind": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
@@ -118,6 +128,11 @@ namespace Datadog.Trace.Tagging
             if (HttpStatusCode is not null)
             {
                 processor.Process(new TagItem<string>("http.status_code", HttpStatusCode, HttpStatusCodeBytes));
+            }
+
+            if (Host is not null)
+            {
+                processor.Process(new TagItem<string>("out.host", Host, HostBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -164,6 +179,13 @@ namespace Datadog.Trace.Tagging
             {
                 sb.Append("http.status_code (tag):")
                   .Append(HttpStatusCode)
+                  .Append(',');
+            }
+
+            if (Host is not null)
+            {
+                sb.Append("out.host (tag):")
+                  .Append(Host)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -45,6 +45,12 @@ namespace Datadog.Trace.Tagging
 #else
         private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
 #endif
+        // HostBytes = MessagePack.Serialize("out.host");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#else
+        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -56,6 +62,7 @@ namespace Datadog.Trace.Tagging
                 "http.url" => HttpUrl,
                 "http-client-handler-type" => HttpClientHandlerType,
                 "http.status_code" => HttpStatusCode,
+                "out.host" => Host,
                 _ => base.GetTag(key),
             };
         }
@@ -78,6 +85,9 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "http.status_code": 
                     HttpStatusCode = value;
+                    break;
+                case "out.host": 
+                    Host = value;
                     break;
                 case "span.kind": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
@@ -118,6 +128,11 @@ namespace Datadog.Trace.Tagging
             if (HttpStatusCode is not null)
             {
                 processor.Process(new TagItem<string>("http.status_code", HttpStatusCode, HttpStatusCodeBytes));
+            }
+
+            if (Host is not null)
+            {
+                processor.Process(new TagItem<string>("out.host", Host, HostBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -164,6 +179,13 @@ namespace Datadog.Trace.Tagging
             {
                 sb.Append("http.status_code (tag):")
                   .Append(HttpStatusCode)
+                  .Append(',');
+            }
+
+            if (Host is not null)
+            {
+                sb.Append("out.host (tag):")
+                  .Append(Host)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -45,6 +45,12 @@ namespace Datadog.Trace.Tagging
 #else
         private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
 #endif
+        // HostBytes = MessagePack.Serialize("out.host");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#else
+        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -56,6 +62,7 @@ namespace Datadog.Trace.Tagging
                 "http.url" => HttpUrl,
                 "http-client-handler-type" => HttpClientHandlerType,
                 "http.status_code" => HttpStatusCode,
+                "out.host" => Host,
                 _ => base.GetTag(key),
             };
         }
@@ -78,6 +85,9 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "http.status_code": 
                     HttpStatusCode = value;
+                    break;
+                case "out.host": 
+                    Host = value;
                     break;
                 case "span.kind": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
@@ -118,6 +128,11 @@ namespace Datadog.Trace.Tagging
             if (HttpStatusCode is not null)
             {
                 processor.Process(new TagItem<string>("http.status_code", HttpStatusCode, HttpStatusCodeBytes));
+            }
+
+            if (Host is not null)
+            {
+                processor.Process(new TagItem<string>("out.host", Host, HostBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -164,6 +179,13 @@ namespace Datadog.Trace.Tagging
             {
                 sb.Append("http.status_code (tag):")
                   .Append(HttpStatusCode)
+                  .Append(',');
+            }
+
+            if (Host is not null)
+            {
+                sb.Append("out.host (tag):")
+                  .Append(Host)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/HttpTags.g.cs
@@ -45,6 +45,12 @@ namespace Datadog.Trace.Tagging
 #else
         private static readonly byte[] HttpStatusCodeBytes = new byte[] { 176, 104, 116, 116, 112, 46, 115, 116, 97, 116, 117, 115, 95, 99, 111, 100, 101 };
 #endif
+        // HostBytes = MessagePack.Serialize("out.host");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> HostBytes => new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#else
+        private static readonly byte[] HostBytes = new byte[] { 168, 111, 117, 116, 46, 104, 111, 115, 116 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -56,6 +62,7 @@ namespace Datadog.Trace.Tagging
                 "http.url" => HttpUrl,
                 "http-client-handler-type" => HttpClientHandlerType,
                 "http.status_code" => HttpStatusCode,
+                "out.host" => Host,
                 _ => base.GetTag(key),
             };
         }
@@ -78,6 +85,9 @@ namespace Datadog.Trace.Tagging
                     break;
                 case "http.status_code": 
                     HttpStatusCode = value;
+                    break;
+                case "out.host": 
+                    Host = value;
                     break;
                 case "span.kind": 
                     Logger.Value.Warning("Attempted to set readonly tag {TagName} on {TagType}. Ignoring.", key, nameof(HttpTags));
@@ -118,6 +128,11 @@ namespace Datadog.Trace.Tagging
             if (HttpStatusCode is not null)
             {
                 processor.Process(new TagItem<string>("http.status_code", HttpStatusCode, HttpStatusCodeBytes));
+            }
+
+            if (Host is not null)
+            {
+                processor.Process(new TagItem<string>("out.host", Host, HostBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -164,6 +179,13 @@ namespace Datadog.Trace.Tagging
             {
                 sb.Append("http.status_code (tag):")
                   .Append(HttpStatusCode)
+                  .Append(',');
+            }
+
+            if (Host is not null)
+            {
+                sb.Append("out.host (tag):")
+                  .Append(Host)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Tagging/GrpcTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/GrpcTags.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tagging
                         ? "peer.service"
                         : MethodService is not null
                             ? "rpc.service"
-                            : "network.destination.name";
+                            : "out.host";
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Tagging/HttpTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/HttpTags.cs
@@ -29,12 +29,14 @@ namespace Datadog.Trace.Tagging
 
         [Tag(Trace.Tags.HttpStatusCode)]
         public string HttpStatusCode { get; set; }
+
+        [Tag(Trace.Tags.OutHost)]
+        public string Host { get; set; }
     }
 
     internal partial class HttpV1Tags : HttpTags
     {
         private string _peerServiceOverride = null;
-        private string _host = null;
 
         // Use a private setter for setting the "peer.service" tag so we avoid
         // accidentally setting the value ourselves and instead calculate the
@@ -44,7 +46,7 @@ namespace Datadog.Trace.Tagging
         [Tag(Trace.Tags.PeerService)]
         public string PeerService
         {
-            get => _peerServiceOverride ?? _host;
+            get => _peerServiceOverride ?? Host;
             private set => _peerServiceOverride = value;
         }
 
@@ -55,10 +57,8 @@ namespace Datadog.Trace.Tagging
             {
                 return _peerServiceOverride is not null
                         ? "peer.service"
-                        : "network.destination.name";
+                        : "out.host";
             }
         }
-
-        public void SetHost(string host) => _host = host;
     }
 }

--- a/tracer/src/Datadog.Trace/Tagging/SqlTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/SqlTags.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Tagging
                 return _peerServiceOverride is not null
                         ? "peer.service"
                         : DbName is not null
-                            ? "db.instance"
+                            ? "db.name"
                             : "out.host";
             }
         }

--- a/tracer/src/Datadog.Trace/Tagging/SqlTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/SqlTags.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Tagging
                         ? "peer.service"
                         : DbName is not null
                             ? "db.instance"
-                            : "network.destination.name";
+                            : "out.host";
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
@@ -61,6 +61,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 settings.UseFileName($"{nameof(AwsSnsTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
+                settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_sns");
+                settings.AddSimpleScrubber("out.host: aws_sns_arm64", "out.host: aws_sns");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_sns");
                 settings.AddSimpleScrubber("peer.service: aws_sns_arm64", "peer.service: aws_sns");
                 if (!string.IsNullOrWhiteSpace(host))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -61,6 +61,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
                 var settings = VerifyHelper.GetSpanVerifierSettings();
                 settings.UseFileName($"{nameof(AwsSqsTests)}.{frameworkName}.Schema{metadataSchemaVersion.ToUpper()}");
+                settings.AddSimpleScrubber("out.host: localhost", "out.host: aws_sqs");
+                settings.AddSimpleScrubber("out.host: aws_sqs_arm64", "out.host: aws_sqs");
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_sqs");
                 settings.AddSimpleScrubber("peer.service: aws_sqs_arm64", "peer.service: aws_sqs");
                 if (!string.IsNullOrWhiteSpace(host))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -83,8 +83,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             var settings = VerifyHelper.GetSpanVerifierSettings();
             settings.AddRegexScrubber(new Regex("[a-zA-Z0-9]{32}"), "GUID");
+            settings.AddSimpleScrubber("out.host: localhost", "out.host: sqlserver");
             settings.AddSimpleScrubber("out.host: (localdb)\\MSSQLLocalDB", "out.host: sqlserver");
             settings.AddSimpleScrubber("out.host: sqledge_arm64", "out.host: sqlserver");
+            settings.AddSimpleScrubber("peer.service: localhost", "peer.service: sqlserver");
             settings.AddSimpleScrubber("peer.service: (localdb)\\MSSQLLocalDB", "peer.service: sqlserver");
             settings.AddSimpleScrubber("peer.service: sqledge_arm64", "peer.service: sqlserver");
 

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV0Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV0Rules.cs
@@ -261,6 +261,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("http.method")
                 .IsPresent("http.status_code")
                 .IsPresent("http.url")
+                .IsPresent("out.host")
                 .IsPresent("component")
                 .Matches("span.kind", "client"));
 
@@ -459,6 +460,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("http.method")
                 .IsPresent("http.status_code")
                 .IsPresent("http.url")
+                .IsPresent("out.host")
                 .MatchesOneOf("component", "HttpMessageHandler", "WebRequest")
                 .Matches("span.kind", "client"));
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV0Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV0Rules.cs
@@ -348,6 +348,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Type, "sql"))
             .Tags(s => s
                 .IsPresent("db.name")
+                .IsPresent("out.host")
                 .Matches("db.type", "oracle")
                 .Matches("component", "Oracle")
                 .Matches("span.kind", "client"));

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -230,7 +230,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("grpc.status.code")
                 .IsPresent("out.host")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "rpc.service", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "rpc.service", "out.host", "peer.service")
                 .Matches("component", "Grpc")
                 .Matches("span.kind", "client"));
 
@@ -366,6 +366,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches(Type, "sql"))
             .Tags(s => s
                 .IsPresent("db.name")
+                .IsPresent("out.host")
                 .Matches("db.type", "oracle")
                 .IsPresent("peer.service")
                 .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("elasticsearch.url")
                 .IsPresent("out.host")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "out.host", "peer.service")
                 .Matches("component", "elasticsearch-net")
                 .Matches("span.kind", "client"));
 

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("db.name")
                 .IsPresent("db.type")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
                 .Matches("component", "AdoNet")
                 .Matches("span.kind", "client"));
 
@@ -174,7 +174,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("db.type", "cosmosdb")
                 .IsPresent("out.host")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
                 .Matches("component", "CosmosDb")
                 .Matches("span.kind", "client"));
 
@@ -329,7 +329,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "mysql")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
                 .Matches("component", "MySql")
                 .Matches("span.kind", "client"));
 
@@ -342,7 +342,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "postgres")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
                 .Matches("component", "Npgsql")
                 .Matches("span.kind", "client"));
 
@@ -367,7 +367,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("db.name")
                 .Matches("db.type", "oracle")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
                 .Matches("component", "Oracle")
                 .Matches("span.kind", "client"));
 
@@ -449,7 +449,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "sqlite")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
                 .Matches("component", "Sqlite")
                 .Matches("span.kind", "client"));
 
@@ -462,7 +462,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "sql-server")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
                 .Matches("component", "SqlClient")
                 .Matches("span.kind", "client")
                 .IsOptional("_dd.dbm_trace_injected"));

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("db.name")
                 .IsPresent("db.type")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "AdoNet")
                 .Matches("span.kind", "client"));
 
@@ -174,7 +174,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("db.type", "cosmosdb")
                 .IsPresent("out.host")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "CosmosDb")
                 .Matches("span.kind", "client"));
 
@@ -269,8 +269,9 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("http.method")
                 .IsPresent("http.status_code")
                 .IsPresent("http.url")
+                .IsPresent("out.host")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "out.host", "peer.service")
                 .IsPresent("component")
                 .Matches("span.kind", "client"));
 
@@ -303,7 +304,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .IsPresent("out.port")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "MongoDb")
                 .Matches("span.kind", "client"));
 
@@ -329,7 +330,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "mysql")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "MySql")
                 .Matches("span.kind", "client"));
 
@@ -342,7 +343,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "postgres")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "Npgsql")
                 .Matches("span.kind", "client"));
 
@@ -367,7 +368,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("db.name")
                 .Matches("db.type", "oracle")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "Oracle")
                 .Matches("span.kind", "client"));
 
@@ -449,7 +450,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "sqlite")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "Sqlite")
                 .Matches("span.kind", "client"));
 
@@ -462,7 +463,7 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("out.host")
                 .Matches("db.type", "sql-server")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "db.instance", "out.host", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "db.name", "out.host", "peer.service")
                 .Matches("component", "SqlClient")
                 .Matches("span.kind", "client")
                 .IsOptional("_dd.dbm_trace_injected"));
@@ -487,8 +488,9 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("http.method")
                 .IsPresent("http.status_code")
                 .IsPresent("http.url")
+                .IsPresent("out.host")
                 .IsPresent("peer.service")
-                .MatchesOneOf("_dd.peer.service.source", "network.destination.name", "peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "out.host", "peer.service")
                 .MatchesOneOf("component", "HttpMessageHandler", "WebRequest")
                 .Matches("span.kind", "client"));
     }

--- a/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
@@ -20,10 +20,10 @@ namespace Datadog.Trace.Tests.Tagging
             var host = "localhost";
             var tags = new HttpV1Tags();
 
-            tags.SetHost(host);
+            tags.Host = host;
 
             tags.PeerService.Should().Be(host);
-            tags.PeerServiceSource.Should().Be("network.destination.name");
+            tags.PeerServiceSource.Should().Be("out.host");
         }
 
         [Fact]
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests.Tagging
             var tags = new HttpV1Tags();
 
             tags.SetTag("peer.service", customService);
-            tags.SetHost(host);
+            tags.Host = host;
 
             tags.PeerService.Should().Be(customService);
             tags.PeerServiceSource.Should().Be("peer.service");
@@ -137,7 +137,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.DbName = databaseName;
 
             tags.PeerService.Should().Be(databaseName);
-            tags.PeerServiceSource.Should().Be("db.instance");
+            tags.PeerServiceSource.Should().Be("db.name");
         }
 
         [Fact]
@@ -149,7 +149,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.Host = hostName;
 
             tags.PeerService.Should().Be(hostName);
-            tags.PeerServiceSource.Should().Be("network.destination.name");
+            tags.PeerServiceSource.Should().Be("out.host");
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.DbName = databaseName;
 
             tags.PeerService.Should().Be(databaseName);
-            tags.PeerServiceSource.Should().Be("db.instance");
+            tags.PeerServiceSource.Should().Be("db.name");
         }
 
         [Fact]
@@ -243,7 +243,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.OutHost = host;
 
             tags.PeerService.Should().Be(databaseName);
-            tags.PeerServiceSource.Should().Be("db.instance");
+            tags.PeerServiceSource.Should().Be("db.name");
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
@@ -189,7 +189,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.OutHost = host;
 
             tags.PeerService.Should().Be(host);
-            tags.PeerServiceSource.Should().Be("network.destination.name");
+            tags.PeerServiceSource.Should().Be("out.host");
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
@@ -267,7 +267,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.Host = hostName;
 
             tags.PeerService.Should().Be(hostName);
-            tags.PeerServiceSource.Should().Be("network.destination.name");
+            tags.PeerServiceSource.Should().Be("out.host");
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace.Tests.Tagging
             tags.Host = hostName;
 
             tags.PeerService.Should().Be(hostName);
-            tags.PeerServiceSource.Should().Be("network.destination.name");
+            tags.PeerServiceSource.Should().Be("out.host");
         }
 
         [Fact]

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -1084,6 +1084,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamSync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1104,6 +1105,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamSync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_2,
       span.kind: client
     },
@@ -1124,6 +1126,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsSync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_3,
       span.kind: client
     },
@@ -1144,6 +1147,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamAsync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_4,
       span.kind: client
     },
@@ -1164,6 +1168,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamAsync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_5,
       span.kind: client
     },
@@ -1184,6 +1189,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsAsync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_6,
       span.kind: client
     },
@@ -1204,6 +1210,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamVoid,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_7,
       span.kind: client
     },
@@ -1224,6 +1231,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamVoid,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_8,
       span.kind: client
     },
@@ -1244,6 +1252,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsVoid,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_9,
       span.kind: client
     },
@@ -1264,6 +1273,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerNoParamSyncWithContext,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_10,
       span.kind: client
     },
@@ -1284,6 +1294,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerOneParamSyncWithContext,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_11,
       span.kind: client
     },
@@ -1304,6 +1315,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerTwoParamsSyncWithContext,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_12,
       span.kind: client
     },
@@ -1324,6 +1336,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerNoParamSync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_13,
       span.kind: client
     },
@@ -1344,6 +1357,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerTwoParamsSync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_14,
       span.kind: client
     },
@@ -1364,6 +1378,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerOneParamSyncWithContext,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_15,
       span.kind: client
     },
@@ -1384,6 +1399,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerOneParamAsync,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_16,
       span.kind: client
     },
@@ -1404,6 +1420,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/BaseHandlerTwoParamsVoid,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_17,
       span.kind: client
     },
@@ -1424,6 +1441,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerStructParam,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_18,
       span.kind: client
     },
@@ -1444,6 +1462,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerNestedClassParam,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_19,
       span.kind: client
     },
@@ -1464,6 +1483,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerNestedStructParam,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_20,
       span.kind: client
     },
@@ -1484,6 +1504,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_21,
       span.kind: client
     },
@@ -1504,6 +1525,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerNestedGenericDictionaryParam,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_22,
       span.kind: client
     },
@@ -1524,6 +1546,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/HandlerDoublyNestedGenericDictionaryParam,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_23,
       span.kind: client
     },
@@ -1547,6 +1570,7 @@
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandler,
+      out.host: localhost,
       runtime-id: Guid_24,
       span.kind: client
     },
@@ -1570,6 +1594,7 @@
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsync,
+      out.host: localhost,
       runtime-id: Guid_25,
       span.kind: client
     },
@@ -1593,6 +1618,7 @@
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsyncTask,
+      out.host: localhost,
       runtime-id: Guid_26,
       span.kind: client
     },
@@ -1616,6 +1642,7 @@
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandler,
+      out.host: localhost,
       runtime-id: Guid_27,
       span.kind: client
     },
@@ -1639,6 +1666,7 @@
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsync,
+      out.host: localhost,
       runtime-id: Guid_28,
       span.kind: client
     },
@@ -1662,6 +1690,7 @@
       error.type: System.Net.WebException,
       http.method: GET,
       http.url: http://localhost/function/ThrowingHandlerAsyncTask,
+      out.host: localhost,
       runtime-id: Guid_29,
       span.kind: client
     },
@@ -1682,6 +1711,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/GenericBaseType1,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_30,
       span.kind: client
     },
@@ -1702,6 +1732,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/GenericBaseType2,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_31,
       span.kind: client
     },
@@ -1722,6 +1753,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/VirtualGenericBaseType3,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_32,
       span.kind: client
     },
@@ -1742,6 +1774,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/VirtualGenericBaseType4,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_33,
       span.kind: client
     },
@@ -1762,6 +1795,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/AbstractGenericBaseType5,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_34,
       span.kind: client
     },
@@ -1782,6 +1816,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/AbstractGenericBaseType6,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_35,
       span.kind: client
     },
@@ -1802,6 +1837,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/ComplexNestedGeneric,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_36,
       span.kind: client
     },
@@ -1822,6 +1858,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://serverless-dummy-api:9005/function/ComplexNestedGeneric,
+      out.host: serverless-dummy-api,
       runtime-id: Guid_37,
       span.kind: client
     },

--- a/tracer/test/snapshots/AwsSnsTests.NetCore.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/AwsSnsTests.NetCore.SchemaV0.verified.txt
@@ -13,6 +13,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0
@@ -39,6 +40,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0

--- a/tracer/test/snapshots/AwsSnsTests.NetCore.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/AwsSnsTests.NetCore.SchemaV1.verified.txt
@@ -13,11 +13,12 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       peer.service: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     },
     Metrics: {
       process_id: 0,
@@ -41,11 +42,12 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       peer.service: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/AwsSnsTests.NetFramework.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/AwsSnsTests.NetFramework.SchemaV0.verified.txt
@@ -12,6 +12,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0
@@ -37,6 +38,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0

--- a/tracer/test/snapshots/AwsSnsTests.NetFramework.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/AwsSnsTests.NetFramework.SchemaV1.verified.txt
@@ -12,11 +12,12 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       peer.service: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     },
     Metrics: {
       process_id: 0,
@@ -39,11 +40,12 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sns,
       peer.service: aws_sns,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/AwsSqsTests.NetCore.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/AwsSqsTests.NetCore.SchemaV0.verified.txt
@@ -88,6 +88,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -110,6 +111,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -132,6 +134,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -154,6 +157,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -176,6 +180,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },

--- a/tracer/test/snapshots/AwsSqsTests.NetCore.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/AwsSqsTests.NetCore.SchemaV1.verified.txt
@@ -80,9 +80,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -100,9 +101,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -120,9 +122,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -140,9 +143,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -160,9 +164,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {

--- a/tracer/test/snapshots/AwsSqsTests.NetFramework.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/AwsSqsTests.NetFramework.SchemaV0.verified.txt
@@ -87,6 +87,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -108,6 +109,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -129,6 +131,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -150,6 +153,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -171,6 +175,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -942,6 +947,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -963,6 +969,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -984,6 +991,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1005,6 +1013,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1026,6 +1035,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      out.host: aws_sqs,
       runtime-id: Guid_1,
       span.kind: client
     },

--- a/tracer/test/snapshots/AwsSqsTests.NetFramework.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/AwsSqsTests.NetFramework.SchemaV1.verified.txt
@@ -79,9 +79,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -98,9 +99,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -117,9 +119,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -136,9 +139,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -155,9 +159,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -812,9 +817,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -831,9 +837,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -850,9 +857,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -869,9 +877,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MySyncSQSQueue,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -888,9 +897,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MySyncSQSQueue2,
+      out.host: aws_sqs,
       peer.service: aws_sqs,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {

--- a/tracer/test/snapshots/AzureFunctionsTests.InProcess.verified.txt
+++ b/tracer/test/snapshots/AzureFunctionsTests.InProcess.verified.txt
@@ -51,6 +51,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://localhost:00000/api/trigger,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -143,6 +144,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://localhost:00000/api/simple,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -167,6 +169,7 @@
       http.method: GET,
       http.status_code: 500,
       http.url: http://localhost:00000/api/exception,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -191,6 +194,7 @@
       http.method: GET,
       http.status_code: 500,
       http.url: http://localhost:00000/api/error,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -217,6 +221,7 @@
       http.method: GET,
       http.status_code: 400,
       http.url: http://localhost:00000/api/badrequest,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },

--- a/tracer/test/snapshots/AzureFunctionsTests.Isolated.verified.txt
+++ b/tracer/test/snapshots/AzureFunctionsTests.Isolated.verified.txt
@@ -50,6 +50,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://localhost:00000/api/trigger,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -160,6 +161,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://localhost:00000/api/simple,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -184,6 +186,7 @@
       http.method: GET,
       http.status_code: 500,
       http.url: http://localhost:00000/api/exception,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -208,6 +211,7 @@
       http.method: GET,
       http.status_code: 500,
       http.url: http://localhost:00000/api/error,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -234,6 +238,7 @@
       http.method: GET,
       http.status_code: 400,
       http.url: http://localhost:00000/api/badrequest,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client
     },

--- a/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=True.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=True.SchemaV0.verified.txt
@@ -63,6 +63,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/StreamingBothWays,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -190,6 +191,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/StreamingFromClient,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -319,6 +321,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -450,6 +453,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -581,6 +585,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -712,6 +717,7 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -847,6 +853,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -978,6 +985,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1109,6 +1117,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1240,6 +1249,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1373,6 +1383,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/StreamingFromServer,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1500,6 +1511,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/Unary,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1627,6 +1639,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/Unary,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1754,6 +1767,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/VerySlow,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },
@@ -1883,6 +1897,7 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/VerySlow,
+      out.host: 127.0.0.1,
       runtime-id: Guid_1,
       span.kind: client
     },

--- a/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=True.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GrpcDotNet.SubmitTraces_httpclient=True.SchemaV1.verified.txt
@@ -61,9 +61,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/StreamingBothWays,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -184,9 +185,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/StreamingFromClient,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -309,9 +311,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -436,9 +439,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -563,9 +567,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -690,9 +695,10 @@
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -821,9 +827,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -948,9 +955,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1075,9 +1083,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1202,9 +1211,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/ErroringMethod,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1331,9 +1341,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/StreamingFromServer,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1454,9 +1465,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/Unary,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1577,9 +1589,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/Unary,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1700,9 +1713,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/VerySlow,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1825,9 +1839,10 @@ at Samples.GrpcDotNet.Services.GreeterService.ErroringMethod(CreateErrorRequest 
       http.method: POST,
       http.status_code: 200,
       http.url: http://localhost:00000/greet.tester.Greeter/VerySlow,
+      out.host: 127.0.0.1,
       peer.service: 127.0.0.1,
       span.kind: client,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_15.SchemaV1.verified.txt
@@ -81,7 +81,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -103,7 +103,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -125,7 +125,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -147,7 +147,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -169,7 +169,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -191,7 +191,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -213,7 +213,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -235,7 +235,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -257,7 +257,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV1.verified.txt
@@ -116,7 +116,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -137,7 +137,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -159,7 +159,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -181,7 +181,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -221,7 +221,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -242,7 +242,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -264,7 +264,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -286,7 +286,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_2.SchemaV1.verified.txt
@@ -200,7 +200,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -305,7 +305,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -324,7 +324,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   }
 ]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV1.verified.txt
@@ -117,7 +117,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -139,7 +139,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -161,7 +161,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -183,7 +183,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -224,7 +224,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -246,7 +246,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -268,7 +268,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_5.SchemaV1.verified.txt
@@ -202,7 +202,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -309,7 +309,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -328,7 +328,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   }
 ]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=2_7.SchemaV1.verified.txt
@@ -117,7 +117,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -139,7 +139,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -161,7 +161,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -183,7 +183,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -202,7 +202,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -224,7 +224,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -246,7 +246,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -268,7 +268,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -309,7 +309,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -328,7 +328,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   }
 ]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV1.verified.txt
@@ -142,7 +142,7 @@
       peer.service: mongo,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   }
 ]

--- a/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MongoDbTests.SubmitsTraces_packageVersion=PRE_2_2.SchemaV1.verified.txt
@@ -80,7 +80,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -123,7 +123,7 @@
       peer.service: test-db,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {

--- a/tracer/test/snapshots/MySqlCommandTests.Net.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlCommandTests.Net.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlCommandTests.Net462.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlCommandTests.Net462.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlCommandTests.NetCore.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlCommandTests.NetCore.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet.disabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet.disabled.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet.enabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet.enabled.SchemaV1.verified.txt
@@ -18,7 +18,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -40,7 +40,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -62,7 +62,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -84,7 +84,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -106,7 +106,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -128,7 +128,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -150,7 +150,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -172,7 +172,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -194,7 +194,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -216,7 +216,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -238,7 +238,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -260,7 +260,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -282,7 +282,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -304,7 +304,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -326,7 +326,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -348,7 +348,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -370,7 +370,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -392,7 +392,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -414,7 +414,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -436,7 +436,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -480,7 +480,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -502,7 +502,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -524,7 +524,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -546,7 +546,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -568,7 +568,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -590,7 +590,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -612,7 +612,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -634,7 +634,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -656,7 +656,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -678,7 +678,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -700,7 +700,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -722,7 +722,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -744,7 +744,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -766,7 +766,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -788,7 +788,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -810,7 +810,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -832,7 +832,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -854,7 +854,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -876,7 +876,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -898,7 +898,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -942,7 +942,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -964,7 +964,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -986,7 +986,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1008,7 +1008,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1030,7 +1030,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1052,7 +1052,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1074,7 +1074,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1096,7 +1096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1118,7 +1118,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1140,7 +1140,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1162,7 +1162,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1184,7 +1184,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1206,7 +1206,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1228,7 +1228,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1250,7 +1250,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1272,7 +1272,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1294,7 +1294,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1316,7 +1316,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1338,7 +1338,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1360,7 +1360,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1404,7 +1404,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1426,7 +1426,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1448,7 +1448,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1470,7 +1470,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1492,7 +1492,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1514,7 +1514,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1536,7 +1536,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1558,7 +1558,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1580,7 +1580,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1602,7 +1602,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1624,7 +1624,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1646,7 +1646,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1668,7 +1668,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1690,7 +1690,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1712,7 +1712,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1734,7 +1734,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1756,7 +1756,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1778,7 +1778,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1800,7 +1800,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1822,7 +1822,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1866,7 +1866,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1888,7 +1888,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1910,7 +1910,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1932,7 +1932,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1954,7 +1954,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1976,7 +1976,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1998,7 +1998,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2020,7 +2020,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2042,7 +2042,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2064,7 +2064,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2086,7 +2086,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2108,7 +2108,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2130,7 +2130,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2152,7 +2152,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2174,7 +2174,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2196,7 +2196,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2218,7 +2218,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2240,7 +2240,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2262,7 +2262,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2284,7 +2284,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2328,7 +2328,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2350,7 +2350,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2372,7 +2372,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2394,7 +2394,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2416,7 +2416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2438,7 +2438,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2460,7 +2460,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2482,7 +2482,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2504,7 +2504,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2526,7 +2526,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2548,7 +2548,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2570,7 +2570,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2592,7 +2592,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2614,7 +2614,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2636,7 +2636,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2658,7 +2658,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2680,7 +2680,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2702,7 +2702,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2724,7 +2724,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2746,7 +2746,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2790,7 +2790,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2812,7 +2812,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2834,7 +2834,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2856,7 +2856,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2878,7 +2878,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2900,7 +2900,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2922,7 +2922,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2944,7 +2944,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2966,7 +2966,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2988,7 +2988,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3010,7 +3010,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3032,7 +3032,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3054,7 +3054,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3076,7 +3076,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3098,7 +3098,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3120,7 +3120,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3142,7 +3142,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3164,7 +3164,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3186,7 +3186,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3208,7 +3208,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3230,7 +3230,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet462.disabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet462.disabled.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet462.enabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNet462.enabled.SchemaV1.verified.txt
@@ -18,7 +18,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -40,7 +40,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -62,7 +62,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -84,7 +84,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -106,7 +106,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -128,7 +128,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -150,7 +150,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -172,7 +172,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -194,7 +194,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -216,7 +216,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -238,7 +238,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -260,7 +260,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -282,7 +282,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -304,7 +304,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -326,7 +326,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -348,7 +348,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -370,7 +370,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -392,7 +392,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -414,7 +414,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -436,7 +436,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -480,7 +480,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -502,7 +502,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -524,7 +524,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -546,7 +546,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -568,7 +568,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -590,7 +590,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -612,7 +612,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -634,7 +634,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -656,7 +656,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -678,7 +678,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -700,7 +700,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -722,7 +722,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -744,7 +744,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -766,7 +766,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -788,7 +788,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -810,7 +810,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -832,7 +832,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -854,7 +854,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -876,7 +876,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -898,7 +898,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -942,7 +942,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -964,7 +964,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -986,7 +986,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1008,7 +1008,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1030,7 +1030,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1052,7 +1052,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1074,7 +1074,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1096,7 +1096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1118,7 +1118,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1140,7 +1140,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1162,7 +1162,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1184,7 +1184,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1206,7 +1206,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1228,7 +1228,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1250,7 +1250,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1272,7 +1272,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1294,7 +1294,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1316,7 +1316,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1338,7 +1338,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1360,7 +1360,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1404,7 +1404,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1426,7 +1426,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1448,7 +1448,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1470,7 +1470,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1492,7 +1492,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1514,7 +1514,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1536,7 +1536,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1558,7 +1558,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1580,7 +1580,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1602,7 +1602,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1624,7 +1624,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1646,7 +1646,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1668,7 +1668,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1690,7 +1690,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1712,7 +1712,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1734,7 +1734,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1756,7 +1756,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1778,7 +1778,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1800,7 +1800,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1822,7 +1822,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1866,7 +1866,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1888,7 +1888,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1910,7 +1910,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1932,7 +1932,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1954,7 +1954,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1976,7 +1976,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1998,7 +1998,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2020,7 +2020,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2042,7 +2042,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2064,7 +2064,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2086,7 +2086,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2108,7 +2108,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2130,7 +2130,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2152,7 +2152,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2174,7 +2174,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2196,7 +2196,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2218,7 +2218,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2240,7 +2240,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2262,7 +2262,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2284,7 +2284,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2328,7 +2328,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2350,7 +2350,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2372,7 +2372,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2394,7 +2394,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2416,7 +2416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2438,7 +2438,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2460,7 +2460,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2482,7 +2482,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2504,7 +2504,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2526,7 +2526,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2548,7 +2548,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2570,7 +2570,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2592,7 +2592,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2614,7 +2614,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2636,7 +2636,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2658,7 +2658,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2680,7 +2680,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2702,7 +2702,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2724,7 +2724,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2746,7 +2746,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2790,7 +2790,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2812,7 +2812,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2834,7 +2834,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2856,7 +2856,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2878,7 +2878,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2900,7 +2900,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2922,7 +2922,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2944,7 +2944,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2966,7 +2966,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2988,7 +2988,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3010,7 +3010,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3032,7 +3032,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3054,7 +3054,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3076,7 +3076,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3098,7 +3098,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3120,7 +3120,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3142,7 +3142,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3164,7 +3164,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3186,7 +3186,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3208,7 +3208,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3230,7 +3230,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNetCore.disabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNetCore.disabled.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       peer.service: world,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNetCore.enabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/MySqlDatabaseMonitoringTestsNetCore.enabled.SchemaV1.verified.txt
@@ -18,7 +18,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -40,7 +40,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -62,7 +62,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -84,7 +84,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -106,7 +106,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -128,7 +128,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -150,7 +150,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -172,7 +172,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -194,7 +194,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -216,7 +216,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -238,7 +238,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -260,7 +260,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -282,7 +282,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -304,7 +304,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -326,7 +326,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -348,7 +348,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -370,7 +370,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -392,7 +392,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -414,7 +414,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -436,7 +436,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -480,7 +480,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -502,7 +502,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -524,7 +524,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -546,7 +546,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -568,7 +568,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -590,7 +590,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -612,7 +612,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -634,7 +634,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -656,7 +656,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -678,7 +678,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -700,7 +700,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -722,7 +722,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -744,7 +744,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -766,7 +766,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -788,7 +788,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -810,7 +810,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -832,7 +832,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -854,7 +854,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -876,7 +876,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -898,7 +898,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -942,7 +942,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -964,7 +964,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -986,7 +986,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1008,7 +1008,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1030,7 +1030,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1052,7 +1052,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1074,7 +1074,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1096,7 +1096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1118,7 +1118,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1140,7 +1140,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1162,7 +1162,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1184,7 +1184,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1206,7 +1206,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1228,7 +1228,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1250,7 +1250,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1272,7 +1272,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1294,7 +1294,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1316,7 +1316,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1338,7 +1338,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1360,7 +1360,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1404,7 +1404,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1426,7 +1426,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1448,7 +1448,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1470,7 +1470,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1492,7 +1492,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1514,7 +1514,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1536,7 +1536,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1558,7 +1558,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1580,7 +1580,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1602,7 +1602,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1624,7 +1624,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1646,7 +1646,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1668,7 +1668,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1690,7 +1690,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1712,7 +1712,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1734,7 +1734,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1756,7 +1756,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1778,7 +1778,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1800,7 +1800,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1822,7 +1822,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1866,7 +1866,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1888,7 +1888,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1910,7 +1910,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1932,7 +1932,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1954,7 +1954,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1976,7 +1976,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1998,7 +1998,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2020,7 +2020,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2042,7 +2042,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2064,7 +2064,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2086,7 +2086,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2108,7 +2108,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2130,7 +2130,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2152,7 +2152,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2174,7 +2174,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2196,7 +2196,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2218,7 +2218,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2240,7 +2240,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2262,7 +2262,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2284,7 +2284,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2328,7 +2328,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2350,7 +2350,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2372,7 +2372,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2394,7 +2394,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2416,7 +2416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2438,7 +2438,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2460,7 +2460,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2482,7 +2482,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2504,7 +2504,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2526,7 +2526,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2548,7 +2548,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2570,7 +2570,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2592,7 +2592,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2614,7 +2614,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2636,7 +2636,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2658,7 +2658,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2680,7 +2680,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2702,7 +2702,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2724,7 +2724,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2746,7 +2746,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2790,7 +2790,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2812,7 +2812,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2834,7 +2834,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2856,7 +2856,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2878,7 +2878,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2900,7 +2900,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2922,7 +2922,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2944,7 +2944,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2966,7 +2966,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2988,7 +2988,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3010,7 +3010,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3032,7 +3032,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3054,7 +3054,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3076,7 +3076,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3098,7 +3098,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3120,7 +3120,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3142,7 +3142,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3164,7 +3164,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3186,7 +3186,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3208,7 +3208,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3230,7 +3230,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/NpgsqlDatabaseMonitoringTests.disabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/NpgsqlDatabaseMonitoringTests.disabled.SchemaV1.verified.txt
@@ -16,7 +16,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -36,7 +36,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -56,7 +56,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -76,7 +76,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -96,7 +96,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -116,7 +116,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -136,7 +136,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -156,7 +156,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -176,7 +176,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -196,7 +196,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -216,7 +216,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -236,7 +236,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -256,7 +256,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -276,7 +276,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -296,7 +296,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -316,7 +316,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -336,7 +336,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -356,7 +356,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -376,7 +376,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -396,7 +396,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -436,7 +436,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -456,7 +456,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -476,7 +476,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -496,7 +496,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -516,7 +516,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -536,7 +536,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -556,7 +556,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -576,7 +576,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -596,7 +596,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -616,7 +616,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -636,7 +636,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -656,7 +656,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -676,7 +676,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -696,7 +696,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -716,7 +716,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -736,7 +736,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -756,7 +756,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -776,7 +776,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -796,7 +796,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -816,7 +816,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -856,7 +856,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -876,7 +876,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -896,7 +896,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -916,7 +916,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -936,7 +936,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -956,7 +956,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -976,7 +976,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -996,7 +996,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1016,7 +1016,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1036,7 +1036,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1056,7 +1056,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1076,7 +1076,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1096,7 +1096,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1116,7 +1116,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1136,7 +1136,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1156,7 +1156,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1176,7 +1176,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1196,7 +1196,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1216,7 +1216,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1236,7 +1236,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1276,7 +1276,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1296,7 +1296,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1316,7 +1316,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1336,7 +1336,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1356,7 +1356,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1376,7 +1376,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1396,7 +1396,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1416,7 +1416,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1436,7 +1436,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1456,7 +1456,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1476,7 +1476,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1496,7 +1496,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1516,7 +1516,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1536,7 +1536,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1556,7 +1556,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1576,7 +1576,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1596,7 +1596,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1616,7 +1616,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1636,7 +1636,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1656,7 +1656,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1696,7 +1696,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1716,7 +1716,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1736,7 +1736,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1756,7 +1756,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1776,7 +1776,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1796,7 +1796,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1816,7 +1816,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1836,7 +1836,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1856,7 +1856,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1876,7 +1876,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1896,7 +1896,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1916,7 +1916,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1936,7 +1936,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1956,7 +1956,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1976,7 +1976,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1996,7 +1996,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2016,7 +2016,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2036,7 +2036,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2056,7 +2056,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2076,7 +2076,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2116,7 +2116,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2136,7 +2136,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2156,7 +2156,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2176,7 +2176,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2196,7 +2196,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2216,7 +2216,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2236,7 +2236,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2256,7 +2256,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2276,7 +2276,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2296,7 +2296,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2316,7 +2316,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2336,7 +2336,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2356,7 +2356,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2376,7 +2376,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2396,7 +2396,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2416,7 +2416,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2436,7 +2436,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2456,7 +2456,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2476,7 +2476,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2496,7 +2496,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2536,7 +2536,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2556,7 +2556,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2576,7 +2576,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2596,7 +2596,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2616,7 +2616,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2636,7 +2636,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2656,7 +2656,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2676,7 +2676,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2696,7 +2696,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2716,7 +2716,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2736,7 +2736,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2756,7 +2756,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2776,7 +2776,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2796,7 +2796,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2816,7 +2816,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2836,7 +2836,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2856,7 +2856,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2876,7 +2876,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2896,7 +2896,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2916,7 +2916,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/NpgsqlDatabaseMonitoringTests.enabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/NpgsqlDatabaseMonitoringTests.enabled.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/NpgsqlDatabaseMonitoringTestsNet462.disabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/NpgsqlDatabaseMonitoringTestsNet462.disabled.SchemaV1.verified.txt
@@ -16,7 +16,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -36,7 +36,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -56,7 +56,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -76,7 +76,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -96,7 +96,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -116,7 +116,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -136,7 +136,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -156,7 +156,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -176,7 +176,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -196,7 +196,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -216,7 +216,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -236,7 +236,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -256,7 +256,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -276,7 +276,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -296,7 +296,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -316,7 +316,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -336,7 +336,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -356,7 +356,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -376,7 +376,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -396,7 +396,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -436,7 +436,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -456,7 +456,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -476,7 +476,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -496,7 +496,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -516,7 +516,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -536,7 +536,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -556,7 +556,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -576,7 +576,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -596,7 +596,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -616,7 +616,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -636,7 +636,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -656,7 +656,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -676,7 +676,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -696,7 +696,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -716,7 +716,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -736,7 +736,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -756,7 +756,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -776,7 +776,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -796,7 +796,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -816,7 +816,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -856,7 +856,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -876,7 +876,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -896,7 +896,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -916,7 +916,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -936,7 +936,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -956,7 +956,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -976,7 +976,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -996,7 +996,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1016,7 +1016,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1036,7 +1036,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1056,7 +1056,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1076,7 +1076,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1096,7 +1096,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1116,7 +1116,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1136,7 +1136,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1156,7 +1156,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1176,7 +1176,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1196,7 +1196,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1216,7 +1216,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1236,7 +1236,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1276,7 +1276,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1296,7 +1296,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1316,7 +1316,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1336,7 +1336,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1356,7 +1356,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1376,7 +1376,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1396,7 +1396,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1416,7 +1416,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1436,7 +1436,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1456,7 +1456,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1476,7 +1476,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1496,7 +1496,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1516,7 +1516,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1536,7 +1536,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1556,7 +1556,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1576,7 +1576,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1596,7 +1596,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1616,7 +1616,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1636,7 +1636,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1656,7 +1656,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1696,7 +1696,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1716,7 +1716,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1736,7 +1736,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1756,7 +1756,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1776,7 +1776,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1796,7 +1796,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1816,7 +1816,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1836,7 +1836,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1856,7 +1856,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1876,7 +1876,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1896,7 +1896,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1916,7 +1916,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1936,7 +1936,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1956,7 +1956,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1976,7 +1976,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1996,7 +1996,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2016,7 +2016,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2036,7 +2036,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2056,7 +2056,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2076,7 +2076,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2116,7 +2116,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2136,7 +2136,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2156,7 +2156,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2176,7 +2176,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2196,7 +2196,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2216,7 +2216,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2236,7 +2236,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2256,7 +2256,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2276,7 +2276,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2296,7 +2296,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2316,7 +2316,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2336,7 +2336,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2356,7 +2356,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2376,7 +2376,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2396,7 +2396,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2416,7 +2416,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2436,7 +2436,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2456,7 +2456,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2476,7 +2476,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2496,7 +2496,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2536,7 +2536,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2556,7 +2556,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2576,7 +2576,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2596,7 +2596,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2616,7 +2616,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2636,7 +2636,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2656,7 +2656,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2676,7 +2676,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2696,7 +2696,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2716,7 +2716,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2736,7 +2736,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2756,7 +2756,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2776,7 +2776,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2796,7 +2796,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2816,7 +2816,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2836,7 +2836,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2856,7 +2856,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2876,7 +2876,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2896,7 +2896,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2916,7 +2916,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       peer.service: postgres,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/NpgsqlDatabaseMonitoringTestsNet462.enabled.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/NpgsqlDatabaseMonitoringTestsNet462.enabled.SchemaV1.verified.txt
@@ -17,7 +17,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -38,7 +38,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -59,7 +59,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -80,7 +80,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -101,7 +101,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -122,7 +122,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -143,7 +143,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -164,7 +164,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -185,7 +185,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -206,7 +206,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -227,7 +227,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -248,7 +248,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -269,7 +269,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -290,7 +290,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -311,7 +311,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -332,7 +332,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -353,7 +353,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -374,7 +374,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -395,7 +395,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -416,7 +416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -437,7 +437,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -458,7 +458,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -479,7 +479,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -500,7 +500,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -521,7 +521,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -542,7 +542,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -563,7 +563,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -584,7 +584,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -605,7 +605,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -626,7 +626,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -647,7 +647,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -668,7 +668,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -689,7 +689,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -710,7 +710,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -731,7 +731,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -752,7 +752,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -773,7 +773,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -794,7 +794,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -815,7 +815,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -836,7 +836,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -857,7 +857,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -878,7 +878,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -899,7 +899,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -920,7 +920,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -941,7 +941,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -962,7 +962,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -983,7 +983,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1004,7 +1004,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1025,7 +1025,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1046,7 +1046,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1067,7 +1067,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1088,7 +1088,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1109,7 +1109,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1130,7 +1130,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1151,7 +1151,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1172,7 +1172,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1193,7 +1193,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1214,7 +1214,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1235,7 +1235,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1256,7 +1256,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1277,7 +1277,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1298,7 +1298,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1319,7 +1319,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1340,7 +1340,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1361,7 +1361,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1382,7 +1382,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1403,7 +1403,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1424,7 +1424,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1445,7 +1445,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1466,7 +1466,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1487,7 +1487,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1508,7 +1508,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1529,7 +1529,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1550,7 +1550,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1571,7 +1571,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1592,7 +1592,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1613,7 +1613,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1634,7 +1634,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1655,7 +1655,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1676,7 +1676,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1697,7 +1697,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1718,7 +1718,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1739,7 +1739,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1760,7 +1760,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1781,7 +1781,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1802,7 +1802,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1823,7 +1823,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1844,7 +1844,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1865,7 +1865,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1886,7 +1886,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1907,7 +1907,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1928,7 +1928,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1949,7 +1949,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1970,7 +1970,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -1991,7 +1991,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2012,7 +2012,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2033,7 +2033,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2054,7 +2054,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2075,7 +2075,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2096,7 +2096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2117,7 +2117,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2138,7 +2138,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2159,7 +2159,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2180,7 +2180,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2201,7 +2201,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2222,7 +2222,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2243,7 +2243,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2264,7 +2264,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2285,7 +2285,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2306,7 +2306,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2327,7 +2327,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2348,7 +2348,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2369,7 +2369,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2390,7 +2390,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2411,7 +2411,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2432,7 +2432,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2453,7 +2453,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2474,7 +2474,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2495,7 +2495,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2516,7 +2516,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2537,7 +2537,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2558,7 +2558,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2579,7 +2579,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2600,7 +2600,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2621,7 +2621,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2642,7 +2642,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2663,7 +2663,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2684,7 +2684,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2705,7 +2705,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2726,7 +2726,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2747,7 +2747,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2768,7 +2768,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2789,7 +2789,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2810,7 +2810,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2831,7 +2831,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2852,7 +2852,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2873,7 +2873,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2894,7 +2894,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2915,7 +2915,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2936,7 +2936,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2957,7 +2957,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2978,7 +2978,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -2999,7 +2999,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3020,7 +3020,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3041,7 +3041,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3062,7 +3062,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   },
   {
@@ -3083,7 +3083,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: db.instance
+      _dd.peer.service.source: db.name
     }
   }
 ]

--- a/tracer/test/snapshots/SystemDataSqlClientTests.SchemaV1.disabled.verified.txt
+++ b/tracer/test/snapshots/SystemDataSqlClientTests.SchemaV1.disabled.verified.txt
@@ -15,7 +15,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -34,7 +34,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -53,7 +53,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -72,7 +72,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -91,7 +91,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -110,7 +110,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -129,7 +129,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -148,7 +148,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -167,7 +167,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -186,7 +186,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -205,7 +205,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -224,7 +224,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -243,7 +243,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -262,7 +262,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -281,7 +281,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -300,7 +300,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -319,7 +319,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -338,7 +338,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -357,7 +357,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -376,7 +376,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -395,7 +395,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -414,7 +414,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -433,7 +433,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -452,7 +452,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -471,7 +471,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -490,7 +490,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -509,7 +509,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -528,7 +528,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -547,7 +547,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -566,7 +566,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -585,7 +585,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -604,7 +604,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -623,7 +623,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -642,7 +642,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -661,7 +661,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -680,7 +680,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -699,7 +699,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -718,7 +718,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -737,7 +737,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -756,7 +756,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -775,7 +775,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -794,7 +794,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -813,7 +813,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -832,7 +832,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -851,7 +851,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -870,7 +870,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -889,7 +889,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -908,7 +908,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -927,7 +927,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -946,7 +946,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -965,7 +965,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -984,7 +984,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1003,7 +1003,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1022,7 +1022,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1041,7 +1041,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1060,7 +1060,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1079,7 +1079,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1098,7 +1098,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1117,7 +1117,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1136,7 +1136,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1155,7 +1155,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1174,7 +1174,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1193,7 +1193,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1212,7 +1212,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1231,7 +1231,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1250,7 +1250,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1269,7 +1269,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1288,7 +1288,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1307,7 +1307,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1326,7 +1326,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1345,7 +1345,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1364,7 +1364,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1383,7 +1383,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1402,7 +1402,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1421,7 +1421,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1440,7 +1440,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1459,7 +1459,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1478,7 +1478,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1497,7 +1497,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1516,7 +1516,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1535,7 +1535,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1554,7 +1554,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1573,7 +1573,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1592,7 +1592,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1611,7 +1611,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1630,7 +1630,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1649,7 +1649,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1668,7 +1668,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1687,7 +1687,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1706,7 +1706,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1725,7 +1725,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1744,7 +1744,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1763,7 +1763,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1782,7 +1782,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1801,7 +1801,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1820,7 +1820,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1839,7 +1839,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1858,7 +1858,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1877,7 +1877,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1896,7 +1896,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1915,7 +1915,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1934,7 +1934,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1953,7 +1953,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1972,7 +1972,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1991,7 +1991,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2010,7 +2010,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2029,7 +2029,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2048,7 +2048,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2067,7 +2067,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2086,7 +2086,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2105,7 +2105,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2124,7 +2124,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2143,7 +2143,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2162,7 +2162,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2181,7 +2181,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2200,7 +2200,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2219,7 +2219,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2238,7 +2238,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2257,7 +2257,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2276,7 +2276,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2295,7 +2295,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2314,7 +2314,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2333,7 +2333,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2352,7 +2352,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2371,7 +2371,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2390,7 +2390,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2409,7 +2409,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2428,7 +2428,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2447,7 +2447,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2466,7 +2466,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2485,7 +2485,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2504,7 +2504,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2523,7 +2523,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2542,7 +2542,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2561,7 +2561,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2580,7 +2580,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2599,7 +2599,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2618,7 +2618,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2637,7 +2637,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2656,7 +2656,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2675,7 +2675,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2694,7 +2694,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2713,7 +2713,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2732,7 +2732,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2751,7 +2751,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2770,7 +2770,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2789,7 +2789,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2808,7 +2808,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2827,7 +2827,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2846,7 +2846,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2865,7 +2865,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2884,7 +2884,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2903,7 +2903,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2922,7 +2922,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2941,7 +2941,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2960,7 +2960,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2979,7 +2979,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2998,7 +2998,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3017,7 +3017,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3036,7 +3036,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3055,7 +3055,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3074,7 +3074,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3093,7 +3093,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3112,7 +3112,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3131,7 +3131,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3150,7 +3150,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3169,7 +3169,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3188,7 +3188,7 @@
       peer.service: sqlserver,
       span.kind: client,
       version: 1.0.0,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   }
 ]

--- a/tracer/test/snapshots/SystemDataSqlClientTests.SchemaV1.enabled.verified.txt
+++ b/tracer/test/snapshots/SystemDataSqlClientTests.SchemaV1.enabled.verified.txt
@@ -16,7 +16,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -36,7 +36,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -56,7 +56,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -76,7 +76,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -96,7 +96,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -116,7 +116,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -136,7 +136,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -156,7 +156,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -176,7 +176,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -196,7 +196,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -216,7 +216,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -236,7 +236,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -256,7 +256,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -276,7 +276,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -296,7 +296,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -316,7 +316,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -336,7 +336,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -356,7 +356,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -376,7 +376,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -396,7 +396,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -416,7 +416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -436,7 +436,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -456,7 +456,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -476,7 +476,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -496,7 +496,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -516,7 +516,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -536,7 +536,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -556,7 +556,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -576,7 +576,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -596,7 +596,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -616,7 +616,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -636,7 +636,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -656,7 +656,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -676,7 +676,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -696,7 +696,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -716,7 +716,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -736,7 +736,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -756,7 +756,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -776,7 +776,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -796,7 +796,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -816,7 +816,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -836,7 +836,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -856,7 +856,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -876,7 +876,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -896,7 +896,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -916,7 +916,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -936,7 +936,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -956,7 +956,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -976,7 +976,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -996,7 +996,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1016,7 +1016,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1036,7 +1036,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1056,7 +1056,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1076,7 +1076,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1096,7 +1096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1116,7 +1116,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1136,7 +1136,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1156,7 +1156,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1176,7 +1176,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1196,7 +1196,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1216,7 +1216,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1236,7 +1236,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1256,7 +1256,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1276,7 +1276,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1296,7 +1296,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1316,7 +1316,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1336,7 +1336,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1356,7 +1356,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1376,7 +1376,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1396,7 +1396,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1416,7 +1416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1436,7 +1436,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1456,7 +1456,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1476,7 +1476,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1496,7 +1496,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1516,7 +1516,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1536,7 +1536,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1556,7 +1556,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1576,7 +1576,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1596,7 +1596,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1616,7 +1616,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1636,7 +1636,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1656,7 +1656,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1676,7 +1676,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1696,7 +1696,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1716,7 +1716,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1736,7 +1736,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1756,7 +1756,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1776,7 +1776,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1796,7 +1796,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1816,7 +1816,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1836,7 +1836,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1856,7 +1856,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1876,7 +1876,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1896,7 +1896,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1916,7 +1916,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1936,7 +1936,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1956,7 +1956,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1976,7 +1976,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -1996,7 +1996,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2016,7 +2016,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2036,7 +2036,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2056,7 +2056,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2076,7 +2076,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2096,7 +2096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2116,7 +2116,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2136,7 +2136,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2156,7 +2156,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2176,7 +2176,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2196,7 +2196,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2216,7 +2216,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2236,7 +2236,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2256,7 +2256,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2276,7 +2276,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2296,7 +2296,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2316,7 +2316,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2336,7 +2336,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2356,7 +2356,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2376,7 +2376,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2396,7 +2396,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2416,7 +2416,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2436,7 +2436,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2456,7 +2456,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2476,7 +2476,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2496,7 +2496,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2516,7 +2516,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2536,7 +2536,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2556,7 +2556,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2576,7 +2576,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2596,7 +2596,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2616,7 +2616,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2636,7 +2636,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2656,7 +2656,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2676,7 +2676,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2696,7 +2696,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2716,7 +2716,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2736,7 +2736,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2756,7 +2756,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2776,7 +2776,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2796,7 +2796,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2816,7 +2816,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2836,7 +2836,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2856,7 +2856,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2876,7 +2876,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2896,7 +2896,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2916,7 +2916,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2936,7 +2936,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2956,7 +2956,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2976,7 +2976,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -2996,7 +2996,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3016,7 +3016,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3036,7 +3036,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3056,7 +3056,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3076,7 +3076,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3096,7 +3096,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3116,7 +3116,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3136,7 +3136,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3156,7 +3156,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3176,7 +3176,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3196,7 +3196,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3216,7 +3216,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3236,7 +3236,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3256,7 +3256,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3276,7 +3276,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3296,7 +3296,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3316,7 +3316,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3336,7 +3336,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   },
   {
@@ -3356,7 +3356,7 @@
       span.kind: client,
       version: 1.0.0,
       _dd.dbm_trace_injected: true,
-      _dd.peer.service.source: network.destination.name
+      _dd.peer.service.source: out.host
     }
   }
 ]

--- a/tracer/test/snapshots/TelemetryTests.verified.txt
+++ b/tracer/test/snapshots/TelemetryTests.verified.txt
@@ -41,6 +41,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://localhost:00000/Guid_4/,
+      out.host: localhost,
       runtime-id: Guid_2,
       span.kind: client
     },

--- a/tracer/test/snapshots/TransportTests.verified.txt
+++ b/tracer/test/snapshots/TransportTests.verified.txt
@@ -13,6 +13,7 @@
       http.method: GET,
       http.status_code: 200,
       http.url: http://localhost:00000/Guid_2/,
+      out.host: localhost,
       runtime-id: Guid_1,
       span.kind: client,
       _dd.p.dm: -0


### PR DESCRIPTION
## Summary of changes

Change
* `network.destination.name` -> `out.host` and
* `db.instance` -> `db.name`

For `_dd.peer.service.source`.

## Reason for change

Tags referenced in `_dd.peer.service.source` should exist. `network.destination.name` and `db.instance` were never used in the tracer.

## Implementation details

Change schemas and span metadata rules to match this criteria, also regenerate docs.

## Test coverage

Update affected snapshots for integration and smoke tests.

## Other details

Some integrations have had `out.host` added to v0 as well.