### PR TITLE
[DSM] - Default time in queue + payload size

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.0",
-    "rollForward": "minor",
-    "allowPrerelease": true
+    "version": "7.0.306",
+    "rollForward": "minor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.306",
-    "rollForward": "minor"
+    "version": "7.0.0",
+    "rollForward": "minor",
+    "allowPrerelease": true
   }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeader.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeader.cs
@@ -1,0 +1,23 @@
+// <copyright file="IHeader.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
+{
+    /// <summary>
+    /// Header interface for duck-typing
+    /// </summary>
+    internal interface IHeader
+    {
+        /// <summary>
+        ///  Gets key
+        /// </summary>
+        string Key { get; }
+
+        /// <summary>
+        ///  Returns value bytes
+        /// </summary>
+        byte[] GetValueBytes();
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeaders.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeaders.cs
@@ -10,8 +10,18 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
     /// <summary>
     /// Headers interface for duck-typing
     /// </summary>
-    internal interface IHeaders : IEnumerable<IHeader>
+    internal interface IHeaders
     {
+        /// <summary>
+        /// Gets number of headers
+        /// </summary>
+        public int Count { get; }
+
+        /// <summary>
+        /// Gets the header at the specified index
+        /// </summary>
+        public IHeader this[int index] { get;  }
+
         /// <summary>
         /// Adds a header to the collection
         /// </summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeaders.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeaders.cs
@@ -10,13 +10,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
     /// <summary>
     /// Headers interface for duck-typing
     /// </summary>
-    internal interface IHeaders
+    internal interface IHeaders : IEnumerable<IHeader>
     {
-        /// <summary>
-        ///  Gets of headers
-        /// </summary>
-        IReadOnlyList<IHeader> BackingList { get; }
-
         /// <summary>
         /// Adds a header to the collection
         /// </summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeaders.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IHeaders.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Collections.Generic;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 {
     /// <summary>
@@ -10,6 +12,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
     /// </summary>
     internal interface IHeaders
     {
+        /// <summary>
+        ///  Gets of headers
+        /// </summary>
+        IReadOnlyList<IHeader> BackingList { get; }
+
         /// <summary>
         /// Adds a header to the collection
         /// </summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IMessage.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IMessage.cs
@@ -11,6 +11,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
     internal interface IMessage
     {
         /// <summary>
+        /// Gets the key of the message
+        /// </summary>
+        public object Key { get; }
+
+        /// <summary>
         /// Gets the value of the message
         /// </summary>
         public object Value { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -128,7 +128,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
             if (message.Headers != null)
             {
-                foreach (var header in message.Headers.BackingList)
+                foreach (var header in message.Headers)
                 {
                     size += Encoding.UTF8.GetByteCount(header.Key);
                     size += header.GetValueBytes().Length;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -128,10 +128,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 
             if (message.Headers != null)
             {
-                foreach (var header in message.Headers)
+                for (var i = 0; i < message.Headers.Count; i++)
                 {
+                    var header = message.Headers[i];
                     size += Encoding.UTF8.GetByteCount(header.Key);
-                    size += header.GetValueBytes().Length;
+                    var value = header.GetValueBytes();
+                    if (value != null)
+                    {
+                        size += value.Length;
+                    }
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -102,10 +102,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 return size;
             }
 
-            if (message.Key != null)
-            {
-                
-            }
+            // TODO:
 
             return size;
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/AmqpTimestamp.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/AmqpTimestamp.cs
@@ -1,12 +1,15 @@
-// <copyright file="IAmqpTimestamp.cs" company="Datadog">
+// <copyright file="AmqpTimestamp.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.DuckTyping;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
-    internal interface IAmqpTimestamp
+    [DuckCopy]
+    internal struct AmqpTimestamp
     {
-        long UnixTime { get; }
+        public long UnixTime;
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
                     if (basicProperties != null)
                     {
-                        RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(Tracer.Instance, scope.Span, tags, basicProperties.Headers);
+                        RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(Tracer.Instance, scope.Span, tags, basicGetResult.Body, basicProperties);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -105,7 +105,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
                     if (basicProperties != null)
                     {
-                        RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(Tracer.Instance, scope.Span, tags, basicGetResult.Body, basicProperties);
+                        RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(
+                            Tracer.Instance,
+                            scope.Span,
+                            tags,
+                            basicProperties.Headers,
+                            basicGetResult.Body?.Length ?? 0,
+                            basicProperties.Timestamp.UnixTime != 0 ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - basicProperties.Timestamp.UnixTime : 0);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                     }
 
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
-                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(Tracer.Instance, scope.Span, tags, basicProperties.Headers);
+                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(Tracer.Instance, scope.Span, tags, basicProperties, body);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                     }
 
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
-                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(Tracer.Instance, scope.Span, tags, basicProperties, body);
+                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(Tracer.Instance, scope.Span, tags, body, basicProperties);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -79,7 +79,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                     }
 
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
-                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(Tracer.Instance, scope.Span, tags, basicProperties.Headers, body?.Length ?? 0);
+                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(
+                        Tracer.Instance,
+                        scope.Span,
+                        tags,
+                        basicProperties.Headers,
+                        body.Instance != null ? body.Length : 0);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                     }
 
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
-                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(Tracer.Instance, scope.Span, tags, body, basicProperties);
+                    RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(Tracer.Instance, scope.Span, tags, basicProperties.Headers, body?.Length ?? 0);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IAmqpTimestamp.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IAmqpTimestamp.cs
@@ -1,0 +1,12 @@
+// <copyright file="IBasicProperties.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
+{
+    internal interface IAmqpTimestamp
+    {
+        long UnixTime { get; }
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IAmqpTimestamp.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IAmqpTimestamp.cs
@@ -1,4 +1,4 @@
-// <copyright file="IBasicProperties.cs" company="Datadog">
+// <copyright file="IAmqpTimestamp.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <summary>
         /// Gets timestamp at which the message was produced
         /// </summary>
-        IAmqpTimestamp Timestamp { get; }
+        AmqpTimestamp Timestamp { get; }
 
         /// <summary>
         /// Returns true if the DeliveryMode property is present

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
@@ -24,6 +24,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         byte DeliveryMode { get; }
 
         /// <summary>
+        /// Gets timestamp at which the message was produced
+        /// </summary>
+        IAmqpTimestamp Timestamp { get; }
+
+        /// <summary>
         /// Returns true if the DeliveryMode property is present
         /// </summary>
         /// <returns>true if the DeliveryMode property is present</returns>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
@@ -129,7 +129,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 var pathwayContext = dataStreamsManager.ExtractPathwayContext(headersAdapter);
                 span.Context.MergePathwayContext(pathwayContext);
                 // size of headers is ignored for now
-                span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Consume, edgeTags, body?.Length ?? 0, basicProperties.Timestamp?.UnixTime ?? 0);
+                span.SetDataStreamsCheckpoint(
+                    dataStreamsManager,
+                    CheckpointKind.Consume,
+                    edgeTags,
+                    body?.Length ?? 0,
+                    basicProperties.Timestamp == null ? 0 : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - basicProperties.Timestamp.UnixTime);
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
@@ -130,7 +130,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                                    // exchange can be empty for "direct"
                                    new[] { "direction:out", $"topic:{tags.Queue ?? tags.RoutingKey}", "type:rabbitmq" } :
                                    new[] { "direction:out", $"exchange:{tags.Exchange}", $"has_routing_key:{!string.IsNullOrEmpty(tags.RoutingKey)}", "type:rabbitmq" };
-                // size of headers is ignored for now
                 span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Produce, edgeTags, GetHeadersSize(headers) + messageSize, 0);
                 dataStreamsManager.InjectPathwayContext(span.Context.PathwayContext, headersAdapter);
             }
@@ -154,14 +153,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 var edgeTags = new[] { "direction:in", $"topic:{tags.Queue ?? tags.RoutingKey}", "type:rabbitmq" };
                 var pathwayContext = dataStreamsManager.ExtractPathwayContext(headersAdapter);
                 span.Context.MergePathwayContext(pathwayContext);
-                // size of headers is ignored for now
                 span.SetDataStreamsCheckpoint(
                     dataStreamsManager,
                     CheckpointKind.Consume,
                     edgeTags,
                     GetHeadersSize(headers) + messageSize,
                     messageTimestamp);
-                // basicProperties.Timestamp == null ? 0 : DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - basicProperties.Timestamp.UnixTime
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
@@ -127,6 +127,7 @@ internal class DataStreamsAggregator
             {
                 _sketchPool.Release(bucket.Value.EdgeLatency);
                 _sketchPool.Release(bucket.Value.PathwayLatency);
+                _sketchPool.Release(bucket.Value.PayloadSize);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsAggregator.cs
@@ -149,7 +149,8 @@ internal class DataStreamsAggregator
                 hash: point.Hash,
                 parentHash: point.ParentHash,
                 pathwayLatency: _sketchPool.Get(),
-                edgeLatency: _sketchPool.Get());
+                edgeLatency: _sketchPool.Get(),
+                payloadSize: _sketchPool.Get());
             bucket[point.Hash.Value] = group;
         }
 
@@ -158,6 +159,7 @@ internal class DataStreamsAggregator
 
         var edgeLatencySeconds = Convert.ToDouble(point.EdgeLatencyNs) / 1_000_000_000;
         group.EdgeLatency.Add(Math.Max(edgeLatencySeconds, 0));
+        group.PayloadSize.Add(point.PayloadSizeBytes);
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/DataStreamsMessagePackFormatter.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
         private readonly byte[] _parentHashBytes = StringEncoding.UTF8.GetBytes("ParentHash");
         private readonly byte[] _pathwayLatencyBytes = StringEncoding.UTF8.GetBytes("PathwayLatency");
         private readonly byte[] _edgeLatencyBytes = StringEncoding.UTF8.GetBytes("EdgeLatency");
+        private readonly byte[] _payloadSizeBytes = StringEncoding.UTF8.GetBytes("PayloadSize");
         private readonly byte[] _timestampTypeBytes = StringEncoding.UTF8.GetBytes("TimestampType");
         private readonly byte[] _currentTimestampTypeBytes = StringEncoding.UTF8.GetBytes("current");
         private readonly byte[] _originTimestampTypeBytes = StringEncoding.UTF8.GetBytes("origin");
@@ -108,10 +109,10 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
                 {
                     var hasEdges = point.EdgeTags.Length > 0;
 
-                    // 6 entries per StatsPoint:
-                    // 5 if no edge tags
+                    // 7 entries per StatsPoint:
+                    // 6 if no edge tags
                     // https://github.com/DataDog/data-streams-go/blob/6772b163707c0a8ecc8c9a3b28e0dab7e0cf58d4/datastreams/payload.go#L44
-                    var itemCount = hasEdges ? 6 : 5;
+                    var itemCount = hasEdges ? 7 : 6;
                     bytesWritten += MessagePackBinary.WriteMapHeader(stream, itemCount);
 
                     bytesWritten += MessagePackBinary.WriteStringBytes(stream, _hashBytes);
@@ -128,6 +129,9 @@ namespace Datadog.Trace.DataStreamsMonitoring.Aggregation
 
                     bytesWritten += MessagePackBinary.WriteStringBytes(stream, _edgeLatencyBytes);
                     bytesWritten += SerializeSketch(stream, point.EdgeLatency);
+
+                    bytesWritten += MessagePackBinary.WriteStringBytes(stream, _payloadSizeBytes);
+                    bytesWritten += SerializeSketch(stream, point.PayloadSize);
 
                     if (hasEdges)
                     {

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsBucket.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsBucket.cs
@@ -16,13 +16,15 @@ internal readonly struct StatsBucket
     public readonly PathwayHash ParentHash;
     public readonly DDSketch PathwayLatency;
     public readonly DDSketch EdgeLatency;
+    public readonly DDSketch PayloadSize;
 
-    public StatsBucket(string[] edgeTags, PathwayHash hash, PathwayHash parentHash, DDSketch pathwayLatency, DDSketch edgeLatency)
+    public StatsBucket(string[] edgeTags, PathwayHash hash, PathwayHash parentHash, DDSketch pathwayLatency, DDSketch edgeLatency, DDSketch payloadSize)
     {
         EdgeTags = edgeTags;
         Hash = hash;
         ParentHash = parentHash;
         PathwayLatency = pathwayLatency;
         EdgeLatency = edgeLatency;
+        PayloadSize = payloadSize;
     }
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsPoint.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/Aggregation/StatsPoint.cs
@@ -16,6 +16,7 @@ internal readonly struct StatsPoint
     public readonly long TimestampNs;
     public readonly long PathwayLatencyNs;
     public readonly long EdgeLatencyNs;
+    public readonly long PayloadSizeBytes;
 
     public StatsPoint(
         string[] edgeTags,
@@ -23,7 +24,8 @@ internal readonly struct StatsPoint
         PathwayHash parentHash,
         long timestampNs,
         long pathwayLatencyNs,
-        long edgeLatencyNs)
+        long edgeLatencyNs,
+        long payloadSizeBytes)
     {
         EdgeTags = edgeTags;
         Hash = hash;
@@ -31,5 +33,6 @@ internal readonly struct StatsPoint
         TimestampNs = timestampNs;
         PathwayLatencyNs = pathwayLatencyNs;
         EdgeLatencyNs = edgeLatencyNs;
+        PayloadSizeBytes = payloadSizeBytes;
     }
 }

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -132,7 +132,7 @@ internal class DataStreamsManager
             }
 
             var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
-            var edgeStartNs = previousContext == null && timeInQueueMs > 0 ? nowNs - (timeInQueueMs * 1000_000) : nowNs;
+            var edgeStartNs = previousContext == null && timeInQueueMs > 0 ? nowNs - (timeInQueueMs * 1_000_000) : nowNs;
             var pathwayStartNs = previousContext?.PathwayStart ?? edgeStartNs;
 
             var nodeHash = HashHelper.CalculateNodeHash(_nodeHashBase, edgeTags);

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -132,6 +132,9 @@ internal class DataStreamsManager
             }
 
             var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+            // We should use timeInQueue to offset the edge / pathway start if this is a beginning of a pathway
+            // This allows tracking edge / pathway latency for pipelines starting with a queue (no producer instrumented upstream)
+            // by relying on the message timestamp.
             var edgeStartNs = previousContext == null && timeInQueueMs > 0 ? nowNs - (timeInQueueMs * 1_000_000) : nowNs;
             var pathwayStartNs = previousContext?.PathwayStart ?? edgeStartNs;
 

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -131,7 +131,8 @@ internal class DataStreamsManager
                 previousContext = PreviousCheckpoint.Value.Context;
             }
 
-            var edgeStartNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+            var nowNs = DateTimeOffset.UtcNow.ToUnixTimeNanoseconds();
+            var edgeStartNs = previousContext == null && timeInQueueMs > 0 ? nowNs - (timeInQueueMs * 1000_000) : nowNs;
             var pathwayStartNs = previousContext?.PathwayStart ?? edgeStartNs;
 
             var nodeHash = HashHelper.CalculateNodeHash(_nodeHashBase, edgeTags);
@@ -144,9 +145,9 @@ internal class DataStreamsManager
                     edgeTags: edgeTags,
                     hash: pathwayHash,
                     parentHash: parentHash,
-                    timestampNs: edgeStartNs,
-                    pathwayLatencyNs: edgeStartNs - pathwayStartNs,
-                    edgeLatencyNs: edgeStartNs - (previousContext?.EdgeStart ?? edgeStartNs),
+                    timestampNs: nowNs,
+                    pathwayLatencyNs: nowNs - pathwayStartNs,
+                    edgeLatencyNs: nowNs - (previousContext?.EdgeStart ?? edgeStartNs),
                     payloadSizeBytes));
 
             var pathway = new PathwayContext(

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs
@@ -108,8 +108,15 @@ internal class DataStreamsManager
     /// <param name="parentPathway">The current pathway</param>
     /// <param name="checkpointKind">Is this a Produce or Consume operation?</param>
     /// <param name="edgeTags">Edge tags to set for the new pathway. MUST be sorted in alphabetical order</param>
+    /// <param name="payloadSizeBytes">Payload size in bytes</param>
+    /// <param name="timeInQueueMs">Edge start time extracted from the message metadata. Used only if this is start of the pathway</param>
     /// <returns>If disabled, returns <c>null</c>. Otherwise returns a new <see cref="PathwayContext"/></returns>
-    public PathwayContext? SetCheckpoint(in PathwayContext? parentPathway, CheckpointKind checkpointKind, string[] edgeTags)
+    public PathwayContext? SetCheckpoint(
+        in PathwayContext? parentPathway,
+        CheckpointKind checkpointKind,
+        string[] edgeTags,
+        long payloadSizeBytes,
+        long timeInQueueMs)
     {
         if (!IsEnabled)
         {
@@ -139,7 +146,8 @@ internal class DataStreamsManager
                     parentHash: parentHash,
                     timestampNs: edgeStartNs,
                     pathwayLatencyNs: edgeStartNs - pathwayStartNs,
-                    edgeLatencyNs: edgeStartNs - (previousContext?.EdgeStart ?? edgeStartNs)));
+                    edgeLatencyNs: edgeStartNs - (previousContext?.EdgeStart ?? edgeStartNs),
+                    payloadSizeBytes));
 
             var pathway = new PathwayContext(
                 hash: pathwayHash,

--- a/tracer/src/Datadog.Trace/DataStreamsMonitoring/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/DataStreamsMonitoring/SpanExtensions.cs
@@ -14,9 +14,11 @@ internal static class SpanExtensions
     /// <param name="manager">The <see cref="DataStreamsManager"/> to use</param>
     /// <param name="checkpointKind">The type of checkpoint we're setting</param>
     /// <param name="edgeTags">The edge tags for this checkpoint. NOTE: These MUST be sorted alphabetically</param>
-    internal static void SetDataStreamsCheckpoint(this Span span, DataStreamsManager manager, CheckpointKind checkpointKind, string[] edgeTags)
+    /// <param name="payloadSizeBytes">Payload size in bytes</param>
+    /// <param name="timeInQueueMs">Edge start time extracted from the message metadata. Used only if this is start of the pathway</param>
+    internal static void SetDataStreamsCheckpoint(this Span span, DataStreamsManager manager, CheckpointKind checkpointKind, string[] edgeTags, long payloadSizeBytes, long timeInQueueMs)
     {
-       span.Context.SetCheckpoint(manager, checkpointKind, edgeTags);
+       span.Context.SetCheckpoint(manager, checkpointKind, edgeTags, payloadSizeBytes, timeInQueueMs);
        var hash = span.Context.PathwayContext?.Hash.Value ?? 0;
        if (hash != 0)
        {

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -436,9 +436,11 @@ namespace Datadog.Trace
         /// <param name="manager">The <see cref="DataStreamsManager"/> to use</param>
         /// <param name="checkpointKind">The type of the checkpoint</param>
         /// <param name="edgeTags">The edge tags for this checkpoint. NOTE: These MUST be sorted alphabetically</param>
-        internal void SetCheckpoint(DataStreamsManager manager, CheckpointKind checkpointKind, string[] edgeTags)
+        /// <param name="payloadSizeBytes">Payload size in bytes</param>
+        /// <param name="timeInQueueMs">Edge start time extracted from the message metadata. Used only if this is start of the pathway</param>
+        internal void SetCheckpoint(DataStreamsManager manager, CheckpointKind checkpointKind, string[] edgeTags, long payloadSizeBytes, long timeInQueueMs)
         {
-            PathwayContext = manager.SetCheckpoint(PathwayContext, checkpointKind, edgeTags);
+            PathwayContext = manager.SetCheckpoint(PathwayContext, checkpointKind, edgeTags, payloadSizeBytes, timeInQueueMs);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace
 
                 var edgeTags = edgeTagString.Split(',');
                 spanContext.MergePathwayContext(pathwayContext);
-                spanContext.SetCheckpoint(dsm, CheckpointKind.Consume, edgeTags);
+                spanContext.SetCheckpoint(dsm, CheckpointKind.Consume, edgeTags, 0, 0);
             }
 
             return spanContext;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
@@ -54,6 +54,9 @@ public class DataStreamsMonitoringRabbitMQTests : TestHelper
                     _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(
                         x => x.PathwayLatency,
                         (_, v) =>  v?.Length == 0 ? v : new byte[] { 0xFF });
+                    _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(
+                        x => x.PayloadSize,
+                        (_, v) =>  v?.Length == 0 ? v : new byte[] { 0xFF });
                 });
             await Verifier.Verify(PayloadsToPoints(agent.DataStreams), settings)
                           .UseFileName($"{nameof(DataStreamsMonitoringRabbitMQTests)}.{nameof(HandleProduceAndConsume)}")

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -9,7 +9,6 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.TestHelpers.DataStreamsMonitoring;
 using FluentAssertions;
@@ -85,6 +84,7 @@ public class DataStreamsMonitoringTests : TestHelper
             {
                 _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.EdgeLatency, ScrubByteArray);
                 _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.PathwayLatency, ScrubByteArray);
