### PR TITLE
Minor refactor of `BatchingSink`

### DIFF
--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -338,7 +338,7 @@ namespace Datadog.Trace.MSBuild
             }
         }
 
-        private class MsBuildLogEvent : DatadogLogEvent
+        private class MsBuildLogEvent : DirectSubmissionLogEvent
         {
             private readonly string _level;
             private readonly string _message;

--- a/tracer/src/Datadog.Trace/Ci/Logging/DirectSubmission/CIVisibilityLogEvent.cs
+++ b/tracer/src/Datadog.Trace/Ci/Logging/DirectSubmission/CIVisibilityLogEvent.cs
@@ -11,7 +11,7 @@ using Datadog.Trace.Logging.DirectSubmission.Sink;
 
 namespace Datadog.Trace.Ci.Logging.DirectSubmission
 {
-    internal class CIVisibilityLogEvent : DatadogLogEvent
+    internal class CIVisibilityLogEvent : DirectSubmissionLogEvent
     {
         private readonly string _source;
         private readonly string? _logLevel;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLogger.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLogger.cs
@@ -22,14 +22,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
     {
         private readonly string _name;
         private readonly IExternalScopeProvider? _scopeProvider;
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly LogFormatter? _logFormatter;
         private readonly int _minimumLogLevel;
 
         internal DirectSubmissionLogger(
             string name,
             IExternalScopeProvider? scopeProvider,
-            IDatadogSink sink,
+            IDirectSubmissionLogSink sink,
             LogFormatter? logFormatter,
             DirectSubmissionLogLevel minimumLogLevel)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLogger.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLogger.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
             var logFormatter = _logFormatter ?? TracerManager.Instance.DirectLogSubmission.Formatter;
             var serializedLog = LoggerLogFormatter.FormatLogEvent(logFormatter, logEntry);
 
-            var log = new LoggerDatadogLogEvent(serializedLog);
+            var log = new LoggerDirectSubmissionLogEvent(serializedLog);
 
             TelemetryFactory.Metrics.RecordCountDirectLogLogs(MetricTags.IntegrationName.ILogger);
             _sink.EnqueueLog(log);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/DirectSubmissionLoggerProvider.cs
@@ -22,19 +22,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
     {
         private readonly Func<string, DirectSubmissionLogger> _createLoggerFunc;
         private readonly ConcurrentDictionary<string, DirectSubmissionLogger> _loggers = new();
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly LogFormatter? _formatter;
         private readonly DirectSubmissionLogLevel _minimumLogLevel;
         private IExternalScopeProvider? _scopeProvider;
 
-        internal DirectSubmissionLoggerProvider(IDatadogSink sink, DirectSubmissionLogLevel minimumLogLevel, IExternalScopeProvider? scopeProvider)
+        internal DirectSubmissionLoggerProvider(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLogLevel, IExternalScopeProvider? scopeProvider)
             : this(sink, formatter: null, minimumLogLevel, scopeProvider)
         {
         }
 
         // used for testing
         internal DirectSubmissionLoggerProvider(
-            IDatadogSink sink,
+            IDirectSubmissionLogSink sink,
             LogFormatter? formatter,
             DirectSubmissionLogLevel minimumLogLevel,
             IExternalScopeProvider? scopeProvider)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerDirectSubmissionLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerDirectSubmissionLogEvent.cs
@@ -1,21 +1,20 @@
-﻿// <copyright file="NLogDatadogLogEvent.cs" company="Datadog">
+﻿// <copyright file="LoggerDirectSubmissionLogEvent.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+#nullable enable
 
-using System.Collections.Generic;
 using System.Text;
-using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
 using Datadog.Trace.Logging.DirectSubmission.Sink;
 
-namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
 {
-    internal class NLogDatadogLogEvent : DatadogLogEvent
+    internal class LoggerDirectSubmissionLogEvent : DirectSubmissionLogEvent
     {
-        private readonly string _serializedEvent;
+        private readonly string? _serializedEvent;
 
-        public NLogDatadogLogEvent(string serializedEvent)
+        public LoggerDirectSubmissionLogEvent(string? serializedEvent)
         {
             _serializedEvent = serializedEvent;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetAppender.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetAppender.cs
@@ -20,11 +20,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
     {
         private static DirectSubmissionLog4NetAppender _instance = null!;
 
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly DirectSubmissionLogLevel _minimumLevel;
 
         // internal for testing
-        internal DirectSubmissionLog4NetAppender(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        internal DirectSubmissionLog4NetAppender(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLevel)
         {
             _sink = sink;
             _minimumLevel = minimumLevel;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetAppender.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetAppender.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
                 return;
             }
 
-            var log = new Log4NetDatadogLogEvent(logEvent, logEvent.TimeStampUtc);
+            var log = new Log4NetDirectSubmissionLogEvent(logEvent, logEvent.TimeStampUtc);
             TelemetryFactory.Metrics.RecordCountDirectLogLogs(MetricTags.IntegrationName.Log4Net);
             _sink.EnqueueLog(log);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetLegacyAppender.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetLegacyAppender.cs
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
                 return;
             }
 
-            var log = new Log4NetDatadogLogEvent(logEvent, logEvent.TimeStamp.ToUniversalTime());
+            var log = new Log4NetDirectSubmissionLogEvent(logEvent, logEvent.TimeStamp.ToUniversalTime());
             TelemetryFactory.Metrics.RecordCountDirectLogLogs(MetricTags.IntegrationName.Log4Net);
             _sink.EnqueueLog(log);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetLegacyAppender.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/DirectSubmissionLog4NetLegacyAppender.cs
@@ -20,11 +20,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
     {
         private static DirectSubmissionLog4NetLegacyAppender _instance = null!;
 
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly DirectSubmissionLogLevel _minimumLevel;
 
         // internal for testing
-        internal DirectSubmissionLog4NetLegacyAppender(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        internal DirectSubmissionLog4NetLegacyAppender(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLevel)
         {
             _sink = sink;
             _minimumLevel = minimumLevel;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetDirectSubmissionLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetDirectSubmissionLogEvent.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Log4NetDatadogLogEvent.cs" company="Datadog">
+﻿// <copyright file="Log4NetDirectSubmissionLogEvent.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -11,12 +11,12 @@ using Datadog.Trace.Logging.DirectSubmission.Sink;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission
 {
-    internal class Log4NetDatadogLogEvent : DatadogLogEvent
+    internal class Log4NetDirectSubmissionLogEvent : DirectSubmissionLogEvent
     {
         private readonly ILoggingEventDuckBase _logEvent;
         private readonly DateTime _timestamp;
 
-        public Log4NetDatadogLogEvent(ILoggingEventDuckBase logEvent, DateTime timestamp)
+        public Log4NetDirectSubmissionLogEvent(ILoggingEventDuckBase logEvent, DateTime timestamp)
         {
             _logEvent = logEvent;
             _timestamp = timestamp;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogLegacyTarget.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogLegacyTarget.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
             var serializedLog = NLogLogFormatter.FormatLogEvent(logFormatter, logEvent);
 
             TelemetryFactory.Metrics.RecordCountDirectLogLogs(MetricTags.IntegrationName.NLog);
-            _sink.EnqueueLog(new NLogDatadogLogEvent(serializedLog));
+            _sink.EnqueueLog(new NLogDirectSubmissionLogEvent(serializedLog));
         }
 
         internal void SetGetContextPropertiesFunc(Func<IDictionary<string, object?>?> func)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogLegacyTarget.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogLegacyTarget.cs
@@ -22,19 +22,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
     /// </summary>
     internal class DirectSubmissionNLogLegacyTarget
     {
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly int _minimumLevel;
         private readonly LogFormatter? _formatter;
         private Func<IDictionary<string, object?>?>? _getProperties = null;
 
-        internal DirectSubmissionNLogLegacyTarget(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        internal DirectSubmissionNLogLegacyTarget(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLevel)
             : this(sink, minimumLevel, formatter: null)
         {
         }
 
         // internal for testing
         internal DirectSubmissionNLogLegacyTarget(
-            IDatadogSink sink,
+            IDirectSubmissionLogSink sink,
             DirectSubmissionLogLevel minimumLevel,
             LogFormatter? formatter)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogTarget.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogTarget.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
             var serializedLog = NLogLogFormatter.FormatLogEvent(logFormatter, logEvent);
 
             TelemetryFactory.Metrics.RecordCountDirectLogLogs(MetricTags.IntegrationName.NLog);
-            _sink.EnqueueLog(new NLogDatadogLogEvent(serializedLog));
+            _sink.EnqueueLog(new NLogDirectSubmissionLogEvent(serializedLog));
         }
 
         internal void SetBaseProxy(ITargetWithContextBaseProxy baseProxy)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogTarget.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogTarget.cs
@@ -20,19 +20,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
     /// </summary>
     internal class DirectSubmissionNLogTarget
     {
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly int _minimumLevel;
         private readonly LogFormatter? _formatter;
         private ITargetWithContextBaseProxy? _baseProxy;
 
-        internal DirectSubmissionNLogTarget(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        internal DirectSubmissionNLogTarget(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLevel)
             : this(sink, minimumLevel, formatter: null)
         {
         }
 
         // internal for testing
         internal DirectSubmissionNLogTarget(
-            IDatadogSink sink,
+            IDirectSubmissionLogSink sink,
             DirectSubmissionLogLevel minimumLevel,
             LogFormatter? formatter)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogV5Target.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogV5Target.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
             var logFormatter = _formatter ?? TracerManager.Instance.DirectLogSubmission.Formatter;
             var serializedLog = NLogLogFormatter.FormatLogEvent(logFormatter, logEvent);
 
-            _sink.EnqueueLog(new NLogDatadogLogEvent(serializedLog));
+            _sink.EnqueueLog(new NLogDirectSubmissionLogEvent(serializedLog));
         }
 
         internal void SetBaseProxy(ITargetWithContextV5BaseProxy baseProxy)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogV5Target.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/DirectSubmissionNLogV5Target.cs
@@ -18,19 +18,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
     /// </summary>
     internal class DirectSubmissionNLogV5Target
     {
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly int _minimumLevel;
         private readonly LogFormatter? _formatter;
         private ITargetWithContextV5BaseProxy? _baseProxy;
 
-        internal DirectSubmissionNLogV5Target(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        internal DirectSubmissionNLogV5Target(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLevel)
             : this(sink, minimumLevel, formatter: null)
         {
         }
 
         // internal for testing
         internal DirectSubmissionNLogV5Target(
-            IDatadogSink sink,
+            IDirectSubmissionLogSink sink,
             DirectSubmissionLogLevel minimumLevel,
             LogFormatter? formatter)
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogDirectSubmissionLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/Formatting/NLogDirectSubmissionLogEvent.cs
@@ -1,20 +1,21 @@
-﻿// <copyright file="LoggerDatadogLogEvent.cs" company="Datadog">
+﻿// <copyright file="NLogDirectSubmissionLogEvent.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
-#nullable enable
 
+using System.Collections.Generic;
 using System.Text;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Proxies;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
 using Datadog.Trace.Logging.DirectSubmission.Sink;
 
-namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting
 {
-    internal class LoggerDatadogLogEvent : DatadogLogEvent
+    internal class NLogDirectSubmissionLogEvent : DirectSubmissionLogEvent
     {
-        private readonly string? _serializedEvent;
+        private readonly string _serializedEvent;
 
-        public LoggerDatadogLogEvent(string? serializedEvent)
+        public NLogDirectSubmissionLogEvent(string serializedEvent)
         {
             _serializedEvent = serializedEvent;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
@@ -17,11 +17,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
     /// </summary>
     internal class DirectSubmissionSerilogSink
     {
-        private readonly IDatadogSink _sink;
+        private readonly IDirectSubmissionLogSink _sink;
         private readonly int _minimumLevel;
         private bool _isDisabled;
 
-        internal DirectSubmissionSerilogSink(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        internal DirectSubmissionSerilogSink(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLevel)
         {
             _sink = sink;
             _minimumLevel = (int)minimumLevel;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/DirectSubmissionSerilogSink.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
             }
 
             TelemetryFactory.Metrics.RecordCountDirectLogLogs(MetricTags.IntegrationName.Serilog);
-            _sink.EnqueueLog(new SerilogDatadogLogEvent(logEvent));
+            _sink.EnqueueLog(new SerilogDirectSubmissionLogEvent(logEvent));
         }
 
         internal void Disable()

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/SerilogDirectSubmissionLogEvent.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/SerilogDirectSubmissionLogEvent.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SerilogDatadogLogEvent.cs" company="Datadog">
+﻿// <copyright file="SerilogDirectSubmissionLogEvent.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -11,11 +11,11 @@ using Datadog.Trace.Logging.DirectSubmission.Sink;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSubmission
 {
-    internal class SerilogDatadogLogEvent : DatadogLogEvent
+    internal class SerilogDirectSubmissionLogEvent : DirectSubmissionLogEvent
     {
         private readonly ILogEvent _logEvent;
 
-        public SerilogDatadogLogEvent(ILogEvent logEvent)
+        public SerilogDirectSubmissionLogEvent(ILogEvent logEvent)
         {
             _logEvent = logEvent;
         }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
     {
         private static readonly IDatadogLogger Logger = DatadogLogging.GetLoggerFor<DirectLogSubmissionManager>();
 
-        private DirectLogSubmissionManager(ImmutableDirectLogSubmissionSettings settings, IDatadogSink sink, LogFormatter formatter)
+        private DirectLogSubmissionManager(ImmutableDirectLogSubmissionSettings settings, IDirectSubmissionLogSink sink, LogFormatter formatter)
         {
             Settings = settings;
             Sink = sink;
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
         public ImmutableDirectLogSubmissionSettings Settings { get; }
 
-        public IDatadogSink Sink { get; }
+        public IDirectSubmissionLogSink Sink { get; }
 
         public LogFormatter Formatter { get; }
 
@@ -49,13 +49,13 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
             if (!settings.IsEnabled)
             {
-                return new DirectLogSubmissionManager(settings, new NullDatadogSink(), formatter);
+                return new DirectLogSubmissionManager(settings, new NullDirectSubmissionLogSink(), formatter);
             }
 
             var apiFactory = LogsTransportStrategy.Get(settings);
             var logsApi = new LogsApi(settings.ApiKey, apiFactory);
 
-            return new DirectLogSubmissionManager(settings, new DatadogSink(logsApi, formatter, settings.BatchingOptions), formatter);
+            return new DirectLogSubmissionManager(settings, new DirectSubmissionLogSink(logsApi, formatter, settings.BatchingOptions), formatter);
         }
 
         public async Task DisposeAsync()

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DatadogSink.cs
@@ -11,10 +11,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
 using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
-    internal class DatadogSink : BatchingSink, IDatadogSink
+    internal class DatadogSink : BatchingSink<DatadogLogEvent>, IDatadogSink
     {
         // Maximum size for a single log is 1MB, we slightly err on the cautious side
         internal const int MaxMessageSizeBytes = 1000 * 1024;
@@ -164,6 +165,11 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
                 _logger.Error(e, "An error occured sending logs to Datadog");
                 return false;
             }
+        }
+
+        protected override void FlushingEvents(int queueSizeBeforeFlush)
+        {
+            TelemetryFactory.Metrics.RecordGaugeDirectLogQueue(queueSizeBeforeFlush);
         }
 
         public override async Task DisposeAsync()

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DirectSubmissionLogEvent.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DirectSubmissionLogEvent.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DatadogLogEvent.cs" company="Datadog">
+﻿// <copyright file="DirectSubmissionLogEvent.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -9,7 +9,7 @@ using Datadog.Trace.Logging.DirectSubmission.Formatting;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
-    internal abstract class DatadogLogEvent
+    internal abstract class DirectSubmissionLogEvent
     {
         /// <summary>
         /// Formats the event to the provided <see cref="StringBuilder"/>

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DirectSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DirectSubmissionLogSink.cs
@@ -1,4 +1,4 @@
-// <copyright file="DatadogSink.cs" company="Datadog">
+// <copyright file="DirectSubmissionLogSink.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -15,7 +15,7 @@ using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
-    internal class DatadogSink : BatchingSink<DatadogLogEvent>, IDatadogSink
+    internal class DirectSubmissionLogSink : BatchingSink<DatadogLogEvent>, IDirectSubmissionLogSink
     {
         // Maximum size for a single log is 1MB, we slightly err on the cautious side
         internal const int MaxMessageSizeBytes = 1000 * 1024;
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         private const byte SuffixAsUtf8Byte = 0x5D; // ']'
         private const byte SeparatorAsUtf8Byte = 0x2C; // ','
 
-        private readonly IDatadogLogger _logger = DatadogLogging.GetLoggerFor<DatadogSink>();
+        private readonly IDatadogLogger _logger = DatadogLogging.GetLoggerFor<DirectSubmissionLogSink>();
         private readonly ILogsApi _api;
         private readonly LogFormatter _formatter;
         private readonly Action<DatadogLogEvent>? _oversizeLogCallback;
@@ -47,12 +47,12 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         private int _byteCount = 0;
         private int _logCount = 0;
 
-        public DatadogSink(ILogsApi api, LogFormatter formatter, BatchingSinkOptions sinkOptions)
+        public DirectSubmissionLogSink(ILogsApi api, LogFormatter formatter, BatchingSinkOptions sinkOptions)
             : this(api, formatter, sinkOptions, oversizeLogCallback: null, sinkDisabledCallback: null)
         {
         }
 
-        public DatadogSink(
+        public DirectSubmissionLogSink(
             ILogsApi api,
             LogFormatter formatter,
             BatchingSinkOptions sinkOptions,

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DirectSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/DirectSubmissionLogSink.cs
@@ -15,7 +15,7 @@ using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
-    internal class DirectSubmissionLogSink : BatchingSink<DatadogLogEvent>, IDirectSubmissionLogSink
+    internal class DirectSubmissionLogSink : BatchingSink<DirectSubmissionLogEvent>, IDirectSubmissionLogSink
     {
         // Maximum size for a single log is 1MB, we slightly err on the cautious side
         internal const int MaxMessageSizeBytes = 1000 * 1024;
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         private readonly IDatadogLogger _logger = DatadogLogging.GetLoggerFor<DirectSubmissionLogSink>();
         private readonly ILogsApi _api;
         private readonly LogFormatter _formatter;
-        private readonly Action<DatadogLogEvent>? _oversizeLogCallback;
+        private readonly Action<DirectSubmissionLogEvent>? _oversizeLogCallback;
         private readonly StringBuilder _logStringBuilder = new(InitialBuilderSizeBytes);
         private byte[] _serializedLogs = new byte[InitialAllLogsSizeBytes];
         private int _byteCount = 0;
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
             ILogsApi api,
             LogFormatter formatter,
             BatchingSinkOptions sinkOptions,
-            Action<DatadogLogEvent>? oversizeLogCallback,
+            Action<DirectSubmissionLogEvent>? oversizeLogCallback,
             Action? sinkDisabledCallback)
             : base(sinkOptions, sinkDisabledCallback)
         {
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         /// Emit a batch of log events to Datadog logs-backend.
         /// </summary>
         /// <param name="events">The events to emit.</param>
-        protected override async Task<bool> EmitBatch(Queue<DatadogLogEvent> events)
+        protected override async Task<bool> EmitBatch(Queue<DirectSubmissionLogEvent> events)
         {
             var allSucceeded = true;
             try

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDirectSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDirectSubmissionLogSink.cs
@@ -1,4 +1,4 @@
-// <copyright file="IDatadogSink.cs" company="Datadog">
+// <copyright file="IDirectSubmissionLogSink.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
-    internal interface IDatadogSink
+    internal interface IDirectSubmissionLogSink
     {
         /// <summary>
         /// Emit the provided log event to the sink. If the sink is being disposed or

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDirectSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/IDirectSubmissionLogSink.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
         /// </summary>
         /// <param name="logEvent">Log event to emit.</param>
         /// <exception cref="ArgumentNullException">The event is null.</exception>
-        void EnqueueLog(DatadogLogEvent logEvent);
+        void EnqueueLog(DirectSubmissionLogEvent logEvent);
 
         /// <summary>
         /// Start the background process to send logs to the backend

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDirectSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDirectSubmissionLogSink.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
     internal class NullDirectSubmissionLogSink : IDirectSubmissionLogSink
     {
-        public void EnqueueLog(DatadogLogEvent logEvent)
+        public void EnqueueLog(DirectSubmissionLogEvent logEvent)
         {
         }
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDirectSubmissionLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/NullDirectSubmissionLogSink.cs
@@ -1,4 +1,4 @@
-// <copyright file="NullDatadogSink.cs" company="Datadog">
+// <copyright file="NullDirectSubmissionLogSink.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink
 {
-    internal class NullDatadogSink : IDatadogSink
+    internal class NullDirectSubmissionLogSink : IDirectSubmissionLogSink
     {
         public void EnqueueLog(DatadogLogEvent logEvent)
         {

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSink.cs
@@ -8,22 +8,18 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Datadog.Trace.Telemetry;
-using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
 {
-    internal abstract class BatchingSink
+    internal abstract class BatchingSink<T>
     {
-        internal const int FailuresBeforeCircuitBreak = 10;
-
-        private readonly IDatadogLogger _log = DatadogLogging.GetLoggerFor<BatchingSink>();
+        private readonly IDatadogLogger _log;
         private readonly int _batchSizeLimit;
         private readonly TimeSpan _flushPeriod;
         private readonly TimeSpan _circuitBreakPeriod;
-        private readonly BoundedConcurrentQueue<DatadogLogEvent> _queue;
-        private readonly Queue<DatadogLogEvent> _waitingBatch = new();
+        private readonly BoundedConcurrentQueue<T> _queue;
+        private readonly Queue<T> _waitingBatch = new();
         private readonly CircuitBreaker _circuitBreaker;
         private readonly Task _flushTask;
         private readonly Action? _disableSinkAction;
@@ -32,7 +28,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         private readonly ConcurrentQueue<TaskCompletionSource<bool>> _flushCompletionSources = new();
         private volatile bool _enqueueLogEnabled = true;
 
-        protected BatchingSink(BatchingSinkOptions sinkOptions, Action? disableSinkAction)
+        protected BatchingSink(BatchingSinkOptions sinkOptions, Action? disableSinkAction, IDatadogLogger? log = null)
         {
             if (sinkOptions == null)
             {
@@ -49,14 +45,15 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
                 ThrowHelper.ThrowArgumentOutOfRangeException(nameof(sinkOptions), "The period must be greater than zero.");
             }
 
+            _log = log ?? DatadogLogging.GetLoggerFor<BatchingSink<T>>();
             _disableSinkAction = disableSinkAction;
 
             _batchSizeLimit = sinkOptions.BatchSizeLimit;
             _flushPeriod = sinkOptions.Period;
             _circuitBreakPeriod = sinkOptions.CircuitBreakPeriod;
 
-            _queue = new BoundedConcurrentQueue<DatadogLogEvent>(sinkOptions.QueueLimit);
-            _circuitBreaker = new CircuitBreaker(FailuresBeforeCircuitBreak);
+            _queue = new BoundedConcurrentQueue<T>(sinkOptions.QueueLimit);
+            _circuitBreaker = new CircuitBreaker(sinkOptions.FailuresBeforeCircuitBreak);
 
             _flushTask = Task.Run(FlushBuffersTaskLoopAsync);
             _flushTask.ContinueWith(
@@ -74,7 +71,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         /// </summary>
         /// <param name="logEvent">Log event to emit.</param>
         /// <exception cref="ArgumentNullException">The event is null.</exception>
-        public void EnqueueLog(DatadogLogEvent logEvent)
+        public void EnqueueLog(T logEvent)
         {
             if (logEvent == null)
             {
@@ -113,11 +110,28 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         }
 
         /// <summary>
+        /// Disables the sink entirely, drops any queued logs, and stops flushing
+        /// Does not attempt to flush any logs
+        /// </summary>
+        public void CloseImmediately()
+        {
+            _enqueueLogEnabled = false;
+            _disableSinkAction?.Invoke();
+            _processExit.TrySetResult(false);
+            // ditch all the remaining logs
+            while (_queue.TryDequeue(out _))
+            {
+            }
+        }
+
+        /// <summary>
         /// Emit a batch of log events, running to completion synchronously.
         /// </summary>
         /// <param name="events">The events to emit.</param>
         /// <returns><c>true</c> if the batch was emitted successfully. <c>false</c> if there was an error</returns>
-        protected abstract Task<bool> EmitBatch(Queue<DatadogLogEvent> events);
+        protected abstract Task<bool> EmitBatch(Queue<T> events);
+
+        protected abstract void FlushingEvents(int queueSizeBeforeFlush);
 
         private async Task FlushBuffersTaskLoopAsync()
         {
@@ -177,7 +191,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
                 var haveMultipleBatchesToSend = false;
                 do
                 {
-                    TelemetryFactory.Metrics.RecordGaugeDirectLogQueue(_queue.Count);
+                    FlushingEvents(_queue.Count);
 
                     while (_waitingBatch.Count < _batchSizeLimit &&
                            _queue.TryDequeue(out var next))

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkOptions.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkOptions.cs
@@ -33,7 +33,8 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
              batchSizeLimit,
              queueLimit,
              period,
-             circuitBreakPeriod: TimeSpan.FromTicks(period.Ticks))
+             circuitBreakPeriod: TimeSpan.FromTicks(period.Ticks),
+             failuresBeforeCircuitBreak: 10)
         {
         }
 
@@ -41,12 +42,14 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
             int batchSizeLimit,
             int queueLimit,
             TimeSpan period,
-            TimeSpan circuitBreakPeriod)
+            TimeSpan circuitBreakPeriod,
+            int failuresBeforeCircuitBreak)
         {
             BatchSizeLimit = batchSizeLimit;
             QueueLimit = queueLimit;
             Period = period;
             CircuitBreakPeriod = circuitBreakPeriod;
+            FailuresBeforeCircuitBreak = failuresBeforeCircuitBreak;
         }
 
         /// <summary>
@@ -68,5 +71,10 @@ namespace Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching
         /// Gets maximum number of events to hold in the sink's internal queue
         /// </summary>
         public int QueueLimit { get; }
+
+        /// <summary>
+        /// Gets the number of failures to emit the batch before the circuit breaker breaks
+        /// </summary>
+        public int FailuresBeforeCircuitBreak { get; }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
@@ -108,9 +108,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
 
         internal class TestSink : IDirectSubmissionLogSink
         {
-            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+            public ConcurrentQueue<DirectSubmissionLogEvent> Events { get; } = new();
 
-            public void EnqueueLog(DatadogLogEvent logEvent)
+            public void EnqueueLog(DirectSubmissionLogEvent logEvent)
             {
                 Events.Enqueue(logEvent);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/DirectSubmissionLoggerTests.cs
@@ -106,7 +106,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
                 minimumLogLevel: settings.MinimumLevel);
         }
 
-        internal class TestSink : IDatadogSink
+        internal class TestSink : IDirectSubmissionLogSink
         {
             public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
@@ -24,13 +24,13 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
 {
     public class ILoggerDuckTypingTests
     {
-        private readonly NullDatadogSink _sink;
+        private readonly NullDirectSubmissionLogSink _sink;
         private readonly LogFormatter _formatter;
         private readonly Type _iloggerProviderType;
 
         public ILoggerDuckTypingTests()
         {
-            _sink = new NullDatadogSink();
+            _sink = new NullDirectSubmissionLogSink();
             _formatter = LogSettingsHelper.GetFormatter();
             _iloggerProviderType = LoggerFactoryIntegrationCommon<ILoggerProvider>.ProviderInterfaces;
         }
@@ -128,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
         public void CanDuckTypeExternalScopeProviderAndUseWithProxyProvider()
         {
             var scopeProvider = new LoggerExternalScopeProvider();
-            var loggerProvider = new DirectSubmissionLoggerProvider(new NullDatadogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug, scopeProvider: null);
+            var loggerProvider = new DirectSubmissionLoggerProvider(new NullDirectSubmissionLogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug, scopeProvider: null);
             var proxyProvider = (ISupportExternalScope)loggerProvider.DuckImplement(_iloggerProviderType);
             proxyProvider.SetScopeProvider(scopeProvider);
 
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
         public void CanSetProviderUsingHelper()
         {
             var factory = new LoggerFactory();
-            var loggerProvider = new DirectSubmissionLoggerProvider(new NullDatadogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug, scopeProvider: null);
+            var loggerProvider = new DirectSubmissionLoggerProvider(new NullDirectSubmissionLogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug, scopeProvider: null);
             LoggerFactoryIntegrationCommon<LoggerFactory>.AddDirectSubmissionLoggerProvider(factory, loggerProvider);
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
@@ -16,20 +16,20 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Lo
     internal class Log4NetHelper
     {
 #if LOG4NET_2
-        public static DirectSubmissionLog4NetAppender GetAppender(IDatadogSink sink, DirectSubmissionLogLevel level)
+        public static DirectSubmissionLog4NetAppender GetAppender(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel level)
             => new(sink, level);
 
         public static ILoggingEventDuck DuckCastLogEvent(LoggingEvent logEvent)
             => logEvent.DuckCast<ILoggingEventDuck>();
 #else
-        public static DirectSubmissionLog4NetLegacyAppender GetAppender(IDatadogSink sink, DirectSubmissionLogLevel level)
+        public static DirectSubmissionLog4NetLegacyAppender GetAppender(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel level)
             => new(sink, level);
 
         public static ILoggingEventLegacyDuck DuckCastLogEvent(LoggingEvent logEvent)
             => logEvent.DuckCast<ILoggingEventLegacyDuck>();
 #endif
 
-        internal class TestSink : IDatadogSink
+        internal class TestSink : IDirectSubmissionLogSink
         {
             public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetHelper.cs
@@ -31,9 +31,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Lo
 
         internal class TestSink : IDirectSubmissionLogSink
         {
-            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+            public ConcurrentQueue<DirectSubmissionLogEvent> Events { get; } = new();
 
-            public void EnqueueLog(DatadogLogEvent logEvent)
+            public void EnqueueLog(DirectSubmissionLogEvent logEvent)
             {
                 Events.Enqueue(logEvent);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogDuckTypingTests.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
         public void CanReverseDuckTypeTarget()
         {
             var targetType = typeof(Target);
-            var target = NLogHelper.CreateTarget(new NullDatadogSink(), DirectSubmissionLogLevel.Debug);
+            var target = NLogHelper.CreateTarget(new NullDirectSubmissionLogSink(), DirectSubmissionLogLevel.Debug);
             var proxy = NLogCommon<Target>.CreateNLogTargetProxy(target);
 
             proxy.Should().NotBeNull();

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
         public static void AddTargetToConfig(LoggingConfiguration config, object targetProxy)
             => NLogCommon<LoggingConfiguration>.AddDatadogTargetNLog50(config, targetProxy);
 #elif NLOG_45
-        public static DirectSubmissionNLogTarget CreateTarget(IDatadogSink sink, DirectSubmissionLogLevel minimumLevel)
+        public static DirectSubmissionNLogTarget CreateTarget(IDirectSubmissionLogSink sink, DirectSubmissionLogLevel minimumLevel)
             => new(sink, minimumLevel, LogSettingsHelper.GetFormatter());
 
         public static ILogEventInfoProxy GetLogEventProxy(LogEventInfo logEvent)
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
             => NLogCommon<LoggingConfiguration>.AddDatadogTargetNLogPre43(config, targetProxy);
 #endif
 
-        public class TestSink : IDatadogSink
+        public class TestSink : IDirectSubmissionLogSink
         {
             public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/NLog/NLogHelper.cs
@@ -55,9 +55,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.NL
 
         public class TestSink : IDirectSubmissionLogSink
         {
-            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+            public ConcurrentQueue<DirectSubmissionLogEvent> Events { get; } = new();
 
-            public void EnqueueLog(DatadogLogEvent logEvent)
+            public void EnqueueLog(DirectSubmissionLogEvent logEvent)
             {
                 Events.Enqueue(logEvent);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
@@ -30,9 +30,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Se
 
         internal class TestSink : IDirectSubmissionLogSink
         {
-            public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
+            public ConcurrentQueue<DirectSubmissionLogEvent> Events { get; } = new();
 
-            public void EnqueueLog(DatadogLogEvent logEvent)
+            public void EnqueueLog(DirectSubmissionLogEvent logEvent)
             {
                 Events.Enqueue(logEvent);
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Serilog/SerilogHelper.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Se
                     propagateExceptions: false));
         }
 
-        internal class TestSink : IDatadogSink
+        internal class TestSink : IDirectSubmissionLogSink
         {
             public ConcurrentQueue<DatadogLogEvent> Events { get; } = new();
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ILogger/DirectSubmissionLoggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ILogger/DirectSubmissionLoggerTests.cs
@@ -296,10 +296,10 @@ public class DirectSubmissionLoggerTests
         AssertLogs(api, expectedLogs: 3);
     }
 
-    private static Microsoft.Extensions.Logging.ILogger GetLogger(out DatadogSinkTests.TestLogsApi api, out DatadogSink sink)
+    private static Microsoft.Extensions.Logging.ILogger GetLogger(out DatadogSinkTests.TestLogsApi api, out DirectSubmissionLogSink sink)
     {
         api = new DatadogSinkTests.TestLogsApi();
-        sink = new DatadogSink(api, Formatter, BatchingOptions);
+        sink = new DirectSubmissionLogSink(api, Formatter, BatchingOptions);
 
         var rawLogger = new DirectSubmissionLogger(
             name: nameof(DirectSubmissionLoggerTests),

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
 {
     public class DatadogSinkTests
     {
+        private const int FailuresBeforeCircuitBreak = 10;
         private const int DefaultQueueLimit = 100_000;
         private static readonly TimeSpan TinyWait = TimeSpan.FromMilliseconds(50);
 
@@ -198,7 +199,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
             sink.Start();
 
-            for (var i = 0; i < BatchingSink.FailuresBeforeCircuitBreak; i++)
+            for (var i = 0; i < FailuresBeforeCircuitBreak; i++)
             {
                 sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "A message"));
                 mutex.Wait(30_000).Should().BeTrue();
@@ -209,7 +210,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "A message"));
             mutex.Wait(3_000).Should().BeFalse(); // don't expect it to be set
 
-            logsReceived.Should().Be(BatchingSink.FailuresBeforeCircuitBreak);
+            logsReceived.Should().Be(FailuresBeforeCircuitBreak);
         }
 
         internal class TestLogEvent : DatadogLogEvent

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
                 return true;
             });
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
-            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            var sink = new DirectSubmissionLogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
             sink.Start();
 
             sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message"));
@@ -55,7 +55,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
 
             var logsApi = new TestLogsApi();
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
-            var sink = new DatadogSink(
+            var sink = new DirectSubmissionLogSink(
                 logsApi,
                 LogSettingsHelper.GetFormatter(),
                 options,
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
 
             var logsApi = new TestLogsApi(LogsSentCallback);
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
-            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            var sink = new DirectSubmissionLogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
             sink.Start();
 
             var firstMessage = "First message";
@@ -133,7 +133,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
 
             var logsApi = new TestLogsApi(LogsSentCallback);
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
-            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            var sink = new DirectSubmissionLogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
             sink.Start();
 
             sink.EnqueueLog(new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message"));
@@ -196,7 +196,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
 
             var logsApi = new TestLogsApi(LogsSentCallback);
             var options = new BatchingSinkOptions(batchSizeLimit: 2, queueLimit: DefaultQueueLimit, period: TinyWait);
-            var sink = new DatadogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
+            var sink = new DirectSubmissionLogSink(logsApi, LogSettingsHelper.GetFormatter(), options);
             sink.Start();
 
             for (var i = 0; i < FailuresBeforeCircuitBreak; i++)
@@ -269,7 +269,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             public int NumberOfLogs { get; }
         }
 
-        internal class TestSink : DatadogSink
+        internal class TestSink : DirectSubmissionLogSink
         {
             public TestSink(ILogsApi api, LogFormatter formatter, BatchingSinkOptions sinkOptions)
                 : base(api, formatter, sinkOptions)

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/DatadogSinkTests.cs
@@ -173,7 +173,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             var sink = new TestSink(logsApi, LogSettingsHelper.GetFormatter(), options);
             sink.Start();
             var log = new TestLogEvent(DirectSubmissionLogLevel.Debug, "First message");
-            var queue = new Queue<DatadogLogEvent>();
+            var queue = new Queue<DirectSubmissionLogEvent>();
             queue.Enqueue(log);
 
             var result = await sink.CallEmitBatch(queue);
@@ -213,7 +213,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             logsReceived.Should().Be(FailuresBeforeCircuitBreak);
         }
 
-        internal class TestLogEvent : DatadogLogEvent
+        internal class TestLogEvent : DirectSubmissionLogEvent
         {
             public TestLogEvent(DirectSubmissionLogLevel level, string message)
             {
@@ -276,7 +276,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             {
             }
 
-            public Task<bool> CallEmitBatch(Queue<DatadogLogEvent> events)
+            public Task<bool> CallEmitBatch(Queue<DirectSubmissionLogEvent> events)
             {
                 return EmitBatch(events);
             }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/PeriodicBatching/BatchingSinkTests.cs
@@ -16,7 +16,7 @@ using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
-using BatchingSink = Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching.BatchingSink<Datadog.Trace.Logging.DirectSubmission.Sink.DatadogLogEvent>;
+using BatchingSink = Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching.BatchingSink<Datadog.Trace.Logging.DirectSubmission.Sink.DirectSubmissionLogEvent>;
 
 namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
 {
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
 
             sink.Batches.Count.Should().Be(1);
             sink.Batches.TryPeek(out var batch).Should().BeTrue();
-            batch.Should().BeEquivalentTo(new List<DatadogLogEvent> { evt });
+            batch.Should().BeEquivalentTo(new List<DirectSubmissionLogEvent> { evt });
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
 
             batches.Count.Should().Be(1);
             sink.Batches.TryPeek(out var batch).Should().BeTrue();
-            batch.Should().BeEquivalentTo(new List<DatadogLogEvent> { evt });
+            batch.Should().BeEquivalentTo(new List<DirectSubmissionLogEvent> { evt });
         }
 
         [Fact]
@@ -214,7 +214,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             sink.Batches.Should().BeEmpty();
         }
 
-        private static ConcurrentStack<IList<DatadogLogEvent>> WaitForBatches(InMemoryBatchedSink pbs, int batchCount = 1)
+        private static ConcurrentStack<IList<DirectSubmissionLogEvent>> WaitForBatches(InMemoryBatchedSink pbs, int batchCount = 1)
         {
             var deadline = DateTime.UtcNow.AddSeconds(30);
             var batches = pbs.Batches;
@@ -227,7 +227,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
             return batches;
         }
 
-        internal class TestEvent : DatadogLogEvent
+        internal class TestEvent : DirectSubmissionLogEvent
         {
             private readonly string _evt;
 
@@ -256,9 +256,9 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink.PeriodicBatching
                 _emitResults = emitResults ?? Array.Empty<bool>();
             }
 
-            public ConcurrentStack<IList<DatadogLogEvent>> Batches { get; } = new();
+            public ConcurrentStack<IList<DirectSubmissionLogEvent>> Batches { get; } = new();
 
-            protected override Task<bool> EmitBatch(Queue<DatadogLogEvent> events)
+            protected override Task<bool> EmitBatch(Queue<DirectSubmissionLogEvent> events)
             {
                 Batches.Push(events.ToList());
                 _emitCount++;


### PR DESCRIPTION
## Summary of changes

- Update `BatchingSink` to support generic `T` events, instead of only direct-submission logs
- Rename `DatadogSink` to `DirectSubmissionLogSink`

## Reason for change

When sending telemetry logs, we want to reuse the `BatchingSink` implementation, but currently it's tied to direct log submission.

Renaming the derived `DatadogSink` to be clearer about what it is

## Implementation details

A few minor tweaks to `BatchingSink` and a rename

## Test coverage

A few unit tests for the new `CloseImmediately()` method, but otherwise covered by existing tests

## Other details
Stacked on https://github.com/DataDog/dd-trace-dotnet/pull/4388
