### PR TITLE
Swap to Datadog as default propagation style

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -121,6 +121,7 @@ namespace Datadog.Trace.Configuration
             RouteTemplateResourceNamesEnabled = settings.RouteTemplateResourceNamesEnabled;
             DelayWcfInstrumentationEnabled = settings.DelayWcfInstrumentationEnabled;
             WcfObfuscationEnabled = settings.WcfObfuscationEnabled;
+            PropagationStyle = settings.PropagationStyle;
             PropagationStyleInject = settings.PropagationStyleInject;
             PropagationStyleExtract = settings.PropagationStyleExtract;
             TraceMethods = settings.TraceMethods;
@@ -441,6 +442,11 @@ namespace Datadog.Trace.Configuration
         /// into the <c>resourceName</c> of a span.
         /// </summary>
         internal bool WcfObfuscationEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating the injection and extraction propagation styles.
+        /// </summary>
+        internal string[] PropagationStyle { get; }
 
         /// <summary>
         /// Gets a value indicating the injection propagation style.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -121,7 +121,6 @@ namespace Datadog.Trace.Configuration
             RouteTemplateResourceNamesEnabled = settings.RouteTemplateResourceNamesEnabled;
             DelayWcfInstrumentationEnabled = settings.DelayWcfInstrumentationEnabled;
             WcfObfuscationEnabled = settings.WcfObfuscationEnabled;
-            PropagationStyle = settings.PropagationStyle;
             PropagationStyleInject = settings.PropagationStyleInject;
             PropagationStyleExtract = settings.PropagationStyleExtract;
             TraceMethods = settings.TraceMethods;
@@ -442,11 +441,6 @@ namespace Datadog.Trace.Configuration
         /// into the <c>resourceName</c> of a span.
         /// </summary>
         internal bool WcfObfuscationEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating the injection and extraction propagation styles.
-        /// </summary>
-        internal string[] PropagationStyle { get; }
 
         /// <summary>
         /// Gets a value indicating the injection propagation style.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -263,18 +263,6 @@ namespace Datadog.Trace.Configuration
                                                      .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryLegacyOperationNameEnabled)
                                                      .AsBool(false);
 
-            var propagationStyle = config
-                                  .WithKeys(ConfigurationKeys.PropagationStyle)
-                                  .AsString();
-
-            PropagationStyle = TrimSplitString(propagationStyle, commaSeparator);
-
-            if (PropagationStyle.Length == 0)
-            {
-                // default value
-                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog };
-            }
-
             var propagationStyleInject = config
                                         .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
                                         .AsString();
@@ -721,11 +709,6 @@ namespace Datadog.Trace.Configuration
         /// This value is not used when extracting an incoming propagation header from an upstream service.
         /// </remarks>
         internal int OutgoingTagPropagationHeaderMaxLength { get; }
-
-        /// <summary>
-        /// Gets a value indicating the injection and extraction propagation styles.
-        /// </summary>
-        internal string[] PropagationStyle { get; }
 
         /// <summary>
         /// Gets a value indicating the injection propagation style.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -263,6 +263,18 @@ namespace Datadog.Trace.Configuration
                                                      .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryLegacyOperationNameEnabled)
                                                      .AsBool(false);
 
+            var propagationStyle = config
+                                  .WithKeys(ConfigurationKeys.PropagationStyle)
+                                  .AsString();
+
+            PropagationStyle = TrimSplitString(propagationStyle, commaSeparator);
+
+            if (PropagationStyle.Length == 0)
+            {
+                // default value
+                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext };
+            }
+
             var propagationStyleInject = config
                                         .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
                                         .AsString();
@@ -272,7 +284,7 @@ namespace Datadog.Trace.Configuration
             if (PropagationStyleInject.Length == 0)
             {
                 // default value
-                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
+                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext };
             }
 
             var propagationStyleExtract = config
@@ -284,7 +296,7 @@ namespace Datadog.Trace.Configuration
             if (PropagationStyleExtract.Length == 0)
             {
                 // default value
-                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
+                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext };
             }
 
             // If Activity support is enabled, we must enable the W3C Trace Context propagators.
@@ -709,6 +721,11 @@ namespace Datadog.Trace.Configuration
         /// This value is not used when extracting an incoming propagation header from an upstream service.
         /// </remarks>
         internal int OutgoingTagPropagationHeaderMaxLength { get; }
+
+        /// <summary>
+        /// Gets a value indicating the injection and extraction propagation styles.
+        /// </summary>
+        internal string[] PropagationStyle { get; }
 
         /// <summary>
         /// Gets a value indicating the injection propagation style.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -272,7 +272,7 @@ namespace Datadog.Trace.Configuration
             if (PropagationStyle.Length == 0)
             {
                 // default value
-                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext };
+                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog };
             }
 
             var propagationStyleInject = config
@@ -284,7 +284,7 @@ namespace Datadog.Trace.Configuration
             if (PropagationStyleInject.Length == 0)
             {
                 // default value
-                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext };
+                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog };
             }
 
             var propagationStyleExtract = config
