### PR TITLE
Refactor `TelemetryControllerV2` to be a singleton

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
@@ -258,7 +258,7 @@ internal class TelemetryControllerV2 : ITelemetryController
             _products.GetData());
 
         var sendAppStarted = !AppStartedSent;
-        var data = _dataBuilder.BuildTelemetryData(application, host, in input, sendAppStarted, _namingVersion);
+        var data = _dataBuilder.BuildTelemetryData(application, host, in input, _namingVersion);
 
         Log.Debug("Pushing telemetry changes");
         var result = await _transportManager.TryPushTelemetry(data).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
@@ -1,11 +1,11 @@
-// <copyright file="TelemetryControllerV2.cs" company="Datadog">
+﻿// <copyright file="TelemetryControllerV2.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 #nullable enable
 using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +17,6 @@ using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Telemetry.Collectors;
 using Datadog.Trace.Telemetry.Metrics;
-using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Telemetry;
 
@@ -25,37 +24,32 @@ internal class TelemetryControllerV2 : ITelemetryController
 {
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TelemetryControllerV2>();
     private readonly TelemetryDataBuilderV2 _dataBuilder = new();
+    private readonly ConcurrentQueue<WorkItem> _queue = new();
     private readonly TelemetryDataAggregator _aggregator = new(previous: null);
-    private readonly ApplicationTelemetryCollectorV2 _application;
+    private readonly ApplicationTelemetryCollectorV2 _application = new();
     private readonly IConfigurationTelemetry _configuration;
     private readonly IDependencyTelemetryCollector _dependencies;
-    private readonly IntegrationTelemetryCollector _integrations;
-    private readonly ProductsTelemetryCollector _products;
-    private readonly TelemetryTransportManagerV2 _transportManager;
+    private readonly IntegrationTelemetryCollector _integrations = new();
+    private readonly ProductsTelemetryCollector _products = new();
     private readonly IMetricsTelemetryCollector _metrics;
-    private readonly TimeSpan _flushInterval;
     private readonly TaskCompletionSource<bool> _tracerInitialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private readonly TaskCompletionSource<bool> _processExit = new();
     private readonly Task _flushTask;
-    private bool _fatalError;
+    private TelemetryTransportManagerV2 _transportManager;
+    private TimeSpan _flushInterval;
+    private bool _sendTelemetry;
     private string? _namingVersion;
 
     internal TelemetryControllerV2(
         IConfigurationTelemetry configuration,
         IDependencyTelemetryCollector dependencies,
-        IntegrationTelemetryCollector integrations,
         IMetricsTelemetryCollector metrics,
-        ProductsTelemetryCollector products,
-        ApplicationTelemetryCollectorV2 application,
         TelemetryTransportManagerV2 transportManager,
         TimeSpan flushInterval)
     {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
-        _integrations = integrations ?? throw new ArgumentNullException(nameof(integrations));
-        _products = products ?? throw new ArgumentNullException(nameof(products));
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
-        _application = application ?? throw new ArgumentNullException(nameof(application));
         _transportManager = transportManager ?? throw new ArgumentNullException(nameof(transportManager));
         _flushInterval = flushInterval;
 
@@ -79,8 +73,6 @@ internal class TelemetryControllerV2 : ITelemetryController
         _flushTask = Task.Run(PushTelemetryLoopAsync);
     }
 
-    public bool FatalError => Volatile.Read(ref _fatalError);
-
     public void RecordTracerSettings(ImmutableTracerSettings settings, string defaultServiceName)
     {
         // Note that this _doesn't_ clear the configuration held by ImmutableTracerSettings
@@ -90,6 +82,7 @@ internal class TelemetryControllerV2 : ITelemetryController
         settings.Telemetry.CopyTo(_configuration);
         _application.RecordTracerSettings(settings, defaultServiceName);
         _namingVersion = ((int)settings.MetadataSchemaVersion).ToString();
+        _queue.Enqueue(new WorkItem(WorkItem.ItemType.EnableSending, null));
     }
 
     public void Start()
@@ -128,23 +121,38 @@ internal class TelemetryControllerV2 : ITelemetryController
     public void IntegrationDisabledDueToError(IntegrationId integrationId, string error)
         => _integrations.IntegrationDisabledDueToError(integrationId, error);
 
-    public async Task DisposeAsync(bool sendAppClosingTelemetry)
+    public Task DisposeAsync(bool sendAppClosingTelemetry)
     {
-        TerminateLoop(sendAppClosingTelemetry);
+        // Nothing to do, remove this method when telemetry V1 is removed
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        TerminateLoop();
         await _flushTask.ConfigureAwait(false);
     }
 
-    public Task DisposeAsync()
+    public void DisableSending()
     {
-        return DisposeAsync(sendAppClosingTelemetry: true);
+        _queue.Enqueue(new WorkItem(WorkItem.ItemType.DisableSending, null));
     }
 
-    private void TerminateLoop(bool sendAppClosingTelemetry)
+    public void SetTransportManager(TelemetryTransportManagerV2 manager)
+    {
+        _queue.Enqueue(new WorkItem(WorkItem.ItemType.SetTransportManager, manager));
+    }
+
+    public void SetFlushInterval(TimeSpan flushInterval)
+    {
+        _queue.Enqueue(new WorkItem(WorkItem.ItemType.SetFlushInterval, _flushInterval));
+    }
+
+    private void TerminateLoop()
     {
         // If there's a fatal error, TerminateLoop() may be called more than once
         // (at error-time, and at process end). The following are idempotent so that's safe.
-        _processExit.TrySetResult(sendAppClosingTelemetry);
-        _tracerInitialized.TrySetResult(true);
+        _processExit.TrySetResult(true);
         AppDomain.CurrentDomain.AssemblyLoad -= CurrentDomain_OnAssemblyLoad;
     }
 
@@ -172,7 +180,7 @@ internal class TelemetryControllerV2 : ITelemetryController
         tasks[0] = _tracerInitialized.Task;
         tasks[1] = _processExit.Task;
 
-        // wait for initialization before trying to send first telemetry
+        // wait for Tracer initialization before trying to send first telemetry to avoid circular reference issues
         // .NET 5.0 has an explicit overload for this
         await Task.WhenAny(tasks).ConfigureAwait(false);
 #else
@@ -181,17 +189,42 @@ internal class TelemetryControllerV2 : ITelemetryController
 
         while (true)
         {
+            // Process all the messages in the queue before sending next telemetry
+            while (_queue.TryDequeue(out var item))
+            {
+                switch (item.Type)
+                {
+                    case WorkItem.ItemType.SetTransportManager:
+                        _transportManager = (TelemetryTransportManagerV2)item.State!;
+                        break;
+                    case WorkItem.ItemType.EnableSending:
+                        _sendTelemetry = true;
+                        break;
+                    case WorkItem.ItemType.DisableSending:
+                        _sendTelemetry = false;
+                        break;
+                    case WorkItem.ItemType.SetFlushInterval:
+                        _flushInterval = (TimeSpan)item.State!;
+                        break;
+                }
+            }
+
+            if (_sendTelemetry)
+            {
+                await PushTelemetry().ConfigureAwait(false);
+            }
+
             if (_processExit.Task.IsCompleted)
             {
                 Log.Debug("Process exit requested, ending telemetry loop");
-                var sendAppClosingTelemetry = _processExit.Task.Result;
+                if (_sendTelemetry)
+                {
+                    await PushClosingTelemetry().ConfigureAwait(false);
+                }
 
-                await PushTelemetry(isFinalPush: sendAppClosingTelemetry).ConfigureAwait(false);
-
+                TerminateLoop();
                 return;
             }
-
-            await PushTelemetry(isFinalPush: false).ConfigureAwait(false);
 
 #if NET5_0_OR_GREATER
             // .NET 5.0 has an explicit overload for this
@@ -203,7 +236,70 @@ internal class TelemetryControllerV2 : ITelemetryController
         }
     }
 
