### PR TITLE
Improve query string obfuscation regex 

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
@@ -11,11 +11,9 @@ namespace Datadog.Trace.AppSec.Waf
 {
     internal class Result : IResult
     {
-        private readonly WafReturnCode _returnCode;
-
         public Result(DdwafResultStruct returnStruct, WafReturnCode returnCode, ulong aggregatedTotalRuntime, ulong aggregatedTotalRuntimeWithBindings)
         {
-            _returnCode = returnCode;
+            ReturnCode = returnCode;
             Actions = returnStruct.Actions.DecodeStringArray();
             Derivatives = returnStruct.Derivatives.DecodeMap();
             ShouldBeReported = returnCode >= WafReturnCode.Match;
@@ -33,7 +31,7 @@ namespace Datadog.Trace.AppSec.Waf
             Timeout = returnStruct.Timeout;
         }
 
-        public WafReturnCode ReturnCode => _returnCode;
+        public WafReturnCode ReturnCode { get; }
 
         public string Data { get; }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -366,7 +366,8 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Configuration key for specifying a custom regex to obfuscate query strings.
-        /// Default value is in TracerSettings
+        /// Default value is in TracerSettingsConstants
+        ///  WARNING: This regex cause crashes under netcoreapp2.1 / linux / arm64, dont use on manual instrumentation in this environment
         /// </summary>
         /// <seealso cref="TracerSettings.ObfuscationQueryStringRegex"/>
         public const string ObfuscationQueryStringRegex = "DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP";

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -417,6 +417,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets a value indicating the regex to apply to obfuscate http query strings.
+        ///  WARNING: This regex cause crashes under netcoreapp2.1 / linux / arm64, dont use on manual instrumentation in this environment
         /// </summary>
         /// <seealso cref="ConfigurationKeys.ObfuscationQueryStringRegex"/>
         internal string ObfuscationQueryStringRegex { get; }

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -36,11 +36,6 @@ namespace Datadog.Trace.Configuration
         private readonly TracerSettingsSnapshot _initialSettings;
 
         /// <summary>
-        /// Default obfuscation query string regex if none specified via env DD_OBFUSCATION_QUERY_STRING_REGEXP
-        /// </summary>
-        internal const string DefaultObfuscationQueryStringRegex = @"((?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:""|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:""|%22)(?:%2[^2]|%[^2]|[^""%])+(?:""|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,})";
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TracerSettings"/> class with default values.
         /// </summary>
         [PublicApi]
@@ -237,7 +232,7 @@ namespace Datadog.Trace.Configuration
 
             ObfuscationQueryStringRegex = config
                                          .WithKeys(ConfigurationKeys.ObfuscationQueryStringRegex)
-                                         .AsString(defaultValue: DefaultObfuscationQueryStringRegex);
+                                         .AsString(defaultValue: TracerSettingsConstants.DefaultObfuscationQueryStringRegex);
 
             QueryStringReportingEnabled = config
                                          .WithKeys(ConfigurationKeys.QueryStringReportingEnabled)
@@ -683,6 +678,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets a value indicating the regex to apply to obfuscate http query strings.
+        /// Warning: This regex cause crashes under netcoreapp2.1 / linux / arm64, DON'T use default value on manual instrumentation
         /// </summary>
         internal string ObfuscationQueryStringRegex { get; }
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettingsConstants.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettingsConstants.cs
@@ -1,0 +1,17 @@
+// <copyright file="TracerSettingsConstants.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Configuration;
+
+internal class TracerSettingsConstants
+{
+    /// <summary>
+    /// WARNING: This regex cause crashes under netcoreapp2.1 / linux / arm64, dont use on manual instrumentation in this environment
+    /// Default obfuscation query string regex if none specified via env DD_OBFUSCATION_QUERY_STRING_REGEXP.
+    /// </summary>
+    internal const string DefaultObfuscationQueryStringRegex = """
+                                                               (?:"|%22)?(?:(?:old[-_]?|new[-_]?)?p(?:ass)?w(?:or)?d(?:1|2)?|pass(?:[-_]?phrase)?|secret|(?:api[-_]?|private[-_]?|public[-_]?|access[-_]?|secret[-_]?)key(?:[-_]?id)?|token|consumer[-_]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9._\-]+|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+/=-]|%3D|%2F|%2B)+)?|-{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY-{5}[^\-]+-{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY(?:-{5})?(?:\n|%0A)?|(?:ssh-(?:rsa|dss)|ecdsa-[a-z0-9]+-[a-z0-9]+)(?:\s|%20|%09)+(?:[a-z0-9/.+]|%2F|%5C|%2B){100,}(?:=|%3D)*(?:(?:\s|%20|%09)+[a-z0-9._-]+)?
+                                                               """;
+}

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -443,7 +443,7 @@ namespace Datadog.Trace
                     writer.WritePropertyName("obfuscation_querystring_size");
                     writer.WriteValue(instanceSettings.QueryStringReportingSize);
 
-                    if (string.Compare(instanceSettings.ObfuscationQueryStringRegex, TracerSettings.DefaultObfuscationQueryStringRegex, StringComparison.Ordinal) != 0)
+                    if (string.Compare(instanceSettings.ObfuscationQueryStringRegex, TracerSettingsConstants.DefaultObfuscationQueryStringRegex, StringComparison.Ordinal) != 0)
                     {
                         writer.WritePropertyName("obfuscation_querystring_regex");
                         writer.WriteValue(instanceSettings.ObfuscationQueryStringRegex);

--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
@@ -32,18 +32,18 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
             _timeout = timeout;
             _logger = logger;
 
-            var options =
-                    RegexOptions.IgnoreCase
-                    | RegexOptions.Compiled;
+            var options = RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace | RegexOptions.IgnorePatternWhitespace;
 
 #if NETCOREAPP3_1_OR_GREATER
             options |= RegexOptions.NonBacktracking;
 #endif
 
-            _regex =
-                new(pattern, options, _timeout);
+            _regex = new(pattern, options, _timeout);
         }
 
+        /// <summary>
+        /// WARNING: This regex cause crashes under netcoreapp2.1 / linux / arm64, dont use on manual instrumentation in this environment
+        /// </summary>
         internal override string Obfuscate(string queryString)
         {
             if (string.IsNullOrEmpty(queryString))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -12,6 +12,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using VerifyXunit;
@@ -167,9 +168,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
              && !EnvironmentHelper.IsCoreClr()
              && EnvironmentTools.IsTestTarget64BitProcess())
             {
-                throw new SkipException("ASP.NET Core running on .NET Framework requires x86, because it uses " +
-                                        "the x86 version of libuv unless you compile the dll _explicitly_ for x64, " +
-                                        "which we don't do any more");
+                throw new SkipException(
+                    "ASP.NET Core running on .NET Framework requires x86, because it uses " +
+                    "the x86 version of libuv unless you compile the dll _explicitly_ for x64, " +
+                    "which we don't do any more");
             }
 
             await RunSubmitsTraces();
@@ -189,7 +191,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             SetServiceVersion(ServiceVersion);
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
-
+#if NETCOREAPP2_1
+            // NET 2.1, sometimes times out
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.ObfuscationQueryStringRegexTimeout, "600");
+#endif
             _testName = testName;
             _metadataSchemaVersion = metadataSchemaVersion;
         }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/EvidenceRedactorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/EvidenceRedactorTests.cs
