### PR TITLE
[Profiler] Fix bug in GC threads reporting feature

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -22,9 +22,11 @@ std::list<std::shared_ptr<Sample>> NativeThreadsCpuProviderBase::GetSamples()
         cpuTime += OsSpecificApi::GetThreadCpuTime(thread.get());
     }
 
-    // For native threads, we need to keep the last cpu time
     auto currentTotalCpuTime = cpuTime;
-    cpuTime = currentTotalCpuTime - _previousTotalCpuTime;
+    // There is a case where it's possible to have currentTotalCpuTime < _previousTotalCpuTime: native threads died in the meantime
+    // To avoid sending negative values, just check and returns 0 instead.
+    cpuTime = currentTotalCpuTime >= _previousTotalCpuTime ? currentTotalCpuTime - _previousTotalCpuTime : 0;
+    // For native threads, we need to keep the last cpu time
     _previousTotalCpuTime = currentTotalCpuTime;
 
     auto samples = std::list<std::shared_ptr<Sample>>();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -9,7 +9,8 @@
 #include "RawCpuSample.h"
 
 NativeThreadsCpuProviderBase::NativeThreadsCpuProviderBase(CpuTimeProvider* cpuTimeProvider) :
-    _cpuTimeProvider{cpuTimeProvider}
+    _cpuTimeProvider{cpuTimeProvider},
+    _previousTotalCpuTime{0}
 {
 }
 
@@ -20,6 +21,11 @@ std::list<std::shared_ptr<Sample>> NativeThreadsCpuProviderBase::GetSamples()
     {
         cpuTime += OsSpecificApi::GetThreadCpuTime(thread.get());
     }
+
+    // For native threads, we need to keep the last cpu time
+    auto currentTotalCpuTime = cpuTime;
+    cpuTime = currentTotalCpuTime - _previousTotalCpuTime;
+    _previousTotalCpuTime = currentTotalCpuTime;
 
     auto samples = std::list<std::shared_ptr<Sample>>();
     if (cpuTime == 0)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
@@ -23,4 +23,5 @@ private:
     virtual std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() = 0;
 
     CpuTimeProvider* _cpuTimeProvider;
+    std::uint64_t _previousTotalCpuTime;
 };


### PR DESCRIPTION
## Summary of changes

Fix Bug

## Reason for change

The GC threads CPU time feature does not substract the previous CPU Time  so it reports an increasing amount of CPU  time for GC threads.

## Implementation details
- Substracts the previous CPU time to the current.

## Test coverage

## Other details
<!-- Fixes #{issue} -->
