### PR TITLE
[Tracer] Ensure the configuration of the trace context propagator is included in our telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
@@ -106,7 +106,7 @@ internal readonly struct ConfigurationBuilder
         }
 
         [return: NotNullIfNotNull(nameof(getDefaultValue))]
-        public T? GetAs<T>(Func<T>? getDefaultValue, Func<T, bool>? validator, Func<string, ParsingResult<T>> converter)
+        public T? GetAs<T>(Func<DefaultResult<T>>? getDefaultValue, Func<T, bool>? validator, Func<string, ParsingResult<T>> converter)
         {
             var result = Source.GetAs<T>(Key, Telemetry, converter, validator, recordValue: true)
                       ?? (FallbackKey1 is null ? null : Source.GetAs<T>(FallbackKey1, Telemetry, converter, validator, recordValue: true))
@@ -126,8 +126,8 @@ internal readonly struct ConfigurationBuilder
             }
 
             var defaultValue = getDefaultValue();
-            Telemetry.Record(Key, defaultValue?.ToString(), recordValue: true, ConfigurationOrigins.Default);
-            return defaultValue!;
+            Telemetry.Record(Key, defaultValue.TelemetryValue, recordValue: true, ConfigurationOrigins.Default);
+            return defaultValue.Result!;
         }
 
         // ****************

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
@@ -49,4 +49,10 @@ internal enum ConfigurationOrigins
     /// </summary>
     [Description("default")]
     Default,
+
+    /// <summary>
+    /// Set where it is difficult/not possible to determine the source of a config
+    /// </summary>
+    [Description("unknown")]
+    Unknown,
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/DefaultResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/DefaultResult.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="DefaultResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+internal readonly record struct DefaultResult<T>
+{
+    public DefaultResult(T result, string? telemetryValue)
+    {
+        Result = result;
+        TelemetryValue = telemetryValue ?? result?.ToString();
+    }
+
+    /// <summary>
+    /// Gets the value to use as the default result
+    /// </summary>
+    public T Result { get; }
+
+    /// <summary>
+    /// Gets a string representation of the result to use in telemetry.
+    /// </summary>
+    public string? TelemetryValue { get; }
+
+    public static implicit operator DefaultResult<T>(T result) => new(result, telemetryValue: null);
+}

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -287,21 +287,7 @@ namespace Datadog.Trace.Configuration
                 PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
             }
 
