### PR TITLE
[Tracer] v1 Schema: Update AWS SQS `inbound` spans

### DIFF
--- a/docs/span_attribute_schema/v1.md
+++ b/docs/span_attribute_schema/v1.md
@@ -147,7 +147,6 @@ Type | `http`
 ### Tags
 Name | Required |
 ---------|----------------|
-_dd.peer.service.source | `aws.queue.name`; `peer.service`
 aws.agent | `dotnet-aws-sdk`
 aws.operation | Yes
 aws.queue.name | Yes
@@ -159,8 +158,6 @@ component | `aws-sdk`
 http.method | Yes
 http.status_code | Yes
 http.url | Yes
-peer.service | Yes
-peer.service.remapped_from | No
 span.kind | `consumer`
 
 ## AwsSqsOutbound

--- a/tracer/src/Datadog.Trace/Tagging/AwsSqsTags.cs
+++ b/tracer/src/Datadog.Trace/Tagging/AwsSqsTags.cs
@@ -57,7 +57,15 @@ namespace Datadog.Trace.Tagging
         [Tag(Trace.Tags.PeerService)]
         public string PeerService
         {
-            get => _peerServiceOverride ?? QueueName;
+            get
+            {
+                if (SpanKind == SpanKinds.Consumer)
+                {
+                    return null;
+                }
+
+                return _peerServiceOverride ?? QueueName;
+            }
             private set => _peerServiceOverride = value;
         }
 
@@ -66,6 +74,11 @@ namespace Datadog.Trace.Tagging
         {
             get
             {
+                if (SpanKind == SpanKinds.Consumer)
+                {
+                    return null;
+                }
+
                 return _peerServiceOverride is not null
                            ? "peer.service"
                            : Trace.Tags.AwsQueueName;

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanMetadataV1Rules.cs
@@ -146,9 +146,6 @@ namespace Datadog.Trace.TestHelpers
                 .IsPresent("http.method")
                 .IsPresent("http.status_code")
                 .IsPresent("http.url")
-                .IsPresent("peer.service")
-                .IsOptional("peer.service.remapped_from")
-                .MatchesOneOf("_dd.peer.service.source", "aws.queue.name", "peer.service")
                 .Matches("component", "aws-sdk")
                 .Matches("span.kind", "consumer"));
 

--- a/tracer/test/snapshots/AwsSqsTests.NetCore.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/AwsSqsTests.NetCore.SchemaV1.verified.txt
@@ -220,9 +220,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {
@@ -296,9 +294,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue2,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {
@@ -372,9 +368,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {
@@ -448,9 +442,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue2,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {
@@ -549,9 +541,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {
@@ -600,9 +590,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {
@@ -701,9 +689,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue2,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {
@@ -752,9 +738,7 @@
       http.status_code: 200,
       http.url: http://localhost:00000/000000000000/MyAsyncSQSQueue2,
       language: dotnet,
-      peer.service: MyAsyncSQSQueue2,
-      span.kind: consumer,
-      _dd.peer.service.source: aws.queue.name
+      span.kind: consumer
     }
   },
   {


### PR DESCRIPTION
## Summary of changes

Updates the v1 `peer.service` tagging for AWS SQS `inbound` spans.
The following tags are no longer required for spans which `span.kind` is `consumer`:
- `peer.service`
- `_dd.peer.service.source`

## Reason for change

Inbound spans should not create the relationship between the `peer.service` and the current span.

## Implementation details

1. Updated `AwsSqsTags.cs` to return `null` on `peer.service` when `span.kind` is `consumer`.
2. Updated `SpanMetadataV1Rules.cs` to reflect this change where `peer.service` is no longer required for inbound spans.

## Test coverage

The span metadata rules have been updated and the corresponding integration test snapshots have been updated.

## Other details
<!-- Fixes #{issue} -->
