### PR TITLE
[Tracer] Fix Kafka span.kind tag regression

### DIFF
--- a/docs/span_attribute_schema/v0.md
+++ b/docs/span_attribute_schema/v0.md
@@ -287,11 +287,11 @@ http.status_code | Yes
 http.url | Yes
 span.kind | `client`
 
-## Kafka
+## Kafka - Inbound
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `kafka.consume`; `kafka.produce`
+Name | `kafka.consume`
 Type | `queue`
 ### Tags
 Name | Required |
@@ -302,7 +302,29 @@ kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
 messaging.kafka.bootstrap.servers | Yes
-span.kind | Yes
+span.kind | `consumer`
+### Metrics
+Name | Required |
+---------|----------------|
+_dd.measured | Yes
+message.queue_time_ms | No
+
+## Kafka - Outbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `kafka.produce`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+component | `kafka`
+kafka.group | No
+kafka.offset | No
+kafka.partition | No
+kafka.tombstone | No
+messaging.kafka.bootstrap.servers | Yes
+span.kind | `producer`
 ### Metrics
 Name | Required |
 ---------|----------------|

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -297,11 +297,11 @@ http.url | Yes
 peer.service | Yes
 span.kind | `client`
 
-## Kafka
+## Kafka - Inbound
 ### Span properties
 Name | Required |
 ---------|----------------|
-Name | `kafka.process`; `kafka.send`
+Name | `kafka.process`
 Type | `queue`
 ### Tags
 Name | Required |
@@ -314,7 +314,31 @@ kafka.partition | No
 kafka.tombstone | No
 messaging.kafka.bootstrap.servers | Yes
 peer.service | Yes
-span.kind | Yes
+span.kind | `consumer`
+### Metrics
+Name | Required |
+---------|----------------|
+_dd.measured | Yes
+message.queue_time_ms | No
+
+## Kafka - Outbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `kafka.send`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.peer.service.source | `messaging.kafka.bootstrap.servers`; `peer.service`
+component | `kafka`
+kafka.group | No
+kafka.offset | No
+kafka.partition | No
+kafka.tombstone | No
+messaging.kafka.bootstrap.servers | Yes
+peer.service | Yes
+span.kind | `producer`
 ### Metrics
 Name | Required |
 ---------|----------------|

--- a/tracer/src/Datadog.Trace/Configuration/Schema/MessagingSchema.cs
+++ b/tracer/src/Datadog.Trace/Configuration/Schema/MessagingSchema.cs
@@ -72,8 +72,8 @@ namespace Datadog.Trace.Configuration.Schema
         public KafkaTags CreateKafkaTags(string spanKind)
             => _version switch
             {
-                SchemaVersion.V0 when !_peerServiceTagsEnabled => new KafkaTags(SpanKinds.Consumer),
-                _ => new KafkaV1Tags(SpanKinds.Consumer),
+                SchemaVersion.V0 when !_peerServiceTagsEnabled => new KafkaTags(spanKind),
+                _ => new KafkaV1Tags(spanKind),
             };
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
@@ -130,11 +130,18 @@ namespace Datadog.Trace.TestHelpers
                 _ => span.IsHttpMessageHandlerV0(),
             };
 
-        public static Result IsKafka(this MockSpan span, string metadataSchemaVersion) =>
+        public static Result IsKafkaInbound(this MockSpan span, string metadataSchemaVersion) =>
             metadataSchemaVersion switch
             {
-                "v1" => span.IsKafkaV1(),
-                _ => span.IsKafkaV0(),
+                "v1" => span.IsKafkaInboundV1(),
+                _ => span.IsKafkaInboundV0(),
+            };
+
+        public static Result IsKafkaOutbound(this MockSpan span, string metadataSchemaVersion) =>
+            metadataSchemaVersion switch
+            {
+                "v1" => span.IsKafkaOutboundV1(),
+                _ => span.IsKafkaOutboundV0(),
             };
 
         public static Result IsMongoDb(this MockSpan span, string metadataSchemaVersion) =>

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV0Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV0Rules.cs
@@ -264,9 +264,10 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("component")
                 .Matches("span.kind", "client"));
 