-            // If Activity support is enabled, we must enable the W3C Trace Context propagators.
-            // Take care to not duplicate the W3C propagator so the telemetry obtained from our settings looks okay
-            if (IsActivityListenerEnabled)
-            {
-                if (!PropagationStyleInject.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
-                {
-                    PropagationStyleInject = PropagationStyleInject.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
-                }
-
-                if (!PropagationStyleExtract.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
-                {
-                    PropagationStyleExtract = PropagationStyleExtract.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
-                }
-            }
-            else
+            if (!IsActivityListenerEnabled)
             {
                 DisabledIntegrationNamesInternal.Add(nameof(Configuration.IntegrationId.OpenTelemetry));
             }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.Configuration
             MetadataSchemaVersion = config
                                    .WithKeys(ConfigurationKeys.MetadataSchemaVersion)
                                    .GetAs(
-                                        () => SchemaVersion.V0,
+                                        () => new DefaultResult<SchemaVersion>(SchemaVersion.V0, "V0"),
                                         converter: x => x switch
                                         {
                                             "v1" or "V1" => SchemaVersion.V1,
@@ -263,31 +263,45 @@ namespace Datadog.Trace.Configuration
                                                      .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryLegacyOperationNameEnabled)
                                                      .AsBool(false);
 
-            var propagationStyleInject = config
-                                        .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
-                                        .AsString(defaultValue: "tracecontext,Datadog");
+            PropagationStyleInject = config
+                                    .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
+                                    .GetAs(
+                                         getDefaultValue: () => new DefaultResult<string[]>(
+                                             new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog },
+                                             $"{ContextPropagationHeaderStyle.W3CTraceContext},{ContextPropagationHeaderStyle.Datadog}"),
+                                         validator: styles => styles is { Length: > 0 }, // invalid individual values are rejected later
+                                         converter: style => TrimSplitString(style, commaSeparator));
 
-            PropagationStyleInject = TrimSplitString(propagationStyleInject, commaSeparator);
+            PropagationStyleExtract = config
+                                     .WithKeys(ConfigurationKeys.PropagationStyleExtract, "DD_PROPAGATION_STYLE_EXTRACT", ConfigurationKeys.PropagationStyle)
+                                     .GetAs(
+                                          getDefaultValue: () => new DefaultResult<string[]>(
+                                              new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog },
+                                              $"{ContextPropagationHeaderStyle.W3CTraceContext},{ContextPropagationHeaderStyle.Datadog}"),
+                                          validator: styles => styles is { Length: > 0 }, // invalid individual values are rejected later
+                                          converter: style => TrimSplitString(style, commaSeparator));
 
-            if (PropagationStyleInject.Length == 0)
+            // If Activity support is enabled, we must enable the W3C Trace Context propagators.
+            // Take care to not duplicate the W3C propagator so the telemetry obtained from our settings looks okay
+            if (IsActivityListenerEnabled)
             {
-                // default value
-                PropagationStyleInject = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
+                if (!PropagationStyleInject.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
+                {
+                    PropagationStyleInject = PropagationStyleInject.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
+                    // "manually" record the updated value for v2 telemetry using the "unknown" origin, as we
+                    // can't easily tell from here which was the original source (that we're modifying)
+                    telemetry.Record(ConfigurationKeys.PropagationStyleInject, string.Join(",", PropagationStyleInject), recordValue: true, ConfigurationOrigins.Unknown);
+                }
+
+                if (!PropagationStyleExtract.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
+                {
+                    PropagationStyleExtract = PropagationStyleExtract.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
+                    // "manually" record the updated value for v2 telemetry using the "unknown" origin, as we
+                    // can't easily tell from here which was the original source (that we're modifying)
+                    telemetry.Record(ConfigurationKeys.PropagationStyleExtract, string.Join(",", PropagationStyleExtract), recordValue: true, ConfigurationOrigins.Unknown);
+                }
             }
-
-            var propagationStyleExtract = config
-                                         .WithKeys(ConfigurationKeys.PropagationStyleExtract, "DD_PROPAGATION_STYLE_EXTRACT", ConfigurationKeys.PropagationStyle)
-                                         .AsString(defaultValue: "tracecontext,Datadog");
-
-            PropagationStyleExtract = TrimSplitString(propagationStyleExtract, commaSeparator);
-
-            if (PropagationStyleExtract.Length == 0)
-            {
-                // default value
-                PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
-            }
-
-            if (!IsActivityListenerEnabled)
+            else
             {
                 DisabledIntegrationNamesInternal.Add(nameof(Configuration.IntegrationId.OpenTelemetry));
             }
@@ -350,7 +364,7 @@ namespace Datadog.Trace.Configuration
             DbmPropagationMode = config
                                 .WithKeys(ConfigurationKeys.DbmPropagationMode)
                                 .GetAs(
-                                     () => DbmPropagationLevel.Disabled,
+                                     () => new DefaultResult<DbmPropagationLevel>(DbmPropagationLevel.Disabled, nameof(DbmPropagationLevel.Disabled)),
                                      converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
                                      validator: null);
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -265,7 +265,7 @@ namespace Datadog.Trace.Configuration
 
             var propagationStyleInject = config
                                         .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
-                                        .AsString();
+                                        .AsString(defaultValue: "tracecontext,Datadog");
 
             PropagationStyleInject = TrimSplitString(propagationStyleInject, commaSeparator);
 
@@ -277,7 +277,7 @@ namespace Datadog.Trace.Configuration
 
             var propagationStyleExtract = config
                                          .WithKeys(ConfigurationKeys.PropagationStyleExtract, "DD_PROPAGATION_STYLE_EXTRACT", ConfigurationKeys.PropagationStyle)
-                                         .AsString();
+                                         .AsString(defaultValue: "tracecontext,Datadog");
 
             PropagationStyleExtract = TrimSplitString(propagationStyleExtract, commaSeparator);
 
@@ -288,11 +288,18 @@ namespace Datadog.Trace.Configuration
             }
 
             // If Activity support is enabled, we must enable the W3C Trace Context propagators.
-            // It's ok to include W3C multiple times, we handle that later.
+            // Take care to not duplicate the W3C propagator so the telemetry obtained from our settings looks okay
             if (IsActivityListenerEnabled)
             {
-                PropagationStyleInject = PropagationStyleInject.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
-                PropagationStyleExtract = PropagationStyleExtract.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
+                if (!PropagationStyleInject.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
+                {
+                    PropagationStyleInject = PropagationStyleInject.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
+                }
+
+                if (!PropagationStyleExtract.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
+                {
+                    PropagationStyleExtract = PropagationStyleExtract.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
+                }
             }
             else
             {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             DirectLogSubmissionMinimumLevel = config
                                              .WithKeys(ConfigurationKeys.DirectLogSubmission.MinimumLevel)
                                              .GetAs(
-                                                  () => DefaultMinimumLevel,
+                                                  () => new DefaultResult<DirectSubmissionLogLevel>(DefaultMinimumLevel, nameof(DirectSubmissionLogLevel.Information)),
                                                   converter: x => DirectSubmissionLogLevelExtensions.Parse(x) ?? ParsingResult<DirectSubmissionLogLevel>.Failure(),
                                                   validator: null);
 

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ConfigurationTelemetryCollector.cs
@@ -122,7 +122,7 @@ namespace Datadog.Trace.Telemetry
 
             var settings = _settings.Settings;
 
-            var data = new List<TelemetryValue>(27 + (settings.IsRunningInAzureAppService ? 5 : 0))
+            var data = new List<TelemetryValue>(29 + (settings.IsRunningInAzureAppService ? 5 : 0))
             {
                 new(ConfigTelemetryData.Platform, value: FrameworkDescription.Instance.ProcessArchitecture),
                 new(ConfigTelemetryData.Enabled, value: settings.TraceEnabledInternal),
@@ -153,6 +153,8 @@ namespace Datadog.Trace.Telemetry
                 new(ConfigTelemetryData.WcfObfuscationEnabled, value: settings.WcfObfuscationEnabled),
                 new(ConfigTelemetryData.DataStreamsMonitoringEnabled, value: settings.IsDataStreamsMonitoringEnabled),
                 new(ConfigTelemetryData.SpanSamplingRules, value: settings.SpanSamplingRules),
+                new(ConfigTelemetryData.PropagationStyleExtract, value: string.Join(",", settings.PropagationStyleExtract)),
+                new(ConfigTelemetryData.PropagationStyleInject, value: string.Join(",", settings.PropagationStyleInject)),
             };
 
             if (settings.IsRunningInAzureAppService)

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -34,6 +34,8 @@ namespace Datadog.Trace.Telemetry
         public const string WcfObfuscationEnabled = "wcf_obfuscation_enabled";
         public const string DataStreamsMonitoringEnabled = "data_streams_enabled";
         public const string SpanSamplingRules = "span_sampling_rules";
+        public const string PropagationStyleExtract = "DD_TRACE_PROPAGATION_STYLE_EXTRACT";
+        public const string PropagationStyleInject = "DD_TRACE_PROPAGATION_STYLE_INJECT";
 
         public const string CloudHosting = "cloud_hosting";
         public const string AasSiteExtensionVersion = "aas_siteextensions_version";

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -16,7 +16,6 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DogStatsd;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Processors;
@@ -150,18 +149,6 @@ namespace Datadog.Trace
             var profiler = Profiler.Instance;
             telemetry.RecordProfilerSettings(profiler);
             telemetry.ProductChanged(TelemetryProductType.Profiler, enabled: profiler.Status.IsProfilerReady, error: null);
-
-            var requestedInjectors = settings.PropagationStyleInject;
-            var requestedExtractors = settings.PropagationStyleExtract;
-
-            // If Activity support is enabled, we must enable the W3C Trace Context propagators.
-            // We have not updated the settings object so our configuration telemetry accurately reflects what was set by the user
-            // It's ok to include W3C multiple times, we handle that later.
-            if (settings.IsActivityListenerEnabled)
-            {
-                requestedInjectors = requestedInjectors.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
-                requestedExtractors = requestedExtractors.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
-            }
 
             SpanContextPropagator.Instance = SpanContextPropagatorFactory.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -69,6 +69,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             telemetry.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "tracecontext,Datadog");
+            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "tracecontext,Datadog");
+
             AssertService(telemetry, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(telemetry, enableDependencies);
             agent.Telemetry.Should().BeEmpty();
@@ -97,6 +100,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
+            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "tracecontext,Datadog");
+            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "tracecontext,Datadog");
+
             AssertService(agent, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(agent, enableDependencies);
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -648,7 +648,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleInject.Should().BeEquivalentTo(isActivityListenerEnabled ? expected.Concat("tracecontext") : expected);
+                settings.PropagationStyleInject.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
             }
         }
 
@@ -672,7 +672,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled ? expected.Concat("tracecontext") : expected);
+                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -648,7 +648,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleInject.Should().BeEquivalentTo(expected);
+                settings.PropagationStyleInject.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
             }
         }
 
