### PR TITLE
Don't inject DBM data into stored procedures

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -169,6 +169,7 @@
    </assembly>
    <assembly fullname="System.Data" />
    <assembly fullname="System.Data.Common">
+      <type fullname="System.Data.CommandType" />
       <type fullname="System.Data.Common.DbCommand" />
       <type fullname="System.Data.Common.DbConnectionStringBuilder" />
       <type fullname="System.Data.DataColumn" />

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -65,7 +65,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     IastModule.OnSqlQuery(commandText, integrationId);
                 }
 
-                if (tracer.Settings.DbmPropagationMode != DbmPropagationLevel.Disabled)
+                if (tracer.Settings.DbmPropagationMode != DbmPropagationLevel.Disabled
+                    && command.CommandType != CommandType.StoredProcedure)
                 {
                     var propagatedCommand = DatabaseMonitoringPropagator.PropagateSpanData(tracer.Settings.DbmPropagationMode, tracer.DefaultServiceName, scope.Span.Context, integrationId);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -151,6 +151,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
             // Should have injected the data
             command.CommandText.Should().NotBe(previousCommandData);
+            command.CommandText.Should().Contain(previousCommandData);
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes

Don't inject DBM data if the command type is `StoredProcedure`

## Reason for change

Comments are not allowed in the `CommandText` if the type is `StoredProcedure`

## Implementation details

Check the command type before injecting

## Test coverage

Added unit tests for the behaviour (including existing behaviou). We don't currently test stored procedures in integration tests.

## Other details
Duplicates some fixes from #4462. Extracted to separate PR due to urgency
