### PR TITLE
Fix `create_draft_release` when not specifying a specific commit

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -20,6 +20,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set SHA
+        id: set_sha
+        run: |
+          if [ -z "${{ github.event.inputs.forced_commit_id }}" ]; then
+              commitsha="${GITHUB_SHA}"
+          else
+              commitsha="${{ github.event.inputs.forced_commit_id }}"
+          fi
+          echo "Using sha $commitsha"
+          echo "sha=${commitsha}" >> $GITHUB_OUTPUT
+
       - uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '7.0.306'
@@ -38,7 +49,7 @@ jobs:
         run: ./tracer/build.sh DownloadReleaseArtifacts
         env:
           TargetBranch: ${{ github.event.ref }}
-          CommitSha: "${{ github.event.inputs.forced_commit_id }}"
+          CommitSha: "${{ steps.set_sha.outputs.sha }}"
 
       - name: "Generate release notes"
         id: release_notes
@@ -89,7 +100,7 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           targetBranch: ${{ github.event.ref }}
-          commitSha: "${{ github.event.inputs.forced_commit_id }}"
+          commitSha: "${{ steps.set_sha.outputs.sha }}"
 
       - name: "Publish nuget packages to nuget.org"
         working-directory: ${{steps.assets.outputs.artifacts_path}}


### PR DESCRIPTION
## Summary of changes

Add step to calculate sha to use in `create_draft_release` GH Action

## Reason for change

The existing script assumes you will always force a specific commit, but that's not required

## Implementation details

Added a small bash script to choose whether to use the "default" sha or the forced one, and reuse the output throughout the script

## Test coverage

Did some (safe) test runs to confirm the correct value is used when doing forced version ([here](https://github.com/DataDog/dd-trace-dotnet/actions/runs/5667140799/job/15355270557)) and non-forced version ([here](https://github.com/DataDog/dd-trace-dotnet/actions/runs/5667155733/job/15355314955))
