### PR TITLE
Update the Rel Env docker-image workflow

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3371,6 +3371,7 @@ stages:
             AZURE_STORAGE_ACCOUNT: $(AZURE_STORAGE_ACCOUNT_NAME)
             AZURE_STORAGE_SAS_TOKEN: $(AZURE_STORAGE_SHARED_ACCESS_TOKEN)
 
+# Only run these on merges to master etc
 - stage: upload_container_images
   condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true), eq(variables.isMainOrReleaseBranch, true))
   dependsOn: [upload_to_azure]
@@ -3395,15 +3396,16 @@ stages:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
       - bash: |
-          echo "Creating dispatch event for https://github.com/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml with ref=$(Build.SourceBranch) and azdo_build_id=$(Build.BuildId) and is_release_version=False"
+          echo "Creating dispatch event for https://github.com/DataDog/dd-trace-dotnet/actions/workflows/create-rel-env-docker-base-images.yml with ref=$(Build.SourceBranch) and azdo_build_id=$(Build.BuildId) and is_release_version=False"
           curl \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token $GITHUB_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml/dispatches \
+            https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/create-rel-env-docker-base-images.yml/dispatches \
             -d '{"ref":"$(Build.SourceBranch)","inputs":{"azdo_build_id":"$(Build.BuildId)","is_release_version":"False"}}'
         displayName: Start the generation of docker base images on GitHub Actions worfklow
+        condition: eq(variables['isMainBranch'], true)
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3395,14 +3395,14 @@ stages:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
       - bash: |
-          echo "Creating dispatch event for https://github.com/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml with ref=$(Build.SourceBranch) and azdo_build_id=$(Build.BuildId) and is_snapshot=$(isMainBranch)"
+          echo "Creating dispatch event for https://github.com/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml with ref=$(Build.SourceBranch) and azdo_build_id=$(Build.BuildId) and is_release_version=False"
           curl \
             -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: token $GITHUB_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml/dispatches \
-            -d '{"ref":"$(Build.SourceBranch)","inputs":{"azdo_build_id":"$(Build.BuildId)","is_snapshot":"$(isMainBranch)"}}'
+            -d '{"ref":"$(Build.SourceBranch)","inputs":{"azdo_build_id":"$(Build.BuildId)","is_release_version":"False"}}'
         displayName: Start the generation of docker base images on GitHub Actions worfklow
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)