+                _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.PayloadSize, ScrubByteArray);
             });
         await Verifier.Verify(payload, settings)
                       .UseFileName($"{nameof(DataStreamsMonitoringTests)}.{nameof(SubmitsDataStreams)}")
@@ -145,6 +145,7 @@ public class DataStreamsMonitoringTests : TestHelper
             {
                 _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.EdgeLatency, ScrubByteArray);
                 _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.PathwayLatency, ScrubByteArray);
+                _.MemberConverter<MockDataStreamsStatsPoint, byte[]>(x => x.PayloadSize, ScrubByteArray);
             });
 
         await Verifier.Verify(payload, settings)

--- a/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsStatsPoint.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/DataStreamsMonitoring/MockDataStreamsStatsPoint.cs
@@ -25,6 +25,9 @@ public class MockDataStreamsStatsPoint
     [Key(nameof(EdgeLatency))]
     public byte[] EdgeLatency { get; set; }
 
+    [Key(nameof(PayloadSize))]
+    public byte[] PayloadSize { get; set; }
+
     [Key(nameof(TimestampType))]
     public string TimestampType { get; set; }
 }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsAggregatorTests.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.Tests.DataStreamsMonitoring;
 public class DataStreamsAggregatorTests
 {
     private const long OneSecondNs = 1_000_000_000;
+    private const long OneKB = 1024;
     private const int BucketDurationMs = DataStreamsConstants.DefaultBucketDurationMs; // 10s
     private const long BucketDurationNs = ((long)BucketDurationMs) * 1_000_000;
 
@@ -116,7 +117,8 @@ public class DataStreamsAggregatorTests
                 parentHash: new PathwayHash(1),
                 timestampNs: t2,
                 pathwayLatencyNs: OneSecondNs,
-                edgeLatencyNs: OneSecondNs));
+                edgeLatencyNs: OneSecondNs,
+                payloadSizeBytes: OneKB));
 
         aggregator.Add(
             new StatsPoint(
@@ -125,7 +127,8 @@ public class DataStreamsAggregatorTests
                 parentHash: new PathwayHash(1),
                 timestampNs: t2,
                 pathwayLatencyNs: 5 * OneSecondNs,
-                edgeLatencyNs: 2 * OneSecondNs));
+                edgeLatencyNs: 2 * OneSecondNs,
+                payloadSizeBytes: OneKB * 2));
 
         aggregator.Add(
             new StatsPoint(
@@ -134,7 +137,8 @@ public class DataStreamsAggregatorTests
                 parentHash: new PathwayHash(1),
                 timestampNs: t2,
                 pathwayLatencyNs: 5 * OneSecondNs,
-                edgeLatencyNs: 2 * OneSecondNs));
+                edgeLatencyNs: 2 * OneSecondNs,
+                payloadSizeBytes: OneKB * 2));
 
         aggregator.Add(
             new StatsPoint(
@@ -143,7 +147,8 @@ public class DataStreamsAggregatorTests
                 parentHash: new PathwayHash(1),
                 timestampNs: t1, // different start time
                 pathwayLatencyNs: 5 * OneSecondNs,
-                edgeLatencyNs: 2 * OneSecondNs));
+                edgeLatencyNs: 2 * OneSecondNs,
+                payloadSizeBytes: OneKB * 2));
         return aggregator;
     }
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -81,7 +81,7 @@ public class DataStreamsManagerTests
     {
         var dsm = GetDataStreamManager(true, out _);
 
-        var context = dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, new[] { "some-tags" });
+        var context = dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, new[] { "some-tags" }, 100, 100);
         context.Should().NotBeNull();
     }
 