@@ -296,7 +296,7 @@ namespace Datadog.Trace.Configuration
             if (PropagationStyleExtract.Length == 0)
             {
                 // default value
-                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext };
+                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.Datadog };
             }
 
             // If Activity support is enabled, we must enable the W3C Trace Context propagators.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -84,8 +84,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
             yield return new object[] { CreateFunc(s => s.TracerMetricsEnabled), false };
             yield return new object[] { CreateFunc(s => s.Exporter.DogStatsdPort), 8125 };
-            yield return new object[] { CreateFunc(s => s.PropagationStyleInject), new[] { "tracecontext", "Datadog" } };
-            yield return new object[] { CreateFunc(s => s.PropagationStyleExtract), new[] { "tracecontext", "Datadog" } };
+            yield return new object[] { CreateFunc(s => s.PropagationStyleInject), new[] { "Datadog" } };
+            yield return new object[] { CreateFunc(s => s.PropagationStyleExtract), new[] { "Datadog" } };
             yield return new object[] { CreateFunc(s => s.ServiceNameMappings), null };
 
             yield return new object[] { CreateFunc(s => s.TraceId128BitGenerationEnabled), false };

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -630,10 +630,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog", "tracecontext" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
-        [InlineData(null, null, null, new[] { "Datadog", "tracecontext" })]
+        [InlineData(null, null, null, new[] { "Datadog" })]
         public void PropagationStyleInject(string value, string legacyValue, string fallbackValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_INJECT";
@@ -654,10 +654,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog", "tracecontext" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
-        [InlineData(null, null, null, new[] { "Datadog", "tracecontext" })]
+        [InlineData(null, null, null, new[] { "Datadog" })]
         public void PropagationStyleExtract(string value, string legacyValue, string fallbackValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_EXTRACT";
@@ -678,7 +678,7 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", new[] { "test1", "test2" })]
-        [InlineData("", new[] { "Datadog", "tracecontext" })]
+        [InlineData("", new[] { "Datadog" })]
         public void PropagationStyle(string value, string[] expected)
         {
             foreach (var isActivityListenerEnabled in new[] { true, false })

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -630,10 +630,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "tracecontext", "Datadog" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog", "tracecontext" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
-        [InlineData(null, null, null, new[] { "tracecontext", "Datadog" })]
+        [InlineData(null, null, null, new[] { "Datadog", "tracecontext" })]
         public void PropagationStyleInject(string value, string legacyValue, string fallbackValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_INJECT";
@@ -654,10 +654,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "tracecontext", "Datadog" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog", "tracecontext" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
-        [InlineData(null, null, null, new[] { "tracecontext", "Datadog" })]
+        [InlineData(null, null, null, new[] { "Datadog", "tracecontext" })]
         public void PropagationStyleExtract(string value, string legacyValue, string fallbackValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_EXTRACT";
@@ -668,6 +668,23 @@ namespace Datadog.Trace.Tests.Configuration
                     (ConfigurationKeys.PropagationStyleExtract, value),
                     (legacyKey, legacyValue),
                     (ConfigurationKeys.PropagationStyle, fallbackValue),
+                    (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isActivityListenerEnabled ? "1" : "0"));
+
+                var settings = new TracerSettings(source);
+
+                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled ? expected.Concat("tracecontext") : expected);
+            }
+        }
+
+        [Theory]
+        [InlineData("test1,, ,test2", new[] { "test1", "test2" })]
+        [InlineData("", new[] { "Datadog", "tracecontext" })]
+        public void PropagationStyle(string value, string[] expected)
+        {
+            foreach (var isActivityListenerEnabled in new[] { true, false })
+            {
+                var source = CreateConfigurationSource(
+                    (ConfigurationKeys.PropagationStyleExtract, value),
                     (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isActivityListenerEnabled ? "1" : "0"));
 
                 var settings = new TracerSettings(source);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -677,23 +677,6 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [InlineData("test1,, ,test2", new[] { "test1", "test2" })]
-        [InlineData("", new[] { "Datadog" })]
-        public void PropagationStyle(string value, string[] expected)
-        {
-            foreach (var isActivityListenerEnabled in new[] { true, false })
-            {
-                var source = CreateConfigurationSource(
-                    (ConfigurationKeys.PropagationStyleExtract, value),
-                    (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isActivityListenerEnabled ? "1" : "0"));
-
-                var settings = new TracerSettings(source);
-
-                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled ? expected.Concat("tracecontext") : expected);
-            }
-        }
-
-        [Theory]
         [MemberData(nameof(StringTestCases), "", Strings.AllowEmpty)]
         public void TraceMethods(string value, string expected)
         {


### PR DESCRIPTION
## Summary of changes

Swaps the default propagation style to `Datadog` instead of `tracecontext`.

## Reason for change

Want the default to be `Datadog` now

## Implementation details

- Made the default be `"Datadog"`
- Swapped `PropagationStyleInject` and `PropagationStyleExtract` to default to `"Datadog"` instead of `"tracecontext","Datadog"`

## Test coverage

- Added tests for the settings
- Tested parametric tests for `test_headers_precedence_propagationstyle_default` and it now passes

## Other details
<!-- Fixes #{issue} -->
