### PR TITLE
Send the telemetry app-started event only once

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
@@ -39,7 +39,6 @@ internal class TelemetryControllerV2 : ITelemetryController
     private readonly Task _flushTask;
     private bool _fatalError;
     private string? _namingVersion;
-    private bool _appStartedSent;
 
     internal TelemetryControllerV2(
         IConfigurationTelemetry configuration,
@@ -79,6 +78,8 @@ internal class TelemetryControllerV2 : ITelemetryController
 
         _flushTask = Task.Run(PushTelemetryLoopAsync);
     }
+
+    public bool AppStartedSent { get; set; }
 
     public bool FatalError => Volatile.Read(ref _fatalError);
 
@@ -258,7 +259,7 @@ internal class TelemetryControllerV2 : ITelemetryController
             _metrics.GetMetrics(),
             _products.GetData());
 
-        var sendAppStarted = !_appStartedSent;
+        var sendAppStarted = !AppStartedSent;
         var data = _dataBuilder.BuildTelemetryData(application, host, in input, sendAppStarted, _namingVersion);
 
         Log.Debug("Pushing telemetry changes");
@@ -276,7 +277,7 @@ internal class TelemetryControllerV2 : ITelemetryController
             case TelemetryTransportResult.Success:
                 if (sendAppStarted)
                 {
-                    _appStartedSent = true;
+                    AppStartedSent = true;
                 }
 
                 return true;

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -216,21 +216,6 @@ namespace Datadog.Trace
         {
             try
             {
-                var telemetryReplaced = false;
-                if (oldManager.Telemetry != newManager.Telemetry && oldManager.Telemetry is not null)
-                {
-                    // This needs to be done as soon as possible (before awaiting anything) to avoid a race condition with TracerManager.Start
-                    if (oldManager.Telemetry is TelemetryControllerV2 oldV2 && newManager.Telemetry is TelemetryControllerV2 newV2)
-                    {
-                        if (oldV2.AppStartedSent)
-                        {
-                            newV2.AppStartedSent = true;
-                        }
-                    }
-
-                    telemetryReplaced = true;
-                }
-
                 var agentWriterReplaced = false;
                 if (oldManager.AgentWriter != newManager.AgentWriter && oldManager.AgentWriter is not null)
                 {
@@ -252,8 +237,10 @@ namespace Datadog.Trace
                     oldManager.Statsd?.Dispose();
                 }
 
-                if (telemetryReplaced)
+                var telemetryReplaced = false;
+                if (oldManager.Telemetry != newManager.Telemetry && oldManager.Telemetry is not null)
                 {
+                    telemetryReplaced = true;
                     await oldManager.Telemetry.DisposeAsync(sendAppClosingTelemetry: false).ConfigureAwait(false);
                 }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -216,6 +216,21 @@ namespace Datadog.Trace
         {
             try
             {
+                var telemetryReplaced = false;
+                if (oldManager.Telemetry != newManager.Telemetry && oldManager.Telemetry is not null)
+                {
+                    // This needs to be done as soon as possible (before awaiting anything) to avoid a race condition with TracerManager.Start
+                    if (oldManager.Telemetry is TelemetryControllerV2 oldV2 && newManager.Telemetry is TelemetryControllerV2 newV2)
+                    {
+                        if (oldV2.AppStartedSent)
+                        {
+                            newV2.AppStartedSent = true;
+                        }
+                    }
+
+                    telemetryReplaced = true;
+                }
+
                 var agentWriterReplaced = false;
                 if (oldManager.AgentWriter != newManager.AgentWriter && oldManager.AgentWriter is not null)
                 {
@@ -237,10 +252,8 @@ namespace Datadog.Trace
                     oldManager.Statsd?.Dispose();
                 }
 
-                var telemetryReplaced = false;
-                if (oldManager.Telemetry != newManager.Telemetry && oldManager.Telemetry is not null)
+                if (telemetryReplaced)
                 {
-                    telemetryReplaced = true;
                     await oldManager.Telemetry.DisposeAsync(sendAppClosingTelemetry: false).ConfigureAwait(false);
                 }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -1,4 +1,4 @@
- // <copyright file="TracerManagerFactory.cs" company="Datadog">
+// <copyright file="TracerManagerFactory.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -60,6 +60,17 @@ namespace Datadog.Trace
                 discoveryService: null,
                 dataStreamsManager: null,
                 remoteConfigurationManager: null);
+
+            if (previous?.Telemetry != tracer.Telemetry)
+            {
+                if (previous?.Telemetry is TelemetryControllerV2 oldV2 && tracer.Telemetry is TelemetryControllerV2 newV2)
+                {
+                    if (oldV2.AppStartedSent)
+                    {
+                        newV2.AppStartedSent = true;
+                    }
+                }
+            }
 
             try
             {


### PR DESCRIPTION
## Summary of changes

Telemetry V2 sends the app-started event every time a new tracer is created. This PR changes the logic to send it only once.

## Reason for change

Whenever the configuration changes, the telemetry controller changes the configuration as a `app-started` event the first time, and `app-configuration-change` the next times. Because dynamic configuration creates a new instance of the tracer every time a new configuration is applied, there is a race condition where the new configuration would be sent as `app-started` instead of `app-configuration-change`.

## Implementation details

Just pass along the value of `AppStartedSent` when replacing the TracerManager.

## Test coverage

Writing a test involving TracerManager + TelemetryControllerV2 is a real mess, I'll see with Andrew when he's back.