### PR TITLE
Fix macOS flaky unit test 

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -29,7 +29,10 @@ namespace Datadog.Trace.Tests
             var expectedNow = DateTimeOffset.UtcNow;
 
             // We cannot assume that expectedNow > now due to the difference of accuracy of QPC and UtcNow.
-            Assert.True(Math.Abs(expectedNow.Subtract(now).TotalMilliseconds) <= 30);
+            var allowedVariance = EnvironmentTools.IsOsx()
+                                        ? TimeSpan.FromMilliseconds(100) // The clock in virtualized osx is terrible
+                                        : TimeSpan.FromMilliseconds(30);
+            now.Should().BeCloseTo(expectedNow, allowedVariance);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Allow more variation in macOS timing test

## Reason for change

To quote @tonyredondo 

> the clock in a virtualized macos instance is terrible... well, not only the clock

## Implementation details

Allow 100ms variation on macOS instead of 30ms
