### PR TITLE
CI fixes to increase reliability

### DIFF
--- a/build/cmake/FindGoogleTest.cmake
+++ b/build/cmake/FindGoogleTest.cmake
@@ -6,7 +6,7 @@ add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/archive/e2239ee6043f73722e7aa812a459f54a28552929.zip
+  URL https://github.com/google/googletest/archive/15460959cbbfa20e66ef0b5ab497367e47fc0a04.zip
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -225,6 +225,14 @@ namespace Datadog.Trace.TestHelpers
                 throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
             }
 
+#if NETCOREAPP2_1
+            if (exitCode == 134 && EnvironmentTools.IsLinux())
+            {
+                // We see SIGABRT relatively frequently on .NET Core 2.1 on Linux, but probably not worth investigating further
+                throw new SkipException("SIGABRT on .NET Core 2.1");
+            }
+#endif
+
             ExitCodeException.ThrowIfNonExpected(exitCode, expectedExitCode);
 
             return new ProcessResult(process, standardOutput, standardError, exitCode);

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Tests
 
             // We cannot assume that expectedNow > now due to the difference of accuracy of QPC and UtcNow.
             var allowedVariance = EnvironmentTools.IsOsx()
-                                        ? TimeSpan.FromMilliseconds(100) // The clock in virtualized osx is terrible
+                                        ? TimeSpan.FromMilliseconds(200) // The clock in virtualized osx is terrible
                                         : TimeSpan.FromMilliseconds(30);
             now.Should().BeCloseTo(expectedNow, allowedVariance);
         }


### PR DESCRIPTION
## Summary of changes

- Stop sending retry metrics locally
- Ignore `134` exit code on .NET Core 2.1 on Linux
- Reduce flake in `UtcNow_GivesLegitTime` on macos
- Fix build warnings in macos build

## Reason for change

### Stop sending retry metrics locally

These metrics were added to track retries on certain flaky tests (named pipes), but they attempt to send these metrics even when running locally, which we don't want,, and just adds noise to the local build as they fail with 403 (because api key is not available)

### Ignore `134` exit code on .NET Core 2.1 on Linux

Investigating a `134` exit code recently, I noticed that [these appear to happen almost exclusively on .NET Core 2.1 on Linux x64
](https://ddstaging.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40error.message%3A%22Expected%20exit%20code%3A%200%2C%20actual%20exit%20code%3A%20134.%22%20%40git.branch%3Amaster%20%40runtime.version%3A2.1&citest_explorer_sort=time%2Cdesc&cols=%40test.suite%2C%40test.name%2C%40duration%2C%40test.service%2C%40git.branch%2C%40runtime.version&currentTab=trace&eventStack=&index=citest&sort=time&spanViewType=metadata&start=1689416152290&end=1692008152290&paused=false). Given that we know there are bugs in CoreClr for .NET Core 2.1 (we already ignore some seg faults) these don't seem worth investing any time in, so just skipping a test if we hit a `134` on linux on .NET Core 2.1. This obviously introduces a small risk that we introduce something that breaks only on .NET Core 2.1, but this seems like a reasonable trade-off to me.

### Reduce flake in `UtcNow_GivesLegitTime` on macos

We already tried to reduce the flake here by increasing the margin, [but apparently it wasn't enough](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=142547&view=logs&j=79d4ae43-b0e6-5bea-a939-b9b728cca996&t=3c695537-de72-5d45-0ef0-38ac548cba5a). We still think this is due to performance of virtualized macs, so just increased the margin further.

### Fix build warnings in macos build

We started getting a bunch of cmake deprecation warnings coming from googletest on macos only:

```bash
CMake Deprecation Warning at obj_arm64/_deps/googletest-src/CMakeLists.txt:4 (cmake_minimum_required):
```

This is likely because the version of cmake in the macos images have been updated behind the scenes (obviously this sucks, and is why we use docker/custom images where possible, but macos is a PITA). As a workaround, updated the version of googletest we use from 1.11.0 to [1.12.0](https://github.com/google/googletest/releases/tag/release-1.12.0). I suspect it won't be simple to upgrade this further, as newer versions will require higher versions of C++
