### PR TITLE
Add support for identifying Pivotal Cloud Foundry container IDs

### DIFF
--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -22,7 +23,7 @@ namespace Datadog.Trace.PlatformHelpers
         private const string ContainerRegex = @"[0-9a-f]{64}";
         // The second part is the PCF/Garden regexp. We currently assume no suffix ($) to avoid matching pod UIDs
         // See https://github.com/DataDog/datadog-agent/blob/7.40.x/pkg/util/cgroups/reader.go#L50
-        private const string UuidRegex = @"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)";
+        private const string UuidRegex = @"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|(?:[0-9a-f]{8}(?:-[0-9a-f]{4}){4}$)";
         private const string TaskRegex = @"[0-9a-f]{32}-\d+";
         private const string ContainerIdRegex = @"(" + UuidRegex + "|" + ContainerRegex + "|" + TaskRegex + @")(?:\.scope)?$";
 

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -20,7 +20,9 @@ namespace Datadog.Trace.PlatformHelpers
     {
         private const string ControlGroupsFilePath = "/proc/self/cgroup";
         private const string ContainerRegex = @"[0-9a-f]{64}";
-        private const string UuidRegex = @"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}";
+        // The second part is the PCF/Garden regexp. We currently assume no suffix ($) to avoid matching pod UIDs
+        // See https://github.com/DataDog/datadog-agent/blob/7.40.x/pkg/util/cgroups/reader.go#L50
+        private const string UuidRegex = @"[0-9a-f]{8}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{4}[-_][0-9a-f]{12}|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)";
         private const string TaskRegex = @"[0-9a-f]{32}-\d+";
         private const string ContainerIdRegex = @"(" + UuidRegex + "|" + ContainerRegex + "|" + TaskRegex + @")(?:\.scope)?$";
 

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -96,6 +96,24 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 1:name=systemd:/kubepods.slice/kubepods-pod9508fe66_7675_4003_b7c9_d83e9f8f85e5.slice/cri-containerd-26cfbe35e08b24f053011af4ada23d8fcbf81f27f8331a94f56de5b677c903e4.scope
 ";
 
+        public const string PcfContainer1 =
+            """
+            12:memory:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+            11:rdma:/
+            10:freezer:/garden/6f265890-5165-7fab-6b52-18d1
+            9:hugetlb:/garden/6f265890-5165-7fab-6b52-18d1
+            8:pids:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+            7:perf_event:/garden/6f265890-5165-7fab-6b52-18d1
+            6:cpu,cpuacct:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+            5:net_cls,net_prio:/garden/6f265890-5165-7fab-6b52-18d1
+            4:cpuset:/garden/6f265890-5165-7fab-6b52-18d1
+            3:blkio:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+            2:devices:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+            1:name=systemd:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1
+            """;
+
+        public const string PcfContainer2 = "1:name=systemd:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1";
+
         public static IEnumerable<object[]> GetCgroupFiles()
         {
             yield return new object[] { Docker, "3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860" };
@@ -104,6 +122,8 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             yield return new object[] { Fargate1Dot3, "432624d2150b349fe35ba397284dea788c2bf66b885d14dfc1569b01890ca7da" };
             yield return new object[] { Fargate1Dot4, "34dc0b5e626f2c5c4c5170e34b10e765-1234567890" };
             yield return new object[] { EksNodegroup, "26cfbe35e08b24f053011af4ada23d8fcbf81f27f8331a94f56de5b677c903e4" };
+            yield return new object[] { PcfContainer1, "6f265890-5165-7fab-6b52-18d1" };
+            yield return new object[] { PcfContainer2, "6f265890-5165-7fab-6b52-18d1" };
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes

Updates the Container UUID regex for extracting `ContainerId`

## Reason for change

We currentlyfail to parse container IDs in Pivotal Cloud Foundry since it uses a different UUID format. Other tracer languages already support PCF, and we should to.

## Implementation details

Update the Regex to match that used by other languages and the Agent. The actual change is to add this:

```regex
|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)
```

which matches PCF's container IDs that look like this: `016b5740-120b-42b7-562f-3c62`

## Test coverage

Updated unit tests for the parsing to include PCF examples (copied from other language's implementations)

## Other details
PRs for other languages:
- https://github.com/DataDog/dd-trace-js/pull/2831
- https://github.com/DataDog/dd-trace-java/pull/4183
- https://github.com/DataDog/dd-trace-go/pull/1549
- https://github.com/DataDog/dd-trace-py/pull/4405
