### PR TITLE
[Tracer] Fix WebRequest span when HTTP status code is 4XX

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -95,6 +95,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         {
                             scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.Instance.Settings);
                         }
+                        else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
+                        {
+                            scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.Settings);
+                        }
 
                         scope.DisposeWithException(exception);
                     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -98,12 +98,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         }
                         else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
                         {
-                            scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.Settings);
-
+                            // Add the exception tags without setting the Error property
                             // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
-                            // Add the remaining error attributes without setting the Error property
                             scope.Span.SetExceptionTags(exception);
-                            state.Scope.Dispose();
+
+                            scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.Settings);
                             scope.Dispose();
                         }
                         else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -101,10 +101,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                             scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.Settings);
 
                             // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
-                            // Add the remaining error attributes
-                            scope.Span.SetTag(Trace.Tags.ErrorMsg, exception.Message);
-                            scope.Span.SetTag(Trace.Tags.ErrorStack, exception.ToString());
-                            scope.Span.SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
+                            // Add the remaining error attributes without setting the Error property
+                            scope.Span.SetExceptionTags(exception);
+                            state.Scope.Dispose();
                             scope.Dispose();
                         }
                         else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
@@ -65,6 +65,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 {
                     state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.Instance.Settings);
                 }
+                else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
+                {
+                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.Instance.Settings);
+                }
 
                 state.Scope.DisposeWithException(exception);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
@@ -71,10 +71,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.Instance.Settings);
 
                     // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
-                    // Add the remaining error attributes
-                    state.Scope.Span.SetTag(Trace.Tags.ErrorMsg, exception.Message);
-                    state.Scope.Span.SetTag(Trace.Tags.ErrorStack, exception.ToString());
-                    state.Scope.Span.SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
+                    // Add the remaining error attributes without setting the Error property
+                    state.Scope.Span.SetExceptionTags(exception);
                     state.Scope.Dispose();
                 }
                 else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
@@ -68,11 +68,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 }
                 else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
                 {
-                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.Instance.Settings);
-
+                    // Add the exception tags without setting the Error property
                     // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
-                    // Add the remaining error attributes without setting the Error property
                     state.Scope.Span.SetExceptionTags(exception);
+
+                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.Instance.Settings);
                     state.Scope.Dispose();
                 }
                 else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
@@ -71,11 +71,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 }
                 else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
                 {
+                    // Add the exception tags without setting the Error property
+                    // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
+                    state.Scope.Span.SetExceptionTags(exception);
+
                     state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, tracer.Settings);
 
-                    // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
-                    // Add the remaining error attributes without setting the Error property
-                    state.Scope.Span.SetExceptionTags(exception);
                     state.Scope.Dispose();
                 }
                 else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
@@ -74,10 +74,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, tracer.Settings);
 
                     // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
-                    // Add the remaining error attributes
-                    state.Scope.Span.SetTag(Trace.Tags.ErrorMsg, exception.Message);
-                    state.Scope.Span.SetTag(Trace.Tags.ErrorStack, exception.ToString());
-                    state.Scope.Span.SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
+                    // Add the remaining error attributes without setting the Error property
+                    state.Scope.Span.SetExceptionTags(exception);
                     state.Scope.Dispose();
                 }
                 else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
@@ -67,13 +67,23 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 if (returnValue is HttpWebResponse response)
                 {
                     state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, tracer.Settings);
+                    state.Scope.Dispose();
                 }
                 else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
                 {
                     state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, tracer.Settings);
-                }
 
-                state.Scope.DisposeWithException(exception);
+                    // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
+                    // Add the remaining error attributes
+                    state.Scope.Span.SetTag(Trace.Tags.ErrorMsg, exception.Message);
+                    state.Scope.Span.SetTag(Trace.Tags.ErrorStack, exception.ToString());
+                    state.Scope.Span.SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
+                    state.Scope.Dispose();
+                }
+                else
+                {
+                    state.Scope.DisposeWithException(exception);
+                }
             }
 
             return returnValue;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
@@ -63,10 +63,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
         {
             if (state.Scope != null)
             {
+                Tracer tracer = Tracer.Instance;
                 if (returnValue is HttpWebResponse response)
                 {
-                    Tracer tracer = Tracer.Instance;
                     state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, tracer.Settings);
+                }
+                else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
+                {
+                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, tracer.Settings);
                 }
 
                 state.Scope.DisposeWithException(exception);

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -382,7 +382,16 @@ namespace Datadog.Trace
         internal void SetException(Exception exception)
         {
             Error = true;
+            SetExceptionTags(exception);
+        }
 