@@ -93,7 +93,7 @@ public class DataStreamsManagerTests
         var edgeTags = new[] { "some-tags" };
         var dsm = GetDataStreamManager(true, out _);
 
-        var context = dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, edgeTags);
+        var context = dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, edgeTags, 100, 100);
         context.Should().NotBeNull();
 
         var baseHash = HashHelper.CalculateNodeHashBase(service, env, primaryTag: null);
@@ -112,7 +112,7 @@ public class DataStreamsManagerTests
         var dsm = GetDataStreamManager(true, out _);
         var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
 
-        var context = dsm.SetCheckpoint(parent, CheckpointKind.Consume, edgeTags);
+        var context = dsm.SetCheckpoint(parent, CheckpointKind.Consume, edgeTags, 100, 100);
         context.Should().NotBeNull();
 
         var baseHash = HashHelper.CalculateNodeHashBase(service, env, primaryTag: null);
@@ -128,7 +128,7 @@ public class DataStreamsManagerTests
         var dsm = GetDataStreamManager(false, out _);
         var parent = new PathwayContext(new PathwayHash(123), 12340000, 56780000);
 
-        var context = dsm.SetCheckpoint(parent, CheckpointKind.Consume, new[] { "some-tags" });
+        var context = dsm.SetCheckpoint(parent, CheckpointKind.Consume, new[] { "some-tags" }, 100, 100);
         context.Should().BeNull();
     }
 
