### PR TITLE
Fix ASM WAF benchmarks

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -71,14 +71,14 @@ public class AppSecWafBenchmark
         Waf = initResult.Waf;
     }
 
-    public IEnumerable<Dictionary<string, object>> Source()
+    public IEnumerable<NestedMap> Source()
     {
         yield return MakeNestedMap(10);
         yield return MakeNestedMap(100);
         yield return MakeNestedMap(1000);
     }
 
-    private static Dictionary<string, object> MakeNestedMap(int nestingDepth)
+    private static NestedMap MakeNestedMap(int nestingDepth)
     {
         var root = new Dictionary<string, object>();
         var map = root;
@@ -116,7 +116,7 @@ public class AppSecWafBenchmark
             map = nextMap;
         }
 
-        return root;
+        return new NestedMap(root, nestingDepth);
     }
 
     [IterationSetup]
@@ -127,5 +127,10 @@ public class AppSecWafBenchmark
 
     [Benchmark]
     [ArgumentsSource(nameof(Source))]
-    public void RunWaf(Dictionary<string, object> args) => _context.Run(args, TimeoutMicroSeconds);
+    public void RunWaf(NestedMap args) => _context.Run(args.Map, TimeoutMicroSeconds);
+
+    public record NestedMap(Dictionary<string, object> Map, int NestingDepth)
+    {
+        public override string ToString() => $"NestedMap ({NestingDepth})";
+    }
 }


### PR DESCRIPTION
## Summary of changes

- Update the ASM benchmark so it doesn't break the benchmark comparer

## Reason for change

The current implementation generates the same name for each benchmark run, breaking the comparerer.

## Implementation details

When using complex objects as arguments to a benchmark [you have to override `ToString()` to fix the display names](https://andreyakinshin.github.io/bdn-docs-wip/articles/features/parameterization.html#another-example)

## Test coverage

- [x] I'll check that the names are generated correctly in the CI run

Confirmed this fixes the naming:

- `Benchmarks.Trace.Asm.AppSecWafBenchmark.RunWaf(args: NestedMap (10))`
- `Benchmarks.Trace.Asm.AppSecWafBenchmark.RunWaf(args: NestedMap (100))`
- `Benchmarks.Trace.Asm.AppSecWafBenchmark.RunWaf(args: NestedMap (1000))`

## Other details

Broken in https://github.com/DataDog/dd-trace-dotnet/pull/4534

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
