### PR TITLE
[Tracer] Avoid including peer.service in kafka inbound flow

### DIFF
--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -341,15 +341,12 @@ Type | `queue`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `messaging.kafka.bootstrap.servers`; `peer.service`
 component | `kafka`
 kafka.group | No
 kafka.offset | No
 kafka.partition | No
 kafka.tombstone | No
 messaging.kafka.bootstrap.servers | Yes
-peer.service | Yes
-peer.service.remapped_from | No
 span.kind | `consumer`
 ### Metrics
 Name | Required |

--- a/tracer/src/Datadog.Trace/Tagging/KafkaTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/KafkaTags.cs
@@ -78,7 +78,9 @@ namespace Datadog.Trace.Tagging
         [Tag(Trace.Tags.PeerService)]
         public string PeerService
         {
-            get => _peerServiceOverride ?? BootstrapServers;
+            get => _peerServiceOverride ?? (SpanKind.Equals(SpanKinds.Client) || SpanKind.Equals(SpanKinds.Producer) ?
+                       BootstrapServers
+                       : null);
             private set => _peerServiceOverride = value;
         }
 
@@ -89,7 +91,9 @@ namespace Datadog.Trace.Tagging
             {
                 return _peerServiceOverride is not null
                            ? "peer.service"
-                           : Trace.Tags.KafkaBootstrapServers;
+                           : SpanKind.Equals(SpanKinds.Client) || SpanKind.Equals(SpanKinds.Producer) ?
+                               Trace.Tags.KafkaBootstrapServers
+                               : null;
             }
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -301,9 +301,6 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("kafka.partition")
                 .IsOptional("kafka.tombstone")
                 .IsPresent("messaging.kafka.bootstrap.servers")
-                .IsPresent("peer.service")
-                .IsOptional("peer.service.remapped_from")
-                .MatchesOneOf("_dd.peer.service.source", "messaging.kafka.bootstrap.servers", "peer.service")
                 .Matches("component", "kafka")
                 .Matches("span.kind", "consumer"));
 

--- a/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.Tests.Tagging
         public void KafkaV1Tags_PeerService_PopulatesFromBootstrapServers()
         {
             var bootstrapServer = "localhost";
-            var tags = new KafkaV1Tags(SpanKinds.Consumer);
+            var tags = new KafkaV1Tags(SpanKinds.Producer);
 
             tags.BootstrapServers = bootstrapServer;
 
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Tests.Tagging
         public void KafkaV1Tags_PeerService_PopulatesFromCustom()
         {
             var customService = "client-service";
-            var tags = new KafkaV1Tags(SpanKinds.Consumer);
+            var tags = new KafkaV1Tags(SpanKinds.Producer);
 
             tags.SetTag("peer.service", customService);
 
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tests.Tagging
         {
             var customService = "client-service";
             var bootstrapServer = "localhost";
-            var tags = new KafkaV1Tags(SpanKinds.Consumer);
+            var tags = new KafkaV1Tags(SpanKinds.Producer);
 
             tags.SetTag("peer.service", customService);
             tags.BootstrapServers = bootstrapServer;
@@ -90,6 +90,18 @@ namespace Datadog.Trace.Tests.Tagging
             tags.PeerService.Should().Be(customService);
             tags.PeerServiceSource.Should().Be("peer.service");
             tags.GetTag(Tags.PeerServiceRemappedFrom).Should().BeNull();
+        }
+
+        [Fact]
+        public void KafkaV1Tags_PeerService_ConsumerHasNoPeerService()
+        {
+            var bootstrapServer = "localhost";
+            var tags = new KafkaV1Tags(SpanKinds.Consumer);
+
+            tags.BootstrapServers = bootstrapServer;
+
+            tags.PeerService.Should().BeNull();
+            tags.PeerServiceSource.Should().BeNull();
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Remove `peer.service` from kafka inbound flows.

## Reason for change

Inbound flows should not include `peer.service`

## Implementation details

Discriminate on `span.kind`
