### PR TITLE
Add Nuke helper for performing CPA on pipeline results

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4921,7 +4921,7 @@ stages:
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       eq(variables['isMainBranch'], true)
     )
-  dependsOn: trace_pipeline # so it runs last
+  dependsOn: [trace_pipeline] # so it runs last
   jobs:
   - job: notify
     timeoutInMinutes: 10

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -238,6 +238,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "AnalyzePipelineCriticalPath",
               "AssignLabelsToPullRequest",
               "AssignPullRequestToMilestone",
               "BuildAndRunDebuggerIntegrationTests",
@@ -427,6 +428,7 @@
           "items": {
             "type": "string",
             "enum": [
+              "AnalyzePipelineCriticalPath",
               "AssignLabelsToPullRequest",
               "AssignPullRequestToMilestone",
               "BuildAndRunDebuggerIntegrationTests",

--- a/tracer/build/_build/BenchmarkComparison/Data.cs
+++ b/tracer/build/_build/BenchmarkComparison/Data.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using CsvHelper.Configuration.Attributes;
 using Perfolizer.Mathematics.SignificanceTesting;
 
 namespace BenchmarkComparison

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -236,6 +236,13 @@ partial class Build
             new SetAllVersions.Source(TracerDirectory, NewVersion, NewIsPrerelease.Value!).Run();
         });
 
+    Target AnalyzePipelineCriticalPath => _ => _
+       .Description("Perform critical path analysis on the consolidated pipeline stages")
+       .Executes(async () =>
+        {
+            await CriticalPathAnalysis.CriticalPathAnalyzer.AnalyzeCriticalPath(RootDirectory);
+        });
+
     Target UpdateSnapshots => _ => _
         .Description("Updates verified snapshots files with received ones")
         .Executes(ReplaceReceivedFilesInSnapshots);