@@ -672,7 +672,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleExtract.Should().BeEquivalentTo(expected);
+                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -648,7 +648,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleInject.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
+                settings.PropagationStyleInject.Should().BeEquivalentTo(expected);
             }
         }
 
@@ -672,7 +672,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
+                settings.PropagationStyleExtract.Should().BeEquivalentTo(expected);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -277,19 +277,6 @@ namespace Datadog.Trace.Tests.Telemetry
                 (null, null) => "tracecontext,Datadog",
             };
 
-            // V1 telemetry will collect an additional ",tracecontext" in each propagator style when the following conditions are met
-            // - DD_TRACE_OTEL_ENABLED=true
-            // - "tracecontext" is not already included in the propagation configuration
-            if (activityListenerEnabled == "true" && !extractValue.Split(',').Contains("tracecontext", StringComparer.OrdinalIgnoreCase))
-            {
-                extractValue += ",tracecontext";
-            }
-
-            if (activityListenerEnabled == "true" && !injectValue.Split(',').Contains("tracecontext", StringComparer.OrdinalIgnoreCase))
-            {
-                injectValue += ",tracecontext";
-            }
-
             data[ConfigTelemetryData.PropagationStyleExtract].Should().Be(extractValue);
             data[ConfigTelemetryData.PropagationStyleInject].Should().Be(injectValue);
         }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -277,6 +277,19 @@ namespace Datadog.Trace.Tests.Telemetry
                 (null, null) => "tracecontext,Datadog",
             };
 
