### PR TITLE
Assorted speed improvements to tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -82,12 +82,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private async Task TestInstrumentation(MockTracerAgent agent, string metadataSchemaVersion)
         {
-            int expectedSpanCount = 5;
             // 3 on non-windows because of SecureString
-            if (!EnvironmentTools.IsWindows())
-            {
-                expectedSpanCount = 3;
-            }
+            var expectedSpanCount = EnvironmentTools.IsWindows() ? 5 : 3;
 
             const string expectedOperationName = "command_execution";
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -82,7 +82,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private async Task TestInstrumentation(MockTracerAgent agent, string metadataSchemaVersion)
         {
-            const int expectedSpanCount = 5;
+            int expectedSpanCount = 5;
+            // 3 on non-windows because of SecureString
+            if (!EnvironmentTools.IsWindows())
+            {
+                expectedSpanCount = 3;
+            }
+
             const string expectedOperationName = "command_execution";
 
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -62,7 +62,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private async Task RunTest(string metadataSchemaVersion)
         {
-            const int expectedSpanCount = 5;
+            int expectedSpanCount = 5;
+            // 3 on non-windows because of SecureString
+            if (!EnvironmentTools.IsWindows())
+            {
+                expectedSpanCount = 3;
+            }
+
             const string expectedOperationName = "command_execution";
 
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -46,7 +46,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void IntegrationDisabled()
         {
-            const int totalSpanCount = 5; // we actually expect no spans when disabled
             const string expectedOperationName = "command_execution";
 
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.Process)}_ENABLED", "false");
@@ -54,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = RunSampleAndWaitForExit(agent);
-            var spans = agent.Spans // no spans expected
+            var spans = agent.Spans; // no spans expected
 
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.Process);
@@ -62,12 +61,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         private async Task RunTest(string metadataSchemaVersion)
         {
-            int expectedSpanCount = 5;
             // 3 on non-windows because of SecureString
-            if (!EnvironmentTools.IsWindows())
-            {
-                expectedSpanCount = 3;
-            }
+            var expectedSpanCount = EnvironmentTools.IsWindows() ? 5 : 3;
 
             const string expectedOperationName = "command_execution";
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public void IntegrationDisabled()
         {
-            const int totalSpanCount = 5;
+            const int totalSpanCount = 5; // we actually expect no spans when disabled
             const string expectedOperationName = "command_execution";
 
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.Process)}_ENABLED", "false");
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
+            var spans = agent.WaitForSpans(totalSpanCount, 2_000, returnAllOperations: true); // 2 seconds - no spans expected
 
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.Process);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(totalSpanCount, 2_000, returnAllOperations: true); // 2 seconds - no spans expected
+            var spans = agent.Spans // no spans expected
 
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));
             telemetry.AssertIntegrationDisabled(IntegrationId.Process);

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingSpanTests.cs
@@ -7,6 +7,7 @@ using System;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using FluentAssertions;
 using Moq;
 using OpenTracing;
 using Xunit;
@@ -90,8 +91,9 @@ namespace Datadog.Trace.OpenTracing.Tests
 
             var otSpan = (OpenTracingSpan)span;
             var ddSpan = (Span)otSpan.Span;
