### PR TITLE
Fix the namedpipes runtime metrics tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public async Task NamedPipesSubmitsMetrics()
+        public void NamedPipesSubmitsMetrics()
         {
             if (!EnvironmentTools.IsWindows())
             {
@@ -75,21 +75,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             EnvironmentHelper.EnableWindowsNamedPipes();
-            // The server implementation of named pipes is flaky so have 3 attempts
-            var attemptsRemaining = 3;
-            while (true)
-            {
-                try
-                {
-                    attemptsRemaining--;
-                    RunTest();
-                    return;
-                }
-                catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
-                {
-                    await ReportRetry(_output, attemptsRemaining, this.GetType(), ex);
-                }
-            }
+            RunTest();
         }
 
         private void RunTest()

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -861,23 +861,22 @@ namespace Datadog.Trace.TestHelpers
         {
             if (request.ContentLength is null)
             {
-                return new byte[0];
+                return Array.Empty<byte>();
             }
 
             var i = 0;
             var body = new byte[request.ContentLength.Value];
 
-            while (request.Body.Stream.CanRead && i < request.ContentLength)
+            while (i < request.ContentLength)
             {
-                var nextByte = request.Body.Stream.ReadByte();
+                var read = request.Body.Stream.Read(body, i, body.Length - i);
 
-                if (nextByte == -1)
+                i += read;
+
+                if (read == 0 || read == body.Length)
                 {
                     break;
                 }
-
-                body[i] = (byte)nextByte;
-                i++;
             }
 
             if (i < request.ContentLength)
@@ -1149,7 +1148,6 @@ namespace Datadog.Trace.TestHelpers
         {
             private readonly PipeServer _statsPipeServer;
             private readonly PipeServer _tracesPipeServer;
-            private readonly Task _statsdTask;
 
             public NamedPipeAgent(WindowsPipesConfig config)
                 : base(config.UseTelemetry, TestTransports.WindowsNamedPipe)
@@ -1174,7 +1172,7 @@ namespace Datadog.Trace.TestHelpers
                         ex => Exceptions.Add(ex),
                         x => Output?.WriteLine(x));
 
-                    _statsdTask = Task.Run(_statsPipeServer.Start);
+                    _statsPipeServer.Start();
                 }
 
                 if (File.Exists(config.Traces))
@@ -1208,21 +1206,13 @@ namespace Datadog.Trace.TestHelpers
 
             private async Task HandleNamedPipeStats(NamedPipeServerStream namedPipeServerStream, CancellationToken cancellationToken)
             {
-                // A somewhat large, arbitrary amount, but Runtime metrics sends a lot
-                // Will throw if we exceed that but YOLO
-                var bytesReceived = new byte[0x10_000];
-                var byteCount = 0;
-                int bytesRead;
-                do
-                {
-                    bytesRead = await namedPipeServerStream.ReadAsync(bytesReceived, byteCount, count: 500, cancellationToken);
-                    byteCount += bytesRead;
-                }
-                while (bytesRead > 0);
+                using var reader = new StreamReader(namedPipeServerStream);
 
-                var stats = Encoding.UTF8.GetString(bytesReceived, 0, byteCount);
-                OnMetricsReceived(stats);
-                StatsdRequests.Enqueue(stats);
+                while (await reader.ReadLineAsync() is { } request)
+                {
+                    OnMetricsReceived(request);
+                    StatsdRequests.Enqueue(request);
+                }
             }
 
             private async Task HandleNamedPipeTraces(NamedPipeServerStream namedPipeServerStream, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary of changes

Attempt to fix the named-pipes runtime metrics test.

A few fixes are bundled:

- Start the statsd mock server synchronously
- Rewrite the statsd mock server logic: we were reading all the stats at once in an arbitrary large buffer. Instead, read each request individually (separated by \n)
- Remove the retry in the runtime metrics tests