### PR TITLE
Fix "obsolete warnings in NLog sample

### DIFF
--- a/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
+++ b/tracer/test/test-applications/integrations/LogsInjection.NLog/Program.cs
@@ -10,6 +10,7 @@ using NLog.Config;
 using NLog.Targets;
 using PluginApplication;
 
+#pragma warning disable CS0618 // MappedDiagnosticContext is obsolete
 namespace LogsInjection.NLog
 {
     public class Program


### PR DESCRIPTION
## Summary of changes

Ignore warnings about using obsolete members

## Reason for change

#4223 added additional tests for NLog API, but used obsolete members (intentionally)

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/f4edc5e0-31e1-42be-92b7-994d68658c4d)

## Implementation details

#pragma warning disable CS061
