### PR TITLE
Add Benchmarks public dashboard to the Readme file

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,9 @@ This library powers [Distributed Tracing](https://docs.datadoghq.com/tracing/),
 
 ## Build status
 
-Build status on `master`: [![Build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows_tracer)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master)
+- Build status on `master`: [![Build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/status/consolidated-pipeline?branchName=master&stageName=build_windows_tracer)](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/latest?definitionId=54&branchName=master)
+
+- Benchmarks dashboard on `master`: [Dashboard](https://p.datadoghq.com/sb/c894ecec5-944662bba07ec41974e71682d239f16d?tpl_var_branch%5B0%5D=benchmarks%5C%2F%2A&tpl_var_runtime_name%5B0%5D=.NET%20Core%203.1&from_ts=1683889690697&to_ts=1691665690697&live=true)
 
 ## Copyright
 


### PR DESCRIPTION
## Summary of changes

This PR adds a link to the benchmarks public dashboard into the Readme.md file

## Reason for change

Be transparent and show how we dogfood our product while we improve it.
