### PR TITLE
Split system tests as they're on the critical path

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3911,7 +3911,7 @@ stages:
       jobs: [test]
 
   - job: test
-    timeoutInMinutes: 120 # Expect this to take ~60
+    timeoutInMinutes: 60
     pool:
       vmImage: ubuntu-20.04
 
@@ -3923,12 +3923,37 @@ stages:
         parametric_uds:
           WEBLOG_VARIANT: "uds"
           SCENARIO: PARAMETRIC
-        system_tests_poc:
+        appsec_poc:
           WEBLOG_VARIANT: "poc"
-          SCENARIO: TRACER_RELEASE_SCENARIOS
-        system_tests_uds:
+          SCENARIO: APPSEC_SCENARIOS
+        appsec_uds:
           WEBLOG_VARIANT: "uds"
-          SCENARIO: TRACER_RELEASE_SCENARIOS
+          SCENARIO: APPSEC_SCENARIOS
+        rcm_poc:
+          WEBLOG_VARIANT: "poc"
+          SCENARIO: REMOTE_CONFIG_SCENARIOS
+        rcm_uds:
+          WEBLOG_VARIANT: "uds"
+          SCENARIO: REMOTE_CONFIG_SCENARIOS
+        telemetry_poc:
+          WEBLOG_VARIANT: "poc"
+          SCENARIO: TELEMETRY_SCENARIOS
+        telemetry_uds:
+          WEBLOG_VARIANT: "uds"
+          SCENARIO: TELEMETRY_SCENARIOS
+        default_poc:
+          WEBLOG_VARIANT: "poc"
+          SCENARIO: DEFAULT
+        default_uds:
+          WEBLOG_VARIANT: "uds"
+          SCENARIO: DEFAULT
+        # All the other scenarios that aren't in a secenario group
+        remainder_poc:
+          WEBLOG_VARIANT: "poc"
+          SCENARIO: "+S INTEGRATIONS +S TRACE_PROPAGATION_STYLE_W3C +S PROFILING +S LIBRARY_CONF_CUSTOM_HEADERS_SHORT +S LIBRARY_CONF_CUSTOM_HEADERS_LONG"
+        remainder_uds:
+          WEBLOG_VARIANT: "uds"
+          SCENARIO: "+S INTEGRATIONS +S TRACE_PROPAGATION_STYLE_W3C +S PROFILING +S LIBRARY_CONF_CUSTOM_HEADERS_SHORT +S LIBRARY_CONF_CUSTOM_HEADERS_LONG"
 
     steps:
       - checkout: none


### PR DESCRIPTION
## Summary of changes

Splits the system tests into many more parallel runs

## Reason for change

The critical path analysis [in this PR](https://github.com/DataDog/dd-trace-dotnet/pull/4524) showed that the system tests were sometimes on the critical path. This should solve them

## Implementation details

Run each of the scenario groups separately. The main downside here is that we won't get new "standalone" scenarios being tested automatically unless we explicitly add them

## Test coverage

Previously they were taking ~60mins for both the poc and uds scenarios. AFter the change we're down to ~15-20mins:

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/9de547e1-4983-4b7c-9676-13cbe2d8d041)

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
