### PR TITLE
Updates to propagation telemetry recording

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationBuilder.cs
@@ -106,7 +106,7 @@ internal readonly struct ConfigurationBuilder
         }
 
         [return: NotNullIfNotNull(nameof(getDefaultValue))]
-        public T? GetAs<T>(Func<T>? getDefaultValue, Func<T, bool>? validator, Func<string, ParsingResult<T>> converter)
+        public T? GetAs<T>(Func<DefaultResult<T>>? getDefaultValue, Func<T, bool>? validator, Func<string, ParsingResult<T>> converter)
         {
             var result = Source.GetAs<T>(Key, Telemetry, converter, validator, recordValue: true)
                       ?? (FallbackKey1 is null ? null : Source.GetAs<T>(FallbackKey1, Telemetry, converter, validator, recordValue: true))
@@ -126,8 +126,8 @@ internal readonly struct ConfigurationBuilder
             }
 
             var defaultValue = getDefaultValue();
-            Telemetry.Record(Key, defaultValue?.ToString(), recordValue: true, ConfigurationOrigins.Default);
-            return defaultValue!;
+            Telemetry.Record(Key, defaultValue.TelemetryValue, recordValue: true, ConfigurationOrigins.Default);
+            return defaultValue.Result!;
         }
 
         // ****************

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
@@ -49,4 +49,10 @@ internal enum ConfigurationOrigins
     /// </summary>
     [Description("default")]
     Default,
+
+    /// <summary>
+    /// Set where it is difficult/not possible to determine the source of a config
+    /// </summary>
+    [Description("unknown")]
+    Unknown,
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/DefaultResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/DefaultResult.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="DefaultResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+internal readonly record struct DefaultResult<T>
+{
+    public DefaultResult(T result, string? telemetryValue)
+    {
+        Result = result;
+        TelemetryValue = telemetryValue ?? result?.ToString();
+    }
+
+    /// <summary>
+    /// Gets the value to use as the default result
+    /// </summary>
+    public T Result { get; }
+
+    /// <summary>
+    /// Gets a string representation of the result to use in telemetry.
+    /// </summary>
+    public string? TelemetryValue { get; }
+
+    public static implicit operator DefaultResult<T>(T result) => new(result, telemetryValue: null);
+}

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.Configuration
             MetadataSchemaVersion = config
                                    .WithKeys(ConfigurationKeys.MetadataSchemaVersion)
                                    .GetAs(
-                                        () => SchemaVersion.V0,
+                                        () => new DefaultResult<SchemaVersion>(SchemaVersion.V0, "V0"),
                                         converter: x => x switch
                                         {
                                             "v1" or "V1" => SchemaVersion.V1,
@@ -364,7 +364,7 @@ namespace Datadog.Trace.Configuration
             DbmPropagationMode = config
                                 .WithKeys(ConfigurationKeys.DbmPropagationMode)
                                 .GetAs(
-                                     () => DbmPropagationLevel.Disabled,
+                                     () => new DefaultResult<DbmPropagationLevel>(DbmPropagationLevel.Disabled, nameof(DbmPropagationLevel.Disabled)),
                                      converter: x => ToDbmPropagationInput(x) ?? ParsingResult<DbmPropagationLevel>.Failure(),
                                      validator: null);
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -287,7 +287,21 @@ namespace Datadog.Trace.Configuration
                 PropagationStyleExtract = new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog };
             }
 
