### PR TITLE
Fix some flake and speed up some integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("RunOnWindows", "True")]
         public void IntegrationDisabled()
         {
-            const int totalSpanCount = 21;
+            const int totalSpanCount = 9;
             const string expectedOperationName = "sql-server.query";
 
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.SqlClient)}_ENABLED", "false");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
                 catch (Exception ex) when (transportType == TestTransports.WindowsNamedPipe && attemptsRemaining > 0 && ex is not SkipException)
                 {
-                    await ReportRetry(_output, attemptsRemaining, this.GetType(), ex);
+                    await ReportRetry(_output, attemptsRemaining, ex);
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinIisWebApi2Tests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             { "/api2/transientfailure/true", 200, 2 },
             { "/api2/transientfailure/false", 500, 3 },
             { "/api2/statuscode/201", 201, 2 },
-            { "/api2/statuscode/503", 503, 3 },
+            { "/api2/statuscode/503", 503, 2 },
 
             // The global message handler will fail when ps=false
             // The per-route message handler is not invoked with the route /api2, so ts=true|false has no effect

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -163,7 +163,8 @@ public class DataStreamsMonitoringTests : TestHelper
         using var processResult = RunSampleAndWaitForExit(agent);
 
         using var assertionScope = new AssertionScope();
-        var dataStreams = agent.WaitForDataStreams(2);
+        // We don't expect any streams here, so no point waiting for ages
+        var dataStreams = agent.WaitForDataStreams(2, timeoutInMilliseconds: 2_000);
         dataStreams.Should().BeEmpty();
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -315,7 +315,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     expectedGraphQlExecuteSpanCount++;
                 }
 