-            double durationDifference = Math.Abs((ddSpan.Duration - expectedDuration).TotalMilliseconds);
-            Assert.True(durationDifference < 100);
+
+            var precision = TimeSpan.FromSeconds(1);
+            ddSpan.Duration.Should().BeCloseTo(expectedDuration, precision);
         }
 
         /*

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
@@ -63,10 +63,9 @@ public class WeakCipherTests : TestHelper
     {
         SetEnvironmentVariable("DD_IAST_ENABLED", "true");
         SetEnvironmentVariable(variableName, variableValue);
-        const int expectedSpanCount = 1; // we actually expect 0 here
         using var agent = EnvironmentHelper.GetMockAgent();
         using var process = RunSampleAndWaitForExit(agent);
-        var spans = agent.WaitForSpans(expectedSpanCount, 2_000, returnAllOperations: true); // wait 2 seconds - we expect no spans
+        var spans = agent.Spans; // we expect no spans
 
         Assert.Empty(spans.Where(s => s.Name.Equals(ExpectedOperationName)));
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
@@ -63,10 +63,10 @@ public class WeakCipherTests : TestHelper
     {
         SetEnvironmentVariable("DD_IAST_ENABLED", "true");
         SetEnvironmentVariable(variableName, variableValue);
-        const int expectedSpanCount = 6;
+        const int expectedSpanCount = 1; // we actually expect 0 here
         using var agent = EnvironmentHelper.GetMockAgent();
         using var process = RunSampleAndWaitForExit(agent);
-        var spans = agent.WaitForSpans(expectedSpanCount, returnAllOperations: true);
+        var spans = agent.WaitForSpans(expectedSpanCount, 2_000, returnAllOperations: true); // wait 2 seconds - we expect no spans
 
         Assert.Empty(spans.Where(s => s.Name.Equals(ExpectedOperationName)));
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1080,6 +1080,11 @@ namespace Datadog.Trace.TestHelpers
 
                             var mockTracerResponse = HandleHttpRequest(MockHttpParser.MockHttpRequest.Create(ctx.Request));
 
+                            if (!mockTracerResponse.SendResponse)
+                            {
+                                ctx.Response.Abort(); // close without sending to avoid getting blocked for 15 seconds
+                            }
+
                             if (mockTracerResponse.SendResponse)
                             {
                                 var buffer = Encoding.UTF8.GetBytes(mockTracerResponse.Response);

--- a/tracer/test/test-applications/integrations/Samples.Kafka/Producer.cs
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Producer.cs
@@ -11,12 +11,18 @@ namespace Samples.Kafka
     {
         // Flush every x messages
         private const int FlushInterval = 3;
-        private static readonly TimeSpan FlushTimeout = TimeSpan.FromSeconds(5);
+        private static readonly TimeSpan FlushTimeout = TimeSpan.FromSeconds(1);
         private static int _messageNumber = 0;
 
         public static async Task ProduceAsync(string topic, int numMessages, ClientConfig config, bool isTombstone)
         {
-            using (var producer = new ProducerBuilder<string, string>(config).Build())
+            var producerConfig = new ProducerConfig
+            {
+                BootstrapServers = config.BootstrapServers,
+                MessageTimeoutMs = 3000 // earlier versions would return right away when producing to invalid topics - later versions would block for 30 seconds
+            };
+
+            using (var producer = new ProducerBuilder<string, string>(producerConfig).Build())
             {
                 for (var i=0; i<numMessages; ++i)
                 {
@@ -60,7 +66,13 @@ namespace Samples.Kafka
 
         private static void Produce(string topic, int numMessages, ClientConfig config, Action<DeliveryReport<string, string>> deliveryHandler, bool isTombstone)
         {
-            using (var producer = new ProducerBuilder<string, string>(config).Build())
+            var producerConfig = new ProducerConfig
+            {
+                BootstrapServers = config.BootstrapServers,
+                MessageTimeoutMs = 3000 // earlier versions would return right away when producing to invalid topics - later versions would block for 30 seconds
+            };
+
+            using (var producer = new ProducerBuilder<string, string>(producerConfig).Build())
             {
                 for (var i=0; i<numMessages; ++i)
                 {

--- a/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
@@ -20,6 +20,15 @@ namespace Samples.RuntimeMetrics
 
             new Thread(GenerateEvents) { IsBackground = true }.Start();
 
+            /*
+             * We need runtime metrics to be refreshed at least twice to have the contention metrics
+             * (because it needs a previous value to compute the variation).
+             * Because of the asynchronous initialization of the performance counters, we sometimes
+             * miss the first refresh. 
+             * 
+             * We wait 30 seconds here to ensure that we'll have at least two refreshes.
+             */
+
             Thread.Sleep(30000);
 
             Console.WriteLine("Exiting");

--- a/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper/RelationalDatabaseTestHarness.cs
@@ -169,7 +169,6 @@ namespace Samples.DatabaseHelper
 
                     Console.WriteLine("  Synchronous");
                     Console.WriteLine();
-                    await Task.Delay(100, cancellationToken);
 
                     command = commandFactory.GetCreateTableCommand(connection);
                     commandExecutor.ExecuteNonQuery(command);