@@ -138,7 +138,7 @@ public class DataStreamsManagerTests
         var dsm = GetDataStreamManager(true, out _);
         var span = new Span(new SpanContext(traceId: 123, spanId: 456), DateTimeOffset.UtcNow);
 
-        span.SetDataStreamsCheckpoint(dsm,  CheckpointKind.Produce, new[] { "direction:out" });
+        span.SetDataStreamsCheckpoint(dsm,  CheckpointKind.Produce, new[] { "direction:out" }, 100, 0);
         span.Tags.GetTag("pathway.hash").Should().NotBeNull();
     }
 
@@ -153,7 +153,7 @@ public class DataStreamsManagerTests
         await dsm.DisposeAsync();
         dsm.IsEnabled.Should().BeFalse();
 
-        var context = dsm.SetCheckpoint(parent, CheckpointKind.Consume, new[] { "some-tags" });
+        var context = dsm.SetCheckpoint(parent, CheckpointKind.Consume, new[] { "some-tags" }, 100, 100);
         context.Should().BeNull();
     }
 
@@ -163,7 +163,7 @@ public class DataStreamsManagerTests
         var dsm = GetDataStreamManager(enabled: false, out var writer);
         writer.Should().BeNull(); // can't send points to it, because it's null!
 
-        dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, new[] { "edge" });
+        dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, new[] { "edge" }, 100, 100);
 
         await dsm.DisposeAsync();
     }