-    private async Task PushTelemetry(bool isFinalPush)
+    private async Task PushTelemetry()
+    {
+        try
+        {
+            // Always retrieve the metrics data, regardless of whether it's consumed, because we
+            // need to make sure we clear the buffers. If we don't we could get overflows.
+            // We will lose these metrics if the endpoint errors, but better than growing too much.
+            MetricResults? metrics = _metrics.GetMetrics();
+
+            if (!_sendTelemetry)
+            {
+                // sending is currently disabled, so don't fetch the other data or attempt to send
+                Log.Debug("Telemetry pushing currently disabled, skipping");
+                return;
+            }
+
+            var application = _application.GetApplicationData();
+            var host = _application.GetHostData();
+            if (application is null || host is null)
+            {
+                Log.Debug("Telemetry not initialized, skipping");
+                return;
+            }
+
+            // use values from previous failed attempt if necessary
+            var input = _aggregator.Combine(
+                _configuration.GetData(),
+                _dependencies.GetData(),
+                _integrations.GetData(),
+                in metrics,
+                _products.GetData());
+
+            var data = _dataBuilder.BuildTelemetryData(application, host, in input, _namingVersion);
+
+            Log.Debug("Pushing telemetry changes");
+            var result = await _transportManager.TryPushTelemetry(data).ConfigureAwait(false);
+            _aggregator.SaveDataIfRequired(result, in input);
+
+            switch (result)
+            {
+                case TelemetryTransportResult.FatalError:
+                    Log.Debug("Fatal error sending telemetry");
+                    break;
+
+                case TelemetryTransportResult.TransientError:
+                    Log.Debug("Error sending telemetry");
+                    break;
+
+                case TelemetryTransportResult.Success:
+                    Log.Debug("Successfully sent telemetry");
+                    break;
+
+                default:
+                    // Should never happen
+                    throw new Exception($"Unexpected telemetry result type: {result} sending telemetry");
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Error pushing telemetry");
+        }
+    }
+
+    private async Task PushClosingTelemetry()
     {
         try
         {
@@ -215,63 +311,54 @@ internal class TelemetryControllerV2 : ITelemetryController
                 return;
             }
 
-            var success = await PushTelemetry(application, host).ConfigureAwait(false);
-            if (!success)
-            {
-                if (isFinalPush)
-                {
-                    Log.Debug("Unable to send final telemetry, skipping app-closing telemetry ");
-                    return;
-                }
-                else
-                {
-                    _fatalError = true;
-                    Log.Debug("Unable to send telemetry, ending telemetry loop");
-                    TerminateLoop(sendAppClosingTelemetry: false);
-                }
-            }
+            var closingTelemetryData = _dataBuilder.BuildAppClosingTelemetryData(application, host, _namingVersion);
 
-            if (isFinalPush)
-            {
-                var closingTelemetryData = _dataBuilder.BuildAppClosingTelemetryData(application, host, _namingVersion);
+            Log.Debug("Pushing app-closing telemetry");
+            var result = await _transportManager.TryPushTelemetry(closingTelemetryData).ConfigureAwait(false);
 
-                Log.Debug("Pushing app-closing telemetry");
-                await _transportManager.TryPushTelemetry(closingTelemetryData).ConfigureAwait(false);
+            switch (result)
+            {
+                case TelemetryTransportResult.FatalError:
+                    Log.Debug("Fatal error sending app-closing telemetry");
+                    break;
+
+                case TelemetryTransportResult.TransientError:
+                    Log.Debug("Error sending app-closing telemetry");
+                    break;
+
+                case TelemetryTransportResult.Success: // woo-hoo!
+                    Log.Debug("Successfully sent app-closing telemetry");
+                    break;
+
+                default:
+                    // Should never happen
+                    throw new Exception($"Unexpected telemetry result type: {result} sending app-closing telemetry");
             }
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Error pushing telemetry");
+            Log.Warning(ex, "Error sending app-closing telemetry");
         }
     }
 
-    private async Task<bool> PushTelemetry(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host)
+    private readonly struct WorkItem
     {
-        // use values from previous failed attempt if necessary
-        var input = _aggregator.Combine(
-            _configuration.GetData(),
-            _dependencies.GetData(),
-            _integrations.GetData(),
-            _metrics.GetMetrics(),
-            _products.GetData());
-
-        var data = _dataBuilder.BuildTelemetryData(application, host, in input, _namingVersion);
-
-        Log.Debug("Pushing telemetry changes");
-        var result = await _transportManager.TryPushTelemetry(data).ConfigureAwait(false);
-        _aggregator.SaveDataIfRequired(result, in input);
-
-        switch (result)
+        public WorkItem(ItemType type, object? state)
         {
-            case TelemetryTransportResult.FatalError:
-                return false; // big problem, abandon hope
-
-            case TelemetryTransportResult.TransientError: // there was an error, but try again next time
-            case TelemetryTransportResult.Success: // woo-hoo!
-                return true;
-            default:
-                // Should never happen
-                throw new Exception($"Unexpected telemetry result type: {result}");
+            Type = type;
+            State = state;
         }
+
+        public enum ItemType
+        {
+            SetTransportManager,
+            SetFlushInterval,
+            EnableSending,
+            DisableSending,
+        }
+
+        public ItemType Type { get; }
+
+        public object? State { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryControllerV2.cs
@@ -250,7 +250,7 @@ internal class TelemetryControllerV2 : ITelemetryController
     private async Task<bool> PushTelemetry(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host)
     {
         // use values from previous failed attempt if necessary
-        var input = new TelemetryInput(
+        var input = _aggregator.Combine(
             _configuration.GetData(),
             _dependencies.GetData(),
             _integrations.GetData(),

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataAggregator.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataAggregator.cs
@@ -24,22 +24,21 @@ internal class TelemetryDataAggregator
     /// <summary>
     /// Gets the configuration values that should be sent to telemetry, including any previous, retained, values
     /// </summary>
-    /// <param name="newValues">Changes to configuration values since the last telemetry flush</param>
     /// <returns>The combined configuration values that should be sent, including data that previously failed to send</returns>
-    public TelemetryInput Combine(in TelemetryInput newValues)
+    public TelemetryInput Combine(
+        ICollection<ConfigurationKeyValue>? configuration,
+        ICollection<DependencyTelemetryData>? dependencies,
+        ICollection<IntegrationTelemetryData>? integrations,
+        in MetricResults? metrics,
+        ProductsData? products)
     {
-        if (_previous is null)
-        {
-            return newValues;
-        }
-
         return new TelemetryInput(
-            CombineWith(newValues.Configuration),
-            CombineWith(newValues.Dependencies),
-            CombineWith(newValues.Integrations),
-            CombineWith(newValues.Metrics),
-            CombineWith(newValues.Distributions),
-            CombineWith(newValues.Products));
+            CombineWith(configuration),
+            CombineWith(dependencies),
+            CombineWith(integrations),
+            CombineWith(metrics?.Metrics),
+            CombineWith(metrics?.Distributions),
+            CombineWith(products));
     }
 
     public void SaveDataIfRequired(

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataAggregator.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataAggregator.cs
@@ -6,12 +6,14 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Telemetry;
 
 internal class TelemetryDataAggregator
 {
     private TelemetryInput? _previous;
+    private bool _appStartedSent;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TelemetryDataAggregator"/> class. For testing only.
@@ -38,7 +40,8 @@ internal class TelemetryDataAggregator
             CombineWith(integrations),
             CombineWith(metrics?.Metrics),
             CombineWith(metrics?.Distributions),
-            CombineWith(products));
+            CombineWith(products),
+            sendAppStarted: !_appStartedSent);
     }
 
     public void SaveDataIfRequired(
@@ -53,6 +56,11 @@ internal class TelemetryDataAggregator
                 // (as we are currently, using message-batch), but needs to be
                 // updated to be more granular if this changes
                 _previous = null;
+                if (input.SendAppStarted)
+                {
+                    _appStartedSent = true;
+                }
+
                 break;
 
             case TelemetryTransportResult.FatalError:

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
@@ -1,4 +1,4 @@
-// <copyright file="TelemetryDataBuilderV2.cs" company="Datadog">
+﻿// <copyright file="TelemetryDataBuilderV2.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -21,12 +21,11 @@ internal class TelemetryDataBuilderV2
         ApplicationTelemetryDataV2 application,
         HostTelemetryDataV2 host,
         in TelemetryInput input,
-        bool sendAppStarted,
         string? namingSchemeVersion)
     {
         List<MessageBatchData>? data = null;
 
-        if (sendAppStarted)
+        if (input.SendAppStarted)
         {
             Log.Debug("App started, sending app-started");
             data = new()

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryInput.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryInput.cs
@@ -16,8 +16,9 @@ internal readonly struct TelemetryInput
         ICollection<DependencyTelemetryData>? dependencies,
         ICollection<IntegrationTelemetryData>? integrations,
         MetricResults? metrics,
-        ProductsData? products)
-    : this(configuration, dependencies, integrations, metrics?.Metrics, metrics?.Distributions, products)
+        ProductsData? products,
+        bool sendAppStarted)
+    : this(configuration, dependencies, integrations, metrics?.Metrics, metrics?.Distributions, products, sendAppStarted)
     {
     }
 
@@ -27,7 +28,8 @@ internal readonly struct TelemetryInput
         ICollection<IntegrationTelemetryData>? integrations,
         ICollection<MetricData>? metrics,
         ICollection<DistributionMetricData>? distributions,
-        ProductsData? products)
+        ProductsData? products,
+        bool sendAppStarted)
     {
         Configuration = configuration;
         Dependencies = dependencies;
@@ -35,7 +37,10 @@ internal readonly struct TelemetryInput
         Metrics = metrics;
         Distributions = distributions;
         Products = products;
+        SendAppStarted = sendAppStarted;
     }
+
+    public bool SendAppStarted { get; }
 
     public ICollection<ConfigurationKeyValue>? Configuration { get; }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -62,28 +62,6 @@ namespace Datadog.Trace
                 remoteConfigurationManager: null,
                 dynamicConfigurationManager: null);
 
-            if (previous?.Telemetry != tracer.Telemetry)
-            {
-                if (previous?.Telemetry is TelemetryControllerV2 oldV2 && tracer.Telemetry is TelemetryControllerV2 newV2)
-                {
-                    if (oldV2.AppStartedSent)
-                    {
-                        newV2.AppStartedSent = true;
-                    }
-                }
-            }
-
-            if (previous?.Telemetry != tracer.Telemetry)
-            {
-                if (previous?.Telemetry is TelemetryControllerV2 oldV2 && tracer.Telemetry is TelemetryControllerV2 newV2)
-                {
-                    if (oldV2.AppStartedSent)
-                    {
-                        newV2.AppStartedSent = true;
-                    }
-                }
-            }
-
             try
             {
                 if (Profiler.Instance.Status.IsProfilerReady)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
@@ -283,7 +283,6 @@ public class TelemetryHelperTests
             _dataBuilderV2.BuildTelemetryData(
                 _appV2,
                 _hostV2,
-                new TelemetryInput(configuration, null, integrations, null, null, null),
-                sendAppStarted,
+                new TelemetryInput(configuration, null, integrations, null, null, null, sendAppStarted),
                 namingSchemeVersion: "1"));
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerV2Tests.cs
@@ -33,10 +33,7 @@ public class TelemetryControllerV2Tests
         var controller = new TelemetryControllerV2(
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
-            new IntegrationTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
-            new ProductsTelemetryCollector(),
-            new ApplicationTelemetryCollectorV2(),
             transportManager,
             _flushInterval);
 
@@ -44,7 +41,7 @@ public class TelemetryControllerV2Tests
         controller.Start();
 
         var data = await WaitForRequestStarted(transport, _timeout);
-        await controller.DisposeAsync(false);
+        await controller.DisposeAsync();
     }
 
     [Fact]