--- a/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
+++ b/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
@@ -117,16 +117,15 @@ public static class CriticalPathAnalyzer
     static void UpdateLatestValues(List<PipelineStage> stages)
     {
         // we bootstrap the last stage by setting LatestEnd = EarliestEnd and calculating the corresponding start
-        var lastStage = stages[stages.Count - 1];
-        lastStage.Latest = lastStage.Earliest with { Start = lastStage.Earliest.End - lastStage.Duration };
+        var pipelineEnds = stages.Select(x => x.Earliest.End).Max();
 
-        // Now walk backwards, skipping the one stage we already updated 
-        foreach (var stage in stages.SkipLast(1).Reverse())
+        // Now walk backwards 
+        foreach (var stage in stages.AsEnumerable().Reverse())
         {
-            var latestEnd = stage.Latest.End;
+            var latestEnd = pipelineEnds;
             foreach (var successor in stage.Successors)
             {
-                if (latestEnd == 0 || latestEnd > successor.Latest.Start)
+                if (latestEnd > successor.Latest.Start)
                 {
                     latestEnd = successor.Latest.Start;
                 }

--- a/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
+++ b/tracer/build/_build/CriticalPathAnalysis/CriticalPathAnalyzer.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using nietras.SeparatedValues;
+using Nuke.Common.IO;
+
+#nullable enable
+
+namespace CriticalPathAnalysis;
+
+public static class CriticalPathAnalyzer
+{
+    public static Task AnalyzeCriticalPath(AbsolutePath rootDirectory)
+    {
+        var pipeline = PipelineParser.GetPipelineDefinition(rootDirectory);
+        var stages = GetStages(rootDirectory, pipeline);
+        stages = OrderByDependencies(stages);
+        UpdateEarliestValues(stages);
+        UpdateLatestValues(stages);
+        // displaying in original (pipeline) order
+        var stageOrder = pipeline.Stages.Select((x, i) => (x.Stage, Index: i)).ToDictionary(x => x.Stage, x => x.Index);
+        var ordered = stages.OrderBy(x => stageOrder[x.Id]);
+        var mermaidDiagram = GenerateMermaidDiagram(ordered);
+        var outputPath = rootDirectory / "tracer" / "build_data" / "pipeline_critical_path.md";
+        File.WriteAllText(outputPath, $"""
+                                       ```mermaid
+                                       {mermaidDiagram}
+                                       ```
+                                       """);
+        Serilog.Log.Information("Created mermaid diagram at {OutputPath}", outputPath);
+        return Task.CompletedTask;
+    }
+
+    static List<PipelineStage> GetStages(AbsolutePath rootDirectory, PipelineDefinition pipeline)
+    {
+        var stages = new List<PipelineStage>(pipeline.Stages.Length);
+
+        // Export the data from the widget here by clicking "Download as csv" and moving to tracer/build_data/stages.csv
+        // https://ddstaging.datadoghq.com/dashboard/74k-me3-y2z?from_ts=1689611447016&to_ts=1692289847016&live=true
+        var stagesCsv = rootDirectory / "tracer" / "build_data" / "stages.csv";
+        using var reader = Sep.New(',').Reader().FromFile(stagesCsv);
+        foreach (var row in reader)
+        {
+            var stageName = row[0].ToString();
+            var durationInNanosecond = row[1].Parse<decimal>();
+            var durationInMilliSeconds = (long)(durationInNanosecond / 1_000_000m);
+
+            var stage = new PipelineStage(new(stageName), durationInMilliSeconds);
+            stages.Add(stage);
+        }
+
+        // Fix the predecessors (depends_on) and 
+        // the successors (stages that depend on us)
+        foreach (var currentStage in stages)
+        {
+            var stageDefinition = pipeline.Stages.First(x => x.Stage == currentStage.Id);
+
+            foreach (var dependency in stageDefinition.DependsOn)
+            {
+                var predecessor = stages.First(x => x.Id == dependency);
+                currentStage.Predecessors.Add(predecessor);
+                predecessor.Successors.Add(currentStage);
+            }
+        }
+
+        return stages;
+    }
+
+    static void UpdateEarliestValues(List<PipelineStage> stages)
+    {
+        foreach (var stage in stages)
+        {
+            long earliestStart = 0;
+            foreach (var predecessor in stage.Predecessors)
+            {
+                var predecessorRange = predecessor.Earliest;
+
+                if (earliestStart < predecessorRange.End)
+                {
+                    earliestStart = predecessorRange.End;
+                }
+            }
+
+            var earliestEnd = earliestStart + stage.Duration;
+            stage.Earliest = new(earliestStart, earliestEnd);
+        }
+    }
+
+    static void UpdateLatestValues(List<PipelineStage> stages)
+    {
+        // we bootstrap the last stage by setting LatestEnd = EarliestEnd and calculating the corresponding start
+        var lastStage = stages[stages.Count - 1];
+        lastStage.Latest = lastStage.Earliest with { Start = lastStage.Earliest.End - lastStage.Duration };
+
+        // Now walk backwards, skipping the one stage we already updated 
+        foreach (var stage in stages.SkipLast(1).Reverse())
+        {
+            var latestEnd = stage.Latest.End;
+            foreach (var successor in stage.Successors)
+            {
+                if (latestEnd == 0 || latestEnd > successor.Latest.Start)
+                {
+                    latestEnd = successor.Latest.Start;
+                }
+            }
+
+            var latestStart = latestEnd - stage.Duration;
+            stage.Latest = new(latestStart, latestEnd);
+        }
+    }
+
+    static List<PipelineStage> OrderByDependencies(List<PipelineStage> stages)
+    {
+        var processedPairs = new HashSet<string>();
+        var totalCount = stages.Count;
+        var ordered = new List<PipelineStage>(totalCount);
+        while (ordered.Count < totalCount) {
+            var foundSomethingToProcess = false;
+            foreach (var kvp in stages)
+            {
+                if (!processedPairs.Contains(kvp.Id)
+                 && kvp.Predecessors.All(x => processedPairs.Contains(x.Id)))
+                {
+                    ordered.Add(kvp);
+                    processedPairs.Add(kvp.Id);
+                    foundSomethingToProcess = true;
+                }
+            }
+
+            if (!foundSomethingToProcess)
+            {
+                throw new InvalidOperationException("Loop detected inside stage dependencies");
+            }
+        }
+
+        return ordered;
+    }
+
+    static string GenerateMermaidDiagram(IEnumerable<PipelineStage> stages)
+    {
+        // can't easily show flex in the diagram, so display using earliest start/end
+        // and mark critical tasks
+        var sb = new StringBuilder();
+        sb.AppendLine("""
+             gantt
+                 title Consolidated pipeline critical path analysis
+                 dateFormat s
+                 axisFormat %H:%M
+                 todayMarker off
+             """);
+
+        foreach (var stage in stages)
+        {
+            var duration = TimeSpan.FromMilliseconds(stage.Duration) switch
+            {
+                var x when x.TotalMinutes > 60 => $"{x.Hours}h {x.Minutes}mins",
+                var x when x.TotalMinutes > 1 => $"{x.Minutes}mins",
+                var x when x.TotalSeconds > 1 => $"{x.Seconds}s",
+                _ => "<1s",
+            };
+            
+            sb
+               .Append("    ")
+               .Append(stage.Id)
+               .Append(" (")
+               .Append(duration)
+               .Append(")  : ");
+
+            if (stage.IsOnCriticalPath)
+            {
+                sb.Append("crit, ");
+            }
+
+            // specify alias
+            sb.Append(stage.Id).Append(", ");
+
+            if (stage.Predecessors.Count > 0)
+            {
+                sb.Append("after ");
+                foreach (var predecessor in stage.Predecessors)
+                {
+                    sb.Append(predecessor.Id).Append(' ');
+                }
+
+                sb.Append(", ");
+            }
+            else
+            {
+                // if we don't have an after, we have to specify the start time (assume on app start)
+                sb.Append("0, ");
+            }
+
+            // ms doesnt seem to work, so use seconds
+            sb.Append(stage.Duration / 1_000).Append("s").AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    record PipelineStage(string Id, long Duration)
+    {
+        public List<PipelineStage> Predecessors { get; } = new();
+        public List<PipelineStage> Successors { get; } = new();
+
+        public Range Earliest { get; set; } = Range.Zero;
+        public Range Latest { get; set; } = Range.Zero;
+
+        public bool IsOnCriticalPath => Earliest == Latest;
+
+        public override string ToString() => Id;
+    }
+
+    record Range(long Start, long End)
+    {
+        public static readonly Range Zero = new(0, 0);
+    }
+}

--- a/tracer/build/_build/CriticalPathAnalysis/PipelineStage.cs
+++ b/tracer/build/_build/CriticalPathAnalysis/PipelineStage.cs
@@ -1,0 +1,3 @@
+﻿using System.Collections.Generic;
+
+namespace CriticalPathAnalysis;

--- a/tracer/build/_build/CriticalPathAnalysis/PipelineStage.cs
+++ b/tracer/build/_build/CriticalPathAnalysis/PipelineStage.cs
@@ -1,3 +1,0 @@
-﻿using System.Collections.Generic;
-
-namespace CriticalPathAnalysis;

--- a/tracer/build/_build/PipelineParser/PipelineDefinition.cs
+++ b/tracer/build/_build/PipelineParser/PipelineDefinition.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+class PipelineDefinition
+{
+    public TriggerDefinition Trigger { get; set; }
+    public TriggerDefinition Pr { get; set; }
+    public StageDefinition[] Stages { get; set; } = Array.Empty<StageDefinition>();
+
+    public class TriggerDefinition
+    {
+        public PathDefinition Paths { get; set; }
+    }
+
+    public class PathDefinition
+    {
+        public string[] Exclude { get; set; } = Array.Empty<string>();
+    }
+
+    public class StageDefinition
+    {
+        public string Stage { get; set; }
+        public string[] DependsOn { get; set; }
+    }
+}

--- a/tracer/build/_build/PipelineParser/PipelineParser.cs
+++ b/tracer/build/_build/PipelineParser/PipelineParser.cs
@@ -1,0 +1,19 @@
+﻿using System.IO;
+using Nuke.Common.IO;
+using YamlDotNet.Serialization.NamingConventions;
+
+static class PipelineParser
+{
+    public static PipelineDefinition GetPipelineDefinition(AbsolutePath rootDirectory)
+    {
+        var pipelineYaml = rootDirectory / ".azure-pipelines" / "ultimate-pipeline.yml";
+        Serilog.Log.Information("Reading {PipelineYaml} YAML file", pipelineYaml);
+        var deserializer = new YamlDotNet.Serialization.DeserializerBuilder()
+                          .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                          .IgnoreUnmatchedProperties()
+                          .Build();
+
+        using var sr = new StreamReader(pipelineYaml);
+        return deserializer.Deserialize<PipelineDefinition>(sr);
+    }
+}

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Colorful.Console" Version="1.2.15" />
     <PackageReference Include="Octokit.GraphQL" Version="0.1.8-beta" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
-    <PackageReference Include="CsvHelper" Version="27.1.1" />
+    <PackageReference Include="Sep" Version="0.2.2" />
     <PackageReference Include="ByteSize" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of changes

- Performs Critical Path Method on our CI pipeline

## Reason for change

We've been speeding things up, but if they're not in the critical path for the pipeline, then we won't reduce the _overall_ CI build time. That's not to say doing that isn't valuable, this is just extra information.

## Implementation details

Implements the [Critical Path Method](https://en.wikipedia.org/wiki/Critical_path_method). Reviewed source of a couple of C# implementations [here](https://www.codeproject.com/Articles/25312/Critical-Path-Method-Implementation-in-C) and [here](https://github.com/elerch/Critical-Path-Extension-Method-for-.NET/blob/master/CriticalPathMethod/IEnumerableExtensions.cs) but it's mostly a from-scratch reimplementation.

As input, I created a dashboard based on previous pipeline executions [here](https://ddstaging.datadoghq.com/dashboard/74k-me3-y2z?from_ts=1689611447016&to_ts=1692289847016&live=true), and downloaded the results as a CSV e.g.:

```csv
"STAGE NAME","MEDIAN:@DURATION[CI_LEVEL:STAGE @CI.PIPELINE.NAME:CONSOLIDATED-PIPELINE @GIT.BRANCH:MASTER]"
throughput_profiler,3455237765488.0054
integration_tests_arm64,3003825387962.309
unit_tests_arm64,2611388151487.3335
...
```

Then loaded these durations and the yaml pipeline and used those as input to the algorithm.

Essentially it:
- Loads the list of pipelines and their dependencies 
- Sorts the list by "dependency" order, i.e. each stage can only depend on stages earlier in the list
- Calculate the earliest and latest times that a dependency can run without making the project longer
- Visualize the results as a mermaid diagram and write to a markdown doc (trying to write to the console gives errors due to wrapping)

In an extra step I used different colors to differentiate between (probably different in dark mode!)

- Stages on the critical path, which are required for merging PRs (Red box)
- Stages on the critical path, which are _not_ required for merging PRs (Grey box with red outline)
- Stages _not_ on the critical path, which are required for merging PRs (Blue box)
- Stages _not_ on the critical path, which are _not_ required for merging PRs (Grey box)

I don't think there's any reason to formalize this or anything, just useful for the test engineer!

This is the result of the latest version:

```mermaid
gantt
    title Consolidated pipeline critical path analysis
    dateFormat s
    axisFormat %H:%M
    todayMarker off
    merge_commit_id (17s)  : done, merge_commit_id, 0, 17s
    generate_variables (1mins)  : done, generate_variables, after merge_commit_id , 69s
    build_windows_tracer (14mins)  : done, build_windows_tracer, after merge_commit_id , 886s
    build_windows_profiler (6mins)  : done, build_windows_profiler, after merge_commit_id , 382s
    build_linux_tracer (23mins)  : done, build_linux_tracer, after merge_commit_id , 1433s
    build_linux_profiler (13mins)  : done, build_linux_profiler, after merge_commit_id , 835s
    package_linux (2mins)  : done, package_linux, after merge_commit_id build_linux_tracer build_linux_profiler , 140s
    build_arm64_tracer (21mins)  : done, crit, build_arm64_tracer, after merge_commit_id , 1271s
    build_arm64_profiler (12mins)  : done, build_arm64_profiler, after merge_commit_id , 755s
    package_arm64 (8mins)  : done, crit, package_arm64, after merge_commit_id build_arm64_tracer build_arm64_profiler , 537s
    build_macos (39mins)  : done, build_macos, after merge_commit_id , 2362s
    package_windows (6mins)  : done, package_windows, after build_windows_tracer build_windows_profiler merge_commit_id , 414s
    debug_builds (12mins)  : done, debug_builds, after merge_commit_id , 740s
    unit_tests_windows (27mins)  : unit_tests_windows, after build_windows_tracer merge_commit_id , 1648s
    unit_tests_macos (30mins)  : done, unit_tests_macos, after build_macos merge_commit_id , 1821s
    unit_tests_linux (30mins)  : unit_tests_linux, after build_linux_tracer build_linux_profiler merge_commit_id , 1821s
    unit_tests_arm64 (43mins)  : unit_tests_arm64, after build_arm64_tracer merge_commit_id , 2611s
    integration_tests_windows (37mins)  : integration_tests_windows, after build_windows_tracer generate_variables merge_commit_id , 2225s
    integration_tests_windows_debugger (12mins)  : done, integration_tests_windows_debugger, after build_windows_tracer generate_variables merge_commit_id , 726s
    integration_tests_windows_iis (22mins)  : integration_tests_windows_iis, after build_windows_tracer generate_variables merge_commit_id , 1376s
    integration_tests_windows_iis_security (16mins)  : done, integration_tests_windows_iis_security, after build_windows_tracer generate_variables merge_commit_id , 960s
    integration_tests_azure_functions (9mins)  : done, integration_tests_azure_functions, after build_windows_tracer generate_variables merge_commit_id , 571s
    static_analysis_tests_profiler (41mins)  : done, static_analysis_tests_profiler, after merge_commit_id generate_variables , 2508s
    msi_integration_tests_windows (9mins)  : msi_integration_tests_windows, after build_windows_tracer package_windows generate_variables merge_commit_id , 548s
    integration_tests_linux (39mins)  : integration_tests_linux, after package_linux generate_variables merge_commit_id , 2362s
    integration_tests_linux_debugger (22mins)  : done, integration_tests_linux_debugger, after package_linux generate_variables merge_commit_id , 1349s
    profiler_integration_tests_windows (28mins)  : done, profiler_integration_tests_windows, after package_windows generate_variables merge_commit_id , 1715s
    profiler_integration_tests_linux (27mins)  : profiler_integration_tests_linux, after package_linux generate_variables merge_commit_id , 1648s
    asan_profiler_tests (17mins)  : done, asan_profiler_tests, after merge_commit_id generate_variables , 1040s
    ubsan_profiler_tests (18mins)  : done, ubsan_profiler_tests, after merge_commit_id generate_variables , 1105s
    integration_tests_arm64 (50mins)  : crit, integration_tests_arm64, after package_arm64 generate_variables merge_commit_id , 3003s
    integration_tests_arm64_debugger (34mins)  : done, integration_tests_arm64_debugger, after package_arm64 generate_variables merge_commit_id , 2054s
    exploration_tests_windows (6mins)  : done, exploration_tests_windows, after build_windows_tracer generate_variables merge_commit_id , 406s
    exploration_tests_linux (9mins)  : done, exploration_tests_linux, after package_linux generate_variables merge_commit_id , 571s
    benchmarks (21mins)  : done, benchmarks, after build_windows_tracer merge_commit_id , 1271s
    dotnet_tool (10mins)  : dotnet_tool, after build_windows_tracer build_windows_profiler build_linux_tracer build_linux_profiler build_arm64_tracer build_arm64_profiler build_macos merge_commit_id , 631s
    tool_artifacts_tests_windows (3mins)  : tool_artifacts_tests_windows, after dotnet_tool merge_commit_id , 227s
    tool_artifacts_tests_linux (26mins)  : tool_artifacts_tests_linux, after dotnet_tool merge_commit_id , 1583s
    upload_to_s3 (1mins)  : done, upload_to_s3, after package_windows package_linux package_arm64 merge_commit_id , 65s
    upload_to_azure (2mins)  : done, upload_to_azure, after package_windows package_linux package_arm64 dotnet_tool merge_commit_id , 179s
    upload_container_images (<1s)  : done, upload_container_images, after upload_to_azure , 0s
    throughput (37mins)  : done, throughput, after package_linux package_arm64 build_windows_tracer merge_commit_id , 2270s
    throughput_profiler (57mins)  : done, throughput_profiler, after package_linux generate_variables build_windows_tracer merge_commit_id , 3455s
    throughput_appsec (21mins)  : done, throughput_appsec, after package_linux merge_commit_id , 1271s
    coverage (<1s)  : done, crit, coverage, after integration_tests_windows integration_tests_windows_iis integration_tests_windows_iis_security integration_tests_azure_functions msi_integration_tests_windows integration_tests_linux integration_tests_arm64 unit_tests_linux unit_tests_macos unit_tests_arm64 unit_tests_windows merge_commit_id tool_artifacts_tests_windows tool_artifacts_tests_linux , 0s
    execution_benchmarks (15mins)  : done, execution_benchmarks, after build_windows_tracer merge_commit_id , 904s
    system_tests (23mins)  : done, system_tests, after package_linux merge_commit_id , 1433s
    installer_smoke_tests (8mins)  : installer_smoke_tests, after package_linux generate_variables merge_commit_id , 496s
    nuget_installer_smoke_tests (8mins)  : done, nuget_installer_smoke_tests, after dotnet_tool package_windows generate_variables merge_commit_id , 506s
    dotnet_tool_nuget_smoke_tests_linux (7mins)  : done, dotnet_tool_nuget_smoke_tests_linux, after dotnet_tool generate_variables merge_commit_id , 449s
    dotnet_tool_smoke_tests_linux (7mins)  : done, dotnet_tool_smoke_tests_linux, after dotnet_tool generate_variables merge_commit_id , 467s
    dotnet_tool_self_instrument_smoke_tests_linux (6mins)  : done, dotnet_tool_self_instrument_smoke_tests_linux, after dotnet_tool generate_variables merge_commit_id , 382s
    installer_smoke_tests_arm64 (17mins)  : installer_smoke_tests_arm64, after package_arm64 generate_variables merge_commit_id , 1040s
    nuget_installer_smoke_tests_arm64 (23mins)  : done, nuget_installer_smoke_tests_arm64, after dotnet_tool package_windows generate_variables merge_commit_id , 1433s
    dotnet_tool_smoke_tests_arm64 (22mins)  : done, dotnet_tool_smoke_tests_arm64, after dotnet_tool generate_variables merge_commit_id , 1322s
    nuget_installer_smoke_tests_windows (16mins)  : done, nuget_installer_smoke_tests_windows, after dotnet_tool package_windows generate_variables merge_commit_id , 960s
    dotnet_tool_smoke_tests_windows (15mins)  : done, dotnet_tool_smoke_tests_windows, after dotnet_tool package_windows generate_variables merge_commit_id , 922s
    msi_installer_smoke_tests (16mins)  : done, msi_installer_smoke_tests, after package_windows generate_variables merge_commit_id , 960s
    tracer_home_smoke_tests (15mins)  : tracer_home_smoke_tests, after package_windows generate_variables merge_commit_id , 922s
    compare_throughput (2mins)  : done, compare_throughput, after throughput throughput_appsec merge_commit_id , 155s
    trace_pipeline (2mins)  : done, crit, trace_pipeline, after merge_commit_id unit_tests_linux unit_tests_macos unit_tests_windows unit_tests_arm64 integration_tests_windows integration_tests_windows_debugger integration_tests_windows_iis integration_tests_windows_iis_security integration_tests_azure_functions msi_integration_tests_windows integration_tests_linux integration_tests_linux_debugger integration_tests_arm64 integration_tests_arm64_debugger profiler_integration_tests_linux profiler_integration_tests_windows exploration_tests_windows exploration_tests_linux benchmarks throughput throughput_appsec tool_artifacts_tests_windows tool_artifacts_tests_linux upload_to_s3 upload_to_azure upload_container_images execution_benchmarks installer_smoke_tests installer_smoke_tests_arm64 nuget_installer_smoke_tests nuget_installer_smoke_tests_arm64 nuget_installer_smoke_tests_windows dotnet_tool_nuget_smoke_tests_linux dotnet_tool_smoke_tests_linux dotnet_tool_self_instrument_smoke_tests_linux dotnet_tool_smoke_tests_arm64 dotnet_tool_smoke_tests_windows msi_installer_smoke_tests tracer_home_smoke_tests coverage compare_throughput system_tests , 132s
    notify_slack_on_failures (15s)  : done, crit, notify_slack_on_failures, after trace_pipeline , 15s

```