### PR TITLE
Pin aerospike server to single version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
   aerospike:
     # pinning to a known good version because latest version (6.3.0.5 at time of issue)
     # causes 'Server memory error' and flake
-    image: aerospike/aerospike-server:6.3.0.1
+    image: aerospike/aerospike-server:6.2.0.6
     ports:
     - "127.0.0.1:3000:3000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,7 +114,9 @@ services:
     - "127.0.0.1:9324:9324"
 
   aerospike:
-    image: aerospike/aerospike-server
+    # pinning to a known good version because latest version (6.3.0.5 at time of issue)
+    # causes 'Server memory error' and flake
+    image: aerospike/aerospike-server:6.3.0.1
     ports:
     - "127.0.0.1:3000:3000"
 


### PR DESCRIPTION
## Summary of changes

Pins aerospike server version used in tests instead of using latest

## Reason for change

Updated the VM images and now we're seeing a _lot_ of server error flake from aerospike tests:

```
Unhandled exception. Aerospike.Client.AerospikeException: Error 8,1,30000,0,0,BB90C0012AC4202 172.18.0.12 3000: Server memory error
```

## Implementation details

Pinned to the version I believe we were using (best guess) before the last update. I'm trying to confirm this though

## Test coverage

I'll run the CI a few times and see if it happens again.

## Other details
_Grumble grumble_ Stupid CI _grumble_