@@ -173,7 +173,7 @@ public class DataStreamsManagerTests
     {
         var dsm = GetDataStreamManager(enabled: true, out var writer);
 
-        dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, new[] { "edge" });
+        dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, new[] { "edge" }, 100, 100);
 
         await dsm.DisposeAsync();
 

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
@@ -88,6 +88,9 @@ public class DataStreamsMessagePackFormatterTests
         var edgeBytes = new byte[edgeSketch.ComputeSerializedSize()];
         using var ms2 = new MemoryStream(edgeBytes);
         edgeSketch.Serialize(ms2);
+        var payloadSizeBytes = new byte[payloadSizeSketch.ComputeSerializedSize()];
+        using var ms3 = new MemoryStream(payloadSizeBytes);
+        payloadSizeSketch.Serialize(ms3);
 
         var expected = new MockDataStreamsPayload
         {
@@ -110,6 +113,7 @@ public class DataStreamsMessagePackFormatterTests
                             ParentHash = parentHash.Value,
                             EdgeLatency = edgeBytes,
                             PathwayLatency = pathwayBytes,
+                            PayloadSize = payloadSizeBytes,
                             TimestampType = "current",
                         }
                     }
@@ -127,6 +131,7 @@ public class DataStreamsMessagePackFormatterTests
                             ParentHash = parentHash.Value,
                             EdgeLatency = edgeBytes,
                             PathwayLatency = pathwayBytes,
