### PR TITLE
[Dynamic Instrumentation] Fixed update of probes

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Debugger.Expressions
             {
                 _processors.AddOrUpdate(
                     probe.Id,
-                    new ProbeProcessor(probe),
+                    _ => new ProbeProcessor(probe),
                     (s, processor) => processor.UpdateProbeProcessor(probe));
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -35,6 +35,15 @@ namespace Datadog.Trace.Debugger.Expressions
         /// <remarks>Exceptions should be caught and logged by the caller</remarks>
         internal ProbeProcessor(ProbeDefinition probe)
         {
+            InitializeProbeProcessor(probe);
+        }
+
+        internal ProbeInfo ProbeInfo { get; private set; }
+
+        private bool IsMetricCountWithoutExpression => ProbeInfo.ProbeType == ProbeType.Metric && (_metric?.Json == null) && ProbeInfo.MetricKind == MetricKind.COUNT;
+
+        private void InitializeProbeProcessor(ProbeDefinition probe)
+        {
             _evaluator = default;
             var location = probe.Where.MethodName != null
                                ? ProbeLocation.Method
@@ -70,10 +79,6 @@ namespace Datadog.Trace.Debugger.Expressions
                 (probe as SpanDecorationProbe)?.TargetSpan);
         }
 
-        internal ProbeInfo ProbeInfo { get; }
-
-        private bool IsMetricCountWithoutExpression => ProbeInfo.ProbeType == ProbeType.Metric && (_metric?.Json == null) && ProbeInfo.MetricKind == MetricKind.COUNT;
-
         [DebuggerStepThrough]
         private bool HasCondition() => _condition.HasValue;
 
@@ -84,8 +89,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
         internal ProbeProcessor UpdateProbeProcessor(ProbeDefinition probe)
         {
-            SetExpressions(probe);
-            _evaluator = new ProbeExpressionEvaluator(_templates, _condition, _metric, _spanDecorations);
+            InitializeProbeProcessor(probe);
             return this;
         }
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#1..verified.txt
@@ -1,0 +1,32 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": null,
+            "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
+          }
+        },
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": null,
+      "name": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
@@ -1,0 +1,85 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "lastName": {
+                "type": "String",
+                "value": "Run"
+              },
+              "this": {
+                "fields": {
+                  "_privateField": {
+                    "type": "String",
+                    "value": "IRun"
+                  }
+                },
+                "type": "SimpleMethodWithLocalsAndArgsTest",
+                "value": "SimpleMethodWithLocalsAndArgsTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "lastName": {
+                "type": "String",
+                "value": "Run"
+              },
+              "this": {
+                "fields": {
+                  "_privateField": {
+                    "type": "String",
+                    "value": "IRun"
+                  }
+                },
+                "type": "SimpleMethodWithLocalsAndArgsTest",
+                "value": "SimpleMethodWithLocalsAndArgsTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "String",
+                "value": "Run01234567891011121314_Run_IRun"
+              },
+              "biggerName": {
+                "type": "String",
+                "value": "Run01234567891011121314"
+              },
+              "i": {
+                "type": "Int32",
+                "value": "15"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
+          }
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#3..verified.txt
@@ -1,0 +1,32 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": null,
+            "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
+          }
+        },
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": null,
+      "name": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
@@ -1,0 +1,85 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "lastName": {
+                "type": "String",
+                "value": "Run"
+              },
+              "this": {
+                "fields": {
+                  "_privateField": {
+                    "type": "String",
+                    "value": "IRun"
+                  }
+                },
+                "type": "SimpleMethodWithLocalsAndArgsTest",
+                "value": "SimpleMethodWithLocalsAndArgsTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "lastName": {
+                "type": "String",
+                "value": "Run"
+              },
+              "this": {
+                "fields": {
+                  "_privateField": {
+                    "type": "String",
+                    "value": "IRun"
+                  }
+                },
+                "type": "SimpleMethodWithLocalsAndArgsTest",
+                "value": "SimpleMethodWithLocalsAndArgsTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "String",
+                "value": "Run01234567891011121314_Run_IRun"
+              },
+              "biggerName": {
+                "type": "String",
+                "value": "Run01234567891011121314"
+              },
+              "i": {
+                "type": "Int32",
+                "value": "15"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
+          }
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#1..verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#3..verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
@@ -1,0 +1,14 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/SimpleMethodWithLocalsAndArgsTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/SimpleMethodWithLocalsAndArgsTest.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    public class SimpleMethodWithLocalsAndArgsTest : IRun
+    {
+        private string _privateField = nameof(IRun);
+
+        public void Run()
+        {
+            Method(nameof(Run));
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public string Method(string lastName)
+        {
+            var biggerName = lastName;
+
+            for (var i = 0; i < lastName.Length * 5; i++)
+            {
+                biggerName += i.ToString();
+            }
+
+            return biggerName + $"_" + lastName + $"_" + _privateField;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
DI Probes may get updates. Log message, condition and snapshot capturing attributes can be changed at anytime. There was a bug with updating some of these attributes.

## Reason for change
Customers can fine-tune various attributes of probes, and we have to reflect those changes accurately as they arrive from RCM.

## Implementation details
Re-initializing all the fields of `ProbeProcessor` upon probe change.

## Test coverage
`MoveFromSimpleLogToSnapshotLogTest`:
- Sets a probe and updates its Capture Snapshot iteratively from _Not Capturing -> Capturing -> Not Capturing -> Capturing_, and approves the results along the way.
