### PR TITLE
Tweak GitLab jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,6 +35,7 @@ build:
   except:
     variables:
       - $DEPLOY_TO_REL_ENV == "true"
+      - $CI_COMMIT_TAG # We don't need to build/publish when building a release tag
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
@@ -60,6 +61,7 @@ publish:
   except:
     variables:
       - $DEPLOY_TO_REL_ENV == "true"
+      - $CI_COMMIT_TAG # We don't need to build/publish when building a release tag
   stage: publish
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies:
@@ -196,7 +198,8 @@ package:
     - if: $DOTNET_PACKAGE_VERSION
       when: on_success
     - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
-      when: on_success
+      when: manual
+      allow_failure: false
   script:
     - ../.gitlab/build-deb-rpm.sh
 


### PR DESCRIPTION
## Summary of changes

- No need to build/publish tracer when building the Tag (triggered by a release)
- Manually trigger the `package` job (so we can do it in our own time instead of having a deadline

## Reason for change

As part of the draft release process, the GitHub Action creates a `git tag`. Pushing this tag in turn triggers the GitLab build. However, the `package` stage in the GitLab build currently requires that the release is already published. This therefore creates a deadline for publishing a draft release, which we don't want.

Additionally, the stages in the GitLab pipeline that run on the tag, don't rely on the `build` or `publish` stages (as they're get their assets from other places). We can therefore skip these steps (as they take a long time, and block the running of subsequent stages that we _do_ care about)

## Implementation details

- Add `except` clause to `build` and `publish` stages
- Make the `package` stage manually triggered

## Test coverage

No 😬 

## Other details

I _hope_ this does what I think it does. And I _hope_ that skipping the `build` and `publish` stages doesn't affect our ability to run the latter stages. I guess we'll find out..
