### PR TITLE
Assert that we don't timeout for MockTracerAgent

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -203,7 +203,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
                 {
                     agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                    var spans = agent.WaitForSpans(1, 2000);
+                    var spans = agent.Spans;
                     Assert.Equal(0, spans.Count);
 
                     var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -202,9 +202,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
                 {
-                    agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                    var spans = agent.Spans;
-                    Assert.Equal(0, spans.Count);
+                    var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
+                    Assert.Empty(spans);
 
                     var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
                     var parentSpanId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -158,7 +158,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
-                var spans = agent.WaitForSpans(1, 2000);
+                var spans = agent.Spans;
 
                 using var s = new AssertionScope();
                 spans.Should().BeEmpty();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -47,12 +47,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected async Task RunTest(string metadataSchemaVersion, string testName, int expectedSpanCount, bool collectCommands = false)
         {
+            // TODO slightly hacky with expected span count at the moment
             if (EnvironmentTools.IsWindows())
             {
 #if !NETCOREAPP3_1_OR_GREATER
                 // e.g. .NET 4.6.2
-                expectedSpanCount = 6;
+                if (expectedSpanCount >= 10)
+                {
+                    expectedSpanCount = 6;
+                }
 #endif
+            }
+            else if (!EnvironmentTools.IsWindows())
+            {
+                expectedSpanCount -= 2;
             }
 
             const string expectedOperationName = "command_execution";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -47,27 +47,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected async Task RunTest(string metadataSchemaVersion, string testName, int expectedSpanCount, bool collectCommands = false)
         {
-            // TODO slightly hacky with expected span count at the moment
-            if (EnvironmentTools.IsWindows())
-            {
+            // expectedSpanCount (10 is passed into this function but varies depending on OS and .NET version):
+            // Windows .NET Framework/.NET Core 3.0 and lower: 6 spans
+            // Windows .NET Core 3.1+: 10 spans
+            // Linux/OSX .NET Core 3.0 and lower: 6 spans
+            // Linux/OSX .NET Core 3.1+: 8 spans
 #if !NETCOREAPP3_1_OR_GREATER
-                // e.g. .NET 4.6.2
-                if (expectedSpanCount >= 10)
-                {
-                    expectedSpanCount = 6;
-                }
-#endif
-            }
-            else if (!EnvironmentTools.IsWindows())
+            // Windows/Linux/Mac all expect 6 for .NET Framework or .NET Core 3.0 and below
+            if (expectedSpanCount >= 10)
             {
-#if !NETCOREAPP3_1_OR_GREATER
-                if (expectedSpanCount >= 10)
-                {
-                    expectedSpanCount = 6;
-                }
-#endif
-                expectedSpanCount -= 2;
+                expectedSpanCount = 6;
             }
+#else
+            if (!EnvironmentTools.IsWindows())
+            {
+                expectedSpanCount = 8;
+            }
+#endif
 
             const string expectedOperationName = "command_execution";
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 #endif
 
-            if (expectedSpanCount == 5)
+            if (expectedSpanCount == 5 && !EnvironmentTools.IsWindows())
             {
                 expectedSpanCount = 3;
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
 #if !NETCOREAPP3_1_OR_GREATER
                 // e.g. .NET 4.6.2
-                expectedSpanCount -= 4; // we expect 6 spans only
+                expectedSpanCount = 6;
 #endif
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -60,6 +60,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
             else if (!EnvironmentTools.IsWindows())
             {
+#if !NETCOREAPP3_1_OR_GREATER
+                if (expectedSpanCount >= 10)
+                {
+                    expectedSpanCount = 6;
+                }
+#endif
                 expectedSpanCount -= 2;
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -51,17 +51,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Windows .NET Framework/.NET Core 3.0 and lower: 6 spans
             // Windows .NET Core 3.1+: 10 spans
             // Linux/OSX .NET Core 3.0 and lower: 6 spans
-            // Linux/OSX .NET Core 3.1+: 8 spans
+            // Linux/OSX .NET Core 3.1+: 10 spans
 #if !NETCOREAPP3_1_OR_GREATER
             // Windows/Linux/Mac all expect 6 for .NET Framework or .NET Core 3.0 and below
             if (expectedSpanCount >= 10)
             {
                 expectedSpanCount = 6;
-            }
-#else
-            if (!EnvironmentTools.IsWindows())
-            {
-                expectedSpanCount = 8;
             }
 #endif
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -47,11 +47,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected async Task RunTest(string metadataSchemaVersion, string testName, int expectedSpanCount, bool collectCommands = false)
         {
-            // expectedSpanCount (10 is passed into this function but varies depending on OS and .NET version):
+            // expectedSpanCount when 10
             // Windows .NET Framework/.NET Core 3.0 and lower: 6 spans
             // Windows .NET Core 3.1+: 10 spans
             // Linux/OSX .NET Core 3.0 and lower: 6 spans
             // Linux/OSX .NET Core 3.1+: 10 spans
+
+            // expectedSpanCount when 5
+            // Windows will have 5 spans for all
+            // Linux/OSX will have 3 spans
 #if !NETCOREAPP3_1_OR_GREATER
             // Windows/Linux/Mac all expect 6 for .NET Framework or .NET Core 3.0 and below
             if (expectedSpanCount >= 10)
@@ -59,6 +63,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 expectedSpanCount = 6;
             }
 #endif
+
+            if (expectedSpanCount == 5)
+            {
+                expectedSpanCount = 3;
+            }
 
             const string expectedOperationName = "command_execution";
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -47,8 +47,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected async Task RunTest(string metadataSchemaVersion, string testName, int expectedSpanCount, bool collectCommands = false)
         {
-            // 3 on non-windows because of SecureString
-            expectedSpanCount = EnvironmentTools.IsWindows() ? expectedSpanCount : expectedSpanCount - 2;
+            if (EnvironmentTools.IsWindows())
+            {
+#if !NETCOREAPP3_1_OR_GREATER
+                // e.g. .NET 4.6.2
+                expectedSpanCount -= 4; // we expect 6 spans only
+#endif
+            }
 
             const string expectedOperationName = "command_execution";
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -165,7 +165,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var agent = EnvironmentHelper.GetMockAgent();
             using var process = RunSampleAndWaitForExit(agent);
-            var spans = agent.WaitForSpans(1, 2000);
+            var spans = agent.Spans;
 
             Assert.Empty(spans);
             telemetry?.AssertIntegration(IntegrationId.TraceAnnotations, enabled: false, autoEnabled: false);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
             {
                 agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                var spans = agent.WaitForSpans(1, 3000);
+                var spans = agent.Spans;
                 Assert.Equal(0, spans.Count);
 
                 var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -50,9 +50,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
             {
-                agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                var spans = agent.Spans;
-                Assert.Equal(0, spans.Count);
+                var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
+                Assert.Empty(spans);
 
                 var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
                 var parentSpanId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -53,9 +53,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
             {
-                agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                var spans = agent.Spans;
-                Assert.Equal(0, spans.Count);
+                var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
+                Assert.Empty(spans);
 
                 var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);
                 var parentSpanId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.ParentId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
             {
                 agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
-                var spans = agent.WaitForSpans(1, 3000);
+                var spans = agent.Spans;
                 Assert.Equal(0, spans.Count);
 
                 var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);

--- a/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/StatsTests.cs
@@ -227,7 +227,7 @@ namespace Datadog.Trace.IntegrationTests
             await tracer.TracerManager.ShutdownAsync(); // Flushes and closes both traces and stats
 
             var statsPayload = agent.WaitForStats(1);
-            var spans = agent.WaitForSpans(13);
+            var spans = agent.WaitForSpans(6);
 
             statsPayload.Should().HaveCount(1);
             statsPayload[0].Stats.Should().HaveCount(1);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             var url = "/Health";
 
             var settings = VerifyHelper.GetSpanVerifierSettings(test);
-            await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, SecurityEnabled ? 1 : 2, settings, userAgent: "Hello/V");
+            await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, 1, settings, userAgent: "Hello/V");
         }
 
         protected override string GetTestName() => _testName;

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -171,11 +171,6 @@ namespace Datadog.Trace.TestHelpers
                 Thread.Sleep(500);
             }
 
-            if (count == 1 && timedOut)
-            {
-                timedOut = false; // just marking this as maybe we aren't expecting any
-            }
-
             timedOut.Should().BeFalse($"TIMED OUT: Expected spans: {count}; Received spans: {relevantSpans.Count}");
 
             foreach (var headers in TraceRequestHeaders)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -171,6 +171,11 @@ namespace Datadog.Trace.TestHelpers
                 Thread.Sleep(500);
             }
 
+            if (count == 1 && timedOut)
+            {
+                timedOut = false; // just marking this as maybe we aren't expecting any
+            }
+
             timedOut.Should().BeFalse($"TIMED OUT: Expected spans: {count}; Received spans: {relevantSpans.Count}");
 
             foreach (var headers in TraceRequestHeaders)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.TestHelpers
                 Thread.Sleep(500);
             }
 
-            relevantSpans.Should().HaveCountGreaterThanOrEqualTo(count, "because we want to ensure that we don't timeout while waiting for spans from the mock tracer agent.");
+            relevantSpans.Should().HaveCountGreaterThanOrEqualTo(count, "because we want to ensure that we don't timeout while waiting for spans from the mock tracer agent");
 
             foreach (var headers in TraceRequestHeaders)
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -130,7 +130,6 @@ namespace Datadog.Trace.TestHelpers
             DateTimeOffset? minDateTime = null,
             bool returnAllOperations = false)
         {
-            var timedOut = true;
             var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
             var minimumOffset = (minDateTime ?? DateTimeOffset.MinValue).ToUnixTimeNanoseconds();
 
@@ -164,14 +163,13 @@ namespace Datadog.Trace.TestHelpers
 
                 if (relevantSpans.Count(s => operationName == null || s.Name == operationName) >= count)
                 {
-                    timedOut = false;
                     break;
                 }
 
                 Thread.Sleep(500);
             }
 
-            timedOut.Should().BeFalse($"TIMED OUT: Expected spans: {count}; Received spans: {relevantSpans.Count}");
+            relevantSpans.Should().HaveCountGreaterThanOrEqualTo(count, "because we want to ensure that we don't timeout while waiting for spans from the mock tracer agent.");
 
             foreach (var headers in TraceRequestHeaders)
             {

--- a/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SpanTagAssertion.cs
@@ -89,9 +89,9 @@ namespace Datadog.Trace.TestHelpers
                 _tags.Remove(tagName);
             }
 
-            if (!value.Equals(expectedValue))
+            if (value is null || !value.Equals(expectedValue))
             {
-                _result.WithFailure(GenerateMatchesFailureString("tag", tagName, expectedValue.ToString(), value.ToString()));
+                _result.WithFailure(GenerateMatchesFailureString("tag", tagName, expectedValue.ToString(), value?.ToString() ?? "null"));
             }
 
             return this;


### PR DESCRIPTION
## Summary of changes

Asserts that `WaitForSpans` doesn't time out and returns at least the expected number of spans.
Fixes various tests that started to fail because of this.

## Reason for change

Several tests were timing out the `WaitForSpans` which is 20s per test.
Additionally, probably should expect the correct number of spans for tests.

## Implementation details

Added `relevantSpans.Should().HaveCountGreaterThanOrEqualTo()` for `WaitForSpans`
Changed some tests that wait for 0 spans to be `agent.Spans;` instead of `WaitForSpans`
Fixed tests waiting for incorrect number of spans - looked at snapshots as source of truth for correct number.

## Test coverage

N/A

## Other details
<!-- Fixes #{issue} -->
