### PR TITLE
[Profiler] Wrap socket syscalls to prevent application errors

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2110,7 +2110,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e IncludeTestsRequiringDocker=false ProfilerIntegrationTests
+        dockerComposeCommand: run --rm -e baseImage=$(baseImage) ProfilerIntegrationTests
         projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,6 @@ services:
     ports:
     - "127.0.0.1:6391:6379"
 
-
 # Dependencies
   localstack:
     image: localstack/localstack
@@ -318,6 +317,19 @@ services:
       KAFKA_REST_LISTENERS: "http://0.0.0.0:8082"
       KAFKA_REST_SCHEMA_REGISTRY_URL: 'http://kafka-schema-registry:8081'
 
+  openldap:
+    image: osixia/openldap:latest
+    ports:
+      - "389:369"
+      - "636:636"
+    hostname: openldap-server
+    environment:
+      LDAP_ORGANISATION: "Datadog"
+      LDAP_DOMAIN: "dd-trace-dotnet.com"
+      LDAP_ADMIN_PASSWORD: "Passw0rd"
+      LDAP_BASE_DN: "dc=dd-trace-dotnet,dc=com"
+
+
   # The IIS images are based on Windows images, so they can only be run on Docker for Windows,
   # and only after switching to run Windows containers
   IntegrationTests.IIS:
@@ -407,7 +419,10 @@ services:
       - DD_LOGGER_DD_TAGS
       - DD_INTERNAL_TELEMETRY_V2_ENABLED
       - DD_TELEMETRY_METRICS_ENABLED
+      - LDAP_SERVER=openldap-server:389
     hostname: integrationtests
+    depends_on:
+      - openldap
 
   IntegrationTests:
     build:

--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -43,6 +43,11 @@ namespace Samples.Computer01
         private NullThreadNameBugCheck _nullThreadNameBugCheck;
         private MethodsSignature _methodsSignature;
 
+#if NET5_0_OR_GREATER
+        private OpenLdapCrash _openldapCrash;
+        private SocketTimeout _socketTest;
+#endif
+
         public void StartService(Scenario scenario, int nbThreads, int parameter)
         {
             _scenario = scenario;
@@ -146,6 +151,15 @@ namespace Samples.Computer01
                 case Scenario.MethodSignature:
                     StartMethodsSignature();
                     break;
+
+#if NET5_0_OR_GREATER
+                case Scenario.OpenLdapCrash:
+                    StartOpenLdapCrash();
+                    break;
+                case Scenario.SocketTimeout:
+                    StartSocketTimeout();
+                    break;
+#endif
                 default:
                     throw new ArgumentOutOfRangeException(nameof(scenario), $"Unsupported scenario #{_scenario}");
             }
@@ -251,6 +265,15 @@ namespace Samples.Computer01
                 case Scenario.MethodSignature:
                     StopMethodsSignature();
                     break;
+
+#if NET5_0_OR_GREATER
+                case Scenario.OpenLdapCrash:
+                    StopOpenLdapCrash();
+                    break;
+                case Scenario.SocketTimeout:
+                    _socketTest.Stop();
+                    break;
+#endif
             }
         }
 
@@ -362,6 +385,14 @@ namespace Samples.Computer01
                         RunMethodsSignature();
                         break;
 
+#if NET5_0_OR_GREATER
+                    case Scenario.OpenLdapCrash:
+                        RunOpenLdapCrash();
+                        break;
+                    case Scenario.SocketTimeout:
+                        RunSocketTimeout();
+                        break;
+#endif
                     default:
                         throw new ArgumentOutOfRangeException(nameof(scenario), $"Unsupported scenario #{_scenario}");
                 }
@@ -521,6 +552,20 @@ namespace Samples.Computer01
             _methodsSignature.Start();
         }
 
+#if NET5_0_OR_GREATER
+        private void StartOpenLdapCrash()
+        {
+            _openldapCrash = new OpenLdapCrash();
+            _openldapCrash.Start();
+        }
+
+        private void StartSocketTimeout()
+        {
+            _socketTest = new SocketTimeout();
+            _socketTest.Start();
+        }
+#endif
+
         private void StopComputer()
         {
             using (_computer)
@@ -590,6 +635,11 @@ namespace Samples.Computer01
         {
             _linuxSignalHandler.Stop();
         }
+
+        private void StpSocketTimeout()
+        {
+            _socketTest.Stop();
+        }
 #endif
 
         private void StopGarbageCollections()
@@ -636,6 +686,13 @@ namespace Samples.Computer01
         {
             _methodsSignature.Stop();
         }
+
+#if NET5_0_OR_GREATER
+        private void StopOpenLdapCrash()
+        {
+            _openldapCrash.Stop();
+        }
+#endif
 
         private void RunComputer()
         {
@@ -778,6 +835,20 @@ namespace Samples.Computer01
             var methodsSignature = new MethodsSignature();
             methodsSignature.Run();
         }
+
+#if NET5_0_OR_GREATER
+        private void RunOpenLdapCrash()
+        {
+            var openldapCrash = new OpenLdapCrash();
+            openldapCrash.Run();
+        }
+
+        private void RunSocketTimeout()
+        {
+            var socketTest = new SocketTimeout();
+            socketTest.Run();
+        }
+#endif
 
         public class MySpecialClassA
         {

--- a/profiler/src/Demos/Samples.Computer01/OpenLdapCrash.cs
+++ b/profiler/src/Demos/Samples.Computer01/OpenLdapCrash.cs
@@ -23,7 +23,7 @@ namespace Samples.Computer01
             {
                 (_serverHostname, _serverPort) = uri.IndexOf(':') switch
                 {
-                    var colonIdx when colonIdx > -1 => (uri[..colonIdx], int.Parse(uri.AsSpan(colonIdx + 1))),
+                    var colonIdx when colonIdx > -1 => (uri[..colonIdx], int.Parse(uri[(colonIdx + 1)..])),
                     _ => (uri, 389)
                 };
             }

--- a/profiler/src/Demos/Samples.Computer01/OpenLdapCrash.cs
+++ b/profiler/src/Demos/Samples.Computer01/OpenLdapCrash.cs
@@ -1,0 +1,63 @@
+// <copyright file="OpenLdapCrash.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+#if NET5_0_OR_GREATER
+using System;
+using System.DirectoryServices.Protocols;
+using System.Net;
+
+namespace Samples.Computer01
+{
+    internal class OpenLdapCrash : ScenarioBase
+    {
+        private readonly string _serverHostname;
+        private readonly int _serverPort;
+
+        public OpenLdapCrash()
+        {
+            var uri = Environment.GetEnvironmentVariable("LDAP_SERVER") ?? "localhost:389";
+
+            try
+            {
+                (_serverHostname, _serverPort) = uri.IndexOf(':') switch
+                {
+                    var colonIdx when colonIdx > -1 => (uri[..colonIdx], int.Parse(uri.AsSpan(colonIdx + 1))),
+                    _ => (uri, 389)
+                };
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(
+                    $"[Error] Failed to parse ldap server connection information. LDAP_SERVER env var: {Environment.GetEnvironmentVariable("LDAP_SERVER")}" +
+                    $" , Uri: {uri}. Error: {e.Message}");
+            }
+        }
+
+        public override void OnProcess()
+        {
+            if (_serverHostname == null)
+            {
+                return;
+            }
+
+            ConnectToLdapServer();
+        }
+
+        private void ConnectToLdapServer()
+        {
+            try
+            {
+                using var ldapConnection = new LdapConnection(new LdapDirectoryIdentifier(_serverHostname, _serverPort), new NetworkCredential("cn=admin,dc=dd-trace-dotnet,dc=com", "Passw0rd"), AuthType.Basic);
+                ldapConnection.SessionOptions.ProtocolVersion = 3;
+                ldapConnection.Bind();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"[Error] An error occured while trying to connect to the LDAP server `{_serverHostname}:{_serverPort}`. Message: " + e.Message);
+            }
+        }
+    }
+}
+#endif

--- a/profiler/src/Demos/Samples.Computer01/Program.cs
+++ b/profiler/src/Demos/Samples.Computer01/Program.cs
@@ -33,7 +33,9 @@ namespace Samples.Computer01
         InnerMethods,
         LineNumber,
         NullThreadNameBug,
-        MethodSignature
+        MethodSignature,
+        OpenLdapCrash,
+        SocketTimeout
     }
 
     public class Program
