### PR TITLE
Revert "Swap to Datadog as default propagation style (#4420)"

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -272,7 +272,7 @@ namespace Datadog.Trace.Configuration
             if (PropagationStyleInject.Length == 0)
             {
                 // default value
-                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.Datadog };
+                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
             }
 
             var propagationStyleExtract = config
@@ -284,7 +284,7 @@ namespace Datadog.Trace.Configuration
             if (PropagationStyleExtract.Length == 0)
             {
                 // default value
-                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.Datadog };
+                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
             }
 
             // If Activity support is enabled, we must enable the W3C Trace Context propagators.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -84,8 +84,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return new object[] { CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100 };
             yield return new object[] { CreateFunc(s => s.TracerMetricsEnabled), false };
             yield return new object[] { CreateFunc(s => s.Exporter.DogStatsdPort), 8125 };
-            yield return new object[] { CreateFunc(s => s.PropagationStyleInject), new[] { "Datadog" } };
-            yield return new object[] { CreateFunc(s => s.PropagationStyleExtract), new[] { "Datadog" } };
+            yield return new object[] { CreateFunc(s => s.PropagationStyleInject), new[] { "tracecontext", "Datadog" } };
+            yield return new object[] { CreateFunc(s => s.PropagationStyleExtract), new[] { "tracecontext", "Datadog" } };
             yield return new object[] { CreateFunc(s => s.ServiceNameMappings), null };
 
             yield return new object[] { CreateFunc(s => s.TraceId128BitGenerationEnabled), false };

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -630,10 +630,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "tracecontext", "Datadog" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
-        [InlineData(null, null, null, new[] { "Datadog" })]
+        [InlineData(null, null, null, new[] { "tracecontext", "Datadog" })]
         public void PropagationStyleInject(string value, string legacyValue, string fallbackValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_INJECT";
@@ -654,10 +654,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "tracecontext", "Datadog" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
-        [InlineData(null, null, null, new[] { "Datadog" })]
+        [InlineData(null, null, null, new[] { "tracecontext", "Datadog" })]
         public void PropagationStyleExtract(string value, string legacyValue, string fallbackValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_EXTRACT";


### PR DESCRIPTION
## Summary of changes
This reverts commit aff06a76e50f90fb85fbfb80437b49d5a66906c6.

## Reason for change
We've decided across teams that we'll keep the existing defaults for now as we spend more time understanding the various tracer scenarios and user experience.

## Implementation details

## Test coverage

## Other details

