### PR TITLE
[Profiler] Fix a potential bug in libunwind-datadog

### DIFF
--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -1,15 +1,15 @@
-SET(LIBUNWIND_VERSION "1.6.2")
+SET(LIBUNWIND_VERSION "1.7.0-custom")
 
 SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind-build)
 
 ExternalProject_Add(libunwind
     GIT_REPOSITORY https://github.com/DataDog/libunwind.git
-    GIT_TAG gleocadie/backtrace2_3
+    GIT_TAG gleocadie/backtrace2_4
     GIT_PROGRESS true
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -O3 CFLAGS=-fPIC\ -O3 --disable-minidebuginfo && make -j$(nproc)
+    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -O3\ -g CFLAGS=-fPIC\ -O3\ -g --disable-minidebuginfo && make -j$(nproc)
     BUILD_ALWAYS false
     BUILD_BYPRODUCTS ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind-${CMAKE_SYSTEM_PROCESSOR}.a
                      ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind.a


### PR DESCRIPTION
## Summary of changes

Fix a potential bug.

## Reason for change

When calling `uwn_backtrace`, there is a copy of the current thread context. This is done before `tdep_trace` modifies that context and we may end up crashing the application. If `tdep_trace` fails, we fallback to a `slow_backtrace` passing the copied context. But this context could have been modified by the failed call to `tdep_trace` and this could be problematic.
Instead, before calling `slow_backtrace`, we copy the context.

## Implementation details
The fix is https://github.com/DataDog/libunwind/commit/6d2016d522fd28655d7e77b869763ff9fcb10a39

## Test coverage

## Other details
<!-- Fixes #{issue} -->
