### PR TITLE
[tracer] use 2^64-1 as the modulo in the sampling formula

### DIFF
--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -11,8 +11,9 @@ namespace Datadog.Trace.Util
     {
         private const ulong KnuthFactor = 1_111_111_111_111_111_111;
 
-        // This is intentionally not ulong.MaxValue.
-        private const ulong MaxInt64 = long.MaxValue;
+        // This needs to be 2^64-1 to match sampling in other tracing libraries and logs,
+        // regardless of the maximum trace id (which is currently 2^63-1 when 128-bit ids is disabled).
+        private const ulong Modulo = ulong.MaxValue;
 
         /// <summary>
         /// Determines if a trace should be kept based on its trace id and the given sampling rate.
@@ -32,7 +33,7 @@ namespace Datadog.Trace.Util
         /// <param name="rate">The sampling rate to apply.</param>
         /// <returns><c>true</c> if the object should be sampled (kept), <c>false</c> otherwise.</returns>
         internal static bool SampleByRate(ulong id, double rate) =>
-            ((id * KnuthFactor) % MaxInt64) <= (rate * MaxInt64);
+            ((id * KnuthFactor) % Modulo) <= (rate * Modulo);
 
         internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace) =>
             trace.Array![trace.Offset].Context.TraceContext?.SamplingPriority > 0;

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SamplingHelpersTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SamplingHelpersTests.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="SamplingHelpersTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Util;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Sampling;
+
+public class SamplingHelpersTests
+{
+    // see https://github.com/DataDog/system-tests/blob/main/tests/fixtures/sampling_rates.csv
+    [Theory]
+    [InlineData(1, 0.5, true)]                     // Test very small traceID
+    [InlineData(10, 0.5, false)]                   // Test very small traceID
+    [InlineData(100, 0.5, true)]                   // Test very small traceID
+    [InlineData(1000, 0.5, true)]                  // Test very small traceID
+    [InlineData(18444899399302180860, 0.5, false)] // Test random very large traceID
+    [InlineData(18444899399302180861, 0.5, false)] // Test random very large traceID
+    [InlineData(18444899399302180862, 0.5, true)]  // Test random very large traceID
+    [InlineData(18444899399302180863, 0.5, true)]  // Test random very large traceID
+    [InlineData(18446744073709551615, 0.5, false)] // Test the maximum traceID value 2**64-1
+    [InlineData(9223372036854775809, 0.5, false)]  // Test 2**63+1
+    [InlineData(9223372036854775807, 0.5, true)]   // Test 2**63-1
+    [InlineData(4611686018427387905, 0.5, false)]  // Test 2**62+1
+    [InlineData(4611686018427387903, 0.5, false)]  // Test 2**62-1
+    [InlineData(646771306295669658, 0.5, true)]    // random traceIDs
+    [InlineData(1882305164521835798, 0.5, true)]   // random traceIDs
+    [InlineData(5198373796167680436, 0.5, false)]  // random traceIDs
+    [InlineData(6272545487220484606, 0.5, true)]   // random traceIDs
+    [InlineData(8696342848850656916, 0.5, true)]   // random traceIDs
+    [InlineData(10197320802478874805, 0.5, true)]  // random traceIDs
+    [InlineData(10350218024687037124, 0.5, true)]  // random traceIDs
+    [InlineData(12078589664685934330, 0.5, false)] // random traceIDs
+    [InlineData(13794769880582338323, 0.5, true)]  // random traceIDs
+    [InlineData(14629469446186818297, 0.5, false)] // random traceIDs
+    public void SampleByRate(ulong traceId, double rate, bool expected)
+    {
+        SamplingHelpers.SampleByRate(traceId, rate).Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary of changes

Use 2^64-1 as the modulo in the sampling formula instead of `MAX_TRACE_ID` which is currently 2^63-1.

## Reason for change

Although the current formula has a good random distribution, we need to be consistent with other code that makes sampling decisions, such as the other tracing libraries and the Logs backend. This way if different parts make a decision based on the same trace id and sampling rate, the result is the same sampling decisions.

## Implementation details

Change `long.MaxValue` to `ulong.MaxValue` in the formula.

## Test coverage

We have tests for random distributions which should continue passing after this change. I also added the same tests that we are using in the shared tests: https://github.com/DataDog/system-tests/blob/main/tests/fixtures/sampling_rates.csv

## Other details

See also:
- https://datadoghq.atlassian.net/wiki/spaces/APM/pages/2564915820/Trace+Ingestion+Mechanisms?focusedCommentId=2576778394#From-sampling-rate-to-sampling-decision
- https://datadoghq.atlassian.net/wiki/spaces/APM/pages/2564915820/Trace+Ingestion+Mechanisms?focusedCommentId=2576778394

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
