### PR TITLE
[Telemetry] Aggregate metrics in a separate loop

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
@@ -52,7 +52,7 @@ internal static partial class ConfigurationKeys
 
         /// <summary>
         /// Configuration key for locations to write internal diagnostic logs.
-        /// Comma-separated list, containing one of <c>file</c> or <c>datadog</c> e.g. file,datadog
+        /// Currently only <c>file</c> is supported
         /// Defaults to <c>file</c>
         /// </summary>
         public const string LogSinks = "DD_TRACE_LOG_SINKS";

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/IMetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/IMetricsTelemetryCollector.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #nullable enable
+using System.Threading.Tasks;
 using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Telemetry;
@@ -16,12 +17,12 @@ internal partial interface IMetricsTelemetryCollector
     /// <param name="api">The API that was accessed</param>
     public void Record(PublicApiUsage api);
 
-    void AggregateMetrics();
-
     MetricResults GetMetrics();
 
     /// <summary>
     /// Sets the version of the WAF used for future metrics
     /// </summary>
     public void SetWafVersion(string wafVersion);
+
+    public Task DisposeAsync();
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/NullMetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/NullMetricsTelemetryCollector.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #nullable enable
+using System.Threading.Tasks;
 using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Telemetry;
@@ -16,9 +17,7 @@ internal partial class NullMetricsTelemetryCollector : IMetricsTelemetryCollecto
     {
     }
 
-    public void AggregateMetrics()
-    {
-    }
+    public Task DisposeAsync() => Task.CompletedTask;
 
     public MetricResults GetMetrics() => new(null, null);
 

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -91,12 +91,6 @@ namespace Datadog.Trace.Telemetry
                               ? new DependencyTelemetryCollector()
                               : NullDependencyTelemetryCollector.Instance);
 