+        /// <summary>
+        /// Add the StackTrace and other exception metadata to the span,
+        /// but does not mark the span as an error.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        internal void SetExceptionTags(Exception exception)
+        {
             if (exception != null)
             {
                 // for AggregateException, use the first inner exception until we can support multiple errors.

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("SupportsInstrumentationVerification", "True")]
         public void RenamesService()
         {
-            var expectedSpanCount = 76;
+            var expectedSpanCount = 82;
 
             SetInstrumentationVerification();
             const string expectedOperationName = "http.request";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("SupportsInstrumentationVerification", "True")]
         public void RenamesService()
         {
-            var expectedSpanCount = 76;
+            var expectedSpanCount = 82;
 
             SetInstrumentationVerification();
             const string expectedOperationName = "http.request";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public WebRequestTests(ITestOutputHelper output)
             : base("WebRequest", output)
         {
+            SetEnvironmentVariable("DD_HTTP_CLIENT_ERROR_STATUSES", "410-499");
             SetServiceVersion("1.0.0");
         }
 
@@ -95,7 +96,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 (okSpans.Count + notFoundSpans.Count + teapotSpans.Count).Should().Be(expectedSpanCount);
                 okSpans.Should().OnlyContain(s => s.Error == 0);
-                notFoundSpans.Should().OnlyContain(s => s.Error == 1);
+                notFoundSpans.Should().OnlyContain(s => s.Error == 0);
                 teapotSpans.Should().OnlyContain(s => s.Error == 1);
 
                 var firstSpan = spans.First();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         private void RunTest(string metadataSchemaVersion)
         {
             SetInstrumentationVerification();
-            var expectedSpanCount = 76;
+            var expectedSpanCount = 82;
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
@@ -88,6 +88,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var spans = agent.WaitForSpans(expectedSpanCount).OrderBy(s => s.Start);
                 spans.Should().HaveCount(expectedSpanCount);
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
+
+                var okSpans = spans.Where(s => s.Tags[Tags.HttpStatusCode] == "200").ToList();
+                var notFoundSpans = spans.Where(s => s.Tags[Tags.HttpStatusCode] == "404").ToList();
+                var teapotSpans = spans.Where(s => s.Tags[Tags.HttpStatusCode] == "418").ToList();
+
+                (okSpans.Count + notFoundSpans.Count + teapotSpans.Count).Should().Be(expectedSpanCount);
+                okSpans.Should().OnlyContain(s => s.Error == 0);
+                notFoundSpans.Should().OnlyContain(s => s.Error == 1);
+                teapotSpans.Should().OnlyContain(s => s.Error == 1);
 
                 var firstSpan = spans.First();
                 var traceId = StringUtil.GetHeader(processResult.StandardOutput, HttpHeaderNames.TraceId);

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
@@ -98,11 +98,7 @@ namespace Samples.WebRequest
             byte[] responseBytes = Utf8.GetBytes(ResponseContent);
             context.Response.ContentEncoding = Utf8;
             context.Response.ContentLength64 = responseBytes.Length;
-            if (context.Request.RawUrl.Contains("HttpErrorCode"))
-            {
-                context.Response.StatusCode = 502;
-            }
-            else if (context.Request.RawUrl.Contains("NotFound"))
+            if (context.Request.RawUrl.Contains("NotFound"))
             {
                 context.Response.StatusCode = 404;
             }

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
@@ -98,6 +98,19 @@ namespace Samples.WebRequest
             byte[] responseBytes = Utf8.GetBytes(ResponseContent);
             context.Response.ContentEncoding = Utf8;
             context.Response.ContentLength64 = responseBytes.Length;
+            if (context.Request.RawUrl.Contains("HttpErrorCode"))
+            {
+                context.Response.StatusCode = 502;
+            }
+            else if (context.Request.RawUrl.Contains("NotFound"))
+            {
+                context.Response.StatusCode = 404;
+            }
+            else if (context.Request.RawUrl.Contains("Teapot"))
+            {
+                context.Response.StatusCode = 418;
+            }
+
             context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
 
             // we must close the response

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Properties/launchSettings.json
@@ -5,11 +5,11 @@
         "environmentVariables": {
           "COR_ENABLE_PROFILING": "1",
           "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-          "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+          "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
   
           "CORECLR_ENABLE_PROFILING": "1",
           "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
-          "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+          "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
   
           "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
         },

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
@@ -330,6 +330,52 @@ namespace Samples.WebRequest
                     Console.WriteLine("Received response for request.GetResponse()");
                 }
 
+                using (SampleHelpers.CreateScope("GetResponseNotFound"))
+                {
+                    // Create separate request objects since .NET Core asserts only one response per request
+                    HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseNotFound", url));
+                    if (tracingDisabled)
+                    {
+                        request.Headers.Add(TracingEnabled, "false");
+                    }
+
+                    try
+                    {
+                        request.GetResponse().Close();
+                    }
+                    catch
+                    {
+                        // Gotta catch em all!
+                    }
+                    finally
+                    {
+                        Console.WriteLine("Received response for request.GetResponse()");
+                    }
+                }
+
+                using (SampleHelpers.CreateScope("GetResponseTeapot"))
+                {
+                    // Create separate request objects since .NET Core asserts only one response per request
+                    HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseTeapot", url));
+                    if (tracingDisabled)
+                    {
+                        request.Headers.Add(TracingEnabled, "false");
+                    }
+
+                    try
+                    {
+                        request.GetResponse().Close();
+                    }
+                    catch
+                    {
+                        // Gotta catch em all!
+                    }
+                    finally
+                    {
+                        Console.WriteLine("Received response for request.GetResponse()");
+                    }
+                }
+
                 using (SampleHelpers.CreateScope("GetResponseAsync"))
                 {
                     // Create separate request objects since .NET Core asserts only one response per request
@@ -341,6 +387,52 @@ namespace Samples.WebRequest
 
                     (await request.GetResponseAsync()).Close();
                     Console.WriteLine("Received response for request.GetResponseAsync()");
+                }
+
+                using (SampleHelpers.CreateScope("GetResponseAsyncNotFound"))
+                {
+                    // Create separate request objects since .NET Core asserts only one response per request
+                    HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseAsyncNotFound", url));
+                    if (tracingDisabled)
+                    {
+                        request.Headers.Add(TracingEnabled, "false");
+                    }
+
+                    try
+                    {
+                        (await request.GetResponseAsync()).Close();
+                    }
+                    catch
+                    {
+                        // Gotta catch em all!
+                    }
+                    finally
+                    {
+                        Console.WriteLine("Received response for request.GetResponse()");
+                    }
+                }
+
+                using (SampleHelpers.CreateScope("GetResponseAsyncTeapot"))
+                {
+                    // Create separate request objects since .NET Core asserts only one response per request
+                    HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("GetResponseAsyncTeapot", url));
+                    if (tracingDisabled)
+                    {
+                        request.Headers.Add(TracingEnabled, "false");
+                    }
+
+                    try
+                    {
+                        (await request.GetResponseAsync()).Close();
+                    }
+                    catch
+                    {
+                        // Gotta catch em all!
+                    }
+                    finally
+                    {
+                        Console.WriteLine("Received response for request.GetResponse()");
+                    }
                 }
 
                 using (SampleHelpers.CreateScope("GetRequestStream"))
@@ -355,7 +447,17 @@ namespace Samples.WebRequest
 
                 using (SampleHelpers.CreateScope("BeginGetResponse"))
                 {
-                    BeginGetResponse(tracingDisabled, url);
+                    BeginGetResponse(tracingDisabled, "BeginGetResponseAsync", url);
+                }
+
+                using (SampleHelpers.CreateScope("BeginGetResponseNotFound"))
+                {
+                    BeginGetResponse(tracingDisabled, "BeginGetResponseNotFoundAsync", url);
+                }
+
+                using (SampleHelpers.CreateScope("BeginGetResponseTeapot"))
+                {
+                    BeginGetResponse(tracingDisabled, "BeginGetResponseTeapotAsync", url);
                 }
 
                 using (SampleHelpers.CreateScope("BeginGetResponse TaskFactoryFromAsync"))
@@ -380,10 +482,10 @@ namespace Samples.WebRequest
 
         }
 