@@ -57,10 +54,7 @@ public class TelemetryControllerV2Tests
         var controller = new TelemetryControllerV2(
             collector,
             new DependencyTelemetryCollector(),
-            new IntegrationTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
-            new ProductsTelemetryCollector(),
-            new ApplicationTelemetryCollectorV2(),
             transportManager,
             _flushInterval);
 
@@ -89,54 +83,12 @@ public class TelemetryControllerV2Tests
         var controller = new TelemetryControllerV2(
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
-            new IntegrationTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
-            new ProductsTelemetryCollector(),
-            new ApplicationTelemetryCollectorV2(),
             transportManager,
             _flushInterval);
 
         await controller.DisposeAsync();
         await controller.DisposeAsync();
-    }
-
-    [Fact]
-    public async Task TelemetryControllerDisposesOnTwoFatalErrorsFromTelemetry()
-    {
-        var transport = new TestTelemetryTransport(pushResult: TelemetryPushResult.FatalError); // fail to push telemetry
-        var transportManager = new TelemetryTransportManagerV2(new ITelemetryTransport[] { transport });
-
-        var controller = new TelemetryControllerV2(
-            new ConfigurationTelemetry(),
-            new DependencyTelemetryCollector(),
-            new IntegrationTelemetryCollector(),
-            new NullMetricsTelemetryCollector(),
-            new ProductsTelemetryCollector(),
-            new ApplicationTelemetryCollectorV2(),
-            transportManager,
-            _flushInterval);
-
-        controller.RecordTracerSettings(new ImmutableTracerSettings(new TracerSettings()), "DefaultServiceName");
-        controller.Start();
-
-        (await WaitForFatalError(controller)).Should().BeTrue("controller should be disposed on failed push");
-
-        var previousDataCount = transport.GetData();
-
-        previousDataCount
-           .Should()
-           .HaveCount(2)
-           .And
-           .OnlyContain(
-                x => ContainsMessage(x, TelemetryRequestTypes.AppStarted),
-                "Fatal error should mean we try to send app-started twice");
-
-        controller.IntegrationRunning(IntegrationId.Kafka);
-
-        // Shouldn't receive any more data,
-        await Task.Delay(3_000);
-        transport.GetData().Count.Should().Be(previousDataCount.Count, "Should not send more data after disposal");
-        await controller.DisposeAsync(false);
     }
 
     [Fact]
