### PR TITLE
[Profiler] Add Sample value type provider

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -38,7 +38,7 @@ AllocationsProvider::AllocationsProvider(
     MetricsRegistry& metricsRegistry)
     :
     AllocationsProvider(
-        valueTypeProvider.Register(SampleTypeDefinitions),
+        valueTypeProvider.GetOrRegister(SampleTypeDefinitions),
         pCorProfilerInfo, pManagedThreadList, pFrameStore,
         pThreadsCpuManager, pAppDomainStore, pRuntimeIdStore,
         pConfiguration,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
@@ -19,6 +19,7 @@ class IThreadsCpuManager;
 class IAppDomainStore;
 class IRuntimeIdStore;
 class ISampledAllocationsListener;
+class SampleValueTypeProvider;
 
 
 class AllocationsProvider
@@ -27,11 +28,20 @@ class AllocationsProvider
     public IAllocationsListener
 {
 public:
-    static std::vector<SampleValueType> SampleTypeDefinitions;
-
-public:
     AllocationsProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& valueTypeProvider,
+        ICorProfilerInfo4* pCorProfilerInfo,
+        IManagedThreadList* pManagedThreadList,
+        IFrameStore* pFrameStore,
+        IThreadsCpuManager* pThreadsCpuManager,
+        IAppDomainStore* pAppDomainStore,
+        IRuntimeIdStore* pRuntimeIdStore,
+        IConfiguration* pConfiguration,
+        ISampledAllocationsListener* pListener,
+        MetricsRegistry& metricsRegistry);
+
+    AllocationsProvider(
+        std::vector<SampleValueTypeProvider::Offset> valueTypeProvider,
         ICorProfilerInfo4* pCorProfilerInfo,
         IManagedThreadList* pManagedThreadList,
         IFrameStore* pFrameStore,
@@ -50,6 +60,8 @@ public:
                       uint64_t allocationAmount) override;
 
 private:
+    static std::vector<SampleValueType> SampleTypeDefinitions;
+
     ICorProfilerInfo4* _pCorProfilerInfo;
     IManagedThreadList* _pManagedThreadList;
     IFrameStore* _pFrameStore;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -33,7 +33,7 @@ ContentionProvider::ContentionProvider(
     IConfiguration* pConfiguration,
     MetricsRegistry& metricsRegistry)
     :
-    CollectorBase<RawContentionSample>("ContentionProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
+    CollectorBase<RawContentionSample>("ContentionProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
     _pCorProfilerInfo{pCorProfilerInfo},
     _pManagedThreadList{pManagedThreadList},
     _sampler(pConfiguration->ContentionSampleLimit(), pConfiguration->GetUploadInterval(), false),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -12,6 +12,7 @@
 #include "IUpscaleProvider.h"
 #include "OsSpecificApi.h"
 #include "Sample.h"
+#include "SampleValueTypeProvider.h"
 
 
 std::vector<SampleValueType> ContentionProvider::SampleTypeDefinitions(
@@ -22,7 +23,7 @@ std::vector<SampleValueType> ContentionProvider::SampleTypeDefinitions(
 
 
 ContentionProvider::ContentionProvider(
-    uint32_t valueOffset,
+    SampleValueTypeProvider& valueTypeProvider,
     ICorProfilerInfo4* pCorProfilerInfo,
     IManagedThreadList* pManagedThreadList,
     IFrameStore* pFrameStore,
@@ -32,7 +33,7 @@ ContentionProvider::ContentionProvider(
     IConfiguration* pConfiguration,
     MetricsRegistry& metricsRegistry)
     :
-    CollectorBase<RawContentionSample>("ContentionProvider", valueOffset, SampleTypeDefinitions.size(), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
+    CollectorBase<RawContentionSample>("ContentionProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
     _pCorProfilerInfo{pCorProfilerInfo},
     _pManagedThreadList{pManagedThreadList},
     _sampler(pConfiguration->ContentionSampleLimit(), pConfiguration->GetUploadInterval(), false),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -21,6 +21,7 @@ class IFrameStore;
 class IThreadsCpuManager;
 class IAppDomainStore;
 class IRuntimeIdStore;
+class SampleValueTypeProvider;
 
 
 class ContentionProvider :
@@ -29,11 +30,8 @@ class ContentionProvider :
     public IUpscaleProvider
 {
 public:
-    static std::vector<SampleValueType> SampleTypeDefinitions;
-
-public:
     ContentionProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& valueTypeProvider,
         ICorProfilerInfo4* pCorProfilerInfo,
         IManagedThreadList* pManagedThreadList,
         IFrameStore* pFrameStore,
@@ -49,6 +47,8 @@ public:
 
 private:
     static std::string GetBucket(double contentionDurationNs);
+
+    static std::vector<SampleValueType> SampleTypeDefinitions;
 
     ICorProfilerInfo4* _pCorProfilerInfo;
     IManagedThreadList* _pManagedThreadList;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -44,6 +44,7 @@
 #include "RuntimeIdStore.h"
 #include "RuntimeInfo.h"
 #include "Sample.h"
+#include "SampleValueTypeProvider.h"
 #include "StackSamplerLoopManager.h"
 #include "ThreadsCpuManager.h"
 #include "WallTimeProvider.h"
@@ -102,8 +103,6 @@ CorProfilerCallback::~CorProfilerCallback()
     CGroup::Cleanup();
 #endif
 }
-
-#include "SampleValueTypeProvider.h"
 
 bool CorProfilerCallback::InitializeServices()
 {
@@ -1225,8 +1224,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadCreated(ThreadID threadId)
         return S_OK;
     }
 
-    _pManagedThreadList->GetOrCreateThread(threadId); // -> ManagedThreadInfo
-    // _threadProvider->EmitCreationEvent(pThreadInfo);
+    _pManagedThreadList->GetOrCreateThread(threadId);
     return S_OK;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
@@ -17,7 +17,7 @@ std::vector<SampleValueType> CpuTimeProvider::SampleTypeDefinitions(
 
 
 CpuTimeProvider::CpuTimeProvider(
-    uint32_t valueOffset,
+    SampleValueTypeProvider& valueTypeProvider,
     IThreadsCpuManager* pThreadsCpuManager,
     IFrameStore* pFrameStore,
     IAppDomainStore* pAppDomainStore,
@@ -25,6 +25,6 @@ CpuTimeProvider::CpuTimeProvider(
     IConfiguration* pConfiguration
     )
     :
-    CollectorBase<RawCpuSample>("CpuTimeProvider", valueOffset, SampleTypeDefinitions.size(), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawCpuSample>("CpuTimeProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
@@ -25,6 +25,6 @@ CpuTimeProvider::CpuTimeProvider(
     IConfiguration* pConfiguration
     )
     :
-    CollectorBase<RawCpuSample>("CpuTimeProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawCpuSample>("CpuTimeProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.h
@@ -11,6 +11,7 @@ class IConfiguration;
 class IFrameStore;
 class IAppDomainStore;
 class IRuntimeIdStore;
+class SampleValueTypeProvider;
 
 
 class CpuTimeProvider
@@ -18,15 +19,15 @@ class CpuTimeProvider
     public CollectorBase<RawCpuSample> // accepts cputime samples
 {
 public:
-    static std::vector<SampleValueType> SampleTypeDefinitions;
-
-public:
     CpuTimeProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& valueTypeProvider,
         IThreadsCpuManager* pThreadsCpuManager,
         IFrameStore* pFrameStore,
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
         IConfiguration* pConfiguration
         );
+
+private:
+    static std::vector<SampleValueType> SampleTypeDefinitions;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -257,6 +257,7 @@
     <ClInclude Include="NativeThreadsCpuProviderBase.h" />
     <ClInclude Include="ProxyMetric.h" />
     <ClInclude Include="RawGarbageCollectionSample.h" />
+    <ClInclude Include="SampleValueTypeProvider.h" />
     <ClInclude Include="ScopedHandle.h" />
     <ClInclude Include="StopTheWorldGCProvider.h" />
     <ClInclude Include="GenericSampler.h" />
@@ -365,6 +366,7 @@
     <ClCompile Include="NativeThreadsCpuProviderBase.cpp" />
     <ClCompile Include="ProxyMetric.cpp" />
     <ClCompile Include="RawGarbageCollectionSample.cpp" />
+    <ClCompile Include="SampleValueTypeProvider.cpp" />
     <ClCompile Include="StopTheWorldGCProvider.cpp" />
     <ClCompile Include="GenericSampler.cpp" />
     <ClCompile Include="HResultConverter.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -45,6 +45,9 @@
     <Filter Include="GarbageCollections">
       <UniqueIdentifier>{c07c8635-c021-4796-bfac-48f7ee78bf65}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Threads">
+      <UniqueIdentifier>{9343cd1c-a26e-4f7d-a006-85e4612d0813}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="CorProfilerCallback.h">
@@ -70,9 +73,6 @@
     </ClInclude>
     <ClInclude Include="DogstatsdService.h">
       <Filter>Metrics</Filter>
-    </ClInclude>
-    <ClInclude Include="ManagedThreadInfo.h">
-      <Filter>Profiler-Driver</Filter>
     </ClInclude>
     <ClInclude Include="ManagedThreadList.h">
       <Filter>Profiler-Driver</Filter>
@@ -328,10 +328,22 @@
     <ClInclude Include="DebugInfoStore.h" />
     <ClInclude Include="IDebugInfoStore.h" />
     <ClInclude Include="IExceptionsRecorder.h" />
-    <ClInclude Include="IThreadInfo.h" />
     <ClInclude Include="ScopedHandle.h" />
-    <ClInclude Include="GCThreadsCpuProvider.h" />
-    <ClInclude Include="NativeThreadsCpuProviderBase.h" />
+    <ClInclude Include="GCThreadsCpuProvider.h">
+      <Filter>Threads</Filter>
+    </ClInclude>
+    <ClInclude Include="IThreadInfo.h">
+      <Filter>Threads</Filter>
+    </ClInclude>
+    <ClInclude Include="NativeThreadsCpuProviderBase.h">
+      <Filter>Threads</Filter>
+    </ClInclude>
+    <ClInclude Include="ManagedThreadInfo.h">
+      <Filter>Threads</Filter>
+    </ClInclude>
+    <ClInclude Include="SampleValueTypeProvider.h">
+      <Filter>Profiler-Driver</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OpSysTools.cpp">
@@ -357,9 +369,6 @@
     </ClCompile>
     <ClCompile Include="IMetricsSenderFactory.cpp">
       <Filter>Metrics</Filter>
-    </ClCompile>
-    <ClCompile Include="ManagedThreadInfo.cpp">
-      <Filter>Profiler-Driver</Filter>
     </ClCompile>
     <ClCompile Include="ManagedThreadList.cpp">
       <Filter>Profiler-Driver</Filter>
@@ -418,9 +427,6 @@
     </ClCompile>
     <ClCompile Include="ApplicationStore.cpp" />
     <ClCompile Include="RuntimeIdStore.cpp" />
-    <ClCompile Include="ApplicationInfo.cpp">
-      <Filter>Utils</Filter>
-    </ClCompile>
     <ClCompile Include="RawExceptionSample.cpp">
       <Filter>Utils</Filter>
     </ClCompile>
@@ -496,11 +502,17 @@
     <ClCompile Include="DebugInfoStore.cpp">
       <Filter>Utils</Filter>
     </ClCompile>
-    <ClCompile Include="GCThreadsCpuProvider.cpp">
-      <Filter>Utils</Filter>
-    </ClCompile>
     <ClCompile Include="NativeThreadsCpuProviderBase.cpp">
       <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="GCThreadsCpuProvider.cpp">
+      <Filter>Threads</Filter>
+    </ClCompile>
+    <ClCompile Include="ManagedThreadInfo.cpp">
+      <Filter>Threads</Filter>
+    </ClCompile>
+    <ClCompile Include="SampleValueTypeProvider.cpp">
+      <Filter>Profiler-Driver</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
@@ -31,7 +31,7 @@ ExceptionsProvider::ExceptionsProvider(
     IRuntimeIdStore* pRuntimeIdStore,
     MetricsRegistry& metricsRegistry)
     :
-    CollectorBase<RawExceptionSample>("ExceptionsProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
+    CollectorBase<RawExceptionSample>("ExceptionsProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
     _pCorProfilerInfo(pCorProfilerInfo),
     _pManagedThreadList(pManagedThreadList),
     _pFrameStore(pFrameStore),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
@@ -10,6 +10,7 @@
 #include "Log.h"
 #include "OsSpecificApi.h"
 #include "ScopeFinalizer.h"
+#include "SampleValueTypeProvider.h"
 #include "shared/src/native-src/com_ptr.h"
 #include "shared/src/native-src/string.h"
 
@@ -20,7 +21,7 @@ std::vector<SampleValueType> ExceptionsProvider::SampleTypeDefinitions(
     });
 
 ExceptionsProvider::ExceptionsProvider(
-    uint32_t valueOffset,
+    SampleValueTypeProvider& valueTypeProvider,
     ICorProfilerInfo4* pCorProfilerInfo,
     IManagedThreadList* pManagedThreadList,
     IFrameStore* pFrameStore,
@@ -30,7 +31,7 @@ ExceptionsProvider::ExceptionsProvider(
     IRuntimeIdStore* pRuntimeIdStore,
     MetricsRegistry& metricsRegistry)
     :
-    CollectorBase<RawExceptionSample>("ExceptionsProvider", valueOffset, SampleTypeDefinitions.size(), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
+    CollectorBase<RawExceptionSample>("ExceptionsProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration),
     _pCorProfilerInfo(pCorProfilerInfo),
     _pManagedThreadList(pManagedThreadList),
     _pFrameStore(pFrameStore),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
@@ -18,17 +18,15 @@
 #include "IUpscaleProvider.h"
 
 class IConfiguration;
+class SampleValueTypeProvider;
 
 class ExceptionsProvider :
     public CollectorBase<RawExceptionSample>,
     public IUpscaleProvider
 {
 public:
-    static std::vector<SampleValueType> SampleTypeDefinitions;
-
-public:
     ExceptionsProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& valueTypeProvider,
         ICorProfilerInfo4* pCorProfilerInfo,
         IManagedThreadList* pManagedThreadList,
         IFrameStore* pFrameStore,
@@ -56,6 +54,8 @@ private:
 
 
 private:
+    static std::vector<SampleValueType> SampleTypeDefinitions;
+
     ICorProfilerInfo4* _pCorProfilerInfo;
     IManagedThreadList* _pManagedThreadList;
     IFrameStore* _pFrameStore;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCBaseRawSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCBaseRawSample.h
@@ -35,9 +35,10 @@ public:
     // This base class is in charge of storing garbage collection number and generation as labels
     // and fill up the callstack based on generation.
     // The default value is the Duration field; derived class could override by implementing GetValue()
-    inline void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
+    inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        uint32_t durationIndex = valueOffset;
+        assert(valueOffsets.size() == 1);
+        auto durationIndex = valueOffsets[0];
 
         sample->AddValue(GetValue(), durationIndex);
 
@@ -47,7 +48,7 @@ public:
         BuildCallStack(sample, Generation);
 
         // let child classes transform additional fields if needed
-        DoAdditionalTransform(sample, valueOffset);
+        DoAdditionalTransform(sample, valueOffsets);
     }
 
     // Each derived class provides the duration to store as the value for this sample
@@ -58,7 +59,7 @@ public:
     }
 
     // Derived classes are expected to set the event type + any additional field as label
-    virtual void DoAdditionalTransform(std::shared_ptr<Sample> sample, uint32_t valueOffset) const = 0;
+    virtual void DoAdditionalTransform(std::shared_ptr<Sample> sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffset) const = 0;
 
 public:
     int32_t Number;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
@@ -3,6 +3,7 @@
 
 #include "GarbageCollectionProvider.h"
 
+#include "SampleValueTypeProvider.h"
 
 std::vector<SampleValueType> GarbageCollectionProvider::SampleTypeDefinitions(
     {
@@ -10,7 +11,7 @@ std::vector<SampleValueType> GarbageCollectionProvider::SampleTypeDefinitions(
     });
 
 GarbageCollectionProvider::GarbageCollectionProvider(
-    uint32_t valueOffset,
+    SampleValueTypeProvider& valueTypeProvider,
     IFrameStore* pFrameStore,
     IThreadsCpuManager* pThreadsCpuManager,
     IAppDomainStore* pAppDomainStore,
@@ -18,7 +19,7 @@ GarbageCollectionProvider::GarbageCollectionProvider(
     IConfiguration* pConfiguration,
     MetricsRegistry& metricsRegistry)
     :
-    CollectorBase<RawGarbageCollectionSample>("GarbageCollectorProvider", valueOffset, SampleTypeDefinitions.size(), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawGarbageCollectionSample>("GarbageCollectorProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
     _gen0CountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_gc_gen0");
     _gen1CountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_gc_gen1");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
@@ -19,7 +19,7 @@ GarbageCollectionProvider::GarbageCollectionProvider(
     IConfiguration* pConfiguration,
     MetricsRegistry& metricsRegistry)
     :
-    CollectorBase<RawGarbageCollectionSample>("GarbageCollectorProvider", valueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawGarbageCollectionSample>("GarbageCollectorProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
     _gen0CountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_gc_gen0");
     _gen1CountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_gc_gen1");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
@@ -4,12 +4,14 @@
 #pragma once
 
 #include "CollectorBase.h"
+
 #include "IGarbageCollectionsListener.h"
 #include "RawGarbageCollectionSample.h"
 #include "MetricsRegistry.h"
 #include "CounterMetric.h"
 #include "MeanMaxMetric.h"
 
+class SampleValueTypeProvider;
 
 class GarbageCollectionProvider
     : public CollectorBase<RawGarbageCollectionSample>,
@@ -20,7 +22,7 @@ public:
 
 public:
     GarbageCollectionProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& valueTypeProvider,
         IFrameStore* pFrameStore,
         IThreadsCpuManager* pThreadsCpuManager,
         IAppDomainStore* pAppDomainStore,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IUpscaleProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IUpscaleProvider.h
@@ -8,13 +8,14 @@
 #include <vector>
 
 #include "GroupSampler.h"
+#include "SampleValueTypeProvider.h"
 
 using UpscaleStringGroup = UpscaleGroupInfo<std::string>;
 
 struct UpscalingInfo
 {
 public:
-    std::vector<std::uintptr_t> const& Offsets;
+    std::vector<SampleValueTypeProvider::Offset> const& Offsets;
     std::string LabelName;
     std::vector<UpscaleStringGroup> UpscaleGroups;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.cpp
@@ -63,7 +63,7 @@ std::string const LibddprofExporter::ProfileExtension = ".pprof";
 std::string const LibddprofExporter::AllocationsExtension = ".balloc";
 
 LibddprofExporter::LibddprofExporter(
-    std::vector<SampleValueType>&& sampleTypeDefinitions,
+    std::vector<SampleValueType> sampleTypeDefinitions,
     IConfiguration* configuration,
     IApplicationStore* applicationStore,
     IRuntimeInfo* runtimeInfo,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LibddprofExporter.h
@@ -36,7 +36,7 @@ class LibddprofExporter : public IExporter
 {
 public:
     LibddprofExporter(
-        std::vector<SampleValueType>&& sampleTypeDefinitions,
+        std::vector<SampleValueType> sampleTypeDefinitions,
         IConfiguration* configuration,
         IApplicationStore* applicationStore,
         IRuntimeInfo* runtimeInfo,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -9,6 +9,7 @@
 #include "LiveObjectsProvider.h"
 #include "OpSysTools.h"
 #include "Sample.h"
+#include "SampleValueTypeProvider.h"
 
 std::vector<SampleValueType> LiveObjectsProvider::SampleTypeDefinitions(
 {
@@ -23,7 +24,7 @@ const std::string LiveObjectsProvider::Gen2("2");
 
 
 LiveObjectsProvider::LiveObjectsProvider(
-    uint32_t valueOffset,
+    SampleValueTypeProvider& valueTypeProvider,
     ICorProfilerInfo13* pCorProfilerInfo,
     IManagedThreadList* pManagedThreadList,
     IFrameStore* pFrameStore,
@@ -33,7 +34,6 @@ LiveObjectsProvider::LiveObjectsProvider(
     IConfiguration* pConfiguration,
     MetricsRegistry& metricsRegistry)
     :
-    _valueOffset(valueOffset),
     _pCorProfilerInfo(pCorProfilerInfo),
     _pFrameStore(pFrameStore),
     _pAppDomainStore(pAppDomainStore),
@@ -41,7 +41,7 @@ LiveObjectsProvider::LiveObjectsProvider(
     _isTimestampsAsLabelEnabled(pConfiguration->IsTimestampsAsLabelEnabled())
 {
     _pAllocationsProvider = std::make_unique<AllocationsProvider>(
-        valueOffset,  // the values (allocation count and size are stored in the live object values, not tha allocation values)
+        valueTypeProvider.Register(SampleTypeDefinitions),
         pCorProfilerInfo,
         pManagedThreadList,
         pFrameStore,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -41,7 +41,7 @@ LiveObjectsProvider::LiveObjectsProvider(
     _isTimestampsAsLabelEnabled(pConfiguration->IsTimestampsAsLabelEnabled())
 {
     _pAllocationsProvider = std::make_unique<AllocationsProvider>(
-        valueTypeProvider.Register(SampleTypeDefinitions),
+        valueTypeProvider.GetOrRegister(SampleTypeDefinitions),
         pCorProfilerInfo,
         pManagedThreadList,
         pFrameStore,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -23,6 +23,7 @@ class IAppDomainStore;
 class IRuntimeIdStore;
 class IConfiguration;
 class ISampledAllocationsListener;
+class SampleValueTypeProvider;
 
 class LiveObjectsProvider : public IService,
                             public IBatchedSamplesProvider,
@@ -30,11 +31,8 @@ class LiveObjectsProvider : public IService,
                             public IGarbageCollectionsListener
 {
 public:
-    static std::vector<SampleValueType> SampleTypeDefinitions;
-
-public:
     LiveObjectsProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& valueTypeProvider,
         ICorProfilerInfo13* pCorProfilerInfo,
         IManagedThreadList* pManagedThreadList,
         IFrameStore* pFrameStore,
@@ -78,7 +76,8 @@ private:
     bool IsAlive(ObjectHandleID handle) const;
 
 private:
-    uint32_t _valueOffset = 0;
+    static std::vector<SampleValueType> SampleTypeDefinitions;
+
     ICorProfilerInfo13* _pCorProfilerInfo = nullptr;
     IFrameStore* _pFrameStore = nullptr;
     IAppDomainStore* _pAppDomainStore = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawAllocationSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawAllocationSample.h
@@ -34,10 +34,11 @@ public:
         return *this;
     }
 
-    inline void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
+    inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        uint32_t allocationCountIndex = valueOffset;
-        uint32_t allocationSizeIndex = valueOffset + 1;
+        assert(valueOffsets.size() == 2);
+        auto allocationCountIndex = valueOffsets[0];
+        auto allocationSizeIndex = valueOffsets[1];
 
         sample->AddValue(1, allocationCountIndex);
         sample->AddValue(AllocationSize, allocationSizeIndex);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -35,10 +35,11 @@ public:
         return *this;
     }
 
-    void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
+    void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        uint32_t contentionCountIndex = valueOffset;
-        uint32_t contentionDurationIndex = valueOffset + 1;
+        assert(valueOffsets.size() == 2);
+        auto contentionCountIndex = valueOffsets[0];
+        auto contentionDurationIndex = valueOffsets[1];
 
         sample->AddLabel(Label{BucketLabelName, std::move(Bucket)});
         sample->AddValue(1, contentionCountIndex);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawCpuSample.h
@@ -28,9 +28,10 @@ public:
         return *this;
     }
 
-    inline void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
+    inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        sample->AddValue(Duration * 1000000, valueOffset);
+        assert(valueOffsets.size() == 1);
+        sample->AddValue(Duration * 1000000, valueOffsets[0]);
     }
 
     std::uint64_t Duration; // in milliseconds

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawExceptionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawExceptionSample.h
@@ -26,9 +26,10 @@ public:
         return *this;
     }
 
-    inline void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
+    inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        sample->AddValue(1, valueOffset);
+        assert(valueOffsets.size() == 1);
+        sample->AddValue(1, valueOffsets[0]);
         sample->AddLabel(Label(Sample::ExceptionMessageLabel, ExceptionMessage));
         sample->AddLabel(Label(Sample::ExceptionTypeLabel, ExceptionType));
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawGarbageCollectionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawGarbageCollectionSample.h
@@ -46,7 +46,7 @@ public:
         return TotalDuration;
     }
 
-    inline void DoAdditionalTransform(std::shared_ptr<Sample> sample, uint32_t valueOffset) const override
+    inline void DoAdditionalTransform(std::shared_ptr<Sample> sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
         sample->AddLabel(Label(Sample::GarbageCollectionReasonLabel, GetReasonText()));
         sample->AddLabel(Label(Sample::GarbageCollectionTypeLabel, GetTypeText()));

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSample.h
@@ -10,7 +10,7 @@
 #include "cor.h"
 #include "corprof.h"
 #include "ManagedThreadInfo.h"
-
+#include "SampleValueTypeProvider.h"
 
 class Sample;
 
@@ -27,7 +27,7 @@ public:
     RawSample& operator=(RawSample&& other) noexcept;
 
     // set values and additional labels on target sample
-    virtual void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const = 0;
+    virtual void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffset) const = 0;
 
 public:
     std::uint64_t Timestamp;        // _unixTimeUtc;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawStopTheWorldSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawStopTheWorldSample.h
@@ -16,7 +16,7 @@ public:
     RawStopTheWorldSample& operator=(RawStopTheWorldSample&& other) noexcept = default;
 
     // Duration is the suspension time so default sample value
-    void DoAdditionalTransform(std::shared_ptr<Sample> sample, uint32_t valueOffset) const override
+    void DoAdditionalTransform(std::shared_ptr<Sample> sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
         // set event type
         sample->AddLabel(Label(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeStopTheWorld));

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawWallTimeSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawWallTimeSample.h
@@ -30,9 +30,10 @@ public:
         return *this;
     }
 
-    inline void OnTransform(std::shared_ptr<Sample>& sample, uint32_t valueOffset) const override
+    inline void OnTransform(std::shared_ptr<Sample>& sample, std::vector<SampleValueTypeProvider::Offset> const& valueOffsets) const override
     {
-        sample->AddValue(Duration, valueOffset);
+        assert(valueOffsets.size() == 1);
+        sample->AddValue(Duration, valueOffsets[0]);
     }
 
     std::uint64_t Duration; // in nanoseconds

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.cpp
@@ -12,7 +12,7 @@ SampleValueTypeProvider::SampleValueTypeProvider()
     _sampleTypeDefinitions.reserve(16);
 }
 
-std::vector<SampleValueTypeProvider::Offset> SampleValueTypeProvider::Register(std::vector<SampleValueType> const& valueTypes)
+std::vector<SampleValueTypeProvider::Offset> SampleValueTypeProvider::GetOrRegister(std::vector<SampleValueType> const& valueTypes)
 {
     std::vector<Offset> offsets;
     offsets.reserve(valueTypes.size());

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.cpp
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "SampleValueTypeProvider.h"
+
+#include <cassert>
+#include <tuple>
+
+
+SampleValueTypeProvider::SampleValueTypeProvider()
+{
+    _sampleTypeDefinitions.reserve(16);
+}
+
+std::vector<SampleValueTypeProvider::Offset> SampleValueTypeProvider::Register(std::vector<SampleValueType> const& valueTypes)
+{
+    std::vector<Offset> offsets;
+    offsets.reserve(valueTypes.size());
+
+    for (auto const& valueType : valueTypes)
+    {
+        auto idx = GetOffset(valueType);
+        if (idx == -1)
+        {
+            idx = _sampleTypeDefinitions.size();
+            _sampleTypeDefinitions.push_back(valueType);
+        }
+        offsets.push_back(idx);
+    }
+    return offsets;
+}
+
+std::vector<SampleValueType> const& SampleValueTypeProvider::GetValueTypes()
+{
+    return _sampleTypeDefinitions;
+}
+
+std::int8_t SampleValueTypeProvider::GetOffset(SampleValueType const& valueType)
+{
+    for (auto i = 0; i < _sampleTypeDefinitions.size(); i++)
+    {
+        auto const& current = _sampleTypeDefinitions[i];
+        if (valueType.Name == current.Name)
+        {
+            if (valueType.Unit != current.Unit)
+            {
+                throw std::runtime_error("Cannot have the value type name with different unit: " + valueType.Unit + " != " + current.Unit);
+            }
+            return i;
+        }
+    }
+    return -1;
+}
+

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.h
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "Sample.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+// Non-thread-safe class
+// Must be called underlock or make it thread-safe if needed.
+// For now, keep it simple
+class SampleValueTypeProvider
+{
+public:
+    using Offset = std::uintptr_t; // Use std::uintptr_t to make it work with with libdatadog which is expected int32 or int64 indices type
+
+    SampleValueTypeProvider();
+
+    std::vector<Offset> Register(std::vector<SampleValueType> const& valueType);
+    std::vector<SampleValueType> const& GetValueTypes();
+
+private:
+    std::int8_t GetOffset(SampleValueType const& valueType);
+
+    std::vector<SampleValueType> _sampleTypeDefinitions;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleValueTypeProvider.h
@@ -19,7 +19,7 @@ public:
 
     SampleValueTypeProvider();
 
-    std::vector<Offset> Register(std::vector<SampleValueType> const& valueType);
+    std::vector<Offset> GetOrRegister(std::vector<SampleValueType> const& valueType);
     std::vector<SampleValueType> const& GetValueTypes();
 
 private:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
@@ -27,7 +27,7 @@ StopTheWorldGCProvider::StopTheWorldGCProvider(
     IRuntimeIdStore* pRuntimeIdStore,
     IConfiguration* pConfiguration)
     :
-    CollectorBase<RawStopTheWorldSample>("StopTheWorldGCProvider", valueTypeProvider.Register(GarbageCollectionProvider::SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawStopTheWorldSample>("StopTheWorldGCProvider", valueTypeProvider.GetOrRegister(GarbageCollectionProvider::SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
@@ -13,19 +13,21 @@
 #include "IThreadsCpuManager.h"
 #include "Log.h"
 #include "OsSpecificApi.h"
+#include "SampleValueTypeProvider.h"
+
 #include "shared/src/native-src/com_ptr.h"
 #include "shared/src/native-src/string.h"
 
 
 StopTheWorldGCProvider::StopTheWorldGCProvider(
-    uint32_t valueOffset,
+    SampleValueTypeProvider& valueTypeProvider,
     IFrameStore* pFrameStore,
     IThreadsCpuManager* pThreadsCpuManager,
     IAppDomainStore* pAppDomainStore,
     IRuntimeIdStore* pRuntimeIdStore,
     IConfiguration* pConfiguration)
     :
-    CollectorBase<RawStopTheWorldSample>("StopTheWorldGCProvider", valueOffset, GarbageCollectionProvider::SampleTypeDefinitions.size(), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawStopTheWorldSample>("StopTheWorldGCProvider", valueTypeProvider.Register(GarbageCollectionProvider::SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.h
@@ -12,18 +12,17 @@ class IThreadsCpuManager;
 class IAppDomainStore;
 class IRuntimeIdStore;
 class IConfiguration;
-
+class SampleValueTypeProvider;
 
 class StopTheWorldGCProvider
-    :
-    public CollectorBase<RawStopTheWorldSample>,
-    public IGCSuspensionsListener
+    : public CollectorBase<RawStopTheWorldSample>,
+      public IGCSuspensionsListener
 {
-// use the same sample type definition as the GarbageCollectorProvider
+    // use the same sample type definition as the GarbageCollectorProvider
 
 public:
     StopTheWorldGCProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& valueTypeProvider,
         IFrameStore* pFrameStore,
         IThreadsCpuManager* pThreadsCpuManager,
         IAppDomainStore* pAppDomainStore,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
@@ -8,7 +8,7 @@
 #include "IRuntimeIdStore.h"
 #include "IThreadsCpuManager.h"
 #include "RawWallTimeSample.h"
-
+#include "SampleValueTypeProvider.h"
 
 std::vector<SampleValueType> WallTimeProvider::SampleTypeDefinitions(
     {
@@ -17,7 +17,7 @@ std::vector<SampleValueType> WallTimeProvider::SampleTypeDefinitions(
     );
 
 WallTimeProvider::WallTimeProvider(
-    uint32_t valueOffset,
+    SampleValueTypeProvider& sampleValueTypeProvider,
     IThreadsCpuManager* pThreadsCpuManager,
     IFrameStore* pFrameStore,
     IAppDomainStore* pAppDomainStore,
@@ -25,6 +25,6 @@ WallTimeProvider::WallTimeProvider(
     IConfiguration* pConfiguration
     )
     :
-    CollectorBase<RawWallTimeSample>("WallTimeProvider", valueOffset, SampleTypeDefinitions.size(), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawWallTimeSample>("WallTimeProvider", sampleValueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
@@ -8,7 +8,8 @@
 #include "IRuntimeIdStore.h"
 #include "IThreadsCpuManager.h"
 #include "RawWallTimeSample.h"
-#include "SampleValueTypeProvider.h"
+
+class SampleValueTypeProvider;
 
 std::vector<SampleValueType> WallTimeProvider::SampleTypeDefinitions(
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
@@ -26,6 +26,6 @@ WallTimeProvider::WallTimeProvider(
     IConfiguration* pConfiguration
     )
     :
-    CollectorBase<RawWallTimeSample>("WallTimeProvider", sampleValueTypeProvider.Register(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
+    CollectorBase<RawWallTimeSample>("WallTimeProvider", sampleValueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, pConfiguration)
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.h
@@ -13,6 +13,7 @@ class IAppDomainStore;
 class IRuntimeIdStore;
 class IThreadsCpuManager;
 class IConfiguration;
+class SampleValueTypeProvider;
 
 
 class WallTimeProvider
@@ -20,15 +21,15 @@ class WallTimeProvider
     public CollectorBase<RawWallTimeSample> // accepts raw walltime samples
 {
 public:
-    static std::vector<SampleValueType> SampleTypeDefinitions;
-
-public:
     WallTimeProvider(
-        uint32_t valueOffset,
+        SampleValueTypeProvider& sampleValueTypeProvider,
         IThreadsCpuManager* pThreadsCpuManager,
         IFrameStore* pFrameStore,
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
         IConfiguration* pConfiguration
         );
+
+private:
+    static std::vector<SampleValueType> SampleTypeDefinitions;
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -66,6 +66,7 @@
     <ClCompile Include="RuntimeIdTest.cpp" />
     <ClCompile Include="RuntimeInfoHelper.cpp" />
     <ClCompile Include="SamplesCollectorTest.cpp" />
+    <ClCompile Include="SampleValueTypeProviderTest.cpp" />
     <ClCompile Include="StackSnapshotResultBufferTest.cpp" />
     <ClCompile Include="TagsHelperTest.cpp" />
     <ClCompile Include="ProviderTest.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -13,6 +13,9 @@
     <Filter Include="Helpers">
       <UniqueIdentifier>{300fa0f9-3712-4092-bb4a-382f97cb0c58}</UniqueIdentifier>
     </Filter>
+    <Filter Include="External Sources">
+      <UniqueIdentifier>{ecc1aba4-974c-43eb-99cb-8a79be4132ea}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -110,13 +113,23 @@
     <ClCompile Include="OsSpecificApiTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\OsSpecificApi.cpp" />
-    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\SystemTime.cpp" />
-    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Windows64BitStackFramesCollector.cpp" />
-    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Windows32BitStackFramesCollector.cpp" />
-    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\WindowsThreadInfo.cpp" />
     <ClCompile Include="SampleValueTypeProviderTest.cpp">
       <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\OsSpecificApi.cpp">
+      <Filter>External Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\SystemTime.cpp">
+      <Filter>External Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Windows32BitStackFramesCollector.cpp">
+      <Filter>External Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Windows64BitStackFramesCollector.cpp">
+      <Filter>External Sources</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\WindowsThreadInfo.cpp">
+      <Filter>External Sources</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -115,6 +115,9 @@
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Windows64BitStackFramesCollector.cpp" />
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\Windows32BitStackFramesCollector.cpp" />
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\WindowsThreadInfo.cpp" />
+    <ClCompile Include="SampleValueTypeProviderTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -18,6 +18,7 @@
 #include "CpuTimeProvider.h"
 #include "RawCpuSample.h"
 #include "RawWallTimeSample.h"
+#include "SampleValueTypeProvider.h"
 #include "ThreadsCpuManagerHelper.h"
 
 using namespace std::chrono_literals;
@@ -86,13 +87,14 @@ TEST(WallTimeProviderTest, CheckNoMissingSample)
     auto frameStore = FrameStoreHelper(true, "Frame", 1);
     auto appDomainStore = AppDomainStoreHelper(2);
     auto threadscpuManager = ThreadsCpuManagerHelper();
+    auto valueTypeProvider = SampleValueTypeProvider();
     MockRuntimeIdStore runtimeIdStore;
     auto [configuration, mockConfiguration] = CreateConfiguration();
 
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -115,6 +117,7 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
     auto appDomainStore = AppDomainStoreHelper(2);
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto threadscpuManager = ThreadsCpuManagerHelper();
+    auto valueTypeProvider = SampleValueTypeProvider();
     MockRuntimeIdStore runtimeIdStore;
 
     std::string firstExpectedRuntimeId = "MyRid";
@@ -123,7 +126,7 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
     std::string secondExpectedRuntimeId = "OtherRid";
     EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(2))).WillRepeatedly(::testing::Return(secondExpectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -198,12 +201,13 @@ TEST(WallTimeProviderTest, CheckFrames)
     auto appDomainStore = AppDomainStoreHelper(1);
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto threadscpuManager = ThreadsCpuManagerHelper();
+    auto valueTypeProvider = SampleValueTypeProvider();
     MockRuntimeIdStore runtimeIdStore;
 
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(1))).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -256,12 +260,13 @@ TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
     auto appDomainStore = AppDomainStoreHelper(1);
     auto [configuration, mockConfiguration] = CreateConfiguration();
     auto threadscpuManager = ThreadsCpuManagerHelper();
+    auto valueTypeProvider = SampleValueTypeProvider();
     MockRuntimeIdStore runtimeIdStore;
 
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -299,10 +304,11 @@ TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
     auto frameStore = FrameStoreHelper(true, "Frame", 1);
     auto appDomainStore = AppDomainStoreHelper(1);
     auto threadscpuManager = ThreadsCpuManagerHelper();
+    auto valueTypeProvider = SampleValueTypeProvider();
     RuntimeIdStoreHelper runtimeIdStore;
     auto [configuration, mockConfiguration] = CreateConfiguration();
 
-    CpuTimeProvider provider(0, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    CpuTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
     Sample::ValuesCount = 1;
     provider.Start();
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/SampleValueTypeProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SampleValueTypeProviderTest.cpp
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "SampleValueTypeProvider.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+static const SampleValueType CpuValueType = {"cpu", "nanoseconds"};
+static const SampleValueType WallTimeValueType = {"walltime", "nanoseconds"};
+static const SampleValueType ExceptionValueType = {"exception", "count"};
+
+testing::AssertionResult AreSampleValueTypeEqual(SampleValueType const& v1, SampleValueType const& v2)
+{
+    if (v1.Name == v2.Name && v1.Unit == v2.Unit)
+        return testing::AssertionSuccess();
+    else
+        return testing::AssertionFailure() << " sample value type differs";
+}
+
+#define ASSERT_DEFINITIONS(expectedDefinitions, definitions)   \
+    ASSERT_EQ(expectedDefinitions.size(), definitions.size()); \
+    for (auto i = 0; i < expectedDefinitions.size(); i++)      \
+        ASSERT_PRED2(AreSampleValueTypeEqual, expectedDefinitions[i], definitions[i]);
+
+TEST(SampleValueTypeProvider, RegisterValueTypes)
+{
+    SampleValueTypeProvider provider;
+    auto const valueTypes = std::vector<SampleValueType>{CpuValueType, WallTimeValueType};
+
+    auto offsets = provider.Register(valueTypes);
+
+    ASSERT_EQ(2, offsets.size());
+    ASSERT_EQ(0, offsets[0]); // cpu offset
+    ASSERT_EQ(1, offsets[1]); // walltime offset
+
+    ASSERT_DEFINITIONS(valueTypes, provider.GetValueTypes());
+}
+
+TEST(SampleValueTypeProvider, RegisterTwiceSameValueType)
+{
+    SampleValueTypeProvider provider;
+    auto valueTypes = std::vector<SampleValueType>{CpuValueType, WallTimeValueType};
+
+    auto offsets = provider.Register(valueTypes);
+
+    ASSERT_EQ(2, offsets.size());
+    ASSERT_EQ(0, offsets[0]); // cpu offset
+    ASSERT_EQ(1, offsets[1]); // walltime offset
+
+    ASSERT_DEFINITIONS(valueTypes, provider.GetValueTypes());
+
+    // Register a second time
+
+    auto alreadyRegisteredValueType = std::vector<SampleValueType>{WallTimeValueType};
+    auto offsets2 = provider.Register(alreadyRegisteredValueType);
+
+    ASSERT_EQ(1, offsets2.size());
+    ASSERT_EQ(1, offsets2[0]); // walltime offset did not changed
+
+    ASSERT_DEFINITIONS(valueTypes, provider.GetValueTypes());
+}
+
+TEST(SampleValueTypeProvider, CheckSequentialRegistration)
+{
+    SampleValueTypeProvider provider;
+    auto valueTypes = std::vector<SampleValueType>{CpuValueType, WallTimeValueType};
+
+    auto offsets = provider.Register(valueTypes);
+    ASSERT_DEFINITIONS(valueTypes, provider.GetValueTypes());
+
+    // Register ExceptionValueType
+    auto anotherValuetype = std::vector<SampleValueType>{
+        ExceptionValueType};
+
+    auto offsets2 = provider.Register(anotherValuetype);
+
+    ASSERT_EQ(1, offsets2.size());
+    ASSERT_EQ(2, offsets2[0]);
+
+    ASSERT_DEFINITIONS((std::vector<SampleValueType>{CpuValueType, WallTimeValueType, ExceptionValueType}), provider.GetValueTypes());
+}
+
+TEST(SampleValueTypeProvider, EnsureThrowIfAddValueTypeSameNameButDifferentUnit)
+{
+    SampleValueTypeProvider provider;
+    auto valueTypes = std::vector<SampleValueType>{CpuValueType};
+
+    auto offsets = provider.Register(valueTypes);
+    ASSERT_DEFINITIONS(valueTypes, provider.GetValueTypes());
+
+    // Register a cpu value but with different unit
+    auto anotherValuetype = std::vector<SampleValueType>{{"cpu", "non-sense-unit"}};
+
+    EXPECT_THROW(provider.Register(anotherValuetype), std::runtime_error);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/SampleValueTypeProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SampleValueTypeProviderTest.cpp
@@ -35,7 +35,7 @@ TEST(SampleValueTypeProvider, RegisterValueTypes)
     SampleValueTypeProvider provider;
     auto const valueTypes = std::vector<SampleValueType>{CpuValueType, WallTimeValueType};
 
-    auto offsets = provider.Register(valueTypes);
+    auto offsets = provider.GetOrRegister(valueTypes);
 
     ASSERT_OFFSETS((ValueOffsets{0, 1}), offsets);
     //              cpu offset --^  ^-- walltime offset
@@ -48,7 +48,7 @@ TEST(SampleValueTypeProvider, RegisterTwiceSameValueType)
     SampleValueTypeProvider provider;
     auto valueTypes = std::vector<SampleValueType>{CpuValueType, WallTimeValueType};
 
-    auto offsets = provider.Register(valueTypes);
+    auto offsets = provider.GetOrRegister(valueTypes);
 
     ASSERT_OFFSETS((ValueOffsets{0, 1}), offsets);
     //              cpu offset --^  ^-- walltime offset
@@ -58,7 +58,7 @@ TEST(SampleValueTypeProvider, RegisterTwiceSameValueType)
     // Register walltime a second time
 
     auto alreadyRegisteredValueType = std::vector<SampleValueType>{WallTimeValueType};
-    auto offsets2 = provider.Register(alreadyRegisteredValueType);
+    auto offsets2 = provider.GetOrRegister(alreadyRegisteredValueType);
 
     ASSERT_OFFSETS((ValueOffsets{1}), offsets2); // walltime offset did not changed
 
@@ -70,13 +70,13 @@ TEST(SampleValueTypeProvider, CheckSequentialRegistration)
     SampleValueTypeProvider provider;
     auto valueTypes = std::vector<SampleValueType>{CpuValueType, WallTimeValueType};
 
-    auto offsets = provider.Register(valueTypes);
+    auto offsets = provider.GetOrRegister(valueTypes);
     ASSERT_DEFINITIONS(valueTypes, provider.GetValueTypes());
 
     // Register ExceptionValueType
     auto anotherValuetype = std::vector<SampleValueType>{ExceptionValueType};
 
-    auto offsets2 = provider.Register(anotherValuetype);
+    auto offsets2 = provider.GetOrRegister(anotherValuetype);
     ASSERT_OFFSETS((ValueOffsets{2}), offsets2);
 
     ASSERT_DEFINITIONS((std::vector<SampleValueType>{CpuValueType, WallTimeValueType, ExceptionValueType}), provider.GetValueTypes());
@@ -87,11 +87,11 @@ TEST(SampleValueTypeProvider, EnsureThrowIfAddValueTypeSameNameButDifferentUnit)
     SampleValueTypeProvider provider;
     auto valueTypes = std::vector<SampleValueType>{CpuValueType};
 
-    auto offsets = provider.Register(valueTypes);
+    auto offsets = provider.GetOrRegister(valueTypes);
     ASSERT_DEFINITIONS(valueTypes, provider.GetValueTypes());
 
     // Register a cpu value but with different unit
     auto anotherValuetype = std::vector<SampleValueType>{{"cpu", "non-sense-unit"}};
 
-    EXPECT_THROW(provider.Register(anotherValuetype), std::runtime_error);
+    EXPECT_THROW(provider.GetOrRegister(anotherValuetype), std::runtime_error);
 }


### PR DESCRIPTION
## Summary of changes

Add Sample Value Type provider .

## Reason for change

The goal is to be able to reuse, validate Sample Value Types (for example `timeline`).

## Implementation details

- Add `SampleValueTypeProvider` which is in charge of bookkeeping  the sample values types defined and used by the profilers.
- Pass it around.
- 
## Test coverage

Add Unit tests
## Other details
<!-- Fixes #{issue} -->
