### PR TITLE
[Tracer] Separate inbound, outbound and client flows for msmq

### DIFF
--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -402,7 +402,7 @@ peer.service | Yes
 peer.service.remapped_from | No
 span.kind | `client`
 
-## MsmqInbound
+## Msmq - Inbound
 ### Span properties
 Name | Required |
 ---------|----------------|
@@ -419,7 +419,7 @@ msmq.queue.transactional | No
 out.host | Yes
 span.kind | `consumer`
 
-## MsmqOutbound
+## Msmq - Outbound
 ### Span properties
 Name | Required |
 ---------|----------------|

--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -402,7 +402,24 @@ peer.service | Yes
 peer.service.remapped_from | No
 span.kind | `client`
 
-## Msmq
+## MsmqInbound
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `msmq.process`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+component | `msmq`
+msmq.command | Yes
+msmq.message.transactional | No
+msmq.queue.path | Yes
+msmq.queue.transactional | No
+out.host | Yes
+span.kind | `consumer`
+
+## MsmqOutbound
 ### Span properties
 Name | Required |
 ---------|----------------|
@@ -420,7 +437,27 @@ msmq.queue.transactional | No
 out.host | Yes
 peer.service | Yes
 peer.service.remapped_from | No
-span.kind | `client`; `producer`; `consumer`
+span.kind | `producer`
+
+## Msmq - Client
+### Span properties
+Name | Required |
+---------|----------------|
+Name | `msmq.command`
+Type | `queue`
+### Tags
+Name | Required |
+---------|----------------|
+_dd.peer.service.source | `out.host`; `peer.service`
+component | `msmq`
+msmq.command | Yes
+msmq.message.transactional | No
+msmq.queue.path | Yes
+msmq.queue.transactional | No
+out.host | Yes
+peer.service | Yes
+peer.service.remapped_from | No
+span.kind | `client`
 
 ## MySql
 ### Span properties

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MsmqCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MsmqCommon.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
 
@@ -26,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
 
             try
             {
-                string operationName = tracer.CurrentTraceSettings.Schema.Messaging.GetOutboundCommandOperationName(MsmqConstants.MessagingType);
+                string operationName = GetOperationName(tracer, spanKind);
                 string serviceName = tracer.CurrentTraceSettings.Schema.Messaging.GetOutboundServiceName(MsmqConstants.MessagingType);
                 MsmqTags tags = tracer.CurrentTraceSettings.Schema.Messaging.CreateMsmqTags(spanKind);
 
@@ -55,6 +56,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
             }
 
             return scope;
+        }
+
+        // internal for testing
+        internal static string GetOperationName(Tracer tracer, string spanKind)
+        {
+            if (tracer.CurrentTraceSettings.Schema.Version == SchemaVersion.V0)
+            {
+                return MsmqConstants.MsmqCommand;
+            }
+
+            return spanKind switch
+            {
+                SpanKinds.Producer => tracer.CurrentTraceSettings.Schema.Messaging.GetOutboundOperationName(MsmqConstants.MessagingType),
+                SpanKinds.Consumer => tracer.CurrentTraceSettings.Schema.Messaging.GetInboundOperationName(MsmqConstants.MessagingType),
+                _ => MsmqConstants.MsmqCommand
+            };
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MsmqConstants.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MsmqConstants.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         internal const string MsmqPurgeCommand = "msmq.purge";
         internal const string MsmqSendCommand = "msmq.send";
         internal const string MsmqReceiveCommand = "msmq.receive";
+        internal const string MsmqCommand = "msmq.command";
         internal const string MsmqPeekCommand = "msmq.peek";
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.Msmq;
     }

--- a/tracer/src/Datadog.Trace/Tagging/MsmqTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/MsmqTags.cs
@@ -69,7 +69,9 @@ namespace Datadog.Trace.Tagging
         [Tag(Trace.Tags.PeerService)]
         public string PeerService
         {
-            get => _peerServiceOverride ?? Host;
+            get => _peerServiceOverride ?? (SpanKind.Equals(SpanKinds.Client) || SpanKind.Equals(SpanKinds.Producer) ?
+                                                Host
+                                                : null);
             private set => _peerServiceOverride = value;
         }
 
@@ -79,8 +81,10 @@ namespace Datadog.Trace.Tagging
             get
             {
                 return _peerServiceOverride is not null
-                           ? "peer.service"
-                           : Trace.Tags.OutHost;
+                           ? Tags.PeerService
+                           : SpanKind.Equals(SpanKinds.Client) || SpanKind.Equals(SpanKinds.Producer)
+                               ? Tags.OutHost
+                               : null;
             }
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -22,7 +22,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion("1.0.0");
         }
 