@@ -148,10 +100,7 @@ public class TelemetryControllerV2Tests
         var controller = new TelemetryControllerV2(
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
-            new IntegrationTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
-            new ProductsTelemetryCollector(),
-            new ApplicationTelemetryCollectorV2(),
             transportManager,
             _flushInterval);
 
@@ -176,7 +125,7 @@ public class TelemetryControllerV2Tests
                  .Should()
                  .HaveCountGreaterOrEqualTo(requiredHeartbeats);
 
-        await controller.DisposeAsync(false);
+        await controller.DisposeAsync();
     }
 
     [Fact]
@@ -195,10 +144,7 @@ public class TelemetryControllerV2Tests
         var controller = new TelemetryControllerV2(
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
-            new IntegrationTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
-            new ProductsTelemetryCollector(),
-            new ApplicationTelemetryCollectorV2(),
             transportManager,
             _flushInterval);
 
@@ -222,7 +168,7 @@ public class TelemetryControllerV2Tests
                    .ContainEquivalentOf(assemblyName);
         }
 
-        await controller.DisposeAsync(false);
+        await controller.DisposeAsync();
     }
 
     private async Task<List<TelemetryDataV2>> WaitForRequestStarted(TestTelemetryTransport transport, TimeSpan timeout)
@@ -245,23 +191,6 @@ public class TelemetryControllerV2Tests
         }
 
         throw new TimeoutException($"Transport did not receive required data before the timeout {timeout.TotalMilliseconds}ms");