@@ -76,6 +78,7 @@ namespace Samples.Computer01
 
             ParseCommandLine(args, out TimeSpan timeout, out bool runAsService, out Scenario scenario, out int iterations, out int nbThreads, out int parameter);
 
+            Console.WriteLine("Running Scenario " + scenario.ToString());
             // This application is used for several purposes:
             //  - execute a processing for a given duration (for smoke test)
             //  - execute a processing several times (for runtime test)

--- a/profiler/src/Demos/Samples.Computer01/Samples.Computer01.csproj
+++ b/profiler/src/Demos/Samples.Computer01/Samples.Computer01.csproj
@@ -34,4 +34,14 @@
       <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="System.DirectoryServices.Protocols">
+      <Version>7.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="System.DirectoryServices.Protocols">
+      <Version>7.0.1</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
+++ b/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
@@ -5,7 +5,6 @@
 
 #if NET5_0_OR_GREATER
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -15,175 +14,161 @@ namespace Samples.Computer01
 {
     internal class SocketTimeout : ScenarioBase
     {
+        private const int ServerPort = 4242;
+        private const int OperationTimeout = 1_000;
+        private readonly TimeSpan _operationErrorTimeout = TimeSpan.FromSeconds(3);
+        private readonly IPEndPoint _serverEndpoint = new(IPAddress.Loopback, ServerPort);
         private readonly Task _serverThreadTask;
-        private readonly Task _gateThreadTask;
-        private readonly ManualResetEventSlim _readyEvent;
-        private readonly CancellationTokenSource _cts;
-        private readonly int _port;
-        private bool _hasReceiveTimedOut;
-        private bool _hasSendTimedOut;
+        private readonly ManualResetEventSlim _serverReadyEvent;
 
         public SocketTimeout()
         {
-            _port = 4242;
-            _cts = new CancellationTokenSource();
-            _serverThreadTask = Task.Factory.StartNew(StartServerAsync, _cts.Token, TaskCreationOptions.LongRunning);
-            _gateThreadTask = Task.Factory.StartNew(StartGateThread, _cts.Token, TaskCreationOptions.LongRunning);
-            _hasReceiveTimedOut = false;
-            _hasSendTimedOut = true;
-            _readyEvent = new ManualResetEventSlim(false);
+            _serverThreadTask = Task.Factory.StartNew(StartServerAsync, TaskCreationOptions.LongRunning);
+            _serverReadyEvent = new ManualResetEventSlim(false);
         }
+
+        private int TimeoutErrorCode { get; } = OperatingSystem.IsWindows() ? 10060 : 110;
 
         public override void OnProcess()
         {
             // Wait for server and gate threads to be ready
-            if (!_readyEvent.IsSet)
+            if (!_serverReadyEvent.IsSet)
             {
                 Console.WriteLine("** Waiting for server to be ready..");
-                _readyEvent.Wait(_cts.Token);
+                _serverReadyEvent.Wait();
             }
 
-            // In we are called while shutting down
-            if (_cts.Token.IsCancellationRequested)
+            if (IsEventSet())
             {
                 return;
             }
 
-            ReceiveTimeout(_cts.Token).Wait(_cts.Token);
-            SendTimeout(_cts.Token).Wait(_cts.Token);
+            ReceiveTimeout();
+            SendTimeout();
         }
 
-        private async Task ReceiveTimeout(CancellationToken token)
+        private static Socket CreateServerSocket()
         {
-            try
-            {
-                using var socket = await CreateAndConnect(token).ConfigureAwait(false);
-                socket.ReceiveTimeout = 1_000;
+            var s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var ep = new IPEndPoint(IPAddress.Any, ServerPort);
+            s.Bind(ep);
+            s.Listen();
 
-                var buffer = new byte[42];
-                socket.Receive(buffer);
-
-                Console.WriteLine("[Error] The Receive blocking call must timeout.");
-            }
-            catch (SocketException se) when (se.ErrorCode == 110)
-            {
-                _hasReceiveTimedOut = true;
-            }
-            catch (Exception e)
-            {
-                if (!IsEventSet())
-                {
-                    Console.WriteLine("[Error] unknown/unexpected exception: " + e.ToString());
-                }
-            }
+            return s;
         }
 
-        private async Task SendTimeout(CancellationToken token)
+        private Socket CreateAndConnectClientSocket()
         {
-            try
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp)
             {
-                using var socket = await CreateAndConnect(token).ConfigureAwait(false);
-                socket.SendTimeout = 1_000;
-
-                // really big buffer to make sure the call blocks
-                var buffer = new byte[8655535];
-                socket.Send(buffer);
-
-                Console.WriteLine("[Error] The Send blocking call must timeout.");
-            }
-            catch (SocketException e) when (e.ErrorCode == 110)
-            {
-                _hasReceiveTimedOut = true;
-            }
-            catch (Exception e)
-            {
-                if (!IsEventSet())
-                {
-                    Console.WriteLine("[Error] unknown/unexpected exception: " + e.ToString());
-                }
-            }
-        }
-
-        private async Task<Socket> CreateAndConnect(CancellationToken token)
-        {
-            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            var ep = new IPEndPoint(IPAddress.Loopback, _port);
-
-            try
-            {
-                await socket.ConnectAsync(ep, token);
-            }
-            catch
-            {
-                throw;
-            }
+                SendTimeout = OperationTimeout,
+                ReceiveTimeout = OperationTimeout,
+                SendBufferSize = 0,
+                Blocking = true
+            };
+            socket.Connect(_serverEndpoint);
 
             return socket;
         }
 
+        private void ReceiveTimeout()
+        {
+            EnsureOperationTimesOut(
+                (socket) =>
+                {
+                    var buffer = new byte[42];
+                    socket.Receive(buffer);
+                },
+                "Receive");
+        }
+
+        private void SendTimeout()
+        {
+            EnsureOperationTimesOut(
+                (socket) =>
+                {
+                    // really big buffer to make sure the call blocks
+                    var buffer = new byte[200_000];
+                    socket.Send(buffer);
+                },
+                "Send");
+        }
+
+        private bool IsSocketTimeoutException(Exception e)
+        {
+            return e switch
+            {
+                AggregateException ae => IsSocketTimeoutException(ae.InnerException),
+                SocketException se => se.ErrorCode == TimeoutErrorCode,
+                _ => false
+            };
+        }
+
+        private void EnsureOperationTimesOut(Action<Socket> action, string operationName)
+        {
+            try
+            {
+                var cts = new CancellationTokenSource(_operationErrorTimeout);
+                var task = Task.Run(
+                    () =>
+                    {
+                        using var socket = CreateAndConnectClientSocket();
+                        action(socket);
+
+                        if (!IsEventSet())
+                        {
+                            Console.WriteLine($"[Error] The {operationName} blocking call must timeout.");
+                        }
+                    });
+                task.Wait(cts.Token);
+            }
+            catch (Exception e) when (IsSocketTimeoutException(e))
+            {
+                // ok case
+            }
+            catch (OperationCanceledException)
+            {
+                Console.WriteLine($"[Error] The {operationName} operation was cancelled because it reached the 2s timeout.");
+            }
+            catch (Exception e)
+            {
+                if (!IsEventSet())
+                {
+                    Console.WriteLine("[Error] unknown/unexpected exception: " + e.ToString());
+                }
+            }
+        }
+
         private async Task StartServerAsync(object obj)
         {
-            Console.WriteLine("** Start server");
-
             Thread.CurrentThread.Name = "DD Socket Srv";
-            var token = (CancellationToken)obj;
-            using var s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
-            var ep = new IPEndPoint(IPAddress.Any, _port);
-            s.Bind(ep);
-            s.Listen();
 
-            _readyEvent.Set();
+            using var s = CreateServerSocket();
 
-            // This array ensures that we keep the socket alive (avoid the GC from
-            // collecting it) until the timeout is reached
-            var sockets = new Socket[2];
-            var idx = 0;
+            _serverReadyEvent.Set();
+
+            Console.WriteLine("** Server started...");
+
+            // This is needed to keep the connection up for the duration of each operation
+            // As the current test will create only one worker thread (even though there is
+            // --threads on the command-line), we are safe
+            Socket client;
             while (!IsEventSet())
             {
-                idx = idx++ % sockets.Length;
                 try
                 {
-                    sockets[idx] = await s.AcceptAsync(token);
+                    client = await s.AcceptAsync();
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("[Error] Unknown error when starting the server: " + e.ToString());
+                    if (!IsEventSet())
+                    {
+                        Console.WriteLine("[Error] Unknown error when accepting connection: " + e.ToString());
+                    }
+
                     break;
                 }
             }
-
-            if (!_hasReceiveTimedOut)
-            {
-                Console.WriteLine("[Error] Receive operation did not timed-out");
-            }
-
-            if (!_hasSendTimedOut)
-            {
-                Console.WriteLine("[Error] Send operation did not timed-out");
-            }
-
-            Console.WriteLine("** Server stopped");
-        }
-
-        private void StartGateThread(object obj)
-        {
-            Console.WriteLine("** Starting Gate Thread");
-
-            Thread.CurrentThread.Name = "DD Gate Thread";
-            var cts = (CancellationTokenSource)obj;
-            while (!IsEventSet())
-            {
-                Thread.Sleep(TimeSpan.FromSeconds(1));
-            }
-
-            if (!_readyEvent.IsSet)
-            {
-                _readyEvent.Set();
-            }
-
-            cts.Cancel();
-
-            Console.WriteLine("** Gate Thread stopped");
         }
     }
 }

