### PR TITLE
[Tracer] Logs The Setting used by dbm_propagation_mode to TracerManager

### DIFF
--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -22,32 +22,32 @@ namespace Datadog.Trace.DatabaseMonitoring
             if ((integrationId is IntegrationId.MySql or IntegrationId.Npgsql or IntegrationId.SqlClient) &&
                 (propagationStyle is DbmPropagationLevel.Service or DbmPropagationLevel.Full))
             {
-                var propagatorSringBuilder = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-                propagatorSringBuilder.Append($"/*{SqlCommentSpanService}='{Uri.EscapeDataString(context.ServiceNameInternal)}'");
+                var propagatorStringBuilder = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+                propagatorStringBuilder.Append($"/*{SqlCommentSpanService}='{Uri.EscapeDataString(context.ServiceNameInternal)}'");
 
                 if (context.TraceContext?.Environment is { } envTag)
                 {
-                    propagatorSringBuilder.Append($",{SqlCommentEnv}='{Uri.EscapeDataString(envTag)}'");
+                    propagatorStringBuilder.Append($",{SqlCommentEnv}='{Uri.EscapeDataString(envTag)}'");
                 }
 
-                propagatorSringBuilder.Append($",{SqlCommentRootService}='{Uri.EscapeDataString(configuredServiceName)}'");
+                propagatorStringBuilder.Append($",{SqlCommentRootService}='{Uri.EscapeDataString(configuredServiceName)}'");
 
                 if (context.TraceContext?.ServiceVersion is { } versionTag)
                 {
-                    propagatorSringBuilder.Append($",{SqlCommentVersion}='{Uri.EscapeDataString(versionTag)}'");
+                    propagatorStringBuilder.Append($",{SqlCommentVersion}='{Uri.EscapeDataString(versionTag)}'");
                 }
 
                 // For SqlServer we don't inject the traceparent yet to not affect performance since this DB generates a new plan for any query changes
                 if (propagationStyle == DbmPropagationLevel.Full && integrationId is not IntegrationId.SqlClient)
                 {
-                    propagatorSringBuilder.Append($",{W3CTraceContextPropagator.TraceParentHeaderName}='{W3CTraceContextPropagator.CreateTraceParentHeader(context)}'*/");
+                    propagatorStringBuilder.Append($",{W3CTraceContextPropagator.TraceParentHeaderName}='{W3CTraceContextPropagator.CreateTraceParentHeader(context)}'*/");
                 }
                 else
                 {
-                    propagatorSringBuilder.Append("*/");
+                    propagatorStringBuilder.Append("*/");
                 }
 
-                return StringBuilderCache.GetStringAndRelease(propagatorSringBuilder);
+                return StringBuilderCache.GetStringAndRelease(propagatorStringBuilder);
             }
 
             return string.Empty;

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -524,6 +524,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("stats_computation_enabled");
                     writer.WriteValue(instanceSettings.StatsComputationEnabledInternal);
 
+                    writer.WritePropertyName("dbm_propagation_mode");
+                    writer.WriteValue(instanceSettings.DbmPropagationMode.ToString());
+
                     writer.WritePropertyName("header_tags");
                     WriteDictionary(instanceSettings.HeaderTagsInternal);
 


### PR DESCRIPTION
## Summary of changes
Logs the configuration used by the tracer for the dbm_propagation_mode.

Separation of the [4462]( https://github.com/DataDog/dd-trace-dotnet/pull/4462) PR.