-    }
-
-    private async Task<bool> WaitForFatalError(TelemetryControllerV2 controller)
-    {
-        var deadline = DateTimeOffset.UtcNow.Add(_timeout);
-        while (DateTimeOffset.UtcNow < deadline)
-        {
-            if (controller.FatalError)
-            {
-                // was disposed
-                return true;
-            }
-
-            await Task.Delay(_flushInterval);
-        }
-
-        return false;
     }
 
     private bool ContainsMessage(TelemetryDataV2 data, string requestType)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerV2Tests.cs
@@ -45,7 +45,7 @@ public class TelemetryControllerV2Tests
     }
 
     [Fact]
-    public void TelemetryControllerRecordsConfigurationFromTracerSettings()
+    public async Task TelemetryControllerRecordsConfigurationFromTracerSettings()
     {
         var transport = new TestTelemetryTransport(pushResult: TelemetryPushResult.Success);
         var transportManager = new TelemetryTransportManagerV2(new ITelemetryTransport[] { transport });
@@ -72,6 +72,7 @@ public class TelemetryControllerV2Tests
                                   .And.Subject;
 
         collector.GetQueueForTesting().Count.Should().Be(configCount);
+        await controller.DisposeAsync();
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataAggregatorTests.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
@@ -44,7 +43,7 @@ public class TelemetryDataAggregatorTests
             next.Configuration,
             next.Dependencies,
             next.Integrations,
-            new MetricResults(next.Metrics?.ToList(), next.Distributions?.ToList()),
+            new MetricResults((List<MetricData>)next.Metrics, (List<DistributionMetricData>)next.Distributions),
             next.Products);
 
         result.Configuration.Should().BeSameAs(next.Configuration);