@@ -195,15 +194,12 @@ namespace Samples.DatabaseHelper
 
                 if (commandExecutor.SupportsAsyncMethods)
                 {
-                    await Task.Delay(100, cancellationToken);
-
                     using (var scope = SampleHelpers.CreateScope("async"))
                     {
                         SampleHelpers.TrySetResourceName(scope, commandName);
 
                         Console.WriteLine("  Asynchronous");
                         Console.WriteLine();
-                        await Task.Delay(100, cancellationToken);
 
                         command = commandFactory.GetCreateTableCommand(connection);
                         await commandExecutor.ExecuteNonQueryAsync(command);
@@ -227,15 +223,12 @@ namespace Samples.DatabaseHelper
                         await commandExecutor.ExecuteNonQueryAsync(command);
                     }
 
-                    await Task.Delay(100, cancellationToken);
-
                     using (var scope = SampleHelpers.CreateScope("async-with-cancellation"))
                     {
                         SampleHelpers.TrySetResourceName(scope, commandName);
 
                         Console.WriteLine("  Asynchronous with cancellation");
                         Console.WriteLine();
-                        await Task.Delay(100, cancellationToken);
 
                         command = commandFactory.GetCreateTableCommand(connection);
                         await commandExecutor.ExecuteNonQueryAsync(command, cancellationToken);
@@ -260,8 +253,6 @@ namespace Samples.DatabaseHelper
                     }
                 }
             }
-
-            await Task.Delay(100, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

An assortment of changes to mainly reduce the time the tests take on CI.

## Reason for change

Make CI faster and better

## Implementation details

I've attempted to split each commit here into one change/fix for a given group of tests

- [Increase assertion range](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/a4a157724ece5f74f73146ebdba88c92d6fc39d3)
  - Flaking as the previous range was too strict at 100ms (and would fail locally on me occasionally)
- [Abort response when not sending](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/122d71fe736deed707a04c8d3c04c5e387c786cc)
  - This affects 2 tests for `AgentMalfunctionTests` where the agent is set to not respond for TCP - previously this one was blocking on the `GetContext` call for 15 seconds after it would skip the send and then error out.
  - **Time saved: ~30 seconds** (2x tests at 15 seconds each -> 2x tests at ~1 second))
- [Reduce wait time for IAST disabled tests](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/9964708bc7e78f691b3a6915aaa68533dcd86084)
  - There's no spans expected here (none are returned at least) but waits for 20 seconds, so I've reduced it to wait for 2 seconds
  - **Time saved: ~54 seconds** (3x tests at ~21 seconds each -> 3x tests at ~2-3 seconds)
- [Wait for 2 seconds for ProcessStartTests Disabled spans](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/9f0ee94c4a95ea2e16d93353f9ae5ff591c1e6be)
  - There's no spans expected here - so wait for 2 seconds instead of the 20 seconds default
  - **Time saved: ~18 seconds** (1x test at ~21 seconds -> 1x test at ~2-3 seconds)
- [Set expected spans counts for ProcessStartTests for non-Windows](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/59a9f8b57ed0b52044ac1b994a217842efac93b5)
  - On Windows we'd expect 5, otherwise we'd expect 3 (per snapshots), but always wait for 5, so I've added the expectation for non-Windows.
  - **Time saved: ~60 seconds** (3x tests at ~40 seconds each -> 20x tests at ~1-2 seconds)
- [Change expected spans to 3 for Linux for AgentMalfunctionTests](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/87ea06745303a2016096e68b9b1854e4236bd816)
  - On Windows we'd expect 5, otherwise we'd expect 3 (per snapshots), but always wait for 5, so I've added the expectation for non-Windows.
  - **Time saved: ~800 seconds** (20x tests at ~40 seconds each -> 20x tests at ~1-2 seconds)
- [Timeout after 3 seconds for Kafka and flush every 1 second](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/74e7ec8c08626bf14f4c29a358c1efb94a73063d)
  - The Kafka integration tests on later package versions were taking 1 minute and 10 seconds each, this was because earlier versions would return right away when producing to an invalid topic - but later versions would block for 30 seconds (2x tests)
  - **Time saved: ~240 seconds** (4x tests at ~70 seconds each -> 4x tests at ~13 seconds each)
- [Remove Task.Delays in RelationalDatabaseTestHarness](https://github.com/DataDog/dd-trace-dotnet/pull/4479/commits/64301e50b466974034bae6f15f27fe928ce6e32c)
  - Noticed that many of the Database-related integration tests were some of the longer running tests and appears that for each individual `RunAsync` they had an added 600ms of wait time - removing it didn't seem to introduce flake and I couldn't see a reason for why they were there.
  - **Time saved: ~???** This impacted quite a few tests I didn't really calculate this one

## Test coverage

- N/A

## Other details
<!-- Fixes #{issue} -->