-        public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsMsmq(metadataSchemaVersion);
+        public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) =>
+            span.Tags["span.kind"] switch
+            {
+                SpanKinds.Consumer => span.IsMsmqInbound(metadataSchemaVersion),
+                SpanKinds.Producer => span.IsMsmqOutbound(metadataSchemaVersion),
+                SpanKinds.Client => span.IsMsmqClient(metadataSchemaVersion),
+                _ => throw new ArgumentException($"span.Tags[\"span.kind\"] is not a supported value for the MSMQ integration: {span.Tags["span.kind"]}", nameof(span)),
+            };
 
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataAPI.cs
@@ -151,10 +151,24 @@ namespace Datadog.Trace.TestHelpers
                 _ => span.IsMongoDbV0(),
             };
 
-        public static Result IsMsmq(this MockSpan span, string metadataSchemaVersion) =>
+        public static Result IsMsmqClient(this MockSpan span, string metadataSchemaVersion) =>
             metadataSchemaVersion switch
             {
-                "v1" => span.IsMsmqV1(),
+                "v1" => span.IsMsmqClientV1(),
+                _ => span.IsMsmqV0(),
+            };
+
+        public static Result IsMsmqInbound(this MockSpan span, string metadataSchemaVersion) =>
+            metadataSchemaVersion switch
+            {
+                "v1" => span.IsMsmqInboundV1(),
+                _ => span.IsMsmqV0(),
+            };
+
+        public static Result IsMsmqOutbound(this MockSpan span, string metadataSchemaVersion) =>
+            metadataSchemaVersion switch
+            {
+                "v1" => span.IsMsmqOutboundV1(),
                 _ => span.IsMsmqV0(),
             };
 

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -353,9 +353,6 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("msmq.queue.path")
                 .IsOptional("msmq.queue.transactional")
                 .IsPresent("out.host")
-                .IsPresent("peer.service")
-                .IsOptional("peer.service.remapped_from")
-                .MatchesOneOf("_dd.peer.service.source", "out.host", "peer.service")
                 .Matches("component", "msmq")
                 .Matches("span.kind", "consumer"));
 
@@ -369,6 +366,9 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("msmq.queue.path")
                 .IsOptional("msmq.queue.transactional")
                 .IsPresent("out.host")
+                .IsPresent("peer.service")
+                .IsOptional("peer.service.remapped_from")
+                .MatchesOneOf("_dd.peer.service.source", "out.host", "peer.service")
                 .Matches("component", "msmq")
                 .Matches("span.kind", "producer"));
 

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -344,6 +344,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("span.kind", "client"));
 
         public static Result IsMsmqInboundV1(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Msmq - Inbound")
             .Properties(s => s
                 .Matches(Name, "msmq.process")
                 .Matches(Type, "queue"))
@@ -357,6 +358,7 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("span.kind", "consumer"));
 
         public static Result IsMsmqOutboundV1(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Msmq - Outbound")
             .Properties(s => s
                 .Matches(Name, "msmq.send")
                 .Matches(Type, "queue"))

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -343,9 +343,9 @@ namespace Datadog.Trace.TestHelpers
                 .Matches("component", "MongoDb")
                 .Matches("span.kind", "client"));
 
