### PR TITLE
[Tracer] Distributed context injection API

### DIFF
--- a/tracer/src/Datadog.Trace/ISpanContextInjector.cs
+++ b/tracer/src/Datadog.Trace/ISpanContextInjector.cs
@@ -1,0 +1,30 @@
+// <copyright file="ISpanContextInjector.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Datadog.Trace
+{
+    /// <summary>
+    /// The ISpanContextInjector is responsible for injecting SpanContext in the rare cases where the Tracer couldn't propagate it itself.
+    /// This can happen for instance when we don't support a specific library
+    /// </summary>
+    public interface ISpanContextInjector
+    {
+        /// <summary>
+        /// Given a SpanContext carrier and a function to access the values, this method will extract SpanContext if any
+        /// When enabled (and present in the headers) a data streams monitoring checkpoint is set.
+        /// You should only call <see cref="Inject{TCarrier}"/> once on the message <paramref name="carrier"/>. Calling
+        /// multiple times may lead to incorrect stats when using Data Streams Monitoring.
+        /// </summary>
+        /// <param name="carrier">The carrier of the SpanContext. Often a header (http, kafka message header...)</param>
+        /// <param name="setter">Given a key name, returns values from the carrier</param>
+        /// <typeparam name="TCarrier">Type of the carrier</typeparam>
+        public void Inject<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter);
+    }
+}

--- a/tracer/src/Datadog.Trace/SpanContextInjector.cs
+++ b/tracer/src/Datadog.Trace/SpanContextInjector.cs
@@ -1,0 +1,37 @@
+// <copyright file="SpanContextInjector.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Propagators;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+
+#nullable enable
+
+namespace Datadog.Trace
+{
+    /// <inheritdoc />
+    public class SpanContextInjector : ISpanContextInjector
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<SpanContextExtractor>();
+
+        /// <inheritdoc />
+        [PublicApi]
+        public void Inject<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter)
+        {
+            TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_Inject);
+
+            if (Tracer.Instance.ActiveScope.Span.Context is SpanContext spanContext)
+            {
+                SpanContextPropagator.Instance.Inject(spanContext, carrier, setter);
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/PublicApiUsage.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/PublicApiUsage.cs
@@ -23,6 +23,8 @@ internal enum PublicApiUsage
     [Description("name:eventtrackingsdk_trackuserloginsuccessevent_metadata")]EventTrackingSdk_TrackUserLoginSuccessEvent_Metadata,
 
     [Description("name:spancontextextractor_extract")] SpanContextExtractor_Extract,
+    [Description("name:spancontextinjector_inject")] SpanContextInjector_Inject,
+
 
     [Description("name:spanextensions_setuser")] SpanExtensions_SetUser,
     [Description("name:spanextensions_settracesamplingpriority")] SpanExtensions_SetTraceSamplingPriority,


### PR DESCRIPTION
## Summary of changes

Adds the counterpart of the extraction API. 

## Reason for change

Raised in an escalation  where we don't support WCF over TCP

## Implementation details

Doesn't support DSM. Takes the active context not a one provided (which is debatable)

## Test coverage

None for now 

## Other details
<!-- Fixes #{issue} -->
