### PR TITLE
Fail gracefully when running with NetFx40_LegacySecurityPolicy

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -524,6 +524,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ActivitySampleHelper", "tra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Probes.Unreferenced.External", "tracer\test\test-applications\debugger\dependency-libs\Samples.Probes.Unreferenced.External\Samples.Probes.Unreferenced.External.csproj", "{DE15D292-DC01-4AEA-B473-C2F2908341A7}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sandbox.LegacySecurityPolicy", "tracer\test\test-applications\regression\Sandbox.LegacySecurityPolicy\Sandbox.LegacySecurityPolicy.csproj", "{959E9599-8D99-43BC-8038-B91F76179C1C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1240,6 +1242,10 @@ Global
 		{DE15D292-DC01-4AEA-B473-C2F2908341A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DE15D292-DC01-4AEA-B473-C2F2908341A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DE15D292-DC01-4AEA-B473-C2F2908341A7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{959E9599-8D99-43BC-8038-B91F76179C1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{959E9599-8D99-43BC-8038-B91F76179C1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{959E9599-8D99-43BC-8038-B91F76179C1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{959E9599-8D99-43BC-8038-B91F76179C1C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1442,6 +1448,7 @@ Global
 		{289713D4-5259-4CC4-8CAA-DBF3BDCDCBC0} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{51AF3B29-D107-4E22-8A85-DF02A8A898E5} = {8683D82A-2BBE-4199-9C36-C59F48804F90}
 		{DE15D292-DC01-4AEA-B473-C2F2908341A7} = {0884B566-D22E-498C-BAA9-26D50ABCAE3A}
+		{959E9599-8D99-43BC-8038-B91F76179C1C} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1523,6 +1523,7 @@ partial class Build
                 "MismatchedTracerVersions",
                 "IBM.Data.DB2.DBCommand",
                 "Sandbox.AutomaticInstrumentation", // Doesn't run on Linux
+                "Sandbox.LegacySecurityPolicy", // Doesn't run on Linux
                 "Samples.Trimming",
             };
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3175,7 +3175,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
             return hr;
         }
 
-        // Get a mdMemberRef for System.AppDomain.get_IsFullyTrusted()
+        // Get a mdMemberRef for System.AppDomain.get_IsHomogenous()
         COR_SIGNATURE appdomain_get_ishomogenous_signature[] = {IMAGE_CEE_CS_CALLCONV_HASTHIS, 0,
                                                                   ELEMENT_TYPE_BOOLEAN};
         hr = metadata_emit->DefineMemberRef(

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3141,6 +3141,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     // Create method member ref for AppDomain tokens
     mdMemberRef appdomain_get_currentdomain_member_ref = mdMemberRefNil;
     mdMemberRef appdomain_get_isfullytrusted_member_ref = mdMemberRefNil;
+    mdMemberRef appdomain_get_ishomogenous_member_ref = mdMemberRefNil;
     if (system_appdomain_type_ref != mdTypeRefNil)
     {
         // Get a mdMemberRef for System.AppDomain.get_CurrentDomain()
@@ -3170,7 +3171,20 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
                                             &appdomain_get_isfullytrusted_member_ref);
         if (FAILED(hr))
         {
-            Logger::Warn("GenerateVoidILStartupMethod: DefineMemberRef failed");
+            Logger::Warn("GenerateVoidILStartupMethod: DefineMemberRef failed for get_IsFullyTrusted");
+            return hr;
+        }
+
+        // Get a mdMemberRef for System.AppDomain.get_IsFullyTrusted()
+        COR_SIGNATURE appdomain_get_ishomogenous_signature[] = {IMAGE_CEE_CS_CALLCONV_HASTHIS, 0,
+                                                                  ELEMENT_TYPE_BOOLEAN};
+        hr = metadata_emit->DefineMemberRef(
+            system_appdomain_type_ref, WStr("get_IsHomogenous"), appdomain_get_ishomogenous_signature,
+            sizeof(appdomain_get_ishomogenous_signature), &appdomain_get_ishomogenous_member_ref);
+
+        if (FAILED(hr))
+        {
+            Logger::Warn("GenerateVoidILStartupMethod: DefineMemberRef failed for get_IsHomogenous");
             return hr;
         }
     }
@@ -3370,12 +3384,28 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     rewriterWrapper_void.Return();
 
     ILInstr* pIsFullyTrustedBranch = nullptr;
-    if (appdomain_get_currentdomain_member_ref != mdMemberRefNil && appdomain_get_isfullytrusted_member_ref != mdMemberRefNil)
+    ILInstr* pIsHomogenousBranch = nullptr;
+
+    if (appdomain_get_currentdomain_member_ref != mdMemberRefNil
+        && appdomain_get_isfullytrusted_member_ref != mdMemberRefNil
+        && appdomain_get_ishomogenous_member_ref != mdMemberRefNil)
     {
         // Step 1) Check if the assembly is loaded in a fully trusted domain.
 
         // call System.AppDomain.get_CurrentDomain() and set the false branch target for IsAlreadyLoaded()
         pIsNotAlreadyLoadedBranch->m_pTarget = rewriterWrapper_void.CallMember(appdomain_get_currentdomain_member_ref, false);
+
+        // callvirt System.AppDomain.get_Homogenous()
+        rewriterWrapper_void.CallMember(appdomain_get_ishomogenous_member_ref, true);
+
+        // check if the return of the method call is true or false
+        pIsHomogenousBranch = rewriterWrapper_void.CreateInstr(CEE_BRTRUE_S);
+        // return if IsHomogenous is false
+        rewriterWrapper_void.Return();
+
+        // call System.AppDomain.get_CurrentDomain()
+        pIsHomogenousBranch->m_pTarget = rewriterWrapper_void.CallMember(appdomain_get_currentdomain_member_ref, false);
+
         // callvirt System.AppDomain.get_IsFullyTrusted()
         rewriterWrapper_void.CallMember(appdomain_get_isfullytrusted_member_ref, true);
         // check if the return of the method call is true or false

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxLegacySecurityPolicySmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxLegacySecurityPolicySmokeTest.cs
@@ -1,0 +1,32 @@
+// <copyright file="SandboxLegacySecurityPolicySmokeTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if NETFRAMEWORK
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    /// <summary>
+    /// Tests the behavior of the tracer when instrumenting an app that has NetFx40_LegacySecurityPolicy and a custom AppDomainManager.
+    /// Expected behavior: the tracer should fail gracefully without impacting the app.
+    /// Wrong behavior: the app crashes or the tracer affects the security level of the appdomain.
+    /// </summary>
+    public class SandboxLegacySecurityPolicySmokeTest : SmokeTestBase
+    {
+        public SandboxLegacySecurityPolicySmokeTest(ITestOutputHelper output)
+            : base(output, "Sandbox.LegacySecurityPolicy")
+        {
+        }
+
+        [SkippableFact]
+        [Trait("Category", "Smoke")]
+        public void Fails()
+        {
+            CheckForSmoke(shouldDeserializeTraces: false, expectedExitCode: 0);
+        }
+    }
+}
+#endif

--- a/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/App.config
+++ b/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <runtime>
+    <NetFx40_LegacySecurityPolicy enabled="true" />
+  </runtime>
+</configuration>

--- a/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/Program.cs
+++ b/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/Program.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Sandbox.LegacySecurityPolicy
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            var appDomainSetup = new AppDomainSetup
+            {
+                AppDomainManagerAssembly = typeof(CustomAppDomainManager).Assembly.FullName,
+                AppDomainManagerType = typeof(CustomAppDomainManager).FullName
+            };
+
+            var domain = AppDomain.CreateDomain("ChildDomain", null, appDomainSetup);
+
+            var instance = domain.CreateInstanceAndUnwrap(typeof(RemoteType).Assembly.FullName, typeof(RemoteType).FullName);
+
+            instance.GetType().GetMethod(nameof(RemoteType.Print)).Invoke(instance, null);
+        }
+    }
+
+    public class RemoteType : MarshalByRefObject
+    {
+        public void Print()
+        {
+            if (AppDomain.CurrentDomain.IsHomogenous)
+            {
+                Console.WriteLine("The test is not setup properly (is NetFx40_LegacySecurityPolicy enabled?");
+                Environment.Exit(-1);
+            }
+
+            if (!AppDomain.CurrentDomain.IsFullyTrusted)
+            {
+                Console.WriteLine("The test failed, the current domain should be fully trusted");
+                Environment.Exit(-2);
+            }
+
+            Console.WriteLine("OK");
+        }
+    }
+
+    public class CustomAppDomainManager : AppDomainManager
+    { }
+}

--- a/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "Sandbox.AutomaticInstrumentation": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+        "DD_VERSION": "1.0.0"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/Sandbox.LegacySecurityPolicy.csproj
+++ b/tracer/test/test-applications/regression/Sandbox.LegacySecurityPolicy/Sandbox.LegacySecurityPolicy.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net462</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary of changes

Don't instrument appdomains that are not "homogenous".

I don't fully understand the situation, but it seems that when running with an old security policy (for instance when enabling `NetFx40_LegacySecurityPolicy`, but there might be other cases), security in the appdomain is evaluated per assembly instead of globally. One of the consequences is that the computation of `AppDomain.IsFullyTrusted` takes a different path, and is much more complex. The result of the computation is cached internally (in the native `AppDomainNative` object).

When an app has a non-homogenous appDomain **and** a custom `AppDomainManager`, we end up instrumenting the `AppDomainManager` because it's the first type to be executed in the new appDomain. Then, when we call `AppDomain.IsFullyTrusted` prior to injecting the loader, it happens at a moment when the appDomain is not fully initialized, and the computation of  `AppDomain.IsFullyTrusted` returns a wrong result. Because the result is cached, the value will remain forever wrong in that appDomain, which causes the target application to fail in fancy and creative ways.

To avoid this, we play safe and call `AppDomain.IsFullyTrusted` only if `AppDomain.IsHomogenous` returns true. It's possible that by doing so we exclude applications that could have worked with the tracer, but I haven't been able to create a non-homogenous appDomain without using legacy security policies, so I think the risk is slim.

## Reason for change

The tracer was causing Visual Studio and SSRS (and probably other native applications hosting .NET code) to crash.

## Implementation details

Changed the startup hook logic from `if (AppDomain.CurrentDomain.IsFullyTrusted)` to `if (AppDomain.CurrentDomain.IsHomogenous && AppDomain.CurrentDomain.IsFullyTrusted)`.
Note that we call `AppDomain.CurrentDomain` twice. To cache the value we would need to introduce an additional local variable in the function, which is a real pain in IL. I don't think it's worth the trouble.

## Test coverage

Added a smoke test that uses a custom `AppDomainManager` with `NetFx40_LegacySecurityPolicy`.

## Other details

`AppDomain.IsHomogenous` was a lucky find. It looks like JSON.NET ran into similar issues before us: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/src/Datadog.Trace/Vendors/Newtonsoft.Json/Serialization/JsonTypeReflector.cs#L506