@@ -4,9 +4,11 @@
 // </copyright>
 
 using System;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Util.Http.QueryStringObfuscation;
 using FluentAssertions;
 using Moq;
@@ -38,16 +40,25 @@ namespace Datadog.Trace.Tests.Util.Http
         public void EdgeCases(string querystring)
         {
             var logger = new Mock<IDatadogLogger>();
-            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettings.DefaultObfuscationQueryStringRegex, logger.Object);
+            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettingsConstants.DefaultObfuscationQueryStringRegex, logger.Object);
             var result = queryStringObfuscator.Obfuscate(querystring);
             result.Should().Be(querystring);
         }
 
-        [Fact]
+        [SkippableFact]
         public void ObfuscateWithDefaultPattern()
         {
             var logger = new Mock<IDatadogLogger>();
-            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettings.DefaultObfuscationQueryStringRegex, logger.Object);
+            var obfuscatorRegex = TracerSettingsConstants.DefaultObfuscationQueryStringRegex;
+            // the default regex seems to crash the regex engine on netcoreapp2.1 under arm64, with a null reference exception on the dotnet RegexRunner. Its ok as these arent supported in auto instrumentation, we just warn not to reuse this regex if 2.1&arm64 is the environment
+#if NETCOREAPP2_1
+            // Add old one otherwise NullReferenceException on arm64/netcoreapp2.1
+            if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
+            {
+                obfuscatorRegex = """((?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|token|consumer_?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\s|%20)*(?:=|%3D)[^&]+|(?:"|%22)(?:\s|%20)*(?::|%3A)(?:\s|%20)*(?:"|%22)(?:%2[^2]|%[^2]|[^"%])+(?:"|%22))|bearer(?:\s|%20)+[a-z0-9\._\-]|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\w=-]|%3D)+\.ey[I-L](?:[\w=-]|%3D)+(?:\.(?:[\w.+\/=-]|%3D|%2F|%2B)+)?|[\-]{5}BEGIN(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY[\-]{5}[^\-]+[\-]{5}END(?:[a-z\s]|%20)+PRIVATE(?:\s|%20)KEY|ssh-rsa(?:\s|%20)*(?:[a-z0-9\/\.+]|%2F|%5C|%2B){100,})""";
+            }
+#endif
+            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, obfuscatorRegex, logger.Object);
             var queryString = "key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2";
             var result = queryStringObfuscator.Obfuscate(queryString);
             result.Should().Be("key1=val1&<redacted>&key2=val2");

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -563,7 +563,7 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(StringTestCases), TracerSettings.DefaultObfuscationQueryStringRegex, Strings.AllowEmpty)]
+        [MemberData(nameof(StringTestCases), TracerSettingsConstants.DefaultObfuscationQueryStringRegex, Strings.AllowEmpty)]
         public void ObfuscationQueryStringRegex(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.ObfuscationQueryStringRegex, value));

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
@@ -4,63 +4,97 @@
 // </copyright>
 
 using System;
