### PR TITLE
Fix telemetry metrics and add validator

### DIFF
--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
@@ -44,7 +44,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogLogs => "direct_log_logs",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiRequests => "direct_log_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiResponses => "direct_log_api.responses",
-            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors.responses",
+            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors",
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
@@ -19,7 +19,7 @@ internal static partial class GaugeExtensions
         {
             Datadog.Trace.Telemetry.Metrics.Gauge.StatsBuckets => "stats_buckets",
             Datadog.Trace.Telemetry.Metrics.Gauge.Instrumentations => "instrumentations",
-            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue",
+            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue.length",
             _ => null!,
         };
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -653,7 +653,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors.responses, index = 435
+            // direct_log_api.errors, index = 435
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -37,7 +37,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
-            // direct_log_queue, index = 7
+            // direct_log_queue.length, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
@@ -44,7 +44,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogLogs => "direct_log_logs",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiRequests => "direct_log_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiResponses => "direct_log_api.responses",
-            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors.responses",
+            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors",
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
@@ -19,7 +19,7 @@ internal static partial class GaugeExtensions
         {
             Datadog.Trace.Telemetry.Metrics.Gauge.StatsBuckets => "stats_buckets",
             Datadog.Trace.Telemetry.Metrics.Gauge.Instrumentations => "instrumentations",
-            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue",
+            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue.length",
             _ => null!,
         };
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -653,7 +653,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors.responses, index = 435
+            // direct_log_api.errors, index = 435
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -37,7 +37,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
-            // direct_log_queue, index = 7
+            // direct_log_queue.length, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
@@ -44,7 +44,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogLogs => "direct_log_logs",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiRequests => "direct_log_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiResponses => "direct_log_api.responses",
-            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors.responses",
+            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors",
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
@@ -19,7 +19,7 @@ internal static partial class GaugeExtensions
         {
             Datadog.Trace.Telemetry.Metrics.Gauge.StatsBuckets => "stats_buckets",
             Datadog.Trace.Telemetry.Metrics.Gauge.Instrumentations => "instrumentations",
-            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue",
+            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue.length",
             _ => null!,
         };
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -653,7 +653,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors.responses, index = 435
+            // direct_log_api.errors, index = 435
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -37,7 +37,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
-            // direct_log_queue, index = 7
+            // direct_log_queue.length, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CountExtensions.g.cs
@@ -44,7 +44,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogLogs => "direct_log_logs",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiRequests => "direct_log_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiResponses => "direct_log_api.responses",
-            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors.responses",
+            Datadog.Trace.Telemetry.Metrics.Count.DirectLogApiErrors => "direct_log_api.errors",
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/GaugeExtensions.g.cs
@@ -19,7 +19,7 @@ internal static partial class GaugeExtensions
         {
             Datadog.Trace.Telemetry.Metrics.Gauge.StatsBuckets => "stats_buckets",
             Datadog.Trace.Telemetry.Metrics.Gauge.Instrumentations => "instrumentations",
-            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue",
+            Datadog.Trace.Telemetry.Metrics.Gauge.DirectLogQueue => "direct_log_queue.length",
             _ => null!,
         };
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -653,7 +653,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors.responses, index = 435
+            // direct_log_api.errors, index = 435
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -37,7 +37,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "component_name:iast" }),
             new(new[] { "component_name:iast_derived" }),
             new(new[] { "component_name:iast_aspects" }),
-            // direct_log_queue, index = 7
+            // direct_log_queue.length, index = 7
             new(null),
         };
 

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -162,7 +162,7 @@ internal enum Count
     /// <summary>
     /// The number of requests sent to the api endpoint that errored, tagged by the error type (e.g. Timeout, NetworkError, status_code)
     /// </summary>
-    [TelemetryMetric<MetricTags.ApiError>("direct_log_api.errors.responses", isCommon: false)] DirectLogApiErrors,
+    [TelemetryMetric<MetricTags.ApiError>("direct_log_api.errors", isCommon: false)] DirectLogApiErrors,
 
 #endregion
 #region AppSec Namespace

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Gauge.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Gauge.cs
@@ -26,5 +26,5 @@ internal enum Gauge
     /// <summary>
     /// The number of logs currently enqueued to the direct log submission sink
     /// </summary>
