### PR TITLE
Fix flake in Metrics Telemetry collector tests

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -290,6 +290,9 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
         tasks[0] = _processExit.Task;
         while (true)
         {
+            tasks[1] = Task.Delay(_aggregationInterval);
+            await Task.WhenAny(tasks).ConfigureAwait(false);
+
             // The process may have exited, but we want to do a final aggregation before process end anyway
             AggregateMetrics();
 
@@ -297,9 +300,6 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
             {
                 return;
             }
-
-            tasks[1] = Task.Delay(_aggregationInterval);
-            await Task.WhenAny(tasks).ConfigureAwait(false);
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -18,6 +18,66 @@ namespace Datadog.Trace.Tests.Telemetry.Collectors;
 
 public class MetricsTelemetryCollectorTests
 {
+    [Fact]
+    public void AggregatingMultipleTimes_GivesNoStats()
+    {
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        collector.AggregateMetrics();
+        collector.AggregateMetrics();
+        collector.AggregateMetrics();
+        var metrics = collector.GetMetrics();
+        metrics.Metrics.Should().BeNull();
+        metrics.Distributions.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task WithoutAggregation_HasNoStats()
+    {
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        collector.Record(PublicApiUsage.Tracer_Configure);
+        await Task.Delay(TimeSpan.FromSeconds(1));
+        // Shouldn't have any stats, as no aggregation
+        var metrics = collector.GetMetrics();
+        metrics.Metrics.Should().BeNull();
+        metrics.Distributions.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task AggregatesOnShutdown()
+    {
+        var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
+        collector.Record(PublicApiUsage.Tracer_Configure);
+        collector.RecordDistributionInitTime(MetricTags.InitializationComponent.Managed, 22);
+
+        await collector.DisposeAsync();
+        var metrics = collector.GetMetrics();
+
+        metrics.Metrics.Should().BeEquivalentTo(new[]
+        {
+            new
+            {
+                Metric = "public_api",
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { PublicApiUsage.Tracer_Configure.ToStringFast() },
+                Common = false,
+                Namespace = (string)null,
+            },
+        });
+
+        metrics.Distributions.Should().BeEquivalentTo(new[]
+        {
+            new
+            {
+                Metric = Distribution.InitTime.GetName(),
+                Tags = new[] { "component:managed" },
+                Points = new[] {  22 },
+                Common = true,
+                Namespace = NS.General,
+            },
+        });
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("1.2.3")]
@@ -62,6 +122,7 @@ public class MetricsTelemetryCollectorTests
         }
 
         using var scope = new AssertionScope();
+        scope.FormattingOptions.MaxLines = 1000;
 
         var metrics = collector.GetMetrics();
 


### PR DESCRIPTION
## Summary of changes
- Don't aggregate immediately - wait for one interval
- Fix flake in telemetry tests

## Reason for change

A recent change in how metrics are aggregated (#4491) caused aggregation tests to be flaky. This is because the implementation incorrectly performed an aggregation on startup, instead of waiting for one interval.

## Implementation details

Wait for an aggregation interval (or process exit) before performing the first aggregation

## Test coverage

I reproduced locally by running until failure. After the fix, the flake has gone. Also added some extra tests around the aggregation for peace of mind.