+            // V1 telemetry will collect an additional ",tracecontext" in each propagator style when the following conditions are met
+            // - DD_TRACE_OTEL_ENABLED=true
+            // - "tracecontext" is not already included in the propagation configuration
+            if (activityListenerEnabled == "true" && !extractValue.Split(',').Contains("tracecontext", StringComparer.OrdinalIgnoreCase))
+            {
+                extractValue += ",tracecontext";
+            }
+
+            if (activityListenerEnabled == "true" && !injectValue.Split(',').Contains("tracecontext", StringComparer.OrdinalIgnoreCase))
+            {
+                injectValue += ",tracecontext";
+            }
+
             data[ConfigTelemetryData.PropagationStyleExtract].Should().Be(extractValue);
             data[ConfigTelemetryData.PropagationStyleInject].Should().Be(injectValue);
         }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorV2Tests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ConfigurationTelemetryCollectorV2Tests.cs" company="Datadog">
+// <copyright file="ConfigurationTelemetryCollectorV2Tests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -21,6 +21,13 @@ namespace Datadog.Trace.Tests.Telemetry;
 
 public class ConfigurationTelemetryCollectorV2Tests
 {
+    public static IEnumerable<object[]> GetPropagatorConfigurations()
+        => from propagationStyleExtract in new string[] { null, "tracecontext" }
+           from propagationStyleInject in new string[] { null, "datadog" }
+           from propagationStyle in new string[] { null, "B3" }
+           from activityListenerEnabled in new[] { "false", "true" }
+           select new[] { propagationStyleExtract, propagationStyleInject, propagationStyle, activityListenerEnabled };
+
     [Fact]
     public void HasChangesAfterEachTracerSettingsAdded()
     {
@@ -168,6 +175,42 @@ public class ConfigurationTelemetryCollectorV2Tests
         var s = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, collector));
 
         GetLatestValueFromConfig(collector.GetData(), ConfigTelemetryData.NativeTracerVersion).Should().Be("None");
