### PR TITLE
Add INTEGRATIONS system tests to Dotnet Tracer CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3948,6 +3948,12 @@ stages:
         env:
           DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
 
+      - script: ./run.sh INTEGRATIONS
+        workingDirectory: system-tests
+        displayName: Run Integrations tests
+        env:
+          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
+
       - script: |
           mkdir -p all_logs
           cp -r ./logs* ./all_logs


### PR DESCRIPTION
## Summary of changes
Add the INTEGRATIONS scenario from System Tests to the Dotnet Tracer's CI.

## Reason for change
Enabling INTEGRATIONS scenario allow us to catch potential breakages to integrations early for future PRs.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
