### PR TITLE
[Release] Remove the extra CI variables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,3 +200,15 @@ package:
   stage: deploy
   variables:
     PRODUCT_NAME: auto_inject-dotnet
+
+temporary_test:
+  stage: deploy
+  tags: ["runner:windows-docker", "windowsversion:1809"]
+  rules:
+    - when: manual
+      allow_failure: true
+  script:
+    - echo "print variables"
+    - echo $CI_COMMIT_SHA
+    - echo $CI_COMMIT_TAG
+    - echo "print variables"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,15 +200,3 @@ package:
   stage: deploy
   variables:
     PRODUCT_NAME: auto_inject-dotnet
-
-temporary_test:
-  stage: deploy
-  tags: ["runner:windows-docker", "windowsversion:1809"]
-  rules:
-    - when: manual
-      allow_failure: true
-  script:
-    - echo "print variables"
-    - echo $CI_COMMIT_SHA
-    - echo $CI_COMMIT_TAG
-    - echo "print variables"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -21,10 +21,6 @@ variables:
     description: "Set to true to deploy to debugger backend demo application"
   DOTNET_PACKAGE_VERSION:
     description: "Used by the package stage when triggered manually"
-  CI_COMMIT_SHA:
-    description: "Used to override the commit sha in the deploy stage when triggered manually"
-  CI_COMMIT_TAG:
-    description: "Used to override the commit tag in the deploy stage when triggered manually"
 
 build:
   only:


### PR DESCRIPTION
## Summary of changes

Removed `CI_COMMIT_TAG` and `CI_COMMIT_SHA`

## Reason for change

It broke the release process by overriding the CI variables even when not set. 
Also it is not mandatory to declare them as we can override them anyway.

## Test coverage
Ran this [pipeline](https://gitlab.ddbuild.io/DataDog/dd-trace-dotnet/-/jobs/303371221) by adding an extra job that outputs the overridden variables.

## Other details
The temporary job is visible in the intermediate commit.

<!-- Fixes #{issue} -->