--- a/.github/actions/create-rel-env-docker-base-images/action.yml
+++ b/.github/actions/create-rel-env-docker-base-images/action.yml
@@ -1,0 +1,63 @@
+name: 'Build Rel-Env base images'
+description: 'Builds the reliability-environment docker base images'
+
+inputs:
+  artifacts_path:
+    description: 'The location of the assets to use in the current workflow'
+    required: true
+
+  is_release_version:
+    description: 'Is this run generating release artifacts? Set to "True" to publish `:latest` tags, otherwise generates `:latest-snapshot` tags'
+    required: true
+    default: 'False'
+
+  package_version:
+    description: 'The package version of the assets being used'
+    required: true
+
+  github_token:
+    description: 'Github token for pushing images to ghcr.io Docker repository'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Copy tooling files to artifacts path
+      shell: bash
+      run: |
+        echo "OUTPUT ARTIFACT PATH: ${{inputs.artifacts_path}}"
+        cp ./tracer/build/_build/docker/reliability-env/* ${{inputs.artifacts_path}}
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Generate image tags
+      id: docker-base-image-tags
+      shell: bash
+      run: |
+        if [ "$is_release_version" = "True" ]; then
+          echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest" >> $GITHUB_OUTPUT
+        else
+          echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot" >> $GITHUB_OUTPUT
+        fi
+      env:
+        is_release_version: "${{ inputs.is_release_version}}"
+
+    - name: Login to Docker
+      shell: bash
+      run: docker login -u publisher -p ${{ inputs.github_token }} ghcr.io
+
+    - name: Docker Build linux-x64 image
+      uses: docker/build-push-action@v3
+      with:
+        push: true
+        tags: ${{ steps.docker-base-image-tags.outputs.tag-names }}
+        platforms: 'linux/amd64' 
+        context: ${{inputs.artifacts_path}}
+        build-args: |
+          LINUX_PACKAGE=datadog-dotnet-apm-${{inputs.package_version}}.tar.gz

--- a/.github/workflows/auto_create_rel_env_release_images.yml
+++ b/.github/workflows/auto_create_rel_env_release_images.yml
@@ -1,0 +1,57 @@
+name: Auto create Rel Env docker images on release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+    # If this is a 2.x.0 release, create the rel-env docker images from master
+    # If this is a 2.x.x hotfix release, create the rel-env images from the hotfix branch
+    # If this is a 1.x.x hotfix release, _don't_ create the images (required assets don't exist in that branch)
+    if: startsWith(github.event.release.tag_name, 'v2.')
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: "Calculate variables"
+        id: variables
+        run: |
+          tag_name="${{ github.event.release.tag_name}}"
+          version="${tag_name:1}"
+
+          suffix=".0"
+          if [[ $tag_name == *$suffix ]]; then
+            ref="refs/heads/master"
+          else
+            ref="refs/heads/hotfix/$version"
+          fi
+
+          sha=$(git rev-parse tags/tag_name)
+
+          echo "using '$ref' ref for '$version' version, with sha '$sha'"
+          echo "tag=$tag_name" >> $GITHUB_OUTPUT
+          echo "ref=$ref" >> $GITHUB_OUTPUT
+          echo "version=$version" >> $GITHUB_OUTPUT
+          echo "sha=$sha" >> $GITHUB_OUTPUT
+
+    - name: "Download build assets from Azure Pipelines"
+      id: assets
+      run: |
+        ./tracer/build.sh DownloadReleaseArtifacts
+      env:
+        TargetBranch: "${{ steps.variables.outputs.ref }}"
+        CommitSha: "${{ steps.variables.outputs.sha }}"
+
+    - uses: ./.github/actions/create-rel-env-docker-base-images
+      name: 'Create rel-env docker images'
+      with:
+        artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
+        is_release_version: "True"
+        package_version: "${{steps.variables.outputs.version}}"
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto_create_rel_env_release_images.yml
+++ b/.github/workflows/auto_create_rel_env_release_images.yml
@@ -8,6 +8,7 @@ jobs:
     # If this is a 2.x.0 release, create the rel-env docker images from master
     # If this is a 2.x.x hotfix release, create the rel-env images from the hotfix branch
     # If this is a 1.x.x hotfix release, _don't_ create the images (required assets don't exist in that branch)
+  auto_create_rel_env_images:
     if: startsWith(github.event.release.tag_name, 'v2.')
     runs-on: ubuntu-latest
     env:
@@ -40,18 +41,18 @@ jobs:
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "sha=$sha" >> $GITHUB_OUTPUT
 
-    - name: "Download build assets from Azure Pipelines"
-      id: assets
-      run: |
-        ./tracer/build.sh DownloadReleaseArtifacts
-      env:
-        TargetBranch: "${{ steps.variables.outputs.ref }}"
-        CommitSha: "${{ steps.variables.outputs.sha }}"
+      - name: "Download build assets from Azure Pipelines"
+        id: assets
+        run: |
+          ./tracer/build.sh DownloadReleaseArtifacts
+        env:
+          TargetBranch: "${{ steps.variables.outputs.ref }}"
+          CommitSha: "${{ steps.variables.outputs.sha }}"
 
-    - uses: ./.github/actions/create-rel-env-docker-base-images
-      name: 'Create rel-env docker images'
-      with:
-        artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
-        is_release_version: "True"
-        package_version: "${{steps.variables.outputs.version}}"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: ./.github/actions/create-rel-env-docker-base-images
+        name: 'Create rel-env docker images'
+        with:
+          artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
+          is_release_version: "True"
+          package_version: "${{steps.variables.outputs.version}}"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-rel-env-docker-base-images.yml
+++ b/.github/workflows/create-rel-env-docker-base-images.yml
@@ -1,4 +1,4 @@
-name: "Rel Env docker base images"
+name: "Create Rel Env docker base images"
 on:
   # This GitHub Action is invoked automatically from the main Azure DevOps
   # build when building the main branch (a snapshot). It is launched from

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -88,20 +88,6 @@ jobs:
             ${{steps.assets.outputs.gitlab_artifacts_path}}/*.zip
             ${{steps.assets.outputs.sha_path}}
 
-      - name: "Trigger Docker Base Images Github Pipeline"
-        run: |
-          curl \
-          -X POST \
-          -H "Accept: application/vnd.github+json" \
-          -H "Authorization: token $GITHUB_TOKEN"\
-          -H "X-GitHub-Api-Version: 2022-11-28" \
-          https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/docker-base-images.yml/dispatches \
-          -d '{"event_type": "Trigger Workflow","inputs":{"targetBranch":"$targetBranch","commitSha":"$commitSha"}}'
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          targetBranch: ${{ github.event.ref }}
-          commitSha: "${{ steps.set_sha.outputs.sha }}"
-
       - name: "Publish nuget packages to nuget.org"
         working-directory: ${{steps.assets.outputs.artifacts_path}}
         run: |

--- a/.github/workflows/docker-base-images.yml
+++ b/.github/workflows/docker-base-images.yml
@@ -1,21 +1,25 @@
-name: "Docker base images"
+name: "Rel Env docker base images"
 on:
-  # This GitHub Action will be invoked automatically from the main Azure DevOps build
-  # This job will only be launched when we are building the main branch (a snapshot) or when we are generating a release.
+  # This GitHub Action is invoked automatically from the main Azure DevOps
+  # build when building the main branch (a snapshot). It is launched from
+  # Azure DevOps instead of using a GitHub event, as it requires the assets
+  # that are created by the Azure DevOps build. The build only produces
+  # snapshots, not releases.
+  #
+  # The `auto_create_rel_env_release_images` workflow also invokes the
+  # `create-rel-env-docker-base-images` GitHub Action, which creates
+  # the release/latest (not snapshot) version of the images.
   workflow_dispatch:
     inputs:
       azdo_build_id:
         description: 'The specific AzDo build from which the release artifacts will be downloaded.'
-        required: false
-      is_snapshot:
-        description: 'True when we are building main branch, false when we are building a release'
-        required: false
-      targetBranch:
-        description: Parameter comming from only draft release. The branch that generates the trigger. 
-        required: false
-      commitSha:
-        description: Parameter comming from only draft release. Commit that trigger the build.
-        required: false
+        required: true
+
+      is_release_version:
+        description: 'Is this run generating release artifacts? Set to "True" to publish `:latest` tags, otherwise generates `:latest-snapshot` tags'
+        required: true
+        default: 'False'
+
 jobs:
   build-and-publish-base-image:
     runs-on: ubuntu-latest
@@ -37,48 +41,14 @@ jobs:
 
     - name: "Download build assets from Azure Pipelines"
       id: assets
-      run: |
-        # If AzureDevopsBuildId is empty we download release artifact, else we download the artifacts from azure build id
-        [ -z "$AzureDevopsBuildId" ] && ./tracer/build.sh DownloadReleaseArtifacts || ./tracer/build.sh DownloadAzurePipelineFromBuild     
+      run: ./tracer/build.sh DownloadAzurePipelineFromBuild
       env:
         AzureDevopsBuildId: "${{ github.event.inputs.azdo_build_id }}"
-        TargetBranch: "${{ github.event.inputs.targetBranch }}"
-        CommitSha: "${{ github.event.inputs.commitSha }}"
 
-    - name: Copy tooling files to artifacts path
-      shell: bash
-      run: |
-        echo "OUTPUT ARTIFACT PATH: ${{steps.assets.outputs.artifacts_path}}"
-        cp ./tracer/build/_build/docker/reliability-env/* ${{steps.assets.outputs.artifacts_path}}
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Generate image tags
-      id: docker-base-image-tags
-      shell: bash
-      run: |
-        if [ "$is_snapshot" = "True" ]; then
-          echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot" >> $GITHUB_OUTPUT
-        else
-          echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest" >> $GITHUB_OUTPUT
-        fi
-      env:
-        is_snapshot: "${{ github.event.inputs.is_snapshot}}"
-
-    - name: Login to Docker
-      run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-
-    - name: Docker Build linux-x64 image
-      uses: docker/build-push-action@v3
+    - uses: ./.github/actions/create-rel-env-docker-base-images
+      name: 'Create rel-env docker images'
       with:
-        push: true
-        tags: ${{ steps.docker-base-image-tags.outputs.tag-names }}
-        platforms: 'linux/amd64' 
-        context: ${{steps.assets.outputs.artifacts_path}}
-        build-args: |
-          LINUX_PACKAGE=datadog-dotnet-apm-${{steps.versions.outputs.version}}.tar.gz
+        artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
+        is_release_version: "${{ github.event.inputs.is_release_version}}"
+        package_version: "${{steps.versions.outputs.version}}"
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary of changes

- Remove the creating of the rel env release images out of the `create_draft_release` workflow
- Create a new workflow to create the images _after_ the release is published
- Extract a GitHub action that removes a bit of the complexity from the workflows
- Rename `is_snapshot` to `is_release_version` to make it more explicit about what's happening

## Reason for change

The existing trigger (silently) failed in the `create_draft_release` workflow. The implications of this weren't clear at the time, partly as the naming wasn't clear that it was related to the rel-env (and therefor low impact for the release). 

By moving to a separate workflow it moves it out of the critical path.

## Implementation details

- Extracted a GitHub action to avoid triggering a workflow from inside an automated GH Action (because you can't do that without extra PAT etc)
- Created an "on release" trigger 
- Added some extra comments and renaming to make it ore obvious what things are

## Test coverage

- Ran a test of the "manual" workflow (which passed), which also tests the new action. But it's not easy to test the "release" workflow.

## TODO

- [ ] Update the release documentation to add a step checking the output of the workflow after the release is published, and if it fails, running the "manual" version