-using System.Text.RegularExpressions;
+using System.Collections.Generic;
+using System.Linq;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
+using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Util.Http.QueryStringObfuscation;
 using FluentAssertions;
 using Moq;
 using Xunit;
 
-namespace Datadog.Trace.Tests.Util.Http
+namespace Datadog.Trace.Tests.Util.Http;
+
+[Collection(nameof(QueryStringObfuscatorTests))]
+public class QueryStringObfuscatorTests
 {
-    [Collection(nameof(QueryStringObfuscatorTests))]
-    public class QueryStringObfuscatorTests
+    private const double Timeout = 500;
+
+    public static IEnumerable<object[]> GetData()
     {
-        private const double Timeout = 500;
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void DoesntObfuscateIfNoPattern(string pattern)
+        var allData = new List<(string Data, string Expected)>
         {
-            var logger = new Mock<IDatadogLogger>();
-            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, pattern, logger.Object);
-            var originalQueryString = "key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2";
-            var result = queryStringObfuscator.Obfuscate(originalQueryString);
-            result.Should().Be(originalQueryString);
-        }
+            new(
+                "http://google.fr/waf?key1=val1&key2=val2&key3=val3",
+                "http://google.fr/waf?key1=val1&key2=val2&key3=val3"),
+            new(
+                "http://google.fr/waf?pass=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3",
+                "http://google.fr/waf?<redacted>&key2=val2&key3=val3"),
+            new(
+                "http://google.fr/waf?key1=val1&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3",
+                "http://google.fr/waf?key1=val1&<redacted>&key3=val3"),
+            new(
+                "http://google.fr/waf?key1=val1&key2=val2&token=03cb9f67dbbc4cb8b966329951e10934",
+                "http://google.fr/waf?key1=val1&key2=val2&<redacted>"),
+            new(
+                "http://google.fr/waf?json=%7B%20%22sign%22%3A%20%22%7B0x03cb9f67%2C0xdbbc%2C0x4cb8%2C%7B0xb9%2C0x66%2C0x32%2C0x99%2C0x51%2C0xe1%2C0x09%2C0x34%7D%7D%22%7D",
+                "http://google.fr/waf?json=%7B%20<redacted>%7D"),
+            new(
+                "https://google.fr/waf?token=03cb9f67dbbc4cb8b9&key1=val1&key2=val2&pass=03cb9f67-dbbc-4cb8-b966-329951e10934&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3&json=%7B%20%22sign%22%3A%20%22%7D%7D%22%7D",
+                "https://google.fr/waf?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D"),
+            new(
+                "http://google.fr/waf?password=12345&token=token:1234&bearer 1234&ecdsa-1-1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&old-pwd2=test&ssh-dss aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test",
+                "http://google.fr/waf?<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>"),
+        };
+        return allData.Select(e => new[] { e.Data, e.Expected });
+    }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData(" ")]
-        public void EdgeCases(string querystring)
-        {
-            var logger = new Mock<IDatadogLogger>();
-            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettings.DefaultObfuscationQueryStringRegex, logger.Object);
-            var result = queryStringObfuscator.Obfuscate(querystring);
-            result.Should().Be(querystring);
-        }
+    [SkippableTheory]
+    [MemberData(nameof(GetData))]
+    public void ObfuscateWithDefaultPattern(string url, string expected)
+    {
+        // the default regex seems to crash the regex engine on netcoreapp2.1 under arm64, with a null reference exception on the dotnet RegexRunner. Its ok as these arent supported in auto instrumentation, we just warn not to reuse this regex if 2.1&arm64 is the environment
+#if NETCOREAPP2_1
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
+#endif
+        var logger = new Mock<IDatadogLogger>();
+        var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettingsConstants.DefaultObfuscationQueryStringRegex, logger.Object);
+        var result = queryStringObfuscator.Obfuscate(url);
+        result.Should().Be(expected);
+    }
 