+                            PayloadSize = payloadSizeBytes,
                             TimestampType = "origin",
                         }
                     }

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMessagePackFormatterTests.cs
@@ -36,6 +36,7 @@ public class DataStreamsMessagePackFormatterTests
 
         var pathwaySketch = CreateSketch(5);
         var edgeSketch = CreateSketch(2);
+        var payloadSizeSketch = CreateSketch(2);
 
         var hash1 = new PathwayHash(2);
         var hash2 = new PathwayHash(3);
@@ -53,7 +54,8 @@ public class DataStreamsMessagePackFormatterTests
                             hash: hash1,
                             parentHash: parentHash,
                             pathwayLatency: pathwaySketch,
-                            edgeLatency: edgeSketch)
+                            edgeLatency: edgeSketch,
+                            payloadSize: payloadSizeSketch)
                     },
                 }),
             new SerializableStatsBucket(
@@ -67,7 +69,8 @@ public class DataStreamsMessagePackFormatterTests
                             hash: hash2,
                             parentHash: parentHash,
                             pathwayLatency: pathwaySketch,
-                            edgeLatency: edgeSketch)
+                            edgeLatency: edgeSketch,
+                            payloadSize: payloadSizeSketch)
                     },
                 }),
         };

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -89,7 +89,8 @@ public class DataStreamsMonitoringTransportTests
             parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
             timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
             pathwayLatencyNs: 5_000_000_000,
