### PR TITLE
Allow explicitly disabling CI Visibility

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -448,18 +448,25 @@ namespace Datadog.Trace.Ci
             string? processName = null;
 
             // By configuration
-            if (Settings.Enabled)
+            if (Settings.Enabled is { } enabled)
             {
-                processName ??= GetProcessName();
-                // When is enabled by configuration we only enable it to the testhost child process if the process name is dotnet.
-                if (processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && Environment.CommandLine.IndexOf("testhost.dll", StringComparison.OrdinalIgnoreCase) == -1)
+                if (enabled)
                 {
-                    Log.Information("CI Visibility disabled because the process name is 'dotnet' but the commandline doesn't contain 'testhost.dll': {Cmdline}", Environment.CommandLine);
-                    return false;
+                    processName ??= GetProcessName();
+                    // When is enabled by configuration we only enable it to the testhost child process if the process name is dotnet.
+                    if (processName.Equals("dotnet", StringComparison.OrdinalIgnoreCase) && Environment.CommandLine.IndexOf("testhost.dll", StringComparison.OrdinalIgnoreCase) == -1)
+                    {
+                        Log.Information("CI Visibility disabled because the process name is 'dotnet' but the commandline doesn't contain 'testhost.dll': {Cmdline}", Environment.CommandLine);
+                        return false;
+                    }
+
+                    Log.Information("CI Visibility Enabled by Configuration");
+                    return true;
                 }
 
-                Log.Information("CI Visibility Enabled by Configuration");
-                return true;
+                // explicitly disabled
+                Log.Information("CI Visibility Disabled by Configuration");
+                return false;
             }
 
             // Try to autodetect based in the domain name.

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Ci.Configuration
         public CIVisibilitySettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
         {
             var config = new ConfigurationBuilder(source, telemetry);
-            Enabled = config.WithKeys(ConfigurationKeys.CIVisibility.Enabled).AsBool(false);
+            Enabled = config.WithKeys(ConfigurationKeys.CIVisibility.Enabled).AsBool();
             Agentless = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessEnabled).AsBool(false);
             Logs = config.WithKeys(ConfigurationKeys.CIVisibility.Logs).AsBool(false);
             ApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
@@ -54,9 +54,9 @@ namespace Datadog.Trace.Ci.Configuration
         }
 
         /// <summary>
-        /// Gets a value indicating whether the CI Visibility mode was enabled by configuration
+        /// Gets a value indicating whether the CI Visibility mode was explicitly enabled by configuration
         /// </summary>
-        public bool Enabled { get; }
+        public bool? Enabled { get; }
 
         /// <summary>
         /// Gets a value indicating whether the Agentless writer is going to be used.

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -17,6 +17,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -260,6 +261,7 @@ public class IastInstrumentationUnitTests : TestHelper
                 }
             }
 #endif
+            SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Enabled, "0"); // without this key, ci visibility is enabled for the samples, which we don't really want
             SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", logDirectory);
             SetEnvironmentVariable("DD_IAST_DEDUPLICATION_ENABLED", "0");
             ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, arguments: arguments, forceVsTestParam: true);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
@@ -15,8 +15,8 @@ namespace Datadog.Trace.Tests.Configuration
     public class CIVisibilitySettingsTests : SettingsTestsBase
     {
         [Theory]
-        [MemberData(nameof(BooleanTestCases), false)]
-        public void Enabled(string value, bool expected)
+        [MemberData(nameof(BooleanTestCases), null)]
+        public void Enabled(string value, bool? expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.Enabled, value));
             var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DapperTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DapperTests.cs
@@ -34,10 +34,11 @@ public class DapperTests : InstrumentationTestsBase, IDisposable
         CommandSafe = "Update books set Title = Title where Title ='" + notTaintedValue + "'";
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         dbConnection?.Close();
         dbConnection = null;
+        base.Dispose();
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFBaseTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFBaseTests.cs
@@ -30,11 +30,12 @@ public abstract class EFBaseTests : InstrumentationTestsBase, IDisposable
         queryUnsafe = "SELECT * from Books where title like '" + taintedTitle + "'";
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         db.Database.Connection.Close();
         db.Dispose();
         db = null;
+        base.Dispose();
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreBaseTests.cs
@@ -32,9 +32,10 @@ public abstract class EFCoreBaseTests: InstrumentationTestsBase, IDisposable
         queryUnsafe = "Select * from Books where title ='" + taintedTitle + "'";
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         dbContext.Database.CloseConnection();
+        base.Dispose();
     }
 
 #if NET5_0_OR_GREATER

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/Linq2DbTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/Linq2DbTests.cs
@@ -30,12 +30,13 @@ public class Linq2DbTests : InstrumentationTestsBase, IDisposable
         dataConnection = new TestDb(dbConnection.ConnectionString);
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         dataConnection.Close();
         dataConnection = null;
         dbConnection.Close();
         dbConnection = null;
