### PR TITLE
Add github action to run the generate package versions target

### DIFF
--- a/.github/workflows/generate_package_versions.yml
+++ b/.github/workflows/generate_package_versions.yml
@@ -1,0 +1,39 @@
+name: Generate package versions and push
+
+on:
+  workflow_dispatch:
+
+jobs:
+  generate_package_versions:
+    runs-on: windows-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    steps:
+      - name: Fail if branch is on master
+        if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master'
+        run: |
+          echo "This workflow should not be triggered with workflow_dispatch on the master branch"
+          exit 1
+
+      - name: Support longpaths
+        run: git config --system core.longpaths true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '7.0.306'
+
+      - name: "Regenerating package versions"
+        run: .\tracer\build.ps1 GeneratePackageVersions
+
+      - name: Create commits
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -am "Updated package versions"
+          git push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary of changes

- Workflow that runs the `GeneratePackageVersions` target on Windows

## Reason for change

Currently the generator is a bit broken on Linux/mac, and this is the quickest way to workaround it

## Implementation details

Created a GitHub Action that runs the generation code, commits the changes, and pushes them back to the branch.

## Test coverage

Nope. And it's worse - I can't test on a branch until it's merged to master 🙄 