+    }
+
+    [Theory]
+    [MemberData(nameof(GetPropagatorConfigurations))]
+    public void ConfigurationDataShouldIncludeExpectedPropagationValues(string propagationStyleExtract, string propagationStyleInject, string propagationStyle, string activityListenerEnabled)
+    {
+        var collector = new ConfigurationTelemetry();
+        var config = new NameValueCollection
+        {
+            { ConfigurationKeys.PropagationStyleExtract, propagationStyleExtract },
+            { ConfigurationKeys.PropagationStyleInject, propagationStyleInject },
+            { ConfigurationKeys.PropagationStyle, propagationStyle },
+            { ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, activityListenerEnabled },
+        };
+
+        _ = new ImmutableTracerSettings(new TracerSettings(new NameValueConfigurationSource(config), collector));
+
+        var data = collector.GetData();
+
+        using var scope = new AssertionScope();
+        var (extractKey, extractValue) = (propagationStyleExtract, propagationStyle) switch
+        {
+            (not null, _) => (ConfigurationKeys.PropagationStyleExtract, propagationStyleExtract),
+            (null, not null) => (ConfigurationKeys.PropagationStyle, propagationStyle),
+            (null, null) => (ConfigurationKeys.PropagationStyleExtract, "tracecontext,Datadog"),
+        };
+
+        var (injectKey, injectValue) = (propagationStyleInject, propagationStyle) switch
+        {
+            (not null, _) => (ConfigurationKeys.PropagationStyleInject, propagationStyleInject),
+            (null, not null) => (ConfigurationKeys.PropagationStyle, propagationStyle),
+            (null, null) => (ConfigurationKeys.PropagationStyleInject, "tracecontext,Datadog"),
+        };
+
+        GetLatestValueFromConfig(data, extractKey).Should().Be(extractValue);
+        GetLatestValueFromConfig(data, injectKey).Should().Be(injectValue);
     }
 
 #if NETFRAMEWORK


### PR DESCRIPTION
## Summary of changes
Adds telemetry for `DD_TRACE_PROPAGATION_STYLE_EXTRACT` and `DD_TRACE_PROPAGATION_STYLE_INJECT` in both v0 and v1 telemetry.

For v1 telemetry, we record the exact key-value pair that was configured by the user (or the default `"datadog,tracecontext"` if not configured), ignoring the potential addition of the `tracecontext` propagator when the ActivityListener is enabled.

For v0 telemetry, we record the exact key-value pair that was configured by the user (or the default `"datadog,tracecontext"` if not configured), ignoring the potential addition of the `tracecontext` propagator when the ActivityListener is enabled.

Note: If we do in fact want to record the addition of the `tracecontext` propagator when the ActivityListener is enabled, we can record it with v0 telemetry by reverting the second commit in this PR. However, due to the design of the v1 configuration telemetry, we will not be able to do this with v1 telemetry without additional workarounds. To achieve consistency between the two telemetry versions, I decided not to record it, but we can change that decision collectively.

## Reason for change
Currently, we only record telemetry for the trace context propagators under the following conditions:
- v2 telemetry is enabled (this is not the default)
- the user explicitly sets the trace context propagators via configuration

## Implementation details
- For v0 telemetry, add new configuration telemetry values with names `DD_TRACE_PROPAGATION_STYLE_EXTRACT` and `DD_TRACE_PROPAGATION_STYLE_INJECT`
- For v1 telemetry, when parsing the `PropagationStyleExtract` and `PropagationStyleInject`configurations, add a default value of "tracecontext,Datadog"
- Defer the addition of the `tracecontext` propagator so we do not persist it in the `ImmutableTracerSettings` object, which is the source of truth for v0 telemetry (can be reverted if desired)

## Test coverage
Unit tests have been added to cover the various combinations of the propagators and resulting v0 and v1 telemetry.

Integration tests for `TelemetryTests` have been updated to assert the default v0 and v1 configuration telemetry values.

## Other details
N/A