+        base.Dispose();
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/MicrosoftSqLiteTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/MicrosoftSqLiteTests.cs
@@ -15,11 +15,12 @@ public class MicrosoftSqLiteTests : InstrumentationTestsBase, IDisposable
     string taintedQuery;
     string notTaintedQuery;
 
-    public void Dispose()
+    public override void Dispose()
     {
         dbConnection.Close();
         dbConnection.Dispose();
         dbConnection = null;
+        base.Dispose();
     }
 
     public MicrosoftSqLiteTests()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/MySqlTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/MySqlTests.cs
@@ -28,11 +28,12 @@ public class MySqlTests : InstrumentationTestsBase, IDisposable
         _querySafe = "SELECT * from Books where Title = '" + _notTaintedValue + "'";
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         _connection.Close();
         _connection.Dispose();
         _connection = null;
+        base.Dispose();
     }
 
     // We exclude the tests that only pass when using a real MySql Connection

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/NpgsqlTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/NpgsqlTests.cs
@@ -28,11 +28,12 @@ public class NpgsqlTests : InstrumentationTestsBase, IDisposable
         _querySafe = "SELECT * from Books where Title = '" + _notTaintedValue + "'";
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         _connection.Close();
         _connection.Dispose();
         _connection = null;
+        base.Dispose();
     }
 
     // We exclude the tests that only pass when using a real MySql Connection

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/OracleTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/OracleTests.cs
@@ -28,10 +28,6 @@ public class OracleTests : InstrumentationTestsBase, IDisposable
         _querySafe = "SELECT * from Books where Title = '" + _notTaintedValue + "'";
     }
 
-    public void Dispose()
-    {
-    }
-
     // We exclude the tests that only pass when using a real MySql Connection
     // These tests have been left here for local testing purposes with MySql installed
 

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/SqlCommandTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/SqlCommandTests.cs
@@ -23,7 +23,7 @@ public class SqlCommandTests : InstrumentationTestsBase, IDisposable
         notTaintedQuery = "SELECT * from persons where name = 'Emilio'";
     }
 
-    public void Dispose()
+    public override void Dispose()
     {
         if (databaseConnection != null)
         {
@@ -31,6 +31,7 @@ public class SqlCommandTests : InstrumentationTestsBase, IDisposable
             databaseConnection.Dispose();
             databaseConnection = null;
         }
+        base.Dispose();
     }
 
     [Fact]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/SystemDataSqLiteTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/SystemDataSqLiteTests.cs
@@ -16,11 +16,12 @@ public class SystemDataSqLiteTests : InstrumentationTestsBase, IDisposable
     string taintedQuery;
     string notTaintedQuery;
 
-    public void Dispose()
+    public override void Dispose()
     {
         dbConnection.Close();
         dbConnection.Dispose();
         dbConnection = null;
+        base.Dispose();
     }
 
     public SystemDataSqLiteTests()


### PR DESCRIPTION
## Summary of changes

- Allow disabling CI Visibility if you set `DD_CIVISIBILITY_ENABLED=0`
- Disable CI Visibility in IAST instrumented unit tests to try to avoid flake
- Update IAST instrumented tests to fix assumptions about running in ci-app

## Reason for change

We've been seeing a few strange errors in the integration logs recently (which are causing [flakey builds](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=143111&view=logs&j=69d70bba-d9b1-56bf-447f-e53558989981&t=e13308a9-9d54-5062-b1aa-2f0bc048deda)). While investigating, I discovered that this could be due to the fact that CI Visibility is being enabled for [the IAST Instrumented unit tests](https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs). Aside from whether there's an actual bug in ciapp here (will leave that to Tony to investigate), I don't believe IAST are _intending_ on using CI visibility, so it's just a side effect. 

While investigating this, I realised that there's actually no way to _disable_ ci visibility. Setting `DD_CIVISIBILITY_ENABLED=1` force enables it, but if `DD_CIVISIBILITY_ENABLED=0`, ci visibility [falls back to checking the domain](https://github.com/DataDog/dd-trace-dotnet/blob/8fd5b2ee94f4bc4b2ae694a2694d74b226ff0a7a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs#L467), with no way to override the decision! That doesn't seem right to me.

## Implementation details

As we have done with other features, make the `Enabled` setting nullable, treat the presence of the setting as an explicit enable/disable, and honor that. Only when there's no explicit setting should we fallback to trying to detect whether to enable it or not.

Explicitly passing the `DD_CIVISIBILITY_ENABLED=0` flag into the IAST instrumented tests, and updated the assumption that there would be an "ambient" span when running the test by creating our own scope.

## Test coverage
Updated the unit test for settings, but there's not an easy way to test this logic as currently written, as it depends on a lot of ambient data. It could be extracted, but opted to leave that as an exercise for the next person to look at this 😅 😬 

## Other details
I'll leave this to Tony to check what the correct behaviour actually is here (before merging!), but I'm fairly sure this looks good, and it should solve the severe flakiness we're seeing around the IAST tests