@@ -81,7 +80,8 @@ public class TelemetryDataAggregatorTests
             previousDeps,
             previousIntegrations,
             new MetricResults(previousMetrics, previousDistributions),
-            previousProducts);
+            previousProducts,
+            sendAppStarted: false);
 
         var aggregator = new TelemetryDataAggregator(previous);
 
@@ -151,7 +151,8 @@ public class TelemetryDataAggregatorTests
             null,
             null,
             new MetricResults(previousMetrics, previousDistributions),
-            null);
+            null,
+            sendAppStarted: false);
 
         var aggregator = new TelemetryDataAggregator(previous);
 
@@ -248,7 +249,8 @@ public class TelemetryDataAggregatorTests
             Array.Empty<DependencyTelemetryData>(),
             Array.Empty<IntegrationTelemetryData>(),
             new MetricResults(new List<MetricData>(), new List<DistributionMetricData>()),
-            new ProductsData());
+            new ProductsData(),
+            sendAppStarted: false);
     }
 
     private void AssertStoredValues(TelemetryDataAggregator aggregator, TelemetryInput expected)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderV2Tests.cs
@@ -78,10 +78,11 @@ public class TelemetryDataBuilderV2Tests
     {
         var builder = new TelemetryDataBuilderV2();
 
-        var data = builder.BuildTelemetryData(_application, _host, new TelemetryInput(), sendAppStarted: true, _namingSchemaVersion);
+        var input = new TelemetryInput(null, null, null, null, null, sendAppStarted: true);
+        var data = builder.BuildTelemetryData(_application, _host, input, _namingSchemaVersion);
         data.SeqId.Should().Be(1);
 
-        data = builder.BuildTelemetryData(_application, _host, new TelemetryInput(), sendAppStarted: true, _namingSchemaVersion);
+        data = builder.BuildTelemetryData(_application, _host, input, _namingSchemaVersion);
         data.SeqId.Should().Be(2);
 
         var closingData = builder.BuildAppClosingTelemetryData(_application, _host, _namingSchemaVersion);
@@ -111,10 +112,10 @@ public class TelemetryDataBuilderV2Tests
         var metrics = hasMetrics ? new List<MetricData>() : null;
         var distributions = hasDistributions ? new List<DistributionMetricData>() : null;
         var products = hasProducts ? new ProductsData() : null;
-        var input = new TelemetryInput(config, dependencies, integrations, metrics, distributions, products);
+        var input = new TelemetryInput(config, dependencies, integrations, metrics, distributions, products, sendAppStarted: !hasSentAppStarted);
         var builder = new TelemetryDataBuilderV2();
 
-        var result = builder.BuildTelemetryData(_application, _host, in input, sendAppStarted: !hasSentAppStarted, _namingSchemaVersion);
+        var result = builder.BuildTelemetryData(_application, _host, in input, _namingSchemaVersion);
 
         result.Should().NotBeNull();
         var actualRequestTypes = result.Payload is MessageBatchPayload batch
@@ -201,10 +202,10 @@ public class TelemetryDataBuilderV2Tests
             new DependencyTelemetryData("Something"),
             numOfDependencies)
                                      .ToList();
