### PR TITLE
Bump timeitsharp version to v0.0.15

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net60.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.14
+dotnet tool update -g timeitsharp --version 0.0.15
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net60.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.13
+dotnet tool update -g timeitsharp --version 0.0.14
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net60.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.14
+dotnet tool update -g timeitsharp --version 0.0.15
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net60.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.0.13
+dotnet tool update -g timeitsharp --version 0.0.14
 
 echo *********************
 echo .NET Framework 4.6.1


### PR DESCRIPTION
## Summary of changes

Bump timeitsharp version to v0.0.15

## Reason for change

With the changes introduced in v0.0.13 and new metrics added we are now being rejected by the backend because the size of the test span. 

- Limit test span size by limiting number of metrics. by @tonyredondo in https://github.com/tonyredondo/timeitsharp/pull/19
- Startup hook simplification by @tonyredondo in https://github.com/tonyredondo/timeitsharp/pull/20