-                expectedAspNetcoreRequestSpanCount++;
+                if (EnvironmentHelper.IsCoreClr())
+                {
+                    expectedAspNetcoreRequestSpanCount++;
+                }
+
                 GraphQLCommon.SubmitRequest(
                     Output,
                     aspNetCorePort,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
                 catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
                 {
-                    await ReportRetry(_output, attemptsRemaining, this.GetType(), ex);
+                    await ReportRetry(_output, attemptsRemaining, ex);
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -131,20 +131,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                 Spans = agent.Spans;
             }
 
-#if NETCOREAPP2_1
-            if (result.ExitCode == 139)
-            {
-                // Segmentation faults are expected on .NET Core because of a bug in the runtime: https://github.com/dotnet/runtime/issues/11885
-                throw new SkipException("Segmentation fault on .NET Core 2.1");
-            }
-#endif
-            if (result.ExitCode == 134
-             && standardError?.Contains("System.Threading.AbandonedMutexException: The wait completed due to an abandoned mutex") == true
-             && standardError?.Contains("Coverlet.Core.Instrumentation.Tracker") == true)
-            {
-                // Coverlet occasionally throws AbandonedMutexException during clean up
-                throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
-            }
+            ErrorHelpers.CheckForKnownSkipConditions(Output, result.ExitCode, result.StandardError, EnvironmentHelper);
 
             ExitCodeException.ThrowIfNonExpected(result.ExitCode, expectedExitCode, result.StandardError);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -159,7 +159,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
                 catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
                 {
-                    await ReportRetry(_output, attemptsRemaining, this.GetType(), ex);
+                    await ReportRetry(_output, attemptsRemaining, ex);
                 }
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 }
                 catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
                 {
-                    await ReportRetry(_output, attemptsRemaining, this.GetType(), ex);
+                    await ReportRetry(_output, attemptsRemaining, ex);
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -88,7 +88,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             Output.WriteLine("Starting WcfTests.SubmitsTraces. Starting the Samples.Wcf requires ADMIN privileges");
 
-            var expectedSpanCount = 14;
+            var expectedSpanCount = binding switch
+            {
+                "Custom" => 1,
+                _ => 14,
+            };
 
             using var telemetry = this.ConfigureTelemetry();
             int wcfPort = 8585;

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -1,0 +1,113 @@
+﻿// <copyright file="ErrorHelpers.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.ExtensionMethods;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.TestHelpers;
+
+public static class ErrorHelpers
+{
+    public static void CheckForKnownSkipConditions(ITestOutputHelper output, int exitCode, string standardError, EnvironmentHelper environmentHelper)
+    {
+#if NETCOREAPP2_1
+        if (exitCode == 139)
+        {
+            // Segmentation faults are expected on .NET Core because of a bug in the runtime: https://github.com/dotnet/runtime/issues/11885
+            throw new SkipException("Segmentation fault on .NET Core 2.1");
+        }
+#endif
+        if (exitCode == 134
+         && standardError?.Contains("System.Threading.AbandonedMutexException: The wait completed due to an abandoned mutex") == true
+         && standardError?.Contains("Coverlet.Core.Instrumentation.Tracker") == true)
+        {
+            // Coverlet occasionally throws AbandonedMutexException during clean up
+            throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
+        }
+
+#if NETCOREAPP2_1
+        if (exitCode == 134 && EnvironmentTools.IsLinux())
+        {
+            // We see SIGABRT relatively frequently on .NET Core 2.1 on Linux, but probably not worth investigating further
+            throw new SkipException("SIGABRT on .NET Core 2.1");
+        }
+#endif
+
+        if (exitCode == 13)
+        {
+            // This is an "expected" issue, e.g. timeout talking to a required service
+            // strictly a failure, but skipping to avoid flake in CI etc
+            SendMetric(output, "dd_trace_dotnet.ci.tests.skipped_due_to_flake", environmentHelper).ConfigureAwait(false).GetAwaiter().GetResult();
+            throw new SkipException("Exit code (13) - anticipated flake");
+        }
+    }
+
+    public static async Task SendMetric(ITestOutputHelper outputHelper, string metricName, EnvironmentHelper environmentHelper)
+    {
+        var envKey = Environment.GetEnvironmentVariable("DD_LOGGER_DD_API_KEY");
+        if (string.IsNullOrEmpty(envKey))
+        {
+            // We're probably not in CI
+        }
+
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.Add("DD-API-KEY", envKey);
+
+        var type = outputHelper.GetType();
+        var testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+        var test = (ITest)testMember?.GetValue(outputHelper);
+        var testFullName = type.FullName + test?.TestCase.DisplayName;
+
+        // In addition to logging, send a metric that will help us get more information through tags
+        var srcBranch = Environment.GetEnvironmentVariable("DD_LOGGER_BUILD_SOURCEBRANCH");
+
+        var tags = $$"""
+                         "os.platform:{{SanitizeTagValue(FrameworkDescription.Instance.OSPlatform)}}",
+                         "os.architecture:{{SanitizeTagValue(EnvironmentTools.GetPlatform())}}",
+                         "target.framework:{{SanitizeTagValue(environmentHelper.GetTargetFramework())}}",
+                         "test.name:{{SanitizeTagValue(testFullName)}}",
+                         "git.branch:{{SanitizeTagValue(srcBranch)}}"
+                     """;
+
+        var payload = $$"""
+                            {
+                                "series": [{
+                                    "metric": "{{metricName}}",
+                                    "type": 1,
+                                    "points": [{
+                                        "timestamp": {{((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds()}},
+                                        "value": 1
+                                        }],
+                                    "tags": [
+                                        {{tags}}
+                                    ]
+                                }]
+                            }
+                        """;
+
+        var content = new StringContent(payload, Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("https://api.datadoghq.com/api/v2/series", content);
+        var responseContent = await response.Content.ReadAsStringAsync();
+
+        if (response.StatusCode != HttpStatusCode.Accepted)
+        {
+            outputHelper.WriteLine($"Failed to submit metric {metricName}. Response was: Code: {response.StatusCode}. Response: {responseContent}. Payload sent was: \"{payload}\"");
+        }
+    }
+
+    private static string SanitizeTagValue(string tag)
+    {
+        tag.TryConvertToNormalizedTagName(true, out var normalizedTag);
+        return normalizedTag;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/ErrorHelpers.cs
@@ -58,6 +58,7 @@ public static class ErrorHelpers
         if (string.IsNullOrEmpty(envKey))
         {
             // We're probably not in CI
+            return;
         }
 
         var client = new HttpClient();

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -233,6 +233,14 @@ namespace Datadog.Trace.TestHelpers
             }
 #endif
 
+            if (exitCode == 13)
+            {
+                // This is an "expected" issue, e.g. timeout talking to a required service
+                // strictly a failure, but skipping to avoid flake in CI etc
+                SendMetric(Output, "dd_trace_dotnet.ci.tests.skipped_due_to_flake").ConfigureAwait(false).GetAwaiter().GetResult();
+                throw new SkipException("Exit code (13) - anticipated flake");
+            }
+
             ExitCodeException.ThrowIfNonExpected(exitCode, expectedExitCode);
 
             return new ProcessResult(process, standardOutput, standardError, exitCode);

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -30,9 +30,6 @@ namespace Datadog.Trace.TestHelpers
 {
     public abstract class TestHelper : IDisposable
     {
-        private readonly bool _reportMetrics = false;
-        private readonly HttpClient _client = new();
-
         protected TestHelper(string sampleAppName, string samplePathOverrides, ITestOutputHelper output)
             : this(new EnvironmentHelper(sampleAppName, typeof(TestHelper), output, samplePathOverrides), output)
         {
@@ -59,14 +56,6 @@ namespace Datadog.Trace.TestHelpers
             Output.WriteLine($"TargetFramework: {EnvironmentHelper.GetTargetFramework()}");
             Output.WriteLine($".NET Core: {EnvironmentHelper.IsCoreClr()}");
             Output.WriteLine($"Native Loader DLL: {EnvironmentHelper.GetNativeLoaderPath()}");
-
-            var envKey = Environment.GetEnvironmentVariable("DD_LOGGER_DD_API_KEY");
-            if (!string.IsNullOrEmpty(envKey))
-            {
-                // We're probably in CI
-                _client.DefaultRequestHeaders.Add("DD-API-KEY", Environment.GetEnvironmentVariable("DD_LOGGER_DD_API_KEY"));
-                _reportMetrics = true;
-            }
         }
 
         public bool SecurityEnabled { get; private set; }
@@ -210,36 +199,7 @@ namespace Datadog.Trace.TestHelpers
             Output.WriteLine($"ProcessId: " + process.Id);
             Output.WriteLine($"Exit Code: " + exitCode);
 
-#if NETCOREAPP2_1
-            if (exitCode == 139)
-            {
-                // Segmentation faults are expected on .NET Core because of a bug in the runtime: https://github.com/dotnet/runtime/issues/11885
-                throw new SkipException("Segmentation fault on .NET Core 2.1");
-            }
-#endif
-            if (exitCode == 134
-             && standardError?.Contains("System.Threading.AbandonedMutexException: The wait completed due to an abandoned mutex") == true
-             && standardError?.Contains("Coverlet.Core.Instrumentation.Tracker") == true)
-            {
-                // Coverlet occasionally throws AbandonedMutexException during clean up
-                throw new SkipException("Coverlet threw AbandonedMutexException during cleanup");
-            }
-
-#if NETCOREAPP2_1
-            if (exitCode == 134 && EnvironmentTools.IsLinux())
-            {
-                // We see SIGABRT relatively frequently on .NET Core 2.1 on Linux, but probably not worth investigating further
-                throw new SkipException("SIGABRT on .NET Core 2.1");
-            }
-#endif
-
-            if (exitCode == 13)
-            {
-                // This is an "expected" issue, e.g. timeout talking to a required service
-                // strictly a failure, but skipping to avoid flake in CI etc
-                SendMetric(Output, "dd_trace_dotnet.ci.tests.skipped_due_to_flake").ConfigureAwait(false).GetAwaiter().GetResult();
-                throw new SkipException("Exit code (13) - anticipated flake");
-            }
+            ErrorHelpers.CheckForKnownSkipConditions(Output, exitCode, standardError, EnvironmentHelper);
 
             ExitCodeException.ThrowIfNonExpected(exitCode, expectedExitCode);
 
@@ -668,73 +628,10 @@ namespace Datadog.Trace.TestHelpers
         {
             outputHelper.WriteLine($"Error executing test. {attemptsRemaining} attempts remaining. {ex}");
 
-            if (!_reportMetrics)
-            {
-                return;
-            }
-
-            await SendMetric(outputHelper, "dd_trace_dotnet.ci.tests.retries");
-        }
-
-        private async Task SendMetric(ITestOutputHelper outputHelper, string metricName)
-        {
-            var type = outputHelper.GetType();
-            var testMember = type.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
-            var test = (ITest)testMember?.GetValue(outputHelper);
-            var testFullName = type.FullName + test?.TestCase.DisplayName;
-
-            // In addition to logging, send a metric that will help us get more information through tags
-            var srcBranch = Environment.GetEnvironmentVariable("DD_LOGGER_BUILD_SOURCEBRANCH");
-
-            var tags = $$"""
-                             "os.platform:{{SanitizeTagValue(FrameworkDescription.Instance.OSPlatform)}}",
-                             "os.architecture:{{SanitizeTagValue(EnvironmentTools.GetPlatform())}}",
-                             "target.framework:{{SanitizeTagValue(EnvironmentHelper.GetTargetFramework())}}",
-                             "test.name:{{SanitizeTagValue(testFullName)}}",
-                             "git.branch:{{SanitizeTagValue(srcBranch)}}"
-                         """;
-
-            var payload = $$"""
-                                {
-                                    "series": [{
-                                        "metric": "{{metricName}}",
-                                        "type": 1,
-                                        "points": [{
-                                            "timestamp": {{((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds()}},
-                                            "value": 1
-                                            }],
-                                        "tags": [
-                                            {{tags}}
-                                        ]
-                                    }]
-                                }
-                            """;
-
-            var content = new StringContent(payload, Encoding.UTF8, "application/json");
-            var response = await _client.PostAsync("https://api.datadoghq.com/api/v2/series", content);
-            var responseContent = await response.Content.ReadAsStringAsync();
-
-            if (response.StatusCode != HttpStatusCode.Accepted)
-            {
-                outputHelper.WriteLine($"Failed to submit metric {metricName}. Response was: Code: {response.StatusCode}. Response: {responseContent}. Payload sent was: \"{payload}\"");
-            }
-        }
-
-        private string SanitizeTagValue(string tag)
-        {
-            tag.TryConvertToNormalizedTagName(true, out var normalizedTag);
-            return normalizedTag;
+            await ErrorHelpers.SendMetric(outputHelper, "dd_trace_dotnet.ci.tests.retries", EnvironmentHelper);
         }
 
         private bool IsServerSpan(MockSpan span) =>
             span.Tags.GetValueOrDefault(Tags.SpanKind) == SpanKinds.Server;
-
-        protected internal class TupleList<T1, T2> : List<Tuple<T1, T2>>
-        {
-            public void Add(T1 item, T2 item2)
-            {
-                Add(new Tuple<T1, T2>(item, item2));
-            }
-        }
     }
 }

--- a/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -9,11 +9,27 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
 {
     public class Program
     {
-        public static async Task Main()
+        public static async Task<int> Main()
         {
             try
             {
                 await RunTest();
+                return 0;
+            }
+            catch (Exception ex)
+                when (ex.GetType().Name == "RedisConnectionException"
+                 &&  ex.Message.Contains("No connection is available to service this operation"))
+            {
+                // If the redis server is being too slow in responding, we can end up with timeouts
+                // We could do retries, but then we risk butting up against timeout limits etc
+                // As a workaround, we use the specific exit code 13 to indicate a faulty program,
+                // and skip the test.
+                // We need to keep the catch very specific here, so that we don't accidentally
+                // start skipping tests when we shouldn't be
+                Console.WriteLine("Unexpected exception during execution " + ex);
+                Console.WriteLine("Exiting with skip code (13)");
+                return 13;
+                
             }
             finally
             {


### PR DESCRIPTION
## Summary of changes

- Adds handling for some common flake scenarios
- Fixes span expectations to reduce overall test duration
- Minor refactoring of test helper

## Reason for change

### Adds handling for some common flake scenarios
We have several scenarios where we often flake. For example, Kafka occasionally fails to connect to the broker, or the redis connection fails. These are rare failures, and likely due to an overloaded machine, so they're hard to cope with. Additionally, we can't retry the connection _inside_ the app because a) that would cause more spans, causing the test to failure b) [there are other issues](https://github.com/confluentinc/confluent-kafka-dotnet/issues/1491). 

As a workaround, added `try-catch` to the two most common culprits: KafkaTests and Redis. When an unhandled exception with the expected "flake-identifying" message is found, we now return a specific exit code: `13`. We then look for that exit code in the test, and if we find it, we skip the test.

I decided to add a metric to this scenario, which we may want to alert on, so that we don't suddenly start skipping everything and not realise!

### Fixes span expectations to reduce overall test duration

Following on from @bouwkast's [great work to speed up CI](https://github.com/DataDog/dd-trace-dotnet/pull/4479) (and his presentation on how to use ciapp to do it), fixed some tests that were waiting for the wrong number of spans (or were waiting for 20s when we don't actually expect any anyway)

Most of these changes were trivial. The exception was AspNetWebApi2Tests which produces a different number of spans _for 2 paths only_ when running in classic mode. What I've done is kinda horrible, but it works, and other options (duplicating the list, splitting some paths into separate tests) are also kinda horrible, so meh 😉 

### Minor refactoring of test helper

- Extracted the "SendMetric" routine so we could reuse it for the skipped tests
- Extract common "throw `SkipException`" logic so we reuse it across "normal" integration tests as well as smoke tests

## Test coverage
N/A

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
