### PR TITLE
[Telemetry] Enable V2 and metrics on AAS by default

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -143,8 +143,14 @@ namespace Datadog.Trace.Telemetry
                                    .Value;
 
             var dependencyCollectionEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DependencyCollectionEnabled).AsBool(true);
-            // Currently disabled, will be flipped to true in later versions as part of the rollout
-            var v2Enabled = config.WithKeys(ConfigurationKeys.Telemetry.V2Enabled).AsBool(false);
+
+            // TODO: Remove when we rollout telemetry v2. As of now, it will be activated by default only in AAS.
+            // we already fetch this, so this will overwrite the telemetry.... no biggy as temporary
+            var isRunningInAzureAppService = config
+                                        .WithKeys(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey)
+                                        .AsBool(false);
+
+            var v2Enabled = config.WithKeys(ConfigurationKeys.Telemetry.V2Enabled).AsBool(defaultValue: isRunningInAzureAppService);
 
             // For testing purposes only
             var debugEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DebugEnabled).AsBool(false);
@@ -154,7 +160,7 @@ namespace Datadog.Trace.Telemetry
             var metricsEnabled = config
                                 .WithKeys(ConfigurationKeys.Telemetry.MetricsEnabled)
                                 .AsBool(
-                                     defaultValue: false,
+                                     defaultValue: isRunningInAzureAppService,
                                      validator: enabled =>
                                      {
                                          if (v2Enabled || !enabled)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -308,6 +308,18 @@ namespace Datadog.Trace.Tests.Telemetry
         }
 
         [Theory]
+        [InlineData("true", true)]
+        [InlineData(null, false)]
+        public void V2AndMetricsEnabled_ByDefaultInAAS(string value, bool expected)
+        {
+            var source = CreateConfigurationSource((ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, value));
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);
+
+            settings.V2Enabled.Should().Be(expected);
+            settings.MetricsEnabled.Should().Be(expected);
+        }
+
+        [Theory]
         [InlineData("0", false)]
         [InlineData(null, false)]
         [InlineData("", false)]


### PR DESCRIPTION
## Summary of changes

Enable config telemetry v2 and metrics by default in AAS.

## Reason for change

We want to rollout progressively. AAS represent less than 5% of our services

## Implementation details

Just check for the environment variable. 
I could have passed the `TracerSettings` object to avoid recording a second time this environment variable in telemetry,  but it has no impact and was easier to implement and will be easier to revert.

## Test coverage

UTest

## Other details
Still want to check a few more things before merging, but that doesn't prevent us from reviewing this PR. That way it's easy to merge it before code freeze if we want to.