-        private static void BeginGetResponse(bool tracingDisabled, string url)
+        private static void BeginGetResponse(bool tracingDisabled, string testName, string url)
         {
             // Create separate request objects since .NET Core asserts only one response per request
-            HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest("BeginGetResponseAsync", url));
+            HttpWebRequest request = (HttpWebRequest)System.Net.WebRequest.Create(GetUrlForTest(testName, url));
             request.Method = "POST";
             request.ContentLength = 1;
             request.AllowWriteStreamBuffering = false;
@@ -400,9 +502,15 @@ namespace Samples.WebRequest
                 iar =>
                 {
                     var req = (HttpWebRequest)iar.AsyncState;
-                    var response = req.EndGetResponse(iar);
-
-                    response.Close();
+                    try
+                    {
+                        var response = req.EndGetResponse(iar);
+                        response.Close();
+                    }
+                    catch
+                    {
+                        // Gotta catch em all!
+                    }
 
                     Console.WriteLine("Received response for request.Begin/EndGetResponse()");
                     _allDone.Set();


### PR DESCRIPTION
## Summary of changes
Fixes the `OnMethodEnd` logic for the WebRequest integration to properly decorate the span when a 4XX is returned, which results in the WebRequest API throwing an exception.

## Reason for change
All of our WebRequest spans should have an `http.status_code` tag. Also, if WebRequest throws an exception due to a 4XX status code (this is how the API was designed), we should only mark the corresponding span as an error if the status code lies within the range defined by `DD_HTTP_CLIENT_ERROR_STATUSES`.

## Implementation details
Updates the `OnMethodEnd` logic in the WebRequest integration so that when an exception occurs and it's because of a 4XX status code, we do the following:
1. Set the `http.status_code` tag
2. Set all of the exception information on the span
3. Mark the span as error only if the status code is inside the range defined by `DD_HTTP_CLIENT_ERROR_STATUSES`

For other type of exceptions, we use the original logic to attach the exception information and automatically mark the span with an error.

## Test coverage
Update the `Samples.WebRequest` integration to hit two new endpoints that return a 400 and a 418 status code. In the integration test, ensure that the corresponding spans have the `http.status_code` tag and that they are only marked with `Error: true` when the status code lies within the range of `DD_HTTP_CLIENT_ERROR_STATUSES` (by default this value is `400-499`).

## Other details
N/A