-            if (!IsActivityListenerEnabled)
+            // If Activity support is enabled, we must enable the W3C Trace Context propagators.
+            // Take care to not duplicate the W3C propagator so the telemetry obtained from our settings looks okay
+            if (IsActivityListenerEnabled)
+            {
+                if (!PropagationStyleInject.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
+                {
+                    PropagationStyleInject = PropagationStyleInject.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
+                }
+
+                if (!PropagationStyleExtract.Contains(ContextPropagationHeaderStyle.W3CTraceContext, StringComparer.OrdinalIgnoreCase))
+                {
+                    PropagationStyleExtract = PropagationStyleExtract.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
+                }
+            }
+            else
             {
                 DisabledIntegrationNamesInternal.Add(nameof(Configuration.IntegrationId.OpenTelemetry));
             }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.EnumExtensions.EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -13,7 +13,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 6;
+    public const int Length = 7;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -32,6 +32,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
 
@@ -51,6 +52,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
     /// <summary>
@@ -70,6 +72,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
     /// <summary>
@@ -89,5 +92,6 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             DirectLogSubmissionMinimumLevel = config
                                              .WithKeys(ConfigurationKeys.DirectLogSubmission.MinimumLevel)
                                              .GetAs(
-                                                  () => DefaultMinimumLevel,
+                                                  () => new DefaultResult<DirectSubmissionLogLevel>(DefaultMinimumLevel, nameof(DirectSubmissionLogLevel.Information)),
                                                   converter: x => DirectSubmissionLogLevelExtensions.Parse(x) ?? ParsingResult<DirectSubmissionLogLevel>.Failure(),
                                                   validator: null);
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -16,7 +16,6 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DogStatsd;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Processors;
@@ -150,18 +149,6 @@ namespace Datadog.Trace
             var profiler = Profiler.Instance;
             telemetry.RecordProfilerSettings(profiler);
             telemetry.ProductChanged(TelemetryProductType.Profiler, enabled: profiler.Status.IsProfilerReady, error: null);
-
-            var requestedInjectors = settings.PropagationStyleInject;
-            var requestedExtractors = settings.PropagationStyleExtract;
-
-            // If Activity support is enabled, we must enable the W3C Trace Context propagators.
-            // We have not updated the settings object so our configuration telemetry accurately reflects what was set by the user
-            // It's ok to include W3C multiple times, we handle that later.
-            if (settings.IsActivityListenerEnabled)
-            {
-                requestedInjectors = requestedInjectors.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
-                requestedExtractors = requestedExtractors.Concat(ContextPropagationHeaderStyle.W3CTraceContext);
-            }
 
             SpanContextPropagator.Instance = SpanContextPropagatorFactory.GetSpanContextPropagator(settings.PropagationStyleInject, settings.PropagationStyleExtract);
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -648,7 +648,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleInject.Should().BeEquivalentTo(expected);
+                settings.PropagationStyleInject.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
             }
         }
 
@@ -672,7 +672,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 var settings = new TracerSettings(source);
 
-                settings.PropagationStyleExtract.Should().BeEquivalentTo(expected);
+                settings.PropagationStyleExtract.Should().BeEquivalentTo(isActivityListenerEnabled && !expected.Contains("tracecontext") ? expected.Concat("tracecontext") : expected);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -277,6 +277,19 @@ namespace Datadog.Trace.Tests.Telemetry
                 (null, null) => "tracecontext,Datadog",
             };
 
+            // V1 telemetry will collect an additional ",tracecontext" in each propagator style when the following conditions are met
+            // - DD_TRACE_OTEL_ENABLED=true
+            // - "tracecontext" is not already included in the propagation configuration
+            if (activityListenerEnabled == "true" && !extractValue.Split(',').Contains("tracecontext", StringComparer.OrdinalIgnoreCase))
+            {
+                extractValue += ",tracecontext";
+            }
+
+            if (activityListenerEnabled == "true" && !injectValue.Split(',').Contains("tracecontext", StringComparer.OrdinalIgnoreCase))
+            {
+                injectValue += ",tracecontext";
+            }
+
             data[ConfigTelemetryData.PropagationStyleExtract].Should().Be(extractValue);
             data[ConfigTelemetryData.PropagationStyleInject].Should().Be(injectValue);
         }


### PR DESCRIPTION
## Summary of changes

- Add the "Unknown" config origin (recently allowed)
- Improve recording of default value for `GetAs<T>` for types that don't `ToString()` well
- Update configuration of propagation styles to use `GetAs<T>`
- Update configuration of propagation styles to record value when `tracecontext` is added

## Reason for change

Builds on #4460 but (hopefully) simplifies some things, while still ensuring we record the same values in telemetry for both v1 and v2 telemetry

## Implementation details

There are (unfortunately) some ancillary config-telemetry related changes required in this PR, but the important parts are changing the configuration to be a (mostly) one-shot thing

```csharp
PropagationStyleInject = config
      .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
      .GetAs(
           getDefaultValue: () => new DefaultResult<string[]>(
               new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog },
               $"{ContextPropagationHeaderStyle.W3CTraceContext},{ContextPropagationHeaderStyle.Datadog}"),
           validator: styles => styles is { Length: > 0 }, // invalid individual values are rejected later
           converter: style => TrimSplitString(style, commaSeparator));
```

This moves the splitting and trimming into the `converter` function, adds "validation" to the result (checking for a non-empty array), and if the validation fails, falls back to the default styles.

To record the case where we update the provided values, we record _directly_ in telemetry, instead of using the `ConfigurationBuilder` abstraction:

```csharp
telemetry.Record(
    ConfigurationKeys.PropagationStyleInject, 
    string.Join(",", PropagationStyleInject), 
    recordValue: true, 
    ConfigurationOrigins.Unknown);
```

## Test coverage

Added a couple of unit tests for the new `GetAs<T>` behaviour, and reinstated the updates to the extractor unit tests to account for the fact that the `PropagationStyleInject`/`PropagationStyleExtract` values _do_ have the correct values again. 

## Other details

For merging into #4460 for speed. I could easily extract the telemetry commits out into a separate PR if preferable
