### PR TITLE
[ASM] Create new appsec waf benchmark with benchmark agent

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2707,6 +2707,8 @@ stages:
           agent: "BenchmarkAgent5"
         BenchmarkAgent6:
           agent: "BenchmarkAgent6"
+        BenchmarkAgent7:
+          agent: "BenchmarkAgent7"
 
     timeoutInMinutes: 30
     pool:
@@ -2778,6 +2780,12 @@ stages:
       displayName: Download results BenchmarkAgent6
       inputs:
         artifact: benchmarks_results_BenchmarkAgent6
+        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download results BenchmarkAgent7
+      inputs:
+        artifact: benchmarks_results_BenchmarkAgent7
         path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
 
     # upload the combined results for simplicity in other pipelines

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,6 +22,7 @@
 AspectsDefinitions.g.cs 				@DataDog/asm-dotnet
 /tracer/test/test-applications/integrations/Samples.InstrumentedTests/ @DataDog/asm-dotnet
 /tracer/src/Datadog.Trace/Tags.AppSec.cs @DataDog/asm-dotnet
+/tracer/test/benchmarks/Benchmarks.Trace/Asm/   @DataDog/asm-dotnet
 
 # Profiler
 /profiler/                                @DataDog/profiling-dotnet

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentFilterAttribute.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentFilterAttribute.cs
@@ -38,6 +38,12 @@ namespace Benchmarks.Trace
         {
         }
     }
+    public class BenchmarkAgent7Attribute : AgentFilterAttribute
+    {
+        public BenchmarkAgent7Attribute() : base(Agent.BenchmarkAgent7)
+        {
+        }
+    }
 
     public abstract class AgentFilterAttribute : Attribute
     {
@@ -56,6 +62,7 @@ namespace Benchmarks.Trace
             BenchmarkAgent4,
             BenchmarkAgent5,
             BenchmarkAgent6,
+            BenchmarkAgent7,
         }
     }
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -20,7 +20,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 #endif
 
-namespace Benchmarks.Trace
+namespace Benchmarks.Trace.Asm
 {
     [MemoryDiagnoser]
     [BenchmarkAgent2]

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -1,0 +1,131 @@
+// <copyright file="AppSecWafBenchmark.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Datadog.Trace;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.AppSec.Waf.NativeBindings;
+
+namespace Benchmarks.Trace.Asm;
+
+[MemoryDiagnoser]
+[BenchmarkAgent7]
+public class AppSecWafBenchmark
+{
+    private const int TimeoutMicroSeconds = 1_000_000;
+
+    private static readonly Waf Waf;
+    private Context _context;
+
+    static AppSecWafBenchmark()
+    {
+        var fDesc = FrameworkDescription.Instance;
+        var rid = (fDesc.ProcessArchitecture, fDesc.OSPlatform) switch
+        {
+            ("x64", "Windows") => "win-x64",
+            ("x86", "Windows") => "win-x86",
+            ("x64", "Linux") => "linux-x64",
+            ("arm64", "Linux") => "linux-arm64",
+            _ => throw new Exception($"RID not detected or supported: {fDesc.OSPlatform} / {fDesc.ProcessArchitecture}")
+        };
+
+        var folder = new DirectoryInfo(Environment.CurrentDirectory);
+        var path = Environment.CurrentDirectory;
+        while (folder.Exists)
+        {
+            path = Path.Combine(folder.FullName, "./shared/bin/monitoring-home");
+            if (Directory.Exists(path))
+            {
+                break;
+            }
+
+            if (folder == folder.Parent)
+            {
+                break;
+            }
+
+            folder = folder.Parent;
+        }
+        
+        path = Path.Combine(path, $"./{rid}/");
+        if (!Directory.Exists(path))
+        {
+            throw new DirectoryNotFoundException($"The Path: '{path}' doesn't exist.");
+        }
+
+        Environment.SetEnvironmentVariable("DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH", path);
+        var libInitResult = WafLibraryInvoker.Initialize();
+        if (!libInitResult.Success)
+        {
+            throw new ArgumentException("Waf could not load");
+        }
+
+        var wafLibraryInvoker = libInitResult.WafLibraryInvoker!;
+        var initResult = Waf.Create(wafLibraryInvoker, string.Empty, string.Empty);
+        Waf = initResult.Waf;
+    }
+
+    public IEnumerable<Dictionary<string, object>> Source()
+    {
+        yield return MakeNestedMap(10);
+        yield return MakeNestedMap(100);
+        yield return MakeNestedMap(1000);
+    }
+
+    private static Dictionary<string, object> MakeNestedMap(int nestingDepth)
+    {
+        var root = new Dictionary<string, object>();
+        var map = root;
+
+        for (var i = 0; i < nestingDepth; i++)
+        {
+            if (i % 2 == 0)
+            {
+                var nextList = new List<object>
+                {
+                    true,
+                    false,
+                    false,
+                    false,
+                    true,
+                    123,
+                    "lorem",
+                    "ipsum",
+                    "dolor",
+                    AddressesConstants.RequestCookies, new Dictionary<string, string> { { "something", ".htaccess" }, { "something2", ";shutdown--" } }
+                };
+                map.Add("list", nextList);
+            }
+
+            var nextMap = new Dictionary<string, object>
+            {
+                { "lorem", "ipsum" },
+                { "dolor", "sit" },
+                { "amet", "amet" },
+                { "lorem2", "dolor2" },
+                { "sit2", true },
+                { "amet3", 4356 }
+            };
+            map.Add("item", nextMap);
+            map = nextMap;
+        }
+
+        return root;
+    }
+
+    [IterationSetup]
+    public void Setup() => _context = Waf.CreateContext() as Context;
+
+    [IterationCleanup]
+    public void Cleanup() => _context.Dispose();
+
+    [Benchmark]
+    [ArgumentsSource(nameof(Source))]
+    public void RunWaf(Dictionary<string, object> args) => _context.Run(args, TimeoutMicroSeconds);
+}


### PR DESCRIPTION
## Summary of changes

Create new benchmark agent for future appsec waf benchmark

## Reason for change

See PR https://github.com/DataDog/dd-trace-dotnet/pull/4528

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