-        public static Result IsKafkaV0(this MockSpan span) => Result.FromSpan(span)
+        public static Result IsKafkaInboundV0(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Kafka - Inbound")
             .Properties(s => s
-                .MatchesOneOf(Name, "kafka.consume", "kafka.produce")
+                .Matches(Name, "kafka.consume")
                 .Matches(Type, "queue"))
             .Metrics(s => s
                 .IsPresent("_dd.measured")
@@ -278,7 +279,24 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("kafka.tombstone")
                 .IsPresent("messaging.kafka.bootstrap.servers")
                 .Matches("component", "kafka")
-                .IsPresent("span.kind"));
+                .Matches("span.kind", "consumer"));
+
+        public static Result IsKafkaOutboundV0(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Kafka - Outbound")
+            .Properties(s => s
+                .Matches(Name, "kafka.produce")
+                .Matches(Type, "queue"))
+            .Metrics(s => s
+                .IsPresent("_dd.measured")
+                .IsOptional("message.queue_time_ms"))
+            .Tags(s => s
+                .IsOptional("kafka.group")
+                .IsOptional("kafka.offset")
+                .IsOptional("kafka.partition")
+                .IsOptional("kafka.tombstone")
+                .IsPresent("messaging.kafka.bootstrap.servers")
+                .Matches("component", "kafka")
+                .Matches("span.kind", "producer"));
 
         public static Result IsMongoDbV0(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -274,9 +274,10 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("component")
                 .Matches("span.kind", "client"));
 
-        public static Result IsKafkaV1(this MockSpan span) => Result.FromSpan(span)
+        public static Result IsKafkaInboundV1(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Kafka - Inbound")
             .Properties(s => s
-                .MatchesOneOf(Name, "kafka.process", "kafka.send")
+                .Matches(Name, "kafka.process")
                 .Matches(Type, "queue"))
             .Metrics(s => s
                 .IsPresent("_dd.measured")
@@ -290,7 +291,26 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("peer.service")
                 .MatchesOneOf("_dd.peer.service.source", "messaging.kafka.bootstrap.servers", "peer.service")
                 .Matches("component", "kafka")
-                .IsPresent("span.kind"));
+                .Matches("span.kind", "consumer"));
+
+        public static Result IsKafkaOutboundV1(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Kafka - Outbound")
+            .Properties(s => s
+                .Matches(Name, "kafka.send")
+                .Matches(Type, "queue"))
+            .Metrics(s => s
+                .IsPresent("_dd.measured")
+                .IsOptional("message.queue_time_ms"))
+            .Tags(s => s
+                .IsOptional("kafka.group")
+                .IsOptional("kafka.offset")
+                .IsOptional("kafka.partition")
+                .IsOptional("kafka.tombstone")
+                .IsPresent("messaging.kafka.bootstrap.servers")
+                .IsPresent("peer.service")
+                .MatchesOneOf("_dd.peer.service.source", "messaging.kafka.bootstrap.servers", "peer.service")
+                .Matches("component", "kafka")
+                .Matches("span.kind", "producer"));
 
         public static Result IsMongoDbV1(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s


### PR DESCRIPTION
## Summary of changes
Fixes a regression where the span.kind tag was being set to `consumer` for all Kafka spans, including the producer spans.

## Reason for change
In the recent v1 schema changes, a new method `MessagingSchema.CreateKafkaTags` was introduced to multiplex between the v0 and v1 tags. However, the span kind was not getting propagated correctly and was hard-coded to always set span.kind to `consumer`.

## Implementation details
This PR correctly propagates the specified span.kind tag and updates the span metadata assertions. Without the product change, the span metadata assertions correctly identify the regression and fail the Kafka integration tests, on both v0 and v1 schemas.

## Test coverage
Adds stronger assertions in the Kafka integration tests to identify this regression.

## Other details
This PR also splits the Kafka span assertions into inbound and outbound spans, so we can write stronger assertions.
