### PR TITLE
Fix runtime metric generation

### DIFF
--- a/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
@@ -16,7 +16,12 @@ namespace Datadog.Trace.RuntimeMetrics
 {
     internal class RuntimeMetricsWriter : IDisposable
     {
+#if NETSTANDARD
+        // In < .NET Core 3.1 we don't send CommittedMemory, so we report differently on < .NET Core 3.1
+        private const string ProcessMetrics = $"{MetricsNames.ThreadsCount}, {MetricsNames.CpuUserTime}, {MetricsNames.CpuSystemTime}, {MetricsNames.CpuPercentage}";
+#else
         private const string ProcessMetrics = $"{MetricsNames.ThreadsCount}, {MetricsNames.CommittedMemory}, {MetricsNames.CpuUserTime}, {MetricsNames.CpuSystemTime}, {MetricsNames.CpuPercentage}";
+#endif
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<RuntimeMetricsWriter>();
         private static readonly Func<IDogStatsd, TimeSpan, bool, IRuntimeMetricsListener> InitializeListenerFunc = InitializeListener;
@@ -29,6 +34,12 @@ namespace Datadog.Trace.RuntimeMetrics
         private readonly IRuntimeMetricsListener _listener;
 
         private readonly bool _enableProcessMetrics;
+#if NETSTANDARD
+        // In .NET Core <3.1 on non-Windows, Process.PrivateMemorySize64 returns 0
+        // https://github.com/dotnet/runtime/issues/23284
+        private readonly bool _enableProcessMemory = FrameworkDescription.Instance.IsWindows()
+                                                  || Environment.Version is not { Major: 3, Minor: 0 } and not { Major: < 3 };
+#endif
 
         private readonly ConcurrentDictionary<string, int> _exceptionCounts = new ConcurrentDictionary<string, int>();
 
@@ -116,7 +127,15 @@ namespace Datadog.Trace.RuntimeMetrics
 
                     _statsd.Gauge(MetricsNames.ThreadsCount, threadCount);
 
+#if NETSTANDARD
+                    if (_enableProcessMemory)
+                    {
+                        _statsd.Gauge(MetricsNames.CommittedMemory, memoryUsage);
+                        Log.Debug("Sent the following metrics to the DD agent: {Metrics}", MetricsNames.CommittedMemory);
+                    }
+#else
                     _statsd.Gauge(MetricsNames.CommittedMemory, memoryUsage);
+#endif
 
                     // Get CPU time in milliseconds per second
                     _statsd.Gauge(MetricsNames.CpuUserTime, userCpu.TotalMilliseconds / _delay.TotalSeconds);

--- a/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -71,6 +71,7 @@ namespace Datadog.Trace.Util
         public static void GetCurrentProcessRuntimeMetrics(out TimeSpan userProcessorTime, out TimeSpan systemCpuTime, out int threadCount, out long privateMemorySize)
         {
             var process = CurrentProcess.Instance;
+            process.Refresh();
             userProcessorTime = process.UserProcessorTime;
             systemCpuTime = process.PrivilegedProcessorTime;
             threadCount = process.Threads.Count;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -133,6 +133,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                 .Select(
                                      r =>
                                      {
+                                         _output.WriteLine($"Parsing metrics from {r}");
                                          // parse to find the memory
                                          var startIndex = r.IndexOf(MetricsNames.CommittedMemory, StringComparison.Ordinal);
                                          var separator = r.IndexOf(':', startIndex + 1);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -127,10 +127,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.True(contentionRequestsCount > 0, "No contention metrics received. Metrics received: " + string.Join("\n", requests));
             }
 
+// using #if so it's a different test to the one we use in RuntimeMetricsWriter
+#if NETFRAMEWORK || NETCOREAPP3_1_OR_GREATER
+            var runtimeIsBuggy = false;
+#else
             // https://github.com/dotnet/runtime/issues/23284
-            var runtimeIsBuggy = !EnvironmentTools.IsWindows()
-                              && (Environment.Version is { Major: 3, Minor: 0 } || Environment.Version.Major < 3);
-
+            var runtimeIsBuggy = !EnvironmentTools.IsWindows();
+#endif
             if (runtimeIsBuggy)
             {
                 requests.Should().NotContain(s => s.Contains(MetricsNames.CommittedMemory));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -131,7 +131,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var runtimeIsBuggy = !EnvironmentTools.IsWindows()
                               && (Environment.Version is { Major: 3, Minor: 0 } || Environment.Version.Major < 3);
 
-            if (!runtimeIsBuggy)
+            if (runtimeIsBuggy)
+            {
+                requests.Should().NotContain(s => s.Contains(MetricsNames.CommittedMemory));
+            }
+            else
             {
                 // these values shouldn't stay the same
                 var memoryRequests = requests

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -140,9 +140,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                          var endIndex = r.IndexOf('|', separator + 1);
                                          var name = r.Substring(startIndex, separator - startIndex);
                                          name.Should().Be(MetricsNames.CommittedMemory);
-                                         var value = long.Parse(r.Substring(separator + 1, endIndex - separator - 1));
-                                         value.Should().BeGreaterThan(0);
-                                         return value;
+                                         return long.Parse(r.Substring(separator + 1, endIndex - separator - 1));
                                      })
                                 .ToList();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -148,7 +148,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             if (memoryRequests.Count >= 2)
             {
                 // skip the case where we only get one metric for some reason
-                memoryRequests.Distinct().Should().HaveCount(memoryRequests.Count);
+                // Don't require completely distinct to reduce flake
+                memoryRequests.Distinct().Should().NotHaveCount(1);
             }
 
             Assert.Empty(agent.Exceptions);

--- a/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
@@ -56,7 +56,8 @@ namespace Samples.RuntimeMetrics
         {
             while (true)
             {
-                // Do some big allocating etc
+                // Do some big allocating etc to ensure committed memory increases
+                // over time
                 var bigBuffer = new byte[100_000_000];
                 new Random().NextBytes(bigBuffer);
 

--- a/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.RuntimeMetrics/Program.cs
@@ -18,6 +18,7 @@ namespace Samples.RuntimeMetrics
 
             Monitor.Enter(SyncRoot);
 
+            new Thread(GenerateMemoryPressure) { IsBackground = true }.Start();
             new Thread(GenerateEvents) { IsBackground = true }.Start();
 
             /*
@@ -47,7 +48,19 @@ namespace Samples.RuntimeMetrics
                 }
 
                 // Sleep for 500ms while creating contention
-                Monitor.TryEnter(SyncRoot, 500);                
+                Monitor.TryEnter(SyncRoot, 500);
+            }
+        }
+
+        private static void GenerateMemoryPressure()
+        {
+            while (true)
+            {
+                // Do some big allocating etc
+                var bigBuffer = new byte[100_000_000];
+                new Random().NextBytes(bigBuffer);
+
+                Thread.Sleep(5_000);
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

- Fixes process runtime metrics 
- Stops sending `runtime.dotnet.mem.committed` on non-Windows for <.NET Core 3.1

## Reason for change

In #4157 we started caching the `Process` instance for performance reasons, but that meant we were no longer getting the latest runtime metrics as described in the issue #4529.

As part of working on this fix, realised that we were always sending 0 for `runtime.dotnet.mem.committed` on Linux for <.NET Core 3.1 due to [a bug in the runtime](https://github.com/dotnet/runtime/issues/23284). 

## Implementation details

Call `Refresh()` on the process before reading the runtime metrics. 

Added a check if we're using the .NET Standard binary to see if we should send `runtime.dotnet.mem.committed`. A bit annoying, but only required in the NETSTANDARD target, so didn't seem like we should always check it

## Test coverage

Updated the runtime metrics test to add a thread that allocates a bunch of memory and verify that the value changes in the runtime metrics. The test fails (as expected) before this fix, and passes with the fix.

## Other details
Fixes #4529

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
