### PR TITLE
[ASM] Added 1 hour timer to vulnerability deduplication

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/HashBasedDeduplication.cs
+++ b/tracer/src/Datadog.Trace/Iast/HashBasedDeduplication.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable 
 namespace Datadog.Trace.Iast;
 
 internal class HashBasedDeduplication

--- a/tracer/src/Datadog.Trace/Iast/HashBasedDeduplication.cs
+++ b/tracer/src/Datadog.Trace/Iast/HashBasedDeduplication.cs
@@ -6,7 +6,8 @@
 using System;
 using System.Collections.Generic;
 
-#nullable enable 
+#nullable enable
+
 namespace Datadog.Trace.Iast;
 
 internal class HashBasedDeduplication

--- a/tracer/src/Datadog.Trace/Iast/HashBasedDeduplication.cs
+++ b/tracer/src/Datadog.Trace/Iast/HashBasedDeduplication.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 
 namespace Datadog.Trace.Iast;
@@ -10,31 +11,43 @@ namespace Datadog.Trace.Iast;
 internal class HashBasedDeduplication
 {
     public const int MaximumSize = 1000;
-    private HashSet<int> vulnerabilityHashes = new();
+    public const int MinutesToClearCache = 60;
+    private HashSet<int> _vulnerabilityHashes = new();
+    private DateTime _cacheClearedTime;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="HashBasedDeduplication"/> class.
     /// For testing only.
     /// Note that this API does NOT replace the global HashBasedDeduplication instance.
     /// </summary>
-    internal HashBasedDeduplication()
+    internal HashBasedDeduplication(DateTime? currentTime = null)
     {
+        _cacheClearedTime = currentTime ?? DateTime.Now;
     }
 
     public static HashBasedDeduplication Instance { get; } = new();
 
-    public bool Add(Vulnerability vulnerability)
+    public bool Add(Vulnerability vulnerability, DateTime? addTime = null)
     {
         var hashCode = vulnerability.GetHashCode();
+        var currentTime = addTime ?? DateTime.Now;
 
         bool newVulnerability;
-        lock (vulnerabilityHashes)
+        lock (_vulnerabilityHashes)
         {
-            newVulnerability = vulnerabilityHashes.Add(hashCode);
-            if (newVulnerability && vulnerabilityHashes.Count > MaximumSize)
+            if ((currentTime - _cacheClearedTime).TotalMinutes >= MinutesToClearCache)
             {
-                vulnerabilityHashes.Clear();
-                vulnerabilityHashes.Add(hashCode);
+                _vulnerabilityHashes.Clear();
+                _cacheClearedTime = currentTime;
+            }
+
+            newVulnerability = _vulnerabilityHashes.Add(hashCode);
+
+            if (newVulnerability && _vulnerabilityHashes.Count > MaximumSize)
+            {
+                _vulnerabilityHashes.Clear();
+                _cacheClearedTime = currentTime;
+                _vulnerabilityHashes.Add(hashCode);
             }
         }
 


### PR DESCRIPTION
## Summary of changes

Vulnerability deduplication stores the detected vulnerabilities and reports them only once per execution. A 1 hour timer is required to be set in order to clear the deduplication cache periodically. That will mean that every hour, repeated vulnerabilities might be sent. A single timer will be used for the whole cache. The individual vulnerabilities have no timer associated.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->