-        var input = new TelemetryInput(null, dependencies, null, null, null);
+        var input = new TelemetryInput(null, dependencies, null, null, null, sendAppStarted: false);
         var builder = new TelemetryDataBuilderV2();
 
-        var result = builder.BuildTelemetryData(_application, _host, in input, sendAppStarted: false, _namingSchemaVersion);
+        var result = builder.BuildTelemetryData(_application, _host, in input, _namingSchemaVersion);
 
         result.Should().NotBeNull();
         var actualRequestTypes = result.Payload is MessageBatchPayload batch

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
@@ -215,7 +215,7 @@ public class TelemetryFactoryTests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void TelemetryFactory_V2Telemetry_CollectorsPersistWhenNewController(bool dependencyCollectionEnabled)
+    public void TelemetryFactory_V2Telemetry_ControllerAndCollectorsPersistWhenNewController(bool dependencyCollectionEnabled)
     {
         // set the defaults (module initializer resets everything by default
         TelemetryFactory.SetConfigForTesting(new ConfigurationTelemetry());
@@ -234,32 +234,39 @@ public class TelemetryFactoryTests
             metricsEnabled: true,
             debugEnabled: false);
 
+        // First controller
         var controller1 = factory.CreateTelemetryController(tracerSettings, settings);
         var metrics1 = TelemetryFactory.Metrics;