-            edgeLatencyNs: 2_000_000_000);
+            edgeLatencyNs: 2_000_000_000,
+            payloadSizeBytes: 1024);
 
     private MockTracerAgent Create(TracesTransportType transportType)
         => transportType switch

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsWriterTests.cs
@@ -360,7 +360,8 @@ public class DataStreamsWriterTests
             parentHash: new PathwayHash((ulong)Math.Abs(ThreadSafeRandom.Shared.Next(int.MaxValue))),
             timestampNs: DateTimeOffset.UtcNow.ToUnixTimeNanoseconds(),
             pathwayLatencyNs: 5_000_000_000,
-            edgeLatencyNs: 2_000_000_000);
+            edgeLatencyNs: 2_000_000_000,
+            payloadSizeBytes: 1024);
 
     private async Task WaitForFlushCount(int timeout, int flushCount = 2)
     {

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/SpanContextDataStreamsManagerTests.cs
@@ -22,7 +22,7 @@ public class SpanContextDataStreamsManagerTests
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
         spanContext.PathwayContext.Should().BeNull();
 
-        spanContext.SetCheckpoint(dsm, CheckpointKind.Produce, new[] { "some-edge" });
+        spanContext.SetCheckpoint(dsm, CheckpointKind.Produce, new[] { "some-edge" }, 100, 0);
 
         spanContext.PathwayContext.Should().NotBeNull();
     }
