### PR TITLE
Include `app-closing` in final batch

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
@@ -21,7 +21,8 @@ internal class TelemetryDataBuilderV2
         ApplicationTelemetryDataV2 application,
         HostTelemetryDataV2 host,
         in TelemetryInput input,
-        string? namingSchemeVersion)
+        string? namingSchemeVersion,
+        bool sendAppClosing)
     {
         List<MessageBatchData>? data = null;
 
@@ -107,18 +108,29 @@ internal class TelemetryDataBuilderV2
                 new DistributionsPayload(distributions)));
         }
 
-        if (data is null)
+        if (sendAppClosing)
         {
-            Log.Debug("No changes in telemetry, sending app-heartbeat");
-            return GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null, namingSchemeVersion);
+            Log.Debug("Final push, sending app-closing");
+            if (data is null)
+            {
+                return GetRequest(application, host, TelemetryRequestTypes.AppClosing, payload: null, namingSchemeVersion);
+            }
+
+            data.Add(new(TelemetryRequestTypes.AppClosing, payload: null));
+        }
+        else
+        {
+            if (data is null)
+            {
+                Log.Debug("No changes in telemetry, sending app-heartbeat");
+                return GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null, namingSchemeVersion);
+            }
+
+            data.Add(new(TelemetryRequestTypes.AppHeartbeat, payload: null));
         }
 
-        data.Add(new(TelemetryRequestTypes.AppHeartbeat, payload: null));
         return GetRequest(application, host, new MessageBatchPayload(data), namingSchemeVersion);
     }
-
-    public TelemetryDataV2 BuildAppClosingTelemetryData(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host, string? namingSchemeVersion)
-        => GetRequest(application, host, TelemetryRequestTypes.AppClosing, payload: null, namingSchemeVersion);
 
     public TelemetryDataV2 BuildHeartbeatData(ApplicationTelemetryDataV2 application, HostTelemetryDataV2 host, string? namingSchemeVersion)
         => GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null, namingSchemeVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
@@ -105,10 +105,7 @@ public class TelemetryHelperTests
         };
 
         collector.RecordTracerSettings(new(tracerSettings));
-        telemetryData.Add(BuildTelemetryDataV2(collector.GetData()));
-
-        // we must have an app closing
-        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, "1")));
+        telemetryData.Add(BuildTelemetryDataV2(collector.GetData(), sendAppClosing: true));
 
         using var s = new AssertionScope();
         TelemetryHelper.AssertIntegration(telemetryData, IntegrationId.Aerospike, enabled: true, autoEnabled: true);
@@ -192,10 +189,7 @@ public class TelemetryHelperTests
         telemetryData.Add(BuildTelemetryDataV2(collector.GetData(), sendAppStarted: false));
 
         collector.IntegrationRunning(IntegrationId.Npgsql);
-        telemetryData.Add(BuildTelemetryDataV2(collector.GetData(), sendAppStarted: false));
-
-        // we must have an app closing
-        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, "1")));
+        telemetryData.Add(BuildTelemetryDataV2(collector.GetData(), sendAppStarted: false, sendAppClosing: true));
 
         var checkTelemetryFunc = () => TelemetryHelper.AssertIntegration(telemetryData, IntegrationId.Aerospike, enabled: true, autoEnabled: true);
 
@@ -254,10 +248,7 @@ public class TelemetryHelperTests
         telemetryData.Add(BuildTelemetryDataV2(null, collector.GetData()));
 
         _ = new SecuritySettings(config, collector);
-        telemetryData.Add(BuildTelemetryDataV2(null, collector.GetData(), sendAppStarted: false));
-
-        // we must have an app closing
-        telemetryData.Add(new TelemetryWrapper.V2(_dataBuilderV2.BuildAppClosingTelemetryData(_appV2, _hostV2, "1")));
+        telemetryData.Add(BuildTelemetryDataV2(null, collector.GetData(), sendAppStarted: false, sendAppClosing: true));
 
         using var s = new AssertionScope();
         TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled);
@@ -278,11 +269,13 @@ public class TelemetryHelperTests
     private TelemetryWrapper BuildTelemetryDataV2(
         ICollection<IntegrationTelemetryData> integrations,
         ICollection<ConfigurationKeyValue> configuration = null,
-        bool sendAppStarted = true)
+        bool sendAppStarted = true,
+        bool sendAppClosing = false)
         => new TelemetryWrapper.V2(
             _dataBuilderV2.BuildTelemetryData(
                 _appV2,
                 _hostV2,
                 new TelemetryInput(configuration, null, integrations, null, null, sendAppStarted),
-                namingSchemeVersion: "1"));
+                namingSchemeVersion: "1",
+                sendAppClosing));
 }


### PR DESCRIPTION
## Summary of changes

- Include `app-closing` telemetry in final message-batch

## Reason for change

The `app-closing` can now be included in the final `message-batch`. Previously this needed to be sent separately, so this saves a round trip.

## Implementation details

Mostly simplification by removing the separate `app-closing` flush

## Test coverage

Updated unit tests for data aggregator

## Other details
Stacked on https://github.com/DataDog/dd-trace-dotnet/pull/4371