-        var config1 = TelemetryFactory.Metrics;
+        var config1 = TelemetryFactory.Config;
 
-        var controller2 = factory.CreateTelemetryController(tracerSettings, settings);
-        var metrics2 = TelemetryFactory.Metrics;
-        var config2 = TelemetryFactory.Metrics;
+        var dependencies = GetField<TelemetryControllerV2>("_dependencies");
+        var dependencies1 = dependencies.GetValue(controller1);
+
+        var integrations = GetField<TelemetryControllerV2>("_integrations");
+        var integrations1 = integrations.GetValue(controller1);
+
+        var products = GetField<TelemetryControllerV2>("_products");
+        var products1 = products.GetValue(controller1);
+
+        var application = GetField<TelemetryControllerV2>("_application");
+        var application1 = application.GetValue(controller1);
 
         var v1Controller1 = controller1.Should().BeOfType<TelemetryControllerV2>().Subject;
+
+        // Second controller
+        var controller2 = factory.CreateTelemetryController(tracerSettings, settings);
+        var metrics2 = TelemetryFactory.Metrics;
+        var config2 = TelemetryFactory.Config;
+
         var v1Controller2 = controller2.Should().BeOfType<TelemetryControllerV2>().Subject;
-        v1Controller1.Should().NotBe(v1Controller2);
+        v1Controller1.Should().Be(v1Controller2);
 
         metrics1.Should().Be(metrics2);
         config1.Should().Be(config2);
-
-        var dependencies = GetField<TelemetryControllerV2>("_dependencies");
-        dependencies.GetValue(controller1).Should().BeSameAs(dependencies.GetValue(controller2));
-
-        var integrations = GetField<TelemetryControllerV2>("_integrations");
-        integrations.GetValue(controller1).Should().BeSameAs(integrations.GetValue(controller2));
-
-        var products = GetField<TelemetryControllerV2>("_products");
-        products.GetValue(controller1).Should().BeSameAs(products.GetValue(controller2));
-
-        var application = GetField<TelemetryControllerV2>("_application");
-        application.GetValue(controller1).Should().BeSameAs(application.GetValue(controller2));
+        dependencies1.Should().BeSameAs(dependencies.GetValue(controller2));
+        integrations1.Should().BeSameAs(integrations.GetValue(controller2));
+        products1.Should().BeSameAs(products.GetValue(controller2));
+        application1.Should().BeSameAs(application.GetValue(controller2));
     }
 
     private static FieldInfo GetField<T>(string name)


### PR DESCRIPTION
## Summary of changes

- Makes `TelemetryControllerV2` a singleton
- Add a queue of messages to `TelemetryControllerV2` to allow changing the transport manager
- Moves the tracking of "app started sent" to `TelemetryDataAggregator`

## Reason for change

The addition of the queue was required to handle a bug (surfaced by dynamic config) whereby we briefly have two `TelemetryControllerV2`s sending concurrently. This was not a problem except for the sending of the `app-started` event, which must only ever be sent once. The workaround added in https://github.com/DataDog/dd-trace-dotnet/pull/4319 unfortunately didn't work due to this

## Implementation details

Make the `TelemetryControllerV2` a singleton and allow sending messages to it instead. This ensures 

1. There's only ever a single loop running
2. We can replace the "mutable" parts of the controller safely in-between loops (interval, transport manager)

With the queue change, technically we don't _need_ to move the `AppStartedSent` property any more, but I'd already done it, and I think it probably makes more sense being there anyway!

As part of this, reworked the loop logic a little, as it can be a bit simpler now. The main changes are:

1. Don't do anything when "replacing" the tracer manager. Previously we would force a flush, but that's not necessary now
2. Don't bail out on fatal errors. This is somewhat tangential, but after discussion with @pierotibou, to support an agent dropping out and coming back, we will keep trying subsequently. The logic around this needs more fleshing out and likely simplifying, but I'll do that in a separate PR to avoid muddying the waters.

## Test coverage

Covered by existing tests for the most part. It's fundamentally a refactoring. Tweaked the `TelemetryFactoryTests` to ensure we are creating a singleton controller

## Other details
Discovered a few other minor fixes along the way - I'll work on them in a subsequent PR