-                // we assume we never flip between v1 and v2
-                if (!settings.V2Enabled)
-                {
-                    DisableConfigCollector();
-                }
-
                 // if this changes, we will "lose" startup metrics, but unlikely to happen
                 if (!settings.MetricsEnabled)
                 {
@@ -114,6 +108,7 @@ namespace Datadog.Trace.Telemetry
                 }
                 else
                 {
+                    DisableConfigCollector();
                     log.Debug("Creating telemetry controller v1");
                     return CreateV1Controller(telemetryTransports, settings);
                 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -65,70 +65,92 @@ namespace Datadog.Trace.Telemetry
         {
             // Deliberately not a static field, because otherwise creates a circular dependency during startup
             var log = DatadogLogging.GetLoggerFor<TelemetryFactory>();
-            if (settings.TelemetryEnabled)
+
+            // we assume telemetry can't switch between enabled/disabled
+            if (!settings.TelemetryEnabled)
             {
-                try
-                {
-                    var telemetryTransports = TelemetryTransportFactory.Create(settings, tracerSettings.ExporterInternal);
-
-                    if (!telemetryTransports.HasTransports)
-                    {
-                        log.Debug("Telemetry collection disabled: no available transports");
-                        return NullTelemetryController.Instance;
-                    }
-
-                    LazyInitializer.EnsureInitialized(
-                        ref _dependencies,
-                        () => settings.DependencyCollectionEnabled
-                                  ? new DependencyTelemetryCollector()
-                                  : NullDependencyTelemetryCollector.Instance);
-
-                    // we assume we never flip between v1 and v2
-                    if (!settings.V2Enabled)
-                    {
-                        // if we're not using V2, we don't need the config collector
-                        var oldConfig = Interlocked.Exchange(ref _configurationV2, NullConfigurationTelemetry.Instance);
-                        if (oldConfig is ConfigurationTelemetry config)
-                        {
-                            config.Clear();
-                        }
-                    }
-
-                    // if this changes, we will "lose" startup metrics, but unlikely to happen
-                    if (!settings.MetricsEnabled)
-                    {
-                        // if we're not using metrics, we don't need the metrics collector
-                        log.Debug("Telemetry metrics collection disabled");
-                        var oldMetrics = Interlocked.Exchange(ref _metrics, NullMetricsTelemetryCollector.Instance);
-                        if (oldMetrics is MetricsTelemetryCollector metrics)
-                        {
-                            // "clears" all the data stored so far
-                            metrics.Clear();
-                        }
-                    }
-
-                    // Making assumptions that we never switch from v1 to v2
-                    // so we don't need to "clean up" the collectors.
-                    if (settings.V2Enabled)
-                    {
-                        log.Debug("Creating telemetry controller v2");
-                        return CreateV2Controller(telemetryTransports, settings, discoveryService);
-                    }
-                    else
-                    {
-                        log.Debug("Creating telemetry controller v1");
-                        return CreateV1Controller(telemetryTransports, settings);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    log.Warning(ex, "Telemetry collection disabled: error initializing telemetry");
-                    return NullTelemetryController.Instance;
-                }
+                log.Debug("Telemetry collection disabled");
+                DisableTelemetry();
+                return NullTelemetryController.Instance;
             }
 
-            log.Debug("Telemetry collection disabled");
-            return NullTelemetryController.Instance;
+            try
+            {
+                var telemetryTransports = TelemetryTransportFactory.Create(settings, tracerSettings.ExporterInternal);
+
+                if (!telemetryTransports.HasTransports)
+                {
+                    log.Debug("Telemetry collection disabled: no available transports");
+                    DisableTelemetry();
+                    return NullTelemetryController.Instance;
+                }
+
+                LazyInitializer.EnsureInitialized(
+                    ref _dependencies,
+                    () => settings.DependencyCollectionEnabled
+                              ? new DependencyTelemetryCollector()
+                              : NullDependencyTelemetryCollector.Instance);
+
+                // we assume we never flip between v1 and v2
+                if (!settings.V2Enabled)
+                {
+                    DisableConfigCollector();
+                }
+
+                // if this changes, we will "lose" startup metrics, but unlikely to happen
+                if (!settings.MetricsEnabled)
+                {
+                    // if we're not using metrics, we don't need the metrics collector
+                    log.Debug("Telemetry metrics collection disabled");
+                    DisableMetricsCollector();
+                }
+
+                // Making assumptions that we never switch from v1 to v2
+                // so we don't need to "clean up" the collectors.
+                if (settings.V2Enabled)
+                {
+                    log.Debug("Creating telemetry controller v2");
+                    return CreateV2Controller(telemetryTransports, settings, discoveryService);
+                }
+                else
+                {
+                    log.Debug("Creating telemetry controller v1");
+                    return CreateV1Controller(telemetryTransports, settings);
+                }
+            }
+            catch (Exception ex)
+            {
+                log.Warning(ex, "Telemetry collection disabled: error initializing telemetry");
+                DisableTelemetry();
+                return NullTelemetryController.Instance;
+            }
+        }
+
+        private static void DisableTelemetry()
+        {
+            DisableMetricsCollector();
+            DisableConfigCollector();
+        }
+
+        private static void DisableMetricsCollector()
+        {
+            var oldMetrics = Interlocked.Exchange(ref _metrics, NullMetricsTelemetryCollector.Instance);
+            if (oldMetrics is MetricsTelemetryCollector metrics)
+            {
+                // "clears" all the data stored so far
+                metrics.Clear();
+            }
+        }
+
+        private static void DisableConfigCollector()
+        {
+            // if we're not using V2, we don't need the config collector
+            var oldConfig = Interlocked.Exchange(ref _configurationV2, NullConfigurationTelemetry.Instance);
+            if (oldConfig is ConfigurationTelemetry config)
+            {
+                // "clears" all the data stored so far
+                config.Clear();
+            }
         }
 
         private ITelemetryController CreateV1Controller(


### PR DESCRIPTION
## Summary of changes

- Move metrics aggregation to a separate aggregation loop (ensures we don't impact the aggregation if we are slow sending the payloads to telemetry)
- Disable the metrics and config collectors if telemetry is disabled

## Reason for change

As part of the diagnostic telemetry logs work, we decided that the risk of delays when sending telemetry (as we are potentially sending more and larger batches) was too likely to impact the aggregation loop (for which we want to keep periodicity as close to 10s as possible). Separating the aggregation loop from the sending loop makes this easier, though means we now have to make the aggregations thread safe where they weren't before.

## Implementation details

Extracted the periodic aggregation to a different thread in the `MetricsTelemetryCollector`. The `TelemetryControllerV2.Scheduler` class now looks like it's excessively complicated given we're back to a single loop, but this is made more complex again when we add in diagnostic logs, so not worth changing extensively yet.

For the second part, made sure we switch the v2 metrics and config collectors for the `null` counterparts if telemetry is entirely disabled. Previously we were only doing this if v1 telemetry was enabled.

## Test coverage

Refactoring only, so covered by existing tests, but updated existing/added new unit tests for the behaviour.

## Other details
Prerequisite for diagnostic logs
