### PR TITLE
Bump timeit version

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net60.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.12
+dotnet tool update -g timeitsharp --version 0.0.13
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net60.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.8
+dotnet tool update -g timeitsharp --version 0.0.12
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net60.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.12
+dotnet tool update -g timeitsharp --version 0.0.13
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net60.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.8
+dotnet tool update -g timeitsharp --version 0.0.12
 
 echo *********************
 echo .NET Framework 4.6.1


### PR DESCRIPTION
## Summary of changes

This PR bumps timeit version from `0.0.8 to 0.0.13`

#### Changes:

- Add working directory to path to resolve binary by @gleocadie in https://github.com/tonyredondo/timeitsharp/pull/14
- Fix tags/environment variables collection by @gleocadie in https://github.com/tonyredondo/timeitsharp/pull/16
- Runtime Metrics changes by @tonyredondo in https://github.com/tonyredondo/timeitsharp/pull/17
- General Improvements by @tonyredondo in https://github.com/tonyredondo/timeitsharp/pull/18
- Add template variables support by @gleocadie in https://github.com/tonyredondo/timeitsharp/pull/15
