### PR TITLE
[Tracer] [Kafka] Directly use SetMetric instead of SetTag

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 }
 
                 // Producer spans should always be measured
-                span.SetTag(Tags.Measured, "1");
+                span.SetMetric(Trace.Tags.Measured, 1.0);
 
                 tags.SetAnalyticsSampleRate(KafkaConstants.IntegrationId, settings, enabledWithGlobalSetting: false);
                 tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(KafkaConstants.IntegrationId);


### PR DESCRIPTION
## Summary of changes

Use `SetMetric` instead of `SetTag` in the Kafka integration

## Reason for change

We can do it and it's faster.

## Implementation details

Just replaced the call.

## Test coverage

Covered by [existing tests ](https://github.com/DataDog/dd-trace-dotnet/blob/0069a32644d14bf121c757c26301db14ce8c8a9c/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs#L178)

## Other details
<!-- Fixes #{issue} -->
