### PR TITLE
Do not retry response codes: 429, 413, and 408

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -367,7 +367,7 @@ namespace Datadog.Trace.Agent
                 response?.Dispose();
             }
 
-            if (response.StatusCode == 429)
+            if (response.StatusCode == 429 || response.StatusCode == 413 || response.StatusCode == 408)
             {
                 var retryAfter = response.GetHeader("Retry-After");
                 _log.Debug<int, string>("Failed to submit {Count} traces. Agent responded with 429 Too Many Requests, retry after {RetryAfter}", numberOfTraces, retryAfter ?? "unspecified");

--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -357,7 +357,15 @@ namespace Datadog.Trace.Agent
                 response?.Dispose();
             }
 
-            _log.Debug<int>("Successfully sent {Count} traces to the Datadog Agent.", numberOfTraces);
+            if (response.StatusCode == 429)
+            {
+                var retryAfter = response.GetHeader("Retry-After");
+                _log.Debug<int, string>("Failed to submit {Count} traces. Agent responded with 429 Too Many Requests, retry after {RetryAfter}", numberOfTraces, retryAfter ?? "unspecified");
+            }
+            else
+            {
+                _log.Debug<int>("Successfully sent {Count} traces to the Datadog Agent.", numberOfTraces);
+            }
 
             return true;
         }

--- a/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ApiTests.cs
@@ -68,9 +68,10 @@ namespace Datadog.Trace.Tests.Agent
 
             var api = new Api(apiRequestFactory: factoryMock.Object, statsd: null, updateSampleRates: null, partialFlushEnabled: false);
 
-            await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
+            var responseResult = await api.SendTracesAsync(new ArraySegment<byte>(new byte[64]), 1, false, 0, 0);
 
             requestMock.Verify(x => x.PostAsync(It.IsAny<ArraySegment<byte>>(), MimeTypes.MsgPack), Times.Once());
+            responseResult.Should().Be(false);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

This changes the .NET Tracer to not retry the following response codes when sending traces: 
- `429 Too Many Requests`
- `413 Content Too Large`
- `408 Request Timeout`

## Reason for change

There is an upcoming change to the agent to make it start responding with `429` instead of `200` when payloads are dropped.
Instead of **not** retrying these requests we would start to retry these requests.
Additionally, for `413` and `408` are returned by the Agent and we don't want to retry those either.

Related Agent PR: https://github.com/DataDog/datadog-agent/pull/17917

This change would cause the .NET Tracer to start retrying these requests. We don't know the exact impact of these retries for this scenario where the Agent is having performance issues, so opting to maintain our old behavior in handling this case.

Old behavior before this Agent change:
  - Tracer sends Traces to Agent
  - Agent drops the payload
  - Agent responds with `200`
  - Tracer sees `200` response and treats the send request as successful

Behavior with this Agent change _without this pull request_:
- Tracer sends Traces to Agent
- Agent drops the payload
- Agent responds with `429`
- Tracer sees `429` and begins exponential retry logic
  - 4 additional retries; backoff before each retry of `100*2*n`ms where `n` is the retry count (starts at 1)

Behavior with this Agent change _with this pull request_:
- Trace sends Traces to Agent
- Agent drops the payload
- Agent responds with `429`
- Tracer sees `429` and treats this the same as a `200` (no retry)


## Implementation details

Just added a check for `429`, `413`, and `408` in the `SendTracesAsyncImpl` function 

## Test coverage

- Added a new unit test where the `Api` will send a `429`, `413`, `408` and assert that we only send it once
  - tested that the test failed before the change with 5 total requests being made (1 original, 4 retries)

## Other details
<!-- Fixes #{issue} -->
