### PR TITLE
[ASM] add trusted ip capablity

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -349,6 +349,7 @@ namespace Datadog.Trace.AppSec
             rcm.SetCapability(RcmCapabilitiesIndices.AsmResponseBlocking, _noLocalRules);
             rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomRules, _noLocalRules);
             rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomBlockingResponse, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmTrustedIps, _noLocalRules);
         }
 
         private void InitWafAndInstrumentations(bool fromRemoteConfig = false)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
@@ -39,6 +39,9 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public const uint AsmCustomBlockingResponseUInt32 = 1 << 9;
         public static readonly BigInteger AsmCustomBlockingResponse = new(AsmCustomBlockingResponseUInt32);
+
+        public const uint AsmTrustedIpsUInt32 = 1 << 10;
+        public static readonly BigInteger AsmTrustedIps = new(AsmTrustedIpsUInt32);
 #pragma warning restore SA1203 // Constants should appear before fields
     }
 }


### PR DESCRIPTION
## Summary of changes

Add the flag that tells the backend we now support the trusted IP capabilities. 

## Test coverage

No test coverage, will be tested manually with the backend, when they do end to end testing.