### PR TITLE
New TraceClock instance per TraceContext

### DIFF
--- a/tracer/src/Datadog.Trace/TraceClock.cs
+++ b/tracer/src/Datadog.Trace/TraceClock.cs
@@ -13,40 +13,15 @@ using Datadog.Trace.Util;
 
 namespace Datadog.Trace;
 
-internal sealed class TraceClock
+internal readonly struct TraceClock
 {
-    private static readonly CancellationTokenSource TokenSource;
-    private static TraceClock _instance;
-
     private readonly DateTimeOffset _utcStart;
     private readonly long _timestamp;
 
-    static TraceClock()
-    {
-        TokenSource = new CancellationTokenSource();
-        LifetimeManager.Instance.AddShutdownTask(() => TokenSource.Cancel());
-        _instance = new TraceClock();
-        _ = UpdateClockAsync();
-    }
-
-    private TraceClock()
+    public TraceClock()
     {
         _utcStart = DateTimeOffset.UtcNow;
         _timestamp = Stopwatch.GetTimestamp();
-
-        // The following is to prevent the case of GC hitting between _utcStart and _timestamp set
-        var retries = 3;
-        while ((DateTimeOffset.UtcNow - UtcNow).TotalMilliseconds > 16 && retries-- > 0)
-        {
-            _utcStart = DateTimeOffset.UtcNow;
-            _timestamp = Stopwatch.GetTimestamp();
-        }
-    }
-
-    public static TraceClock Instance
-    {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _instance;
     }
 
     public DateTimeOffset UtcNow
@@ -63,19 +38,4 @@ internal sealed class TraceClock
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public TimeSpan ElapsedSince(DateTimeOffset date) => UtcNow - date;
-
-    private static async Task UpdateClockAsync()
-    {
-        var token = TokenSource.Token;
-        while (true)
-        {
-            await Task.Delay(TimeSpan.FromMinutes(5), token).ConfigureAwait(false);
-            if (token.IsCancellationRequested)
-            {
-                break;
-            }
-
-            _instance = new TraceClock();
-        }
-    }
 }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -23,8 +23,6 @@ namespace Datadog.Trace
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TraceContext>();
 
-        private readonly TraceClock _clock;
-
         private IastRequestContext _iastRequestContext;
 
         private ArrayBuilder<Span> _spans;
@@ -50,7 +48,7 @@ namespace Datadog.Trace
 
             Tracer = tracer;
             Tags = tags ?? new TraceTagCollection();
-            _clock = TraceClock.Instance;
+            Clock = new TraceClock();
         }
 
         public Span RootSpan
@@ -59,7 +57,7 @@ namespace Datadog.Trace
             private set => _rootSpan = value;
         }
 
-        public TraceClock Clock => _clock;
+        public TraceClock Clock { get; }
 
         public IDatadogTracer Tracer { get; }
 


### PR DESCRIPTION
## Summary of changes

This PR restores the Clock behaviour before the optimization, due to an issue detected with Datadog.Trace version conflict.

## Reason for change

See #4450 

