### PR TITLE
Fix flake in StackExchange.Redis integration tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -43,7 +43,7 @@ namespace Samples.StackExchangeRedis
 
                 RunCommands(new TupleList<string, Func<object>>
                 {
-                    { "PING", () => db.PingAsync().Result },
+                    { "PING", () => db.PingAsync(CommandFlags.DemandMaster).Result },
                     { "PING_SLAVE", () => db.PingAsync(CommandFlags.DemandSlave).Result },
                     { "INCR", () => db.StringIncrement($"{prefix}INCR") },
                     { "INCR", () => db.StringIncrement($"{prefix}INCR", 1.25) },
@@ -163,7 +163,7 @@ namespace Samples.StackExchangeRedis
                 { "LockRelease", () => db.LockRelease($"{prefix}Lock", "value1") },
                 { "LockTake", () => db.LockTake($"{prefix}Lock", "value1", new TimeSpan(0, 0, 10)) },
 
-                { "Ping", () => db.Ping() },
+                { "Ping", () => db.Ping(CommandFlags.DemandMaster) },
 #if (STACKEXCHANGEREDIS_1_0_245)
                 { "Publish", () => db.Publish(ApiSafeCreateRedisChannel("value"), "message") },
 #endif

--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -24,6 +24,11 @@ namespace Samples.StackExchangeRedis
             try
             {
                 RunStackExchange(prefix);
+#if NETCOREAPP2_1
+                // Add a delay to avoid a race condition on shutdown: https://github.com/dotnet/coreclr/pull/22712
+                // This would cause a segmentation fault on .net core 2.x
+                System.Threading.Thread.Sleep(5000);
+#endif
                 return 0;
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary of changes

- Fix occasional flake in StackExchange.Redis tests by forcing ping to avoid replica
- Try to avoid connection-based flake

## Reason for change

In [a recent test flake](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=143134&view=ms.vss-test-web.build-test-results-tab), the snapshots showed the following, which suggests that the `PING` went to the wrong instance. This tries to address the issue

```diff
{
  TraceId: Id_205,
  SpanId: Id_206,
  Name: redis.command,
  Resource: PING,
  Service: Samples.StackExchange.Redis,
  Type: redis,
  Tags: {
    component: StackExchangeRedis,
    env: integration_tests,
-   out.host: stackexchangeredis,
+   out.host: stackexchangeredis-replica,
    out.port: 6379,
-   peer.service: stackexchangeredis,
+   peer.service: stackexchangeredis-replica,
    redis.raw_command: PING,
    runtime-id: Guid_1,
    span.kind: client,
    version: 1.0.0,
    _dd.p.dm: -0,
    _dd.peer.service.source: out.host
  },
}
```

Additionally, there's occasional flake due to slow connections, so take the same approach as in #4519 

## Implementation details

- Add `CommandFlags.DemandMaster` to the `PING` commands to try to avoid this issue. The default is `PreferMaster` which is why it's rare, but hopefully this eliminates it.
- Exit with code `13` if we hit a connection issue

## Test coverage

Covered by integration tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
