### PR TITLE
Enable V2 Telemetry and Metrics by default in AAS

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -143,8 +143,13 @@ namespace Datadog.Trace.Telemetry
                                    .Value;
 
             var dependencyCollectionEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DependencyCollectionEnabled).AsBool(true);
-            // Currently disabled, will be flipped to true in later versions as part of the rollout
-            var v2Enabled = config.WithKeys(ConfigurationKeys.Telemetry.V2Enabled).AsBool(false);
+
+            var isRunningInAzureAppService = config
+                                        .WithKeys(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey)
+                                        .AsBool(false);
+
+            // Currently enabled by default in AAS, will be flipped to true for all in later versions as part of the rollout
+            var v2Enabled = config.WithKeys(ConfigurationKeys.Telemetry.V2Enabled).AsBool(defaultValue: isRunningInAzureAppService);
 
             // For testing purposes only
             var debugEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DebugEnabled).AsBool(false);
@@ -154,7 +159,7 @@ namespace Datadog.Trace.Telemetry
             var metricsEnabled = config
                                 .WithKeys(ConfigurationKeys.Telemetry.MetricsEnabled)
                                 .AsBool(
-                                     defaultValue: false,
+                                     defaultValue: v2Enabled,
                                      validator: enabled =>
                                      {
                                          if (v2Enabled || !enabled)


### PR DESCRIPTION
## Summary of changes

Enables V2 telemetry and metrics in AAS

## Reason for change

We want to roll out V2, using AAS as a discriminator allows a staged rollout

## Implementation details

Changed the default value when in AAS. We could also have set the values directly in the extension, I don't think one or the other is particularly preferable

## Test coverage

Added and updated a couple of unit tests