### PR TITLE
Fix warning in sample

### DIFF
--- a/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -14,7 +14,6 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
             try
             {
                 await RunTest();
-                return 0;
             }
             catch (Exception ex)
                 when (ex.GetType().Name == "RedisConnectionException"
@@ -47,6 +46,7 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
             // This would cause a segmentation fault on .net core 2.x
             System.Threading.Thread.Sleep(5000);
 #endif
+            return 0;
         }
 
         private static async Task RunTest()


### PR DESCRIPTION
## Summary of changes

Fix warning about dead code in sample

## Reason for change

In #4519 we added a try-catch to the Redis sample project to handle flake in the connection. As part of that, we accidentally created some dead code (and removed the wait on shutdown, which was added to avoid flake too!).

## Implementation details

Return in the correct place, so that we still do the wait on shutdown

## Test coverage

Covered by existing