-        public static Result IsMsmqV1(this MockSpan span) => Result.FromSpan(span)
+        public static Result IsMsmqInboundV1(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s
-                .Matches(Name, "msmq.send")
+                .Matches(Name, "msmq.process")
                 .Matches(Type, "queue"))
             .Tags(s => s
                 .IsPresent("msmq.command")
@@ -357,7 +357,37 @@ namespace Datadog.Trace.TestHelpers
                 .IsOptional("peer.service.remapped_from")
                 .MatchesOneOf("_dd.peer.service.source", "out.host", "peer.service")
                 .Matches("component", "msmq")
-                .MatchesOneOf("span.kind", "client", "producer", "consumer"));
+                .Matches("span.kind", "consumer"));
+
+        public static Result IsMsmqOutboundV1(this MockSpan span) => Result.FromSpan(span)
+            .Properties(s => s
+                .Matches(Name, "msmq.send")
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                .IsPresent("msmq.command")
+                .IsOptional("msmq.message.transactional")
+                .IsPresent("msmq.queue.path")
+                .IsOptional("msmq.queue.transactional")
+                .IsPresent("out.host")
+                .Matches("component", "msmq")
+                .Matches("span.kind", "producer"));
+
+        public static Result IsMsmqClientV1(this MockSpan span) => Result.FromSpan(span)
+            .WithMarkdownSection("Msmq - Client")
+            .Properties(s => s
+                .Matches(Name, "msmq.command")
+                .Matches(Type, "queue"))
+            .Tags(s => s
+                .IsPresent("msmq.command")
+                .IsOptional("msmq.message.transactional")
+                .IsPresent("msmq.queue.path")
+                .IsOptional("msmq.queue.transactional")
+                .IsPresent("out.host")
+                .IsPresent("peer.service")
+                .IsOptional("peer.service.remapped_from")
+                .MatchesOneOf("_dd.peer.service.source", "out.host", "peer.service")
+                .Matches("component", "msmq")
+                .Matches("span.kind", "client"));
 
         public static Result IsMySqlV1(this MockSpan span) => Result.FromSpan(span)
             .Properties(s => s

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MsmqTests.cs
@@ -1,0 +1,60 @@
+// <copyright file="MsmqTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Agent;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Sampling;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration
+{
+    public class MsmqTests
+    {
+        public static IEnumerable<object[]> GetOperationNameParams()
+            => from schemaVersion in new object[] { SchemaVersion.V0, SchemaVersion.V1 }
+               from spanKind in new[] { SpanKinds.Producer, SpanKinds.Consumer, SpanKinds.Client }
+               select new[] { schemaVersion, spanKind };
+
+        [Theory]
+        [MemberData(nameof(GetOperationNameParams))]
+        public void GetOperationNameIsCorrect(object schemaVersionObject, string spanKind)
+        {
+            var schemaVersion = (SchemaVersion)schemaVersionObject;
+            var configSourceMock = new Mock<IConfigurationSource>();
+            configSourceMock.Setup(c => c.GetString(It.Is<string>(s => s.Equals(ConfigurationKeys.MetadataSchemaVersion)))).Returns(schemaVersion.ToString());
+            var settings = new TracerSettings(configSourceMock.Object, new ConfigurationTelemetry());
+            var writerMock = new Mock<IAgentWriter>();
+            var samplerMock = new Mock<ITraceSampler>();
+            var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+
+            MsmqCommon.GetOperationName(tracer, spanKind).Should().Be(GetExpectedOperationName(schemaVersion, spanKind));
+        }
+
+        private string GetExpectedOperationName(SchemaVersion schemaVersion, string spanKind)
+        {
+            if (schemaVersion.Equals(SchemaVersion.V0))
+            {
+                return MsmqConstants.MsmqCommand;
+            }
+
+            switch (spanKind)
+            {
+                case SpanKinds.Producer:
+                    return "msmq.send";
+                case SpanKinds.Consumer:
+                    return "msmq.process";
+                default:
+                    return MsmqConstants.MsmqCommand;
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/InstrumentationTagsTests.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.Tests.Tagging
         public void MsmqV1Tags_PeerService_PopulatesFromOutHost()
         {
             var host = ".";
-            var tags = new MsmqV1Tags(SpanKinds.Consumer);
+            var tags = new MsmqV1Tags(SpanKinds.Producer);
 
             tags.Host = host;
 
@@ -108,7 +108,7 @@ namespace Datadog.Trace.Tests.Tagging
         public void MsmqV1Tags_PeerService_PopulatesFromCustom()
         {
             var customService = "client-service";
-            var tags = new MsmqV1Tags(SpanKinds.Consumer);
+            var tags = new MsmqV1Tags(SpanKinds.Producer);
 
             tags.SetTag("peer.service", customService);
 
@@ -121,7 +121,7 @@ namespace Datadog.Trace.Tests.Tagging
         {
             var customService = "client-service";
             var host = ".";
-            var tags = new MsmqV1Tags(SpanKinds.Consumer);
+            var tags = new MsmqV1Tags(SpanKinds.Producer);
 
             tags.SetTag("peer.service", customService);
             tags.Host = host;
@@ -129,6 +129,18 @@ namespace Datadog.Trace.Tests.Tagging
             tags.PeerService.Should().Be(customService);
             tags.PeerServiceSource.Should().Be("peer.service");
             tags.GetTag(Tags.PeerServiceRemappedFrom).Should().BeNull();
+        }
+
+        [Fact]
+        public void MsmqV1Tags_PeerService_ConsumerHasNoPeerService()
+        {
+            var host = ".";
+            var tags = new MsmqV1Tags(SpanKinds.Consumer);
+
+            tags.Host = host;
+
+            tags.PeerService.Should().BeNull();
+            tags.PeerServiceSource.Should().BeNull();
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Separate inbound, outbound and client flows for msmq

## Reason for change

Looks like the inventory may have been incorrect for Msmq, and they should be different operations.

## Implementation details

Also only include `peer.service` in outbound flows