### PR TITLE
[Profiler] Fix race in ManagedThreadList class

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -261,6 +261,7 @@ HRESULT ManagedThreadList::TryGetCurrentThreadInfo(std::shared_ptr<ManagedThread
         return E_FAIL;
     }
 
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
     pThreadInfo = FindByClrId(clrThreadId);
     if (pThreadInfo != nullptr)
     {


### PR DESCRIPTION
## Summary of changes

Fix race in the `ManagedThreadList` class.

## Reason for change

When calling `TryGetCurrentThreadInfo`, we call `FindByClrId` which requires locking on the `_mutex` object. But it's not done, which means that at some point we could have invalidated iterators (due to a race) and we might crash (actually we got a report where the crash is happening).

## Implementation details
Add a lock just before calling `FindByClrId` in `TryGetCurrentThreadInfo`.

## Test coverage

The current tests should validate.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