-        [Fact]
-        public void ObfuscateWithDefaultPattern()
-        {
-            var logger = new Mock<IDatadogLogger>();
-            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettings.DefaultObfuscationQueryStringRegex, logger.Object);
-            var queryString = "key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2";
-            var result = queryStringObfuscator.Obfuscate(queryString);
-            result.Should().Be("key1=val1&<redacted>&key2=val2");
-        }
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void DoesntObfuscateIfNoPattern(string pattern)
+    {
+        var logger = new Mock<IDatadogLogger>();
+        var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, pattern, logger.Object);
+        var originalQueryString = "key1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2";
+        var result = queryStringObfuscator.Obfuscate(originalQueryString);
+        result.Should().Be(originalQueryString);
+    }
 
-        [Fact]
-        public void ObfuscateWithCustomPattern()
-        {
-            var logger = new Mock<IDatadogLogger>();
-            var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, @"(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|authentic\d*)(?:\s*=[^&]+|""\s*:\s*""[^""]+"")|[a-z0-9\._\-]{100,}", logger.Object);
-            var queryString = "?authentic1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&authentic3=val2&authentic55=v";
-            var result = queryStringObfuscator.Obfuscate(queryString);
-            result.Should().Be("?<redacted>&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&<redacted>&<redacted>");
-        }
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void EdgeCases(string querystring)
+    {
+        var logger = new Mock<IDatadogLogger>();
+        var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, TracerSettingsConstants.DefaultObfuscationQueryStringRegex, logger.Object);
+        var result = queryStringObfuscator.Obfuscate(querystring);
+        result.Should().Be(querystring);
+    }
+
+    [Fact]
+    public void ObfuscateWithCustomPattern()
+    {
+        var logger = new Mock<IDatadogLogger>();
+        var queryStringObfuscator = ObfuscatorFactory.GetObfuscator(Timeout, @"(?i)(?:p(?:ass)?w(?:or)?d|pass(?:_?phrase)?|secret|(?:api_?|private_?|public_?|access_?|secret_?)key(?:_?id)?|authentic\d*)(?:\s*=[^&]+|""\s*:\s*""[^""]+"")|[a-z0-9\._\-]{100,}", logger.Object);
+        var queryString = "?authentic1=val1&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&authentic3=val2&authentic55=v";
+        var result = queryStringObfuscator.Obfuscate(queryString);
+        result.Should().Be("?<redacted>&token=a0b21ce2-006f-4cc6-95d5-d7b550698482&key2=val2&<redacted>&<redacted>");
     }
 }


### PR DESCRIPTION
## Summary of changes
Improve regex was missing some cases, like api_key or apikey and other cases.
See https://datadoghq.atlassian.net/wiki/spaces/APS/pages/2490990623/QueryString+-+Sensitive+Data+Obfuscation#I.-Improved-regex

## Reason for change

## Implementation details
Changed the regex and added in a TracerSettingsConstant class to keep comments and multiline for readability

## Test coverage
Adapted test data to test cases

## Other details
<!-- Fixes #{issue} -->
