### PR TITLE
[Build] Stop running master on the weekend

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -91,13 +91,6 @@ schedules:
         - master
     always: true
 
-  - cron: "*/6 1 * * Sat"
-    displayName: Saturday CI, every 6 minutes from 1am
-    branches:
-      include:
-        - master
-    always: true
-
 # Global variables
 variables:
   buildConfiguration: Release


### PR DESCRIPTION
## Summary of changes

Remove the scheduled CI runs running on Saturday

## Reason for change

We did that mostly to have more data about flakiness. But now that we have access to CI Visibility and that we have accurate reporting, this is mostly helping global warming more than it helps us.

## Implementation details

Removed the cron in the pipeline

## Test coverage

None :blindfold:

## Other details
<!-- Fixes #{issue} -->
