### PR TITLE
Fix system-tests lib-injection

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -146,6 +146,7 @@ jobs:
       DOCKER_IMAGE_WEBLOG_TAG: ${{ github.sha }}-${{ matrix.runtime }}
       RUNTIME: ${{ matrix.runtime }}
       BUILDX_PLATFORMS: linux/amd64
+      MODE: manual
     steps:
       - name: lib-injection test runner
         id: lib-injection-test-runner


### PR DESCRIPTION
Fix system-tests lib-injection

## Summary of changes

Fix system-tests lib-injection pipeline.
The last changes on lib-injection includes more verbosity in the traces when a test fails, but we need to update pipeline add env variable (system-tests/lib-injection contains this variable from some time ago)

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
