### PR TITLE
Run all the system tests in CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3897,10 +3897,18 @@ stages:
 
     strategy:
       matrix:
-        poc:
+        parametric_poc:
           WEBLOG_VARIANT: "poc"
-        uds:
+          SCENARIO: PARAMETRIC
+        parametric_uds:
           WEBLOG_VARIANT: "uds"
+          SCENARIO: PARAMETRIC
+        system_tests_poc:
+          WEBLOG_VARIANT: "poc"
+          SCENARIO: TRACER_RELEASE_SCENARIOS
+        system_tests_uds:
+          WEBLOG_VARIANT: "uds"
+          SCENARIO: TRACER_RELEASE_SCENARIOS
 
     steps:
       - checkout: none
@@ -3930,15 +3938,9 @@ stages:
         workingDirectory: system-tests
         displayName: Build images
 
-      - script: ./run.sh TRACER_RELEASE_SCENARIOS
+      - script: ./run.sh $(SCENARIO)
         workingDirectory: system-tests
         displayName: Run tests
-        env:
-          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
-      - script: |
-          ./run.sh PARAMETRIC
-        workingDirectory: system-tests
-        displayName: Run parametric tests
         env:
           DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
           TEST_LIBRARY: dotnet

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3930,24 +3930,11 @@ stages:
         workingDirectory: system-tests
         displayName: Build images
 
-      - script: ./run.sh
+      - script: ./run.sh TRACER_RELEASE_SCENARIOS
         workingDirectory: system-tests
         displayName: Run tests
         env:
           DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
-
-      - script: ./run.sh REMOTE_CONFIG_MOCKED_BACKEND_LIVE_DEBUGGING
-        workingDirectory: system-tests
-        displayName: Run RCM tests
-        env:
-          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
-
-      - script: ./run.sh INTEGRATIONS
-        workingDirectory: system-tests
-        displayName: Run Integrations tests
-        env:
-          DD_API_KEY: $(SYSTEM_TESTS_DD_API_KEY)
-
       - script: |
           ./run.sh PARAMETRIC
         workingDirectory: system-tests

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3891,7 +3891,7 @@ stages:
       jobs: [test]
 
   - job: test
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 120 # Except this to take ~60
     pool:
       vmImage: ubuntu-20.04
 


### PR DESCRIPTION
## Summary of changes

- Runs all the system tests on CI

## Reason for change

Previously we were only ever running a select few scenarios. For full coverage, we should at least run the full suite on master.

## Implementation details

For simplicity, _always_ running all the tests on PRs. This is pretty slow (~60 mins) but probably still not an issue. We could consider running fewer scenarios on PRs if it is a problem.

To speed things up a little, moved the parametric tests to a parallel job. There's no easy way of automatically splitting the remaining scenarios without needing to update CI every time a new job is added, so couldn't do any more than that.

## Test coverage

Ran a test, it worked 🎉 They also finished way before most of integration tests, because they can run on public VM images

## Other details

We're running the `TRACER_RELEASE_SCENARIOS` meta-scenario, which runs the following:

https://github.com/DataDog/system-tests/blob/821914aa243b75da7f815d5f93b9bdc9c7c47221/run.sh#L52-L62