-    [TelemetryMetric("direct_log_queue", isCommon: false)] DirectLogQueue,
+    [TelemetryMetric("direct_log_queue.length", isCommon: false)] DirectLogQueue,
 }

--- a/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -54,5 +54,7 @@
   <ItemGroup>
     <None Remove="Telemetry\telemetry_*.json" />
     <EmbeddedResource Include="Telemetry\telemetry_*.json" />
+    <None Remove="Telemetry\Metrics\*.json" />
+    <EmbeddedResource Include="Telemetry\Metrics\*.json" />
   </ItemGroup>
 </Project>

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/MetricTests.cs
@@ -1,0 +1,286 @@
+﻿// <copyright file="MetricTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Datadog.Trace.SourceGenerators;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Telemetry.Metrics;
+
+public class MetricTests
+{
+    private static readonly Dictionary<string, List<string>> IgnoredTagsByMetricName = new()
+    {
+        { "waf.init", new() { "event_rules_version" } }, // we don't send this tag as cardinality is infinite
+        { "waf.updates", new() { "event_rules_version" } }, // we don't send this tag as cardinality is infinite
+        { "waf.requests", new() { "event_rules_version" } }, // we don't send this tag as cardinality is infinite
+        { "spans_finished", new() { "integration_name" } }, // this is technically difficult for us, so we don't tag it
+    };
+
+    private static readonly Dictionary<string, List<string>> OneOfTagsByMetricName = new()
+    {
+        { "init_time", new() { "total", "component" } }, // we only send one of these
+    };
+
+    [Fact]
+    public void OnlyAllowedMetricsAreSubmitted()
+    {
+        // Only metrics defined in the following json documents should be submitted
+        // https://github.com/DataDog/dd-go/trace/apps/tracer-telemetry-intake/telemetry-metrics/static/common_metrics.json
+        // https://github.com/DataDog/dd-go/trace/apps/tracer-telemetry-intake/telemetry-metrics/static/dotnet_metrics.json
+        //
+        // These are duplicated in this repo. When adding new metrics, add them into the embedded json files here, then
+        // after merging, update the source JSON file in dd-go
+
+        var expected = GetIntakeMetricsAndTags();
+        var actual = GetImplementedMetricsAndTags();
+
+        foreach (var implementation in actual)
+        {
+            var expectedMetric = expected.FirstOrDefault(
+                x => string.Equals(x.Namespace, implementation.Namespace)
+                  && string.Equals(x.Metric, implementation.Metric))!;
+
+            expectedMetric.Should().NotBeNull($"Metric {implementation.Metric} with namespace {implementation.Namespace} was not found in intake metrics");
+
+            // compare everything except tags
+            implementation.Should().BeEquivalentTo(expectedMetric, options => options.ExcludingMissingMembers());
+
+            // check that we have the same number of tags as expected
+            // this isn't correct for some tags, but it's true of most,
+            // so we assert it and have an exception list where it's not required
+            var expectedPrefixes = IgnoredTagsByMetricName.TryGetValue(expectedMetric.Metric, out var ignored)
+                                       ? expectedMetric.TagPrefixes.Except(ignored).ToList()
+                                       : expectedMetric.TagPrefixes;
+
+            // if we have any expected prefixes, we should expect some permutations
+            if (expectedPrefixes.Count > 0)
+            {
+                implementation.TagPermutations.Should().NotBeEmpty($"{implementation.Metric} should only use expected prefixes ({string.Join(",", expectedMetric.TagPrefixes)})");
+            }
+
+            // Check all our permutation are valid
+            foreach (var permutation in implementation.TagPermutations)
+            {
+                var permutationPrefixes = permutation.Select(
+                    tag => tag.IndexOf(':') is var i and >= 0
+                               ? tag.Substring(0, i)
+                               : tag);
+
+                permutationPrefixes.Should()
+                                   .OnlyContain(prefix => expectedPrefixes.Contains(prefix), $"{implementation.Metric} should only use expected prefixes ({string.Join(",", expectedMetric.TagPrefixes)})")
+                                   .And.OnlyHaveUniqueItems();
+
+                // for "one of" cases we only expect to send one of the specified tags, so reduce the expected count
+                var expectedCount = OneOfTagsByMetricName.TryGetValue(expectedMetric.Metric, out var oneOfList)
+                                        ? expectedPrefixes.Count - (oneOfList.Count - 1)
+                                        : expectedPrefixes.Count;
+
+                permutation.Should().HaveCount(expectedCount, $"{implementation.Metric} should supply all the expected tags ({string.Join(",", expectedMetric.TagPrefixes)})");
+            }
+        }
+    }
+
+    private static List<ImplementedMetricAndTags> GetImplementedMetricsAndTags()
+    {
+        var results = new List<ImplementedMetricAndTags>();
+
+        results.AddRange(GetCounts());
+        var counts = results.Count;
+        results.AddRange(GetGauges());
+        var gauges = results.Count - counts;
+        results.AddRange(GetDistributions());
+        var distributions = results.Count - gauges;
+
+        results.Should().NotBeEmpty();
+        counts.Should().NotBe(0);
+        gauges.Should().NotBe(0);
+        distributions.Should().NotBe(0);
+        return results;
+
+        static IEnumerable<ImplementedMetricAndTags> GetCounts()
+        {
+            var metricType = typeof(Count);
+            var allMetrics = Enum.GetValues(metricType);
+            foreach (Count metric in allMetrics)
+            {
+                var metricName = metric.GetName();
+                var isCommon = metric.IsCommon();
+                var metricNamespace = metric.GetNamespace();
+                if (isCommon && metricNamespace is null)
+                {
+                    metricNamespace = MetricNamespaceConstants.Tracer;
+                }
+
+                var member = metricType.GetField(metric.ToString());
+                var tags = GetTagPermutations(member, metricNamespace);
+                yield return new ImplementedMetricAndTags(metricNamespace, metricName, isCommon, TelemetryMetricType.Count, tags);
+            }
+        }
+
+        static IEnumerable<ImplementedMetricAndTags> GetGauges()
+        {
+            var metricType = typeof(Gauge);
+            var allMetrics = Enum.GetValues(metricType);
+            foreach (Gauge metric in allMetrics)
+            {
+                var metricName = metric.GetName();
+                var isCommon = metric.IsCommon();
+                var metricNamespace = metric.GetNamespace();
+                if (isCommon && metricNamespace is null)
+                {
+                    metricNamespace = MetricNamespaceConstants.Tracer;
+                }
+
+                var member = metricType.GetField(metric.ToString());
+                var tags = GetTagPermutations(member, metricNamespace);
+                yield return new ImplementedMetricAndTags(metricNamespace, metricName, isCommon, TelemetryMetricType.Gauge, tags);
+            }
+        }
+
+        static IEnumerable<ImplementedMetricAndTags> GetDistributions()
+        {
+            var metricType = typeof(Distribution);
+            var allMetrics = Enum.GetValues(metricType);
+            foreach (Distribution metric in allMetrics)
+            {
+                var metricName = metric.GetName();
+                var isCommon = metric.IsCommon();
+                var metricNamespace = metric.GetNamespace();
+                if (isCommon && metricNamespace is null)
+                {
+                    metricNamespace = MetricNamespaceConstants.Tracer;
+                }
+
+                var member = metricType.GetField(metric.ToString());
+                var tags = GetTagPermutations(member, metricNamespace);
+                yield return new ImplementedMetricAndTags(metricNamespace, metricName, isCommon, TelemetryMetricType.Distribution, tags);
+            }
+        }
+
+        static List<string[]> GetTagPermutations(FieldInfo member, string ns)
+        {
+            // Can't grab open generic attributes using GetCustomAttributes(typeof()) directly it seems
+            foreach (var attr in member.GetCustomAttributesData())
+            {
+                var attributeType = attr.AttributeType;
+                if (attributeType == typeof(TelemetryMetricAttribute))
+                {
+                    // no tags unless this is an ASM metric, in which case we include waf_version
+                    // see src\Datadog.Trace\Telemetry\Collectors\MetricsTelemetryCollector.GetTags(string? ns, string[]? metricKeyTags)
+                    if (ns == MetricNamespaceConstants.ASM)
+                    {
+                        return new() { new[] { "waf_version:unknown" } };
+                    }
+
+                    return new List<string[]>();
+                }
+
+                if (attributeType.IsGenericType)
+                {
+                    var genericDefinition = attributeType.GetGenericTypeDefinition();
+                    if (genericDefinition == typeof(TelemetryMetricAttribute<>))
+                    {
+                        // one tag, grab the tags
+                        return GetAllTagPermutations(attributeType.GenericTypeArguments[0]).ToList();
+                    }
+
+                    if (genericDefinition == typeof(TelemetryMetricAttribute<,>))
+                    {
+                        // two tags, grab the tags
+                        var tags1 = GetAllTagPermutations(attributeType.GenericTypeArguments[0]);
+                        var tags2 = GetAllTagPermutations(attributeType.GenericTypeArguments[1]);
+                        return (from tagset1 in tags1
+                                from tagset2 in tags2
+                                select tagset1.Concat(tagset2).ToArray()).ToList();
+                    }
+                }
+            }
+
+            throw new InvalidOperationException($"Error getting tag prefixes for {member.DeclaringType.Name}.{member.Name}: No {nameof(TelemetryMetricAttribute)} declared");
+
+            static IEnumerable<string[]> GetAllTagPermutations(Type tagType)
+            {
+                var tagValues = Enum.GetValues(tagType);
+                foreach (var tagValue in tagValues)
+                {
+                    var member = tagType.GetField(tagValue.ToString());
+                    var descriptionAttribute = member.GetCustomAttribute<DescriptionAttribute>();
+                    var description = descriptionAttribute.Description;
+
+                    // For ASM we use a trick here to handle multiple tags that are only used in a limited subset of combinations
+                    yield return description.Split(';');
+                }
+            }
+        }
+    }
+
+    private static List<AllowedMetricAndTagPrefixes> GetIntakeMetricsAndTags()
+    {
+        var jsonSettings = new JsonSerializerSettings
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy(), }
+        };
+
+        var rawMetrics = GetMetricsData("common_metrics.json");
+        var commonMetrics = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, IntakeMetric>>>(rawMetrics, jsonSettings);
+
+        rawMetrics = GetMetricsData("dotnet_metrics.json");
+        // Note that dotnet doesn't have a namespace
+        var dotnetMetrics = JsonConvert.DeserializeObject<Dictionary<string, IntakeMetric>>(rawMetrics, jsonSettings);
+
+        var results = new List<AllowedMetricAndTagPrefixes>(commonMetrics.Count + dotnetMetrics.Count);
+
+        foreach (var commonMetricNamespace in commonMetrics)
+        {
+            var metricNamespace = commonMetricNamespace.Key;
+            foreach (var metricDetails in commonMetricNamespace.Value)
+            {
+                var details = metricDetails.Value;
+                results.Add(new AllowedMetricAndTagPrefixes(metricNamespace, metricDetails.Key, IsCommon: true, details.MetricType, details.Tags));
+            }
+        }
+
+        foreach (var metricDetails in dotnetMetrics)
+        {
+            var metricName = metricDetails.Key;
+            var details = metricDetails.Value;
+            results.Add(new AllowedMetricAndTagPrefixes(Namespace: null, metricName, IsCommon: false, details.MetricType, details.Tags));
+        }
+
+        results.Should().NotBeEmpty();
+        return results;
+
+        static string GetMetricsData(string filename)
+        {
+            var thisAssembly = typeof(MetricTests).Assembly;
+            var stream = thisAssembly.GetManifestResourceStream($"Datadog.Trace.Tests.Telemetry.Metrics.{filename}");
+            using var streamReader = new StreamReader(stream);
+            return streamReader.ReadToEnd();
+        }
+    }
+
+    public record AllowedMetricAndTagPrefixes(string Namespace, string Metric, bool IsCommon, string MetricType, List<string> TagPrefixes);
+
+    public record ImplementedMetricAndTags(string Namespace, string Metric, bool IsCommon, string MetricType, List<string[]> TagPermutations);
+
+    public class IntakeMetric
+    {
+        public List<string> Tags { get; set; }
+
+        public string MetricType { get; set; }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -1,0 +1,550 @@
+﻿{
+  "general": {
+    "init_time": {
+      "tags": [
+        "total",
+        "component"
+      ],
+      "metric_type": "distribution",
+      "data_type": "milliseconds",
+      "description": "The time it takes to import/initialize the tracer on startup. If this consists of multiple steps/components, tagged by the component/total e.g. `component:call_target`. Component tags will vary by language",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "logs_created": {
+      "tags": [
+        "level"
+      ],
+      "metric_type": "count",
+      "data_type": "logs",
+      "description": "The number of logs created with a given log level. Useful for calculating impact for other features (automatic sending of logs). Levels should be one of `debug`, `info`, `warn`, `error`, `critical`",
+      "send_to_user": false,
+      "user_tags":[]
+    }
+  },
+  "tracers": {
+    "integration_errors": {
+      "tags": [
+        "integration_name",
+        "error_type"
+      ],
+      "metric_type": "count",
+      "data_type": "instances",
+      "description": "The number of errors/failures in the library integration, tagged by the integration name (e.g. `integration_name:kafka`, `integration_name:rabbitmq`) and ErrorType (e.g. `error:duck_type`, `error:runtime`). Both tags will vary by implementation language",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "spans_created": {
+      "tags": [
+        "integration_name"
+      ],
+      "metric_type": "count",
+      "data_type": "spans",
+      "description": "The number of spans created by the tracer, tagged by automatic integration name (e.g. `integration_name:kafka`, `integration_name:rabbitmq`) or manual API (`integration_name:datadog`, `integration_name:otel` or `integration_name:opentracing`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "spans_finished": {
+      "tags": [
+        "integration_name"
+      ],
+      "metric_type": "count",
+      "data_type": "spans",
+      "description": "The number of spans finished, optionally (if implementation allows) tagged by automatic integration name (e.g. `integration_name:kafka`, `integration_name:rabbitmq`) or manual API (`integration_name:datadog`, `integration_name:otel` or `integration_name:opentracing`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "spans_enqueued_for_serialization": {
+      "tags": [
+        "reason"
+      ],
+      "metric_type": "count",
+      "data_type": "spans",
+      "description": "The number of spans enqueued for serialization/flushing. Tagged by one of `reason:p0_keep` (the span was part of a p0 trace that was kept for sending to the agent), `reason:single_span_sampling` (the span was selected via single_span_sampling, and otherwise would have been dropped as a p0 span), or `reason:default` - The tracer is not dropping p0 spans, so the span was enqueued 'by default' for sending to the trace-agent)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "spans_dropped": {
+      "tags": [
+        "reason"
+      ],
+      "metric_type": "count",
+      "data_type": "spans",
+      "description": "The number of spans dropped and the reason for being dropped, for example `reason:p0_drop` (the span was part of a p0 trace that was droped by the tracer), `reason:overfull_buffer` (the local buffer was full, and the span had to be dropped), `reason:serialization_error` (there was an error serializing the span and it had to be dropped)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_segments_created": {
+      "tags": [
+        "new_continued"
+      ],
+      "metric_type": "count",
+      "data_type": "trace segments",
+      "description": "The number of trace segments (local traces) created, tagged with new/continued depending on whether this is a new trace (no distributed context information) or continued (has distributed context).",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_chunks_enqueued": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "trace chunks",
+      "description": "The number of times a trace chunk is enqueued for sampling/serialization. In partial-flush scenarios, multiple trace chunks may be enququed per trace segment/local trace",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_chunk_size": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "spans",
+      "description": "The number of spans in the trace chunk when it is enqueued",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_chunk_serialization.bytes": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "bytes",
+      "description": "The size in bytes of the serialized trace chunk",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_chunk_serialization.ms": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "milliseconds",
+      "description": "The time it takes to serialize a trace chunk",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_chunks_enqueued_for_serialization": {
+      "tags": [
+        "reason"
+      ],
+      "metric_type": "count",
+      "data_type": "trace chunks",
+      "description": "The number of trace chunks kept for serialization. Excludes single-span sampling spans. Tagged by one of `reason:p0_keep` (the trace was a p0 trace that was kept for sending to the agent) or `reason:default` - The tracer is not dropping p0 spans, so the span was enqueued 'by default' for sending to the trace-agent)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_chunks_dropped": {
+      "tags": [
+        "reason"
+      ],
+      "metric_type": "count",
+      "data_type": "trace chunks",
+      "description": "the number of trace chunks dropped prior to serialization, tagged by reason. Includes traces which are dropped due to errors, overfull buffers, as well as due to sampling decision. For example `reason:p0_drop` (the span a p0 trace that was droped by the tracer), `reason:overfull_buffer` (the local buffer was full, and the trace chunk had to be dropped), `reason:serialization_error` (there was an error serializing the trace and it had to be dropped)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_chunks_sent": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "trace chunks",
+      "description": "The number of trace chunks attempted to be sent to the backend, regardless of response",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_segments_closed": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "trace segments",
+      "description": "The number of trace segments (local traces) closed. In non partial flush scenarios, trace_segments_closed == trace_chunks_enqueued",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_api.requests": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of requests sent to the trace endopint in the agent, regardless of success",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_api.bytes": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "bytes",
+      "description": "The size of the payload sent to the endpoint in bytes",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_api.ms": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "milliseconds",
+      "description": "The time it takes to flush the trace payload to the agent. Note that this is not the per trace time, this is the per payload time",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_api.responses": {
+      "tags": [
+        "status_code"
+      ],
+      "metric_type": "count",
+      "data_type": "responses",
+      "description": "The number of responses received from the trace endpoint, tagged with status code, e.g. `status_code:200`, `status_code:404`. May also use `status_code:5xx` for example as a catch-all for 2xx, 3xx, 4xx, 5xx responses",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_api.errors": {
+      "tags": [
+        "type"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of requests sent to the trace endpoint in the agent that errored, tagged by the error type (e.g. `type:timeout`, `type:network`, `type:status_code`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_partial_flush.count": {
+      "tags": [
+        "reason"
+      ],
+      "metric_type": "count",
+      "data_type": "instances",
+      "description": "The number of times a partial flush (where a span is flushed separately from its local root span) is triggered, tagged by the reason the flush was triggered (`reason:large_trace`, `reason:single_span_ingestion`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_partial_flush.spans_closed": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "spans",
+      "description": "The number of spans included in the trace chunk when partial flush is triggered",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "trace_partial_flush.spans_remaining": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "spans",
+      "description": "The number of open spans remaining in the trace segment (local trace) when partial flush is triggered",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "context_header_style.injected": {
+      "tags": [
+        "header_style"
+      ],
+      "metric_type": "count",
+      "data_type": "instances",
+      "description": "The number of times distributed context is injected into an outgoing span, tagged by header style (`header_style:tracecontext`, `header_style:datadog`, `header_style:b3multi`, `header_style:b3single`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "context_header_style.extracted": {
+      "tags": [
+        "header_style"
+      ],
+      "metric_type": "count",
+      "data_type": "instances",
+      "description": "The number of times distributed context is successfully extracted from an outgoing span, tagged by header style (`header_style:tracecontext`, `header_style:datadog`, `header_style:b3multi`, `header_style:b3single`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "stats_buckets": {
+      "tags": [],
+      "metric_type": "gauge",
+      "data_type": "keys",
+      "description": "The number of unique buckets created for stats aggregation",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "stats_api.requests": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of requests sent to the stats endopint in the agent, regardless of success",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "stats_api.bytes": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "bytes",
+      "description": "The size of the payload sent to the stats endpoint in bytes",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "stats_api.ms": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "milliseconds",
+      "description": "The time it takes to send the payload sent to the endpoint in ms",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "stats_api.responses": {
+      "tags": [
+        "status_code"
+      ],
+      "metric_type": "count",
+      "data_type": "responses",
+      "description": "The number of responses received from the endpoint, tagged with status code, e.g. `status_code:200`, `status_code:404`. May also use `status_code:5xx` for example as a catch-all for 2xx, 3xx, 4xx, 5xx responses",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "stats_api.errors": {
+      "tags": [
+        "type"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of requests sent to the api endpoint in the agent that errored, tagged by the error type (e.g. Timeout, NetworkError, StatusCode)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "host_lib_injection.success": {
+      "tags": [
+        "language",
+        "version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of successful host lib injection",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "host_lib_injection.failure": {
+      "tags": [
+        "language",
+        "version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of failed host lib injection",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "docker_lib_injection.success": {
+      "tags": [
+        "language",
+        "version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of successful docker lib injection",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "docker_lib_injection.failure": {
+      "tags": [
+        "language",
+        "version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of failed docker lib injection",
+      "send_to_user": false,
+      "user_tags": []
+    }
+  },
+  "telemetry": {
+    "telemetry_api.requests": {
+      "tags": [
+        "endpoint"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of requests sent to a telemetry endopint, regardless of success, tagged by the endpoint (`endpoint:agent`, `endpoint:agentless`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "telemetry_api.bytes": {
+      "tags": [
+        "endpoint"
+      ],
+      "metric_type": "distribution",
+      "data_type": "bytes",
+      "description": "The size of the payload sent to the stats endpoint in bytes, tagged by the endpoint (`endpoint:agent`, `endpoint:agentless`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "telemetry_api.ms": {
+      "tags": [],
+      "metric_type": "distribution",
+      "data_type": "milliseconds",
+      "description": "The time it takes to send the payload sent to the endpoint in ms, tagged by the endpoint (`endpoint:agent`, `endpoint:agentless`)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "telemetry_api.responses": {
+      "tags": [
+        "endpoint",
+        "status_code"
+      ],
+      "metric_type": "count",
+      "data_type": "responses",
+      "description": "The number of requests sent to the api endpoint in the agent that errored, tagged by the error type (e.g. `type:timeout`, `type:network`, `type:status_code`)",
+      "send_to_user": false,
+      "user_tags":[]
+
+    },
+    "telemetry_api.errors": {
+      "tags": [
+        "endpoint",
+        "type"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "The number of requests sent to the api endpoint in the agent that errored, tagged by the error type (e.g. `type:timeout`, `type:network`, `type:status_code`) and Endpoint (`endpoint:agent`, `endpoint:agentless`)",
+      "send_to_user": false,
+      "user_tags":[]
+    }
+  },
+  "appsec": {
+    "waf.init": {
+      "tags": [
+        "waf_version",
+        "event_rules_version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of times we is initialized",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "waf.updates": {
+      "tags": [
+        "waf_version",
+        "event_rules_version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of times we reload the rules (startup + Remote Configuration)",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "waf.duration": {
+      "tags": [
+        "waf_version",
+        "event_rules_version"
+      ],
+      "metric_type": "distribution",
+      "data_type": "requests",
+      "description": "Total WAF duration",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "waf.duration_ext": {
+      "tags": [
+        "waf_version",
+        "event_rules_version"
+      ],
+      "metric_type": "distribution",
+      "data_type": "requests",
+      "description": "Total WAF duration  including bindings",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "waf.requests": {
+      "tags": [
+        "waf_version",
+        "event_rules_version",
+        "rule_triggered",
+        "request_blocked",
+        "waf_timeout",
+        "request_excluded"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Requests analyzed by ddwaf",
+      "send_to_user": false,
+      "user_tags":[]
+    }
+  },
+  "iast": {
+    "instrumented.source": {
+      "tags": [
+        "source_type"
+      ],
+      "metric_type": "count",
+      "data_type": "call sites",
+      "description": "Number of source call sites instrumented",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "instrumented.propagation": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "call sites",
+      "description": "Number of propagation call sites instrumented",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "instrumented.sink": {
+      "tags": [
+        "vulnerability_type"
+      ],
+      "metric_type": "count",
+      "data_type": "call sites",
+      "description": "Number of sink call sites instrumented",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "executed.source": {
+      "tags": [
+        "source_type"
+      ],
+      "metric_type": "count",
+      "data_type": "call sites",
+      "description": "Number of source call sites executed",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "executed.propagation": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "call sites",
+      "description": "Number of propagation call sites executed",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "executed.sink": {
+      "tags": [
+        "vulnerability_type"
+      ],
+      "metric_type": "count",
+      "data_type": "call sites",
+      "description": "Number of sink call sites executed",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "executed.tainted": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "operations",
+      "description": "Number of taint operations triggered during a request",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "request.tainted": {
+      "tags": [
+        "vulnerability_type"
+      ],
+      "metric_type": "count",
+      "data_type": "values",
+      "description": "Number of tainted values at the end of a request",
+      "send_to_user": false,
+      "user_tags":[]
+    }
+  },
+  "sidecar": {
+    "server.active_sessions": {
+      "tags": [],
+      "metric_type": "gauge",
+      "data_type": "sessions",
+      "description": "Number of sessions active in parallel",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "server.submitted_payloads": {
+      "tags": [],
+      "metric_type": "count",
+      "data_type": "payloads",
+      "description": "Number of payloads the sidecar has processed",
+      "send_to_user": false,
+      "user_tags":[]
+    }
+  }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/dotnet_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/dotnet_metrics.json
@@ -1,0 +1,109 @@
+﻿{
+  "public_api": {
+    "tags": [
+      "name"
+    ],
+    "metric_type": "count",
+    "data_type": "invocations",
+    "description": "The number of invocations of a given public API, tagged by the name of the api ",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "version_conflict_tracers_created": {
+    "tags": [],
+    "metric_type": "count",
+    "data_type": "traces",
+    "description": "The number of version-confict tracers created",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "instrumentations": {
+    "tags": [
+      "component_name"
+    ],
+    "metric_type": "gauge",
+    "data_type": "instances",
+    "description": "The number of profiler instrumentations created, tagged by the component (e.g. `component_name:calltarget`, `component_name:calltarget_interfaces`)",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "direct_log_logs": {
+    "tags": [
+      "integration_name"
+    ],
+    "metric_type": "count",
+    "data_type": "logs",
+    "description": "The number of logs sent to the direct log submission sink, tagged by IntegrationName. Includes only logs that were sent, not filtered logs",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "direct_log_queue.length": {
+    "tags": [],
+    "metric_type": "gauge",
+    "data_type": "logs",
+    "description": "The number of logs currently enqueued to the direct log submission sink",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "direct_log_api.requests": {
+    "tags": [],
+    "metric_type": "count",
+    "data_type": "requests",
+    "description": "The number of payloads sent to the endpoint",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "direct_log_api.batch_size": {
+    "tags": [],
+    "metric_type": "distribution",
+    "data_type": "logs",
+    "description": "The number of logs included in a payload patch, sent to the submission endpoint",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "direct_log_api.bytes": {
+    "tags": [],
+    "metric_type": "distribution",
+    "data_type": "bytes",
+    "description": "The size of the payload sent to the direct log submission endpoint in bytes, regardless of success",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "direct_log_api.ms": {
+    "tags": [],
+    "metric_type": "distribution",
+    "data_type": "milliseconds",
+    "description": "The time it takes to send the payload sent to the endpoint in ms",
+    "send_to_user": false
+  },
+  "direct_log_api.responses": {
+    "tags": [
+      "status_code"
+    ],
+    "metric_type": "count",
+    "data_type": "responses",
+    "description": "The number of responses received from the endpoint, tagged with status code",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "direct_log_api.errors": {
+    "tags": [
+      "type"
+    ],
+    "metric_type": "count",
+    "data_type": "requests",
+    "description": "The number of requests sent to the api endpoint that errored, tagged by the error type (e.g. Timeout, NetworkError, StatusCode)",
+    "send_to_user": false,
+    "user_tags":[]
+  },
+  "native_init_time": {
+    "tags": [
+      "component_name"
+    ],
+    "metric_type": "gauge",
+    "data_type": "milliseconds",
+    "description": "Essentially all the stats values available from the native profiler. We may potentially want to include these in the 'common' init_time metric - I'm not sure?",
+    "send_to_user": false,
+    "user_tags":[]
+  }
+}


### PR DESCRIPTION
## Summary of changes

- Rename `direct_log_queue` -> `direct_log_queue.length`
- Rename `direct_log_api.errors.responses` -> `direct_log_api.errors`
- Add tests so it doesn't happen again

## Reason for change

We were sending the wrong values in metrics, but they're not always emitted, so we missed them. 

## Implementation details

Two one-line changes + source generators to fix the bug.

## Test coverage

Added unit tests that compare the JSON metrics defined in the intake against our list of metrics. Confirmed that this test would have caught the bugs

Note that the JSON is just copy-pasted for simplicity, so it will have a tendency to drift, but I don't expect this to be a big issue in practice, as metrics should just be added to the intake, not removed.