--- a/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
+++ b/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
@@ -128,7 +128,7 @@ namespace Samples.Computer01
             }
             catch (OperationCanceledException)
             {
-                Console.WriteLine($"[Error] The {operationName} operation was cancelled because it reached the 2s timeout.");
+                Console.WriteLine($"[Error] The {operationName} operation was cancelled because it reached the {_operationErrorTimeout.Seconds}s timeout.");
             }
             catch (Exception e)
             {

--- a/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
+++ b/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
@@ -1,0 +1,190 @@
+// <copyright file="SocketTimeout.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+#if NET5_0_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.Computer01
+{
+    internal class SocketTimeout : ScenarioBase
+    {
+        private readonly Task _serverThreadTask;
+        private readonly Task _gateThreadTask;
+        private readonly ManualResetEventSlim _readyEvent;
+        private readonly CancellationTokenSource _cts;
+        private readonly int _port;
+        private bool _hasReceiveTimedOut;
+        private bool _hasSendTimedOut;
+
+        public SocketTimeout()
+        {
+            _port = 4242;
+            _cts = new CancellationTokenSource();
+            _serverThreadTask = Task.Factory.StartNew(StartServerAsync, _cts.Token, TaskCreationOptions.LongRunning);
+            _gateThreadTask = Task.Factory.StartNew(StartGateThread, _cts.Token, TaskCreationOptions.LongRunning);
+            _hasReceiveTimedOut = false;
+            _hasSendTimedOut = true;
+            _readyEvent = new ManualResetEventSlim(false);
+        }
+
+        public override void OnProcess()
+        {
+            // Wait for server and gate threads to be ready
+            if (!_readyEvent.IsSet)
+            {
+                Console.WriteLine("** Waiting for server to be ready..");
+                _readyEvent.Wait(_cts.Token);
+            }
+
+            // In we are called while shutting down
+            if (_cts.Token.IsCancellationRequested)
+            {
+                return;
+            }
+
+            ReceiveTimeout(_cts.Token).Wait(_cts.Token);
+            SendTimeout(_cts.Token).Wait(_cts.Token);
+        }
+
+        private async Task ReceiveTimeout(CancellationToken token)
+        {
+            try
+            {
+                using var socket = await CreateAndConnect(token).ConfigureAwait(false);
+                socket.ReceiveTimeout = 1_000;
+
+                var buffer = new byte[42];
+                socket.Receive(buffer);
+
+                Console.WriteLine("[Error] The Receive blocking call must timeout.");
+            }
+            catch (SocketException se) when (se.ErrorCode == 110)
+            {
+                _hasReceiveTimedOut = true;
+            }
+            catch (Exception e)
+            {
+                if (!IsEventSet())
+                {
+                    Console.WriteLine("[Error] unknown/unexpected exception: " + e.ToString());
+                }
+            }
+        }
+
+        private async Task SendTimeout(CancellationToken token)
+        {
+            try
+            {
+                using var socket = await CreateAndConnect(token).ConfigureAwait(false);
+                socket.SendTimeout = 1_000;
+
+                // really big buffer to make sure the call blocks
+                var buffer = new byte[8655535];
+                socket.Send(buffer);
+
+                Console.WriteLine("[Error] The Send blocking call must timeout.");
+            }
+            catch (SocketException e) when (e.ErrorCode == 110)
+            {
+                _hasReceiveTimedOut = true;
+            }
+            catch (Exception e)
+            {
+                if (!IsEventSet())
+                {
+                    Console.WriteLine("[Error] unknown/unexpected exception: " + e.ToString());
+                }
+            }
+        }
+
+        private async Task<Socket> CreateAndConnect(CancellationToken token)
+        {
+            var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var ep = new IPEndPoint(IPAddress.Loopback, _port);
+
+            try
+            {
+                await socket.ConnectAsync(ep, token);
+            }
+            catch
+            {
+                throw;
+            }
+
+            return socket;
+        }
+
+        private async Task StartServerAsync(object obj)
+        {
+            Console.WriteLine("** Start server");
+
+            Thread.CurrentThread.Name = "DD Socket Srv";
+            var token = (CancellationToken)obj;
+            using var s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            var ep = new IPEndPoint(IPAddress.Any, _port);
+            s.Bind(ep);
+            s.Listen();
+
+            _readyEvent.Set();
+
+            // This array ensures that we keep the socket alive (avoid the GC from
+            // collecting it) until the timeout is reached
+            var sockets = new Socket[2];
+            var idx = 0;
+            while (!IsEventSet())
+            {
+                idx = idx++ % sockets.Length;
+                try
+                {
+                    sockets[idx] = await s.AcceptAsync(token);
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("[Error] Unknown error when starting the server: " + e.ToString());
+                    break;
+                }
+            }
+
+            if (!_hasReceiveTimedOut)
+            {
+                Console.WriteLine("[Error] Receive operation did not timed-out");
+            }
+
+            if (!_hasSendTimedOut)
+            {
+                Console.WriteLine("[Error] Send operation did not timed-out");
+            }
+
+            Console.WriteLine("** Server stopped");
+        }
+
+        private void StartGateThread(object obj)
+        {
+            Console.WriteLine("** Starting Gate Thread");
+
+            Thread.CurrentThread.Name = "DD Gate Thread";
+            var cts = (CancellationTokenSource)obj;
+            while (!IsEventSet())
+            {
+                Thread.Sleep(TimeSpan.FromSeconds(1));
+            }
+
+            if (!_readyEvent.IsSet)
+            {
+                _readyEvent.Set();
+            }
+
+            cts.Cancel();
+
+            Console.WriteLine("** Gate Thread stopped");
+        }
+    }
+}
+#endif

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -9,7 +9,7 @@ project("Datadog.Linux.ApiWrapper" VERSION 2.39.0)
 # ******************************************************
 
 # Sets compiler options
-add_compile_options(-std=c11 -fPIC) 
+add_compile_options(-std=c11 -fPIC -gdwarf-4) 
 
 
 if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
@@ -33,6 +33,8 @@ SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${DEPLOY_DIR})
 
 add_library(${API_WRAPPER_SHARED_LIB_NAME} SHARED
     functions_to_wrap.c
+    socket_operations.c
+    common.c
 )
 
 # Define linker libraries

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
@@ -1,0 +1,17 @@
+#include "common.h"
+#include "unistd.h"
+#include <errno.h>
+
+int (*volatile dd_set_shared_memory)(int*) = NULL;
+
+__attribute__((visibility("hidden"))) inline int __dd_set_shared_memory(int* mem)
+{
+    if (dd_set_shared_memory == NULL)
+        return 0;
+    return dd_set_shared_memory(mem);
+}
+
+__attribute__((visibility("hidden"))) inline int is_interrupted_by_profiler(int rc, int error_code, int interrupted_by_profiler)
+{
+    return rc == -1L && error_code == EINTR && interrupted_by_profiler != 0;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
@@ -6,9 +6,12 @@ int (*volatile dd_set_shared_memory)(int*) = NULL;
 
 __attribute__((visibility("hidden"))) inline int __dd_set_shared_memory(int* mem)
 {
-    if (dd_set_shared_memory == NULL)
+    // make a copy to avoid race
+    int (*volatile set_shared_memory)(int*) = dd_set_shared_memory
+
+    if (set_shared_memory == NULL)
         return 0;
-    return dd_set_shared_memory(mem);
+    return set_shared_memory(mem);
 }
 
 __attribute__((visibility("hidden"))) inline int is_interrupted_by_profiler(int rc, int error_code, int interrupted_by_profiler)

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.c
@@ -2,12 +2,12 @@
 #include "unistd.h"
 #include <errno.h>
 
-int (*volatile dd_set_shared_memory)(int*) = NULL;
+int (*volatile dd_set_shared_memory)(volatile int*) = NULL;
 
-__attribute__((visibility("hidden"))) inline int __dd_set_shared_memory(int* mem)
+__attribute__((visibility("hidden"))) inline int __dd_set_shared_memory(volatile int* mem)
 {
     // make a copy to avoid race
-    int (*volatile set_shared_memory)(int*) = dd_set_shared_memory
+    int (*volatile set_shared_memory)(volatile int*) = dd_set_shared_memory;
 
     if (set_shared_memory == NULL)
         return 0;

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.h
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.h
@@ -26,7 +26,7 @@
 #endif
 #endif
 
-extern int (*volatile dd_set_shared_memory)(int*);
+extern int (*volatile dd_set_shared_memory)(volatile int*);
 
 int is_interrupted_by_profiler(int rc, int error_code, int interrupted_by_profiler);
-int __dd_set_shared_memory(int* mem);
+int __dd_set_shared_memory(volatile int* mem);

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.h
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/common.h
@@ -1,0 +1,32 @@
+
+#define END(...) END_(__VA_ARGS__)
+// cppcheck-suppress preprocessorErrorDirective
+#define END_(...) __VA_ARGS__##_END
+
+#define PARAMS_LOOP_0(type_, name_) PARAMS_LOOP_BODY(type_, name_) PARAMS_LOOP_A
+#define PARAMS_LOOP_A(type_, name_) , PARAMS_LOOP_BODY(type_, name_) PARAMS_LOOP_B
+#define PARAMS_LOOP_B(type_, name_) , PARAMS_LOOP_BODY(type_, name_) PARAMS_LOOP_A
+#define PARAMS_LOOP_0_END
+#define PARAMS_LOOP_A_END
+#define PARAMS_LOOP_B_END
+#define PARAMS_LOOP_BODY(type_, name_) type_ name_
+
+#define VAR_LOOP_0(type_, name_) name_ VAR_LOOP_A
+#define VAR_LOOP_A(type_, name_) , name_ VAR_LOOP_B
+#define VAR_LOOP_B(type_, name_) , name_ VAR_LOOP_A
+#define VAR_LOOP_0_END
+#define VAR_LOOP_A_END
+#define VAR_LOOP_B_END
+
+#ifdef __GLIBC__
+#define DD_CONST
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 21
+#undef DD_CONST
+#define DD_CONST const
+#endif
+#endif
+
+extern int (*volatile dd_set_shared_memory)(int*);
+
+int is_interrupted_by_profiler(int rc, int error_code, int interrupted_by_profiler);
+int __dd_set_shared_memory(int* mem);

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/socket_operations.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/socket_operations.c
@@ -1,0 +1,68 @@
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <time.h>
+
+#include "common.h"
+
+/*
+ * TL;DR This file wraps socket operations to restart them in case the profiler
+ * interrupted them.
+ * According to man 7 signal, there are system calls won't be restarted by the kernel.
+ * In our case, those system calls are not restarted if a timeout was set. So we need
+ * handle it.
+ * The way we handle it is twofold:
+ * - Establishing a communication pipe between the profiler and the wrapping library.
+ *   The call to __dd_set_shared_memory set a shared memory area where the profiler
+ *   knows if the thread can be interrupted or not, and tell the wrapping library if
+ *   the profiler signal interrupted the thread.
+ * - Retry the system calls: in case of an interruption by a signal (RC == -1 and
+ *   errno == EINTR), if the profiler interrupted the thread (interrupted_by_profiler != 0)
+ *   we restart the system calls
+ */
+#define WRAPPED_FUNCTION(return_type, name, parameters)                           \
+    static return_type (*__dd_real_##name)(END(PARAMS_LOOP_0 parameters)) = NULL; \
+                                                                                  \
+    return_type name(END(PARAMS_LOOP_0 parameters))                               \
+    {                                                                             \
+        if (__dd_real_##name == NULL)                                             \
+        {                                                                         \
+            __dd_real_##name = dlsym(RTLD_NEXT, #name);                           \
+        }                                                                         \
+        int interrupted_by_profiler = 0;                                          \
+        __dd_set_shared_memory(&interrupted_by_profiler);                         \
+        return_type rc;                                                           \
+        do                                                                        \
+        {                                                                         \
+            interrupted_by_profiler = 0;                                          \
+            rc = __dd_real_##name(END(VAR_LOOP_0 parameters));                    \
+        } while (is_interrupted_by_profiler(rc, errno, interrupted_by_profiler)); \
+        __dd_set_shared_memory(NULL);                                             \
+        return rc;                                                                \
+    }                                                                             \
+    static void load_symbols_##name() __attribute__((constructor));               \
+    void load_symbols_##name()                                                    \
+    {                                                                             \
+        __dd_real_##name = dlsym(RTLD_NEXT, #name);                               \
+    }
+
+WRAPPED_FUNCTION(int, select, (int, nfds)(fd_set*, readfds)(fd_set*, writefds)(fd_set*, exceptfds)(struct timeval*, timeout))
+WRAPPED_FUNCTION(int, poll, (struct pollfd*, fds)(nfds_t, nfds)(int, timeout))
+WRAPPED_FUNCTION(int, accept, (int, sockfd)(struct sockaddr*, addr)(socklen_t*, addrlen))
+WRAPPED_FUNCTION(int, accept4, (int, sockfd)(struct sockaddr*, addr)(socklen_t*, addrlen)(int, flags))
+WRAPPED_FUNCTION(ssize_t, recv, (int, sockfd)(void*, buf)(size_t, len)(int, flags))
+WRAPPED_FUNCTION(ssize_t, recvfrom, (int, sockfd)(void*, buf)(size_t, len)(int, flags)(struct sockaddr*, src_addr)(socklen_t*, addrlen))
+WRAPPED_FUNCTION(ssize_t, recvmsg, (int, sockfd)(struct msghdr*, msg)(int, flags))
+#ifdef DD_ALPINE
+WRAPPED_FUNCTION(int, recvmmsg, (int, sockfd)(struct mmsghdr*, msgvec)(unsigned int, vlen)(unsigned int, flags)(struct timespec*, timeout))
+#else
+WRAPPED_FUNCTION(int, recvmmsg, (int, sockfd)(struct mmsghdr*, msgvec)(unsigned int, vlen)(int, flags)(DD_CONST struct timespec*, timeout))
+#endif
+WRAPPED_FUNCTION(int, connect, (int, sockfd)(const struct sockaddr*, addr)(socklen_t, addrlen))
+WRAPPED_FUNCTION(ssize_t, send, (int, sockfd)(const void*, buf)(size_t, len)(int, flags))
+WRAPPED_FUNCTION(ssize_t, sendto, (int, sockfd)(const void*, buf)(size_t, len)(int, flags)(const struct sockaddr*, dest_addr)(socklen_t, addrlen))
+WRAPPED_FUNCTION(ssize_t, sendmsg, (int, sockfd)(const struct msghdr*, msg)(int, flags))

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/socket_operations.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/socket_operations.c
@@ -33,7 +33,7 @@
         {                                                                         \
             __dd_real_##name = dlsym(RTLD_NEXT, #name);                           \
         }                                                                         \
-        int interrupted_by_profiler = 0;                                          \
+        volatile int interrupted_by_profiler = 0;                                 \
         __dd_set_shared_memory(&interrupted_by_profiler);                         \
         return_type rc;                                                           \
         do                                                                        \

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -89,8 +89,9 @@ set_target_properties(${PROFILER_STATIC_LIB_NAME} PROPERTIES PREFIX "")
 
 # Define directories includes
 target_include_directories(${PROFILER_STATIC_LIB_NAME}
-        PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../Datadog.Profiler.Native
-        PUBLIC ${DOTNET_TRACER_REPO_ROOT_PATH}
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../Datadog.Profiler.Native.Linux
+    PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../Datadog.Profiler.Native
+    PUBLIC ${DOTNET_TRACER_REPO_ROOT_PATH}
 )
 
 # Define linker libraries

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj
@@ -117,6 +117,7 @@
     <ClCompile Include="LinuxThreadsCpuManager.cpp" />
     <ClCompile Include="OsSpecificApi.cpp" />
     <ClCompile Include="ProfilerSignalManager.cpp" />
+    <ClCompile Include="SystemCallsShield.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="prepare_loader_for_linking.sh" />
@@ -125,6 +126,7 @@
     <ClInclude Include="LinuxStackFramesCollector.h" />
     <ClInclude Include="LinuxThreadInfo.h" />
     <ClInclude Include="ProfilerSignalManager.h" />
+    <ClInclude Include="SystemCallsShield.h" />
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClCompile Include="LinuxThreadsCpuManager.cpp" />
     <ClCompile Include="ProfilerSignalManager.cpp" />
     <ClCompile Include="LinuxThreadInfo.cpp" />
+    <ClCompile Include="SystemCallsShield.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Scripts">
@@ -22,5 +23,6 @@
     <ClInclude Include="LinuxStackFramesCollector.h" />
     <ClInclude Include="ProfilerSignalManager.h" />
     <ClInclude Include="LinuxThreadInfo.h" />
+    <ClInclude Include="SystemCallsShield.h" />
   </ItemGroup>
 </Project>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -266,6 +266,16 @@ bool LinuxStackFramesCollector::CanCollect(int32_t threadId, pid_t processId) co
     return currentThreadInfo != nullptr && currentThreadInfo->GetOsThreadId() == threadId && processId == _processId;
 }
 
+void LinuxStackFramesCollector::MarkAsInterrupted()
+{
+    auto* currentThreadInfo = _pCurrentCollectionThreadInfo;
+
+    if (currentThreadInfo != nullptr)
+    {
+        currentThreadInfo->MarkAsInterrupted();
+    }
+}
+
 bool LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal, siginfo_t* info, void* context)
 {
     // Libunwind can overwrite the value of errno - save it beforehand and restore it at the end
@@ -284,6 +294,8 @@ bool LinuxStackFramesCollector::CollectStackSampleSignalHandler(int signal, sigi
         // sampling in progress
         if (pCollectorInstance != nullptr)
         {
+            pCollectorInstance->MarkAsInterrupted();
+
             // There can be a race:
             // The sampling thread has sent the signal and is waiting, but another SIGUSR1 signal was sent
             // by another thread and is handled before the one sent by the sampling thread.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.h
@@ -60,6 +60,7 @@ private:
     bool CanCollect(int32_t threadId, pid_t processId) const;
     std::int32_t CollectStackManually(void* ctx);
     std::int32_t CollectStackWithBacktrace2(void* ctx);
+    void MarkAsInterrupted();
 
     std::int32_t _lastStackWalkErrorCode;
     std::condition_variable _stackWalkInProgressWaiter;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.cpp
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "SystemCallsShield.h"
+
+#include "IConfiguration.h"
+#include "ManagedThreadInfo.h"
+
+#include <memory>
+
+#include <sys/syscall.h>
+#include <unistd.h>
+
+thread_local std::shared_ptr<ManagedThreadInfo> managedThreadInfo = nullptr;
+SystemCallsShield* SystemCallsShield::Instance = nullptr;
+
+extern "C" int (*volatile dd_set_shared_memory)(int*) __attribute__((weak));
+
+// check if this symbol is present to know if the wrapper is loaded
+extern "C" unsigned long long dd_inside_wrapped_functions() __attribute__((weak));
+
+SystemCallsShield::SystemCallsShield(IConfiguration* configuration) :
+    _isEnabled{ShouldEnable(configuration)}
+{
+}
+
+bool SystemCallsShield::ShouldEnable(IConfiguration* configuration)
+{
+    // Make sure the wrapper is present.
+    // Walltime and CPU profilers are the only ones that could interrupt a system calls
+    // (It might not be obvious, for the CPU profiler we could be in a race)
+    return dd_inside_wrapped_functions != nullptr && (configuration->IsWallTimeProfilingEnabled() || configuration->IsCpuProfilingEnabled());
+}
+
+bool SystemCallsShield::Start()
+{
+    if (_isEnabled)
+    {
+        Instance = this;
+        dd_set_shared_memory = SystemCallsShield::SetSharedMemory;
+    }
+
+    return true;
+}
+
+bool SystemCallsShield::Stop()
+{
+    if (_isEnabled)
+    {
+        dd_set_shared_memory = nullptr;
+        Instance = nullptr;
+    }
+
+    return true;
+}
+
+const char* SystemCallsShield::GetName()
+{
+    return "Linux System Calls Shield";
+}
+
+void SystemCallsShield::Register(std::shared_ptr<ManagedThreadInfo> const& threadInfo)
+{
+    if (_isEnabled)
+    {
+        managedThreadInfo = threadInfo;
+    }
+}
+
+void SystemCallsShield::Unregister()
+{
+    if (_isEnabled)
+    {
+        managedThreadInfo.reset();
+    }
+}
+
+int SystemCallsShield::SetSharedMemory(int* state)
+{
+    if (Instance == nullptr)
+    {
+        return 0;
+    }
+
+    return Instance->SetSharedMemoryOnThreadInfo(state);
+}
+
+int SystemCallsShield::SetSharedMemoryOnThreadInfo(int* state)
+{
+    auto& threadInfo = managedThreadInfo;
+
+    if (threadInfo == nullptr)
+    {
+        return 0;
+    }
+
+    threadInfo->SetSharedMemory(state);
+
+    return (state != nullptr) ? 1 : 0;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.cpp
@@ -14,7 +14,7 @@
 thread_local std::shared_ptr<ManagedThreadInfo> managedThreadInfo = nullptr;
 SystemCallsShield* SystemCallsShield::Instance = nullptr;
 
-extern "C" int (*volatile dd_set_shared_memory)(int*) __attribute__((weak));
+extern "C" int (*volatile dd_set_shared_memory)(volatile int*) __attribute__((weak));
 
 // check if this symbol is present to know if the wrapper is loaded
 extern "C" unsigned long long dd_inside_wrapped_functions() __attribute__((weak));
@@ -75,7 +75,7 @@ void SystemCallsShield::Unregister()
     }
 }
 
-int SystemCallsShield::SetSharedMemory(int* state)
+int SystemCallsShield::SetSharedMemory(volatile int* state)
 {
     auto current = Instance;
     if (current == nullptr)
@@ -86,7 +86,7 @@ int SystemCallsShield::SetSharedMemory(int* state)
     return current->SetSharedMemoryOnThreadInfo(state);
 }
 
-int SystemCallsShield::SetSharedMemoryOnThreadInfo(int* state)
+int SystemCallsShield::SetSharedMemoryOnThreadInfo(volatile int* state)
 {
     auto& threadInfo = managedThreadInfo;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.cpp
@@ -77,12 +77,13 @@ void SystemCallsShield::Unregister()
 
 int SystemCallsShield::SetSharedMemory(int* state)
 {
-    if (Instance == nullptr)
+    auto current = Instance;
+    if (current == nullptr)
     {
         return 0;
     }
 
-    return Instance->SetSharedMemoryOnThreadInfo(state);
+    return current->SetSharedMemoryOnThreadInfo(state);
 }
 
 int SystemCallsShield::SetSharedMemoryOnThreadInfo(int* state)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.h
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "IService.h"
+#include "MetricsRegistry.h"
+#include "CounterMetric.h"
+
+#include <memory>
+
+class IConfiguration;
+class ManagedThreadInfo;
+
+class SystemCallsShield : public IService
+{
+public:
+    SystemCallsShield(IConfiguration* configurationMetrics);
+
+    void Register(std::shared_ptr<ManagedThreadInfo> const& threadInfo);
+    void Unregister();
+
+    bool Start() override;
+    bool Stop() override;
+
+    const char* GetName() override;
+
+
+private:
+    static SystemCallsShield* Instance;
+    static int SetSharedMemory(int* state);
+    static bool ShouldEnable(IConfiguration* configuration);
+
+    int SetSharedMemoryOnThreadInfo(int* state);
+
+    bool _isEnabled;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.h
@@ -28,10 +28,10 @@ public:
 
 private:
     static SystemCallsShield* Instance;
-    static int SetSharedMemory(int* state);
+    static int SetSharedMemory(volatile int* state);
     static bool ShouldEnable(IConfiguration* configuration);
 
-    int SetSharedMemoryOnThreadInfo(int* state);
+    int SetSharedMemoryOnThreadInfo(volatile int* state);
 
     bool _isEnabled;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -72,6 +72,7 @@ Configuration::Configuration()
     _gitRepositoryUrl = GetEnvironmentValue(EnvironmentVariables::GitRepositoryUrl, DefaultEmptyString);
     _gitCommitSha = GetEnvironmentValue(EnvironmentVariables::GitCommitSha, DefaultEmptyString);
     _isInternalMetricsEnabled = GetEnvironmentValue(EnvironmentVariables::InternalMetricsEnabled, false);
+    _isSystemCallsShieldEnabled = GetEnvironmentValue(EnvironmentVariables::SystemCallsShieldEnabled, true);
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -277,7 +278,6 @@ bool Configuration::IsInternalMetricsEnabled() const
     return _isInternalMetricsEnabled;
 }
 
-
 fs::path Configuration::GetApmBaseDirectory()
 {
 #ifdef _WINDOWS
@@ -469,6 +469,15 @@ bool Configuration::IsAgentless() const
 bool Configuration::IsDebugInfoEnabled() const
 {
     return _isDebugInfoEnabled;
+}
+
+bool Configuration::IsSystemCallsShieldEnabled() const
+{
+#ifdef LINUX
+    return _isSystemCallsShieldEnabled;
+#else
+    return false;
+#endif
 }
 
 bool convert_to(shared::WSTRING const& s, bool& result)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -63,6 +63,7 @@ public:
     std::string const& GetGitRepositoryUrl() const override;
     std::string const& GetGitCommitSha() const override;
     bool IsInternalMetricsEnabled() const override;
+    bool IsSystemCallsShieldEnabled() const override;
 
 private:
     static tags ExtractUserTags();
@@ -141,4 +142,5 @@ private:
     bool _isTimestampsAsLabelEnabled;
     bool _isDebugInfoEnabled;
     bool _isInternalMetricsEnabled;
+    bool _isSystemCallsShieldEnabled;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1331,6 +1331,12 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
 #ifdef LINUX
     if (_systemCallsShield != nullptr)
     {
+        // Register/Unregister rely on the following assumption:
+        // The native thread calling ThreadAssignedToOSThread/ThreadDestroyed is the same native thread assigned to the managed thread.
+        // This assumption has been tested and verified experimentally but there the documentation does not say that.
+        // If at some point, it's not true, we can remove Register/Unregister on the SystemCallsShield class.
+        // Then initiliaze the TLS managedThreadInfo (by calling TryGetCurrentThreadInfo) the first time a call is made in SystemCallsShield
+        // SystemCallsShield::SetSharedMemory callback.
         auto threadInfo = _pManagedThreadList->GetOrCreate(managedThreadId);
         _systemCallsShield->Register(threadInfo);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -50,26 +50,13 @@
 #include "WallTimeProvider.h"
 #include "AllocationsRecorder.h"
 #include "MetadataProvider.h"
+#ifdef LINUX
+#include "SystemCallsShield.h"
+#endif
+
 #include "shared/src/native-src/environment_variables.h"
 #include "shared/src/native-src/pal.h"
 #include "shared/src/native-src/string.h"
-
-// The following macros are used to construct the profiler file:
-#ifdef _WINDOWS
-#define LIBRARY_FILE_EXTENSION ".dll"
-#elif LINUX
-#define LIBRARY_FILE_EXTENSION ".so"
-#elif MACOS
-#define LIBRARY_FILE_EXTENSION ".dylib"
-#else
-Error("unknown platform");
-#endif
-
-#ifdef BIT64
-#define PROFILER_LIBRARY_BINARY_FILE_NAME WStr("Datadog.Profiler.Native" LIBRARY_FILE_EXTENSION)
-#else
-#define PROFILER_LIBRARY_BINARY_FILE_NAME WStr("Datadog.Profiler.Native" LIBRARY_FILE_EXTENSION)
-#endif
 
 IClrLifetime* CorProfilerCallback::GetClrLifetime() const
 {
@@ -112,6 +99,14 @@ bool CorProfilerCallback::InitializeServices()
     _pAppDomainStore = std::make_unique<AppDomainStore>(_pCorProfilerInfo);
 
     _pDebugInfoStore = std::make_unique<DebugInfoStore>(_pCorProfilerInfo, _pConfiguration.get());
+
+#ifdef LINUX
+    if (_pConfiguration->IsSystemCallsShieldEnabled())
+    {
+        // This service must be started before StackSamplerLoop-based profilers to help with non-restartable system calls (ex: socket operations)
+        _systemCallsShield = RegisterService<SystemCallsShield>(_pConfiguration.get());
+    }
+#endif
 
     _pFrameStore = std::make_unique<FrameStore>(_pCorProfilerInfo, _pConfiguration.get(), _pDebugInfoStore.get());
 
@@ -1291,6 +1286,12 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
             _pThreadLifetimeProvider->OnThreadStop(pThreadInfo);
         }
     }
+#ifdef LINUX
+    if (_systemCallsShield != nullptr)
+    {
+        _systemCallsShield->Unregister();
+    }
+#endif
 
     return S_OK;
 }
@@ -1328,6 +1329,12 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
 #endif
 
 #ifdef LINUX
+    if (_systemCallsShield != nullptr)
+    {
+        auto threadInfo = _pManagedThreadList->GetOrCreate(managedThreadId);
+        _systemCallsShield->Register(threadInfo);
+    }
+
     // TL;DR prevent the profiler from deadlocking application thread on malloc
     // When calling uwn_backtraceXX, libunwind will initialize data structures for the current
     // thread using TLS (Thread Local Storage).

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -47,6 +47,9 @@ class IManagedThreadList;
 class IStackSamplerLoopManager;
 class IConfiguration;
 class IExporter;
+#ifdef LINUX
+class SystemCallsShield;
+#endif
 
 namespace shared {
 class Loader;
@@ -234,6 +237,9 @@ private :
     GarbageCollectionProvider* _pGarbageCollectionProvider = nullptr;
     LiveObjectsProvider* _pLiveObjectsProvider = nullptr;
     ThreadLifetimeProvider* _pThreadLifetimeProvider = nullptr;
+#ifdef LINUX
+    SystemCallsShield* _systemCallsShield = nullptr;
+#endif
 
     std::vector<std::unique_ptr<IService>> _services;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -59,4 +59,5 @@ public:
     inline static const shared::WSTRING GcThreadsCpuTimeEnabled     = WStr("DD_INTERNAL_GC_THREADS_CPUTIME_ENABLED");
     inline static const shared::WSTRING InternalMetricsEnabled      = WStr("DD_INTERNAL_METRICS_ENABLED");
     inline static const shared::WSTRING ThreadLifetimeEnabled       = WStr("DD_INTERNAL_THREAD_LIFETIME_ENABLED");
+    inline static const shared::WSTRING SystemCallsShieldEnabled    = WStr("DD_INTERNAL_SYSTEM_CALLS_SHIELD_ENABLED");
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -60,4 +60,5 @@ public:
     virtual std::string const& GetGitRepositoryUrl() const = 0;
     virtual std::string const& GetGitCommitSha() const = 0;
     virtual bool IsInternalMetricsEnabled() const = 0;
+    virtual bool IsSystemCallsShieldEnabled() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
@@ -13,7 +13,6 @@
 class IManagedThreadList : public IService
 {
 public:
-    virtual bool GetOrCreateThread(ThreadID clrThreadId) = 0;
     virtual bool RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThreadInfo) = 0;
     virtual bool UnregisterThread(ThreadID clrThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) = 0;
     virtual bool SetThreadOsInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
@@ -42,6 +42,7 @@ ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, DWORD osThreadId, HAN
     _isThreadDestroyed{false},
     _traceContextTrackingInfo{},
     _cpuConsumptionMilliseconds{0},
-    _timestamp{0}
+    _timestamp{0},
+    _sharedMemoryArea{nullptr}
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -17,7 +17,6 @@
 #include <memory>
 #include <utility>
 
-
 static constexpr int32_t MinFieldAlignRequirement = 8;
 static constexpr int32_t FieldAlignRequirement = (MinFieldAlignRequirement >= alignof(std::uint64_t)) ? MinFieldAlignRequirement : alignof(std::uint64_t);
 
@@ -86,6 +85,12 @@ public:
     inline std::string GetProfileThreadId();
     inline std::string GetProfileThreadName();
 
+#ifdef LINUX
+    inline void SetSharedMemory(int* memoryArea);
+    inline void MarkAsInterrupted();
+#endif
+    inline bool CanBeInterrupted() const;
+
 private:
     inline void BuildProfileThreadId();
     inline void BuildProfileThreadName();
@@ -121,9 +126,14 @@ private:
     //  strings to be used by samples: avoid allocations when rebuilding them over and over again
     std::string _profileThreadId;
     std::string _profileThreadName;
+
+    // Linux only
+    // This is pointer to a shared memory area coming from the Datadog.Linux.ApiWarapper library.
+    // This establishes a simple communication channel between the profiler and this library
+    // to know (for now, maybe more later) if the profiler interrupted a thread which was
+    // doing a syscalls.
+    int* _sharedMemoryArea;
 };
-
-
 
 std::string ManagedThreadInfo::GetProfileThreadId()
 {
@@ -383,3 +393,25 @@ inline bool ManagedThreadInfo::HasTraceContext() const
     }
     return false;
 }
+
+inline bool ManagedThreadInfo::CanBeInterrupted() const
+{
+    return _sharedMemoryArea == nullptr;
+}
+
+#ifdef LINUX
+// This method is called by the signal handler, when the thread has already been interrupted.
+// There is no race and it's safe to call it there.
+inline void ManagedThreadInfo::MarkAsInterrupted()
+{
+    if (_sharedMemoryArea != nullptr)
+    {
+        *_sharedMemoryArea = 1;
+    }
+}
+
+inline void ManagedThreadInfo::SetSharedMemory(int* memoryArea)
+{
+    _sharedMemoryArea = memoryArea;
+}
+#endif

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -86,7 +86,7 @@ public:
     inline std::string GetProfileThreadName();
 
 #ifdef LINUX
-    inline void SetSharedMemory(int* memoryArea);
+    inline void SetSharedMemory(volatile int* memoryArea);
     inline void MarkAsInterrupted();
 #endif
     inline bool CanBeInterrupted() const;
@@ -132,7 +132,7 @@ private:
     // This establishes a simple communication channel between the profiler and this library
     // to know (for now, maybe more later) if the profiler interrupted a thread which was
     // doing a syscalls.
-    int* _sharedMemoryArea;
+    volatile int* _sharedMemoryArea;
 };
 
 std::string ManagedThreadInfo::GetProfileThreadId()
@@ -410,7 +410,7 @@ inline void ManagedThreadInfo::MarkAsInterrupted()
     }
 }
 
-inline void ManagedThreadInfo::SetSharedMemory(int* memoryArea)
+inline void ManagedThreadInfo::SetSharedMemory(volatile int* memoryArea)
 {
     _sharedMemoryArea = memoryArea;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -54,11 +54,6 @@ bool ManagedThreadList::Stop()
     return true;
 }
 
-bool ManagedThreadList::GetOrCreateThread(ThreadID clrThreadId)
-{
-    return GetOrCreate(clrThreadId) != nullptr;
-}
-
 std::shared_ptr<ManagedThreadInfo> ManagedThreadList::GetOrCreate(ThreadID clrThreadId)
 {
     std::lock_guard<std::recursive_mutex> lock(_mutex);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
@@ -30,7 +30,6 @@ public:
     const char* GetName() override;
     bool Start() override;
     bool Stop() override;
-    bool GetOrCreateThread(ThreadID clrThreadId) override;
     bool RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThreadInfo) override;
     bool UnregisterThread(ThreadID clrThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
     bool SetThreadOsInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle) override;
@@ -39,7 +38,7 @@ public:
     uint32_t CreateIterator() override;
     std::shared_ptr<ManagedThreadInfo> LoopNext(uint32_t iterator) override;
     HRESULT TryGetCurrentThreadInfo(std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
-    std::shared_ptr<ManagedThreadInfo> GetOrCreate(ThreadID clrThreadId);
+    std::shared_ptr<ManagedThreadInfo> GetOrCreate(ThreadID clrThreadId) override;
 
 private:
     const char* _serviceName = "ManagedThreadList";

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -263,7 +263,7 @@ void StackSamplerLoop::WalltimeProfilingIteration()
         }
 
         // skip thread if it has a trace context
-        if (_targetThread->HasTraceContext())
+        if (_targetThread->HasTraceContext() || !_targetThread->CanBeInterrupted())
         {
             _targetThread.reset();
             continue;
@@ -384,7 +384,7 @@ void StackSamplerLoop::CodeHotspotIteration()
         }
 
         // skip if it has no trace context
-        if (!_targetThread->HasTraceContext())
+        if (!_targetThread->HasTraceContext() || !_targetThread->CanBeInterrupted())
         {
             _targetThread.reset();
             continue;

--- a/profiler/test/Datadog.Linux.ApiWrapper.Tests/WrappedFunctions.cpp
+++ b/profiler/test/Datadog.Linux.ApiWrapper.Tests/WrappedFunctions.cpp
@@ -7,6 +7,9 @@
 #include <dlfcn.h>
 #include <link.h>
 #include <pthread.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "shared/src/native-src/dd_filesystem.hpp"
 
@@ -37,6 +40,16 @@ INSTANTIATE_TEST_SUITE_P(
 #endif
         (void*)::dl_iterate_phdr,
         (void*)::dlopen,
-        (void*)::dladdr));
+        (void*)::dladdr,
+        (void*)::accept,
+        (void*)::accept4,
+        (void*)::recv,
+        (void*)::recvfrom,
+        (void*)::recvmsg,
+        (void*)::recvmmsg,
+        (void*)::connect,
+        (void*)::send,
+        (void*)::sendto,
+        (void*)::sendmsg));
 
 } // namespace WrappedFunctionsTest

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/OpenLdapTests.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/OpenLdapTests.cs
@@ -1,0 +1,30 @@
+// <copyright file="OpenLdapTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.SmokeTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.LinuxOnly
+{
+    [Trait("Category", "LinuxOnly")]
+    public class OpenLdapTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public OpenLdapTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01", Frameworks = new[] { "net6.0", "net7.0" })]
+        public void CheckOpenLdapCrash(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 21", output: _output);
+            runner.RunAndCheck();
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SocketTimeoutTests.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SocketTimeoutTests.cs
@@ -1,0 +1,30 @@
+// <copyright file="SocketTimeoutTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.SmokeTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.LinuxOnly
+{
+    [Trait("Category", "LinuxOnly")]
+    public class SocketTimeoutTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public SocketTimeoutTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01", Frameworks = new[] { "net6.0", "net7.0" })]
+        public void CheckSocketOperationsTimeoutIsFullfilled(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 22", output: _output);
+            runner.RunAndCheck();
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SocketTimeoutTests.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SocketTimeoutTests.cs
@@ -24,6 +24,14 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         public void CheckSocketOperationsTimeoutIsFullfilled(string appName, string framework, string appAssembly)
         {
             var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 22", output: _output);
+            // TODO: On Alpine, we need to investigate why there is only one pprof file and 2-3 empty profiles.
+            // In the log we can see this message (seen with net6.0):
+            // The profiler for application IntegrationTest-Samples.Computer01 (runtime id:b9f1d85c-6df4-46f4-83eb-f2c9f6722aea) have empty profile. Nothing will be sent.
+            if (EnvironmentHelper.IsAlpine)
+            {
+                runner.MinimumExpectedNbPprofFiles = 1;
+            }
+
             runner.RunAndCheck();
         }
     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
@@ -18,7 +18,6 @@ namespace Datadog.Profiler.SmokeTests
     {
         private readonly ITestOutputHelper _output;
         private readonly TransportType _transportType;
-        private readonly int _minimumExpectedPprofsCount = 2; // 1 empty and at least one normal
 
         private readonly TestApplicationRunner _testApplicationRunner;
 
@@ -44,6 +43,8 @@ namespace Datadog.Profiler.SmokeTests
             _transportType = transportType;
             _testApplicationRunner = new TestApplicationRunner(appName, framework, appAssembly, output, commandLine);
         }
+
+        public int MinimumExpectedNbPprofFiles { get; set; } = 2;
 
         internal EnvironmentHelper EnvironmentHelper
         {
@@ -115,12 +116,12 @@ namespace Datadog.Profiler.SmokeTests
         private void CheckPprofFiles()
         {
             var pprofFiles = Directory.EnumerateFiles(EnvironmentHelper.PprofDir, "*.pprof", SearchOption.AllDirectories).ToList();
-            Assert.True(pprofFiles.Count >= _minimumExpectedPprofsCount, $"The number of pprof files was not greater than or equal to {_minimumExpectedPprofsCount}. Actual value {pprofFiles.Count}");
+            Assert.True(pprofFiles.Count >= MinimumExpectedNbPprofFiles, $"The number of pprof files was not greater than or equal to {MinimumExpectedNbPprofFiles}. Actual value {pprofFiles.Count}");
         }
 
         private void CheckAgent(MockDatadogAgent agent)
         {
-            Assert.True(agent.NbCallsOnProfilingEndpoint >= _minimumExpectedPprofsCount, $"The number of calls to the agent was not greater than or equal to {_minimumExpectedPprofsCount}. Actual value {agent.NbCallsOnProfilingEndpoint}");
+            Assert.True(agent.NbCallsOnProfilingEndpoint >= MinimumExpectedNbPprofFiles, $"The number of calls to the agent was not greater than or equal to {MinimumExpectedNbPprofFiles}. Actual value {agent.NbCallsOnProfilingEndpoint}");
         }
 
         private bool LogFileContainsErrorMessage(string logFile)

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -723,3 +723,36 @@ TEST(ConfigurationTest, CheckGitMetadataIfSet)
     ASSERT_THAT(configuration.GetGitRepositoryUrl(), expectedRepoUrl);
     ASSERT_THAT(configuration.GetGitCommitSha(), expectedCommitSha);
 }
+
+TEST(ConfigurationTest, CheckSystemCallsShieldIsEnabledByDefault)
+{
+    auto configuration = Configuration{};
+    auto expectedValue =
+#ifdef LINUX
+        true;
+#else
+        false;
+#endif
+    ASSERT_THAT(configuration.IsSystemCallsShieldEnabled(), expectedValue);
+}
+
+TEST(ConfigurationTest, CheckSystemCallsShieldIsEnabledIfEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SystemCallsShieldEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    auto expectedValue =
+#ifdef LINUX
+        true;
+#else
+        false; // even other platform it's disabled
+#endif
+    ASSERT_THAT(configuration.IsSystemCallsShieldEnabled(), expectedValue);
+}
+
+TEST(ConfigurationTest, CheckSystemCallsShieldIsDisabledIfEnvVarSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SystemCallsShieldEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    auto expectedValue = false;
+    ASSERT_THAT(configuration.IsSystemCallsShieldEnabled(), expectedValue);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -65,6 +65,7 @@ public:
     MOCK_METHOD(std::string const&, GetGitRepositoryUrl, (), (const override));
     MOCK_METHOD(std::string const&, GetGitCommitSha, (), (const override));
     MOCK_METHOD(bool, IsInternalMetricsEnabled, (), (const override));
+    MOCK_METHOD(bool, IsSystemCallsShieldEnabled, (), (const override));
 };
 
 class MockExporter : public IExporter

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -442,7 +442,7 @@ partial class Build
             CMake.Value(
                 arguments: $"-DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DRUN_ANALYSIS=1 -B {NativeBuildDirectory} -S {RootDirectory} -DCMAKE_BUILD_TYPE={BuildConfiguration}");
 
-            CppCheck.Value($"-j {Environment.ProcessorCount} --enable=all --project={NativeBuildDirectory}/compile_commands.json -D__linux__ -D__x86_64__ --suppressions-list={ProfilerDirectory}/cppcheck-suppressions.txt --xml --output-file={outputFile}");
+            CppCheck.Value($"-j {Environment.ProcessorCount} --inline-suppr --enable=all --project={NativeBuildDirectory}/compile_commands.json -D__linux__ -D__x86_64__ --suppressions-list={ProfilerDirectory}/cppcheck-suppressions.txt --xml --output-file={outputFile}");
         });
 
     Target RunProfilerAsanTest => _ => _

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -54,6 +54,7 @@ RUN apk update \
         gdb \
         musl-dbg \
         cppcheck \
+        libldap \
     && gem install --version 1.6.0 --user-install git \
     && gem install --version 2.7.6 dotenv \
     && gem install --version 1.14.2 --minimal-deps --no-document fpm


### PR DESCRIPTION
## Summary of changes

Wrap some socket functions/syscall from libc to avoid causing applications errors.

## Reason for change

We have customer that uses OpenLDAP library to query his server. This library uses glibc functions (like `select`, `poll`...) (wrapper on system calls) that are not restartable by the kernel. (for more info `man 7 signal`). The OpenLDAP client library implements  the usual restart mechanism but leaves the choice to restart or not to the customer (there is setting specifying if it should restart or not) and this setting is `do not restart` by default.
```
		do {
			fd.revents = 0;
			rc = poll( &fd, 1, timeout );
		} while( rc == AC_SOCKET_ERROR && errno == EINTR &&
			LDAP_BOOL_GET(&ld->ld_options, LDAP_BOOL_RESTART ));
```
[Example with `poll`](https://github.com/openldap/openldap/blob/2738a32de3a324fc56effd44c2fedaff1a359011/libraries/libldap/os-local.c#L253C3-L257C56)

So when the profiler interrupts the execution of one of these functions, the kernel does not restart them, the function returns an error and the application layer consider it as error and fails by throwing an exception.

It's not all, this issue helped us uncovered another problem: if `recv` (or other receiving/sending operations) syscall on a blocking socket has a timeout, and the thread calling it keeps on being interrupted by the profiler, the timeout will never be honored and the call blocks forever.

This change implements a restart mechanism (based on the `EINTR` + returned error) but checks if the interruption comes from the profiler and ensure that the profiler is not too much intrusive with socket operations with timeout.

## Implementation details

- Get the syscalls for OpenLdap issue + sending/receiving functions from `man 7 signal`
- Implement the restart mechanism.
- Add a class which is responsible to interact with the wrapper and the profiler libraries: before calling the `real` function, calls into the profiler library to register a memory area. When the call is done check if the value of this memory area is still `0`.
- When the profiler interrupts the thread execution, it will set a non-zero value to the memory area registered previously.

## Test coverage
- Add a new integration test with an OpenLDAP server.
- Add a test to timeout test to ensure the timeout on socket operations is still honored.

## Other details
<!-- Fixes #{issue} -->
