### PR TITLE
Don't include app-heartbeat in the first message-batch

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilderV2.cs
@@ -126,7 +126,11 @@ internal class TelemetryDataBuilderV2
                 return GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null, namingSchemeVersion);
             }
 
-            data.Add(new(TelemetryRequestTypes.AppHeartbeat, payload: null));
+            if (!input.SendAppStarted)
+            {
+                // don't include the app heartbeat in the app-started request batch
+                data.Add(new(TelemetryRequestTypes.AppHeartbeat, payload: null));
+            }
         }
 
         return GetRequest(application, host, new MessageBatchPayload(data), namingSchemeVersion);

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderV2Tests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderV2Tests.cs
@@ -249,7 +249,7 @@ public class TelemetryDataBuilderV2Tests
                    let payloads = potentialPayloads
                                  .Where(x => !string.IsNullOrEmpty(x))
                                   // we only send heartbeat _or_ app-closing
-                                 .Concat(hasSendAppClosing ? Array.Empty<string>() : heartbeat)
+                                 .Concat(hasSendAppClosing || !hasSentAppStarted ? Array.Empty<string>() : heartbeat)
                                  .ToArray()
                    select new object[] { hasConfig, hasDeps, hasIntegrations, hasMetrics, hasDistributions, hasProducts, hasSentAppStarted, hasSendAppClosing, payloads };
         }


### PR DESCRIPTION
## Summary of changes

Don't send the `app-heartbeat` message in the first `message-batch` that contains `app-started`

## Reason for change

It's not necessary (docs don't specify it's _not_ allowed, but definitely not _required_), and the first request is frequently slower (extra serialization work, more going on etc) which causes system tests that measure timings between heartbeats to complain.

## Implementation details

Stop sending `app-heartbeat` when sending `app-started`

## Test coverage

Covered by unit tests

## Other details
Relates to https://github.com/DataDog/system-tests/pull/1472