@@ -44,7 +44,7 @@ public class SpanContextDataStreamsManagerTests
     {
         var dsm = GetEnabledDataStreamManager();
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
-        spanContext.SetCheckpoint(dsm,  CheckpointKind.Produce, new[] { "some-edge" });
+        spanContext.SetCheckpoint(dsm,  CheckpointKind.Produce, new[] { "some-edge" }, 100, 0);
         spanContext.PathwayContext.Should().NotBeNull();
         var previous = spanContext.PathwayContext;
 
@@ -59,12 +59,12 @@ public class SpanContextDataStreamsManagerTests
         // When we have a context and there's a new context we pick one randomly
         var dsm = GetEnabledDataStreamManager();
         var spanContext = new SpanContext(traceId: 123, spanId: 1234);
-        spanContext.SetCheckpoint(dsm, CheckpointKind.Produce, new[] { "some-edge" });
+        spanContext.SetCheckpoint(dsm, CheckpointKind.Produce, new[] { "some-edge" }, 100, 0);
 
         // Make sure we have a different hash for comparison purposes
         while (spanContext.PathwayContext.Value.Hash.Value < (ulong)iterations)
         {
-            spanContext.SetCheckpoint(dsm, CheckpointKind.Produce, new[] { "some-edge" });
+            spanContext.SetCheckpoint(dsm, CheckpointKind.Produce, new[] { "some-edge" }, 100, 0);
         }
 
         var sameCount = 0;

--- a/tracer/test/snapshots/DataStreamsMonitoringRabbitMQTests.HandleProduceAndConsume.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringRabbitMQTests.HandleProduceAndConsume.verified.txt
@@ -1,4 +1,4 @@
-[
+
   {
     EdgeTags: [
       direction:in,
@@ -9,6 +9,7 @@
     ParentHash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -21,6 +22,7 @@
     ParentHash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -33,6 +35,7 @@
     ParentHash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -45,6 +48,7 @@
     ParentHash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -57,6 +61,7 @@
     ParentHash: 14657415876676768266,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -69,6 +74,7 @@
     ParentHash: 14657415876676768266,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -81,6 +87,7 @@
     Hash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -93,6 +100,7 @@
     Hash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -105,6 +113,7 @@
     ParentHash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -117,6 +126,7 @@
     ParentHash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -129,6 +139,7 @@
     ParentHash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -141,6 +152,7 @@
     ParentHash: 3844962339543100314,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -153,6 +165,7 @@
     ParentHash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -165,6 +178,7 @@
     ParentHash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -177,6 +191,7 @@
     Hash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -189,6 +204,7 @@
     Hash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -201,6 +217,7 @@
     ParentHash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -213,6 +230,7 @@
     ParentHash: 12989439051945111623,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -225,6 +243,7 @@
     ParentHash: 17561246379663323986,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -237,6 +256,7 @@
     ParentHash: 17561246379663323986,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -248,6 +268,7 @@
     Hash: 14657415876676768266,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -259,6 +280,7 @@
     Hash: 14657415876676768266,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   },
   {
@@ -271,6 +293,7 @@
     Hash: 17561246379663323986,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: current
   },
   {
@@ -283,6 +306,7 @@
     Hash: 17561246379663323986,
     PathwayLatency: /w==,
     EdgeLatency: /w==,
+    PayloadSize: /w==,
     TimestampType: origin
   }
 ]

--- a/tracer/test/snapshots/DataStreamsMonitoringRabbitMQTests.HandleProduceAndConsume.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringRabbitMQTests.HandleProduceAndConsume.verified.txt
@@ -1,5 +1,4 @@
-
-  {
+[
     EdgeTags: [
       direction:in,
       topic:TopicQueue2,

--- a/tracer/test/snapshots/DataStreamsMonitoringRabbitMQTests.HandleProduceAndConsume.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringRabbitMQTests.HandleProduceAndConsume.verified.txt
@@ -1,4 +1,5 @@
 [
+  {
     EdgeTags: [
       direction:in,
       topic:TopicQueue2,

--- a/tracer/test/snapshots/DataStreamsMonitoringTests.HandlesFanIn.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringTests.HandlesFanIn.verified.txt
@@ -17,6 +17,7 @@
           Hash: 12768432526128850544,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -30,6 +31,7 @@
           ParentHash: 12768432526128850544,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -42,6 +44,7 @@
           ParentHash: 15097168115956663958,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -55,6 +58,7 @@
           ParentHash: 4255040070006404392,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         }
       ]
@@ -72,6 +76,7 @@
           Hash: 12768432526128850544,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -85,6 +90,7 @@
           ParentHash: 12768432526128850544,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -97,6 +103,7 @@
           ParentHash: 15097168115956663958,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -110,6 +117,7 @@
           ParentHash: 4255040070006404392,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         }
       ]

--- a/tracer/test/snapshots/DataStreamsMonitoringTests.SubmitsDataStreams.verified.txt
+++ b/tracer/test/snapshots/DataStreamsMonitoringTests.SubmitsDataStreams.verified.txt
@@ -17,6 +17,7 @@
           Hash: 4342784100752471956,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -30,6 +31,7 @@
           ParentHash: 4342784100752471956,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -42,6 +44,7 @@
           ParentHash: 4402746642612420525,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -55,6 +58,7 @@
           ParentHash: 10537801879739687974,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -66,6 +70,7 @@
           Hash: 6339134439758159280,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -79,6 +84,7 @@
           ParentHash: 6339134439758159280,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -91,6 +97,7 @@
           ParentHash: 11201031568920715432,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -104,6 +111,7 @@
           ParentHash: 2948096669285107035,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -116,6 +124,7 @@
           ParentHash: 4085740766481138761,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         },
         {
@@ -129,6 +138,7 @@
           ParentHash: 1977769520603636527,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: current
         }
       ]
@@ -146,6 +156,7 @@
           Hash: 4342784100752471956,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -159,6 +170,7 @@
           ParentHash: 4342784100752471956,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -171,6 +183,7 @@
           ParentHash: 4402746642612420525,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -184,6 +197,7 @@
           ParentHash: 10537801879739687974,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -195,6 +209,7 @@
           Hash: 6339134439758159280,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -208,6 +223,7 @@
           ParentHash: 6339134439758159280,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -220,6 +236,7 @@
           ParentHash: 11201031568920715432,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -233,6 +250,7 @@
           ParentHash: 2948096669285107035,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -245,6 +263,7 @@
           ParentHash: 4085740766481138761,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         },
         {
@@ -258,6 +277,7 @@
           ParentHash: 1977769520603636527,
           PathwayLatency: /w==,
           EdgeLatency: /w==,
+          PayloadSize: /w==,
           TimestampType: origin
         }
       ]


### PR DESCRIPTION
## Summary of changes
This PR contains two changes to DSM:

* Tracking payload sizes for Kafka and RabbitMQ
* Time in queue from message headers, in case the consumption happens from a queue without instrumented producers upstream.

## Reason for change
Bringing existing DSM features to customers who use .NET.

## Implementation details
DSM StatsPoint how has `payloadSizeBytes` sketch. The payload size is set on both, produce and consume.
Time in queue used to adjust Edge start time if this is the beginning of the pathway.

## Test coverage
All of the tests / test files were updated to cover the change.