### PR TITLE
Fix: Disable shared clock on version conflict

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -22,6 +22,8 @@ namespace Datadog.Trace.ClrProfiler
 
         bool IDistributedTracer.IsChildTracer => false;
 
+        public bool HasChild => _child is not null;
+
         IReadOnlyDictionary<string, string> IDistributedTracer.GetSpanContextRaw()
         {
             if (_child is null)


### PR DESCRIPTION
## Summary of changes

This PR disabled the shared clock across multiple traces instances when a version conflict is detected.

## Reason for change
See https://github.com/DataDog/dd-trace-dotnet/issues/4450, this is not a complete fix for the issue, but reduces the frequency of happening due to the (15ms) precision of the UtcNow. 

For a complete fix we should create a `ITraceClock` interface and share it between the tracers, this can be done in a new IAutomaticTracer2, IManualTracer2 initiative.
