### PR TITLE
Set the `Integration.Enabled` telemetry flag for direct log submission

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryConstructorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryConstructorIntegration.cs
@@ -57,7 +57,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
                 return CallTargetReturn.GetDefault();
             }
 
-            LoggerFactoryIntegrationCommon<TTarget>.AddDirectSubmissionLoggerProvider(instance);
+            if (LoggerFactoryIntegrationCommon<TTarget>.TryAddDirectSubmissionLoggerProvider(instance))
+            {
+                TracerManager.Instance.Telemetry.IntegrationGeneratedSpan(IntegrationId.ILogger);
+            }
+
             return CallTargetReturn.GetDefault();
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryConstructorNet7Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryConstructorNet7Integration.cs
@@ -49,7 +49,11 @@ public class LoggerFactoryConstructorNet7Integration
         var scopeProvider = state.State is { } rawScopeProvider
             ? rawScopeProvider.DuckCast<IExternalScopeProvider>()
             : null;
-        LoggerFactoryIntegrationCommon<TTarget>.AddDirectSubmissionLoggerProvider(instance, scopeProvider);
+        if (LoggerFactoryIntegrationCommon<TTarget>.TryAddDirectSubmissionLoggerProvider(instance, scopeProvider))
+        {
+            TracerManager.Instance.Telemetry.IntegrationGeneratedSpan(IntegrationId.ILogger);
+        }
+
         return CallTargetReturn.GetDefault();
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryIntegrationCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/LoggerFactoryIntegrationCommon.cs
@@ -65,15 +65,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
             }
         }
 
-        internal static void AddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory)
-            => AddDirectSubmissionLoggerProvider(loggerFactory, scopeProvider: null);
+        internal static bool TryAddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory)
+            => TryAddDirectSubmissionLoggerProvider(loggerFactory, scopeProvider: null);
 
-        internal static void AddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory, IExternalScopeProvider? scopeProvider)
+        internal static bool TryAddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory, IExternalScopeProvider? scopeProvider)
         {
             if (ProviderInterfaces is null)
             {
                 // there was a problem loading the assembly for some reason
-                return;
+                return false;
             }
 
             var provider = new DirectSubmissionLoggerProvider(
@@ -81,16 +81,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
                 TracerManager.Instance.DirectLogSubmission.Settings.MinimumLevel,
                 scopeProvider);
 
-            AddDirectSubmissionLoggerProvider(loggerFactory, provider);
+            return TryAddDirectSubmissionLoggerProvider(loggerFactory, provider);
         }
 
         // Internal for testing
-        internal static object? AddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory, DirectSubmissionLoggerProvider provider)
+        internal static bool TryAddDirectSubmissionLoggerProvider(TLoggerFactory loggerFactory, DirectSubmissionLoggerProvider provider)
         {
             if (ProviderInterfaces is null)
             {
                 // there was a problem loading the assembly for some reason
-                return null;
+                return false;
             }
 
             var proxy = provider.DuckImplement(ProviderInterfaces);
@@ -99,9 +99,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSu
                 var loggerFactoryProxy = loggerFactory.DuckCast<ILoggerFactory>();
                 loggerFactoryProxy.AddProvider(proxy);
                 Log.Information("Direct log submission via ILogger enabled");
+                return true;
             }
 
-            return proxy;
+            return false;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionIntegration.cs
@@ -48,11 +48,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
                 return new CallTargetReturn<TResponse>(response);
             }
 
-            var updatedResponse = Log4NetCommon<TResponse>.AddAppenderToResponse(response, DirectSubmissionLog4NetAppender.Instance);
-            if (!_logWritten)
+            if (Log4NetCommon<TResponse>.TryAddAppenderToResponse(response, DirectSubmissionLog4NetAppender.Instance, out var updatedResponse))
             {
-                _logWritten = true;
-                Log.Information("Direct log submission via Log4Net enabled");
+                if (!_logWritten)
+                {
+                    _logWritten = true;
+                    TracerManager.Instance.Telemetry.IntegrationGeneratedSpan(IntegrationId.Log4Net);
+                    Log.Information("Direct log submission via Log4Net enabled");
+                }
             }
 
             return new CallTargetReturn<TResponse>(updatedResponse);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionLegacyIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/AppenderCollectionLegacyIntegration.cs
@@ -48,11 +48,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
                 return new CallTargetReturn<TResponse>(response);
             }
 
-            var updatedResponse = Log4NetCommon<TResponse>.AddAppenderToResponse(response, DirectSubmissionLog4NetLegacyAppender.Instance);
-            if (!_logWritten)
+            if (Log4NetCommon<TResponse>.TryAddAppenderToResponse(response, DirectSubmissionLog4NetLegacyAppender.Instance, out var updatedResponse))
             {
-                _logWritten = true;
-                Log.Information("Direct log submission via Log4Net Legacy enabled");
+                if (!_logWritten)
+                {
+                    _logWritten = true;
+                    TracerManager.Instance.Telemetry.IntegrationGeneratedSpan(IntegrationId.Log4Net);
+                    Log.Information("Direct log submission via Log4Net Legacy enabled");
+                }
             }
 
             return new CallTargetReturn<TResponse>(updatedResponse);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/DirectSubmission/Log4NetCommon.cs
@@ -23,13 +23,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
             AppenderElementType = typeof(TResponseArray).GetElementType()!;
         }
 
-        public static TResponseArray AddAppenderToResponse<TAppender>(TResponseArray originalResponseArray, TAppender appender)
+        public static bool TryAddAppenderToResponse<TAppender>(TResponseArray originalResponseArray, TAppender appender, out TResponseArray updatedResponseArray)
         {
             try
             {
                 if (originalResponseArray is null)
                 {
-                    return originalResponseArray;
+                    updatedResponseArray = originalResponseArray;
+                    return false;
                 }
 
                 var originalArray = (Array)(object)originalResponseArray;
@@ -46,19 +47,22 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSu
                     if (appender is null)
                     {
                         Log.Error("Error adding Log4Net appender to response: appender is null");
-                        return originalResponseArray;
+                        updatedResponseArray = originalResponseArray;
+                        return false;
                     }
 
                     _appenderProxy = appender.DuckImplement(AppenderElementType);
                 }
 
                 finalArray.SetValue(_appenderProxy, finalArray.Length - 1);
-                return (TResponseArray)(object)finalArray;
+                updatedResponseArray = (TResponseArray)(object)finalArray;
+                return true;
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Error adding Log4Net appender to response");
-                return originalResponseArray;
+                updatedResponseArray = originalResponseArray;
+                return false;
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/LogFactoryGetConfigurationForLoggerInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/DirectSubmission/LogFactoryGetConfigurationForLoggerInstrumentation.cs
@@ -46,11 +46,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmi
         /// <returns>Calltarget state value</returns>
         public static CallTargetState OnMethodBegin<TTarget, TLoggingConfiguration>(TTarget instance, string name, TLoggingConfiguration configuration)
         {
-            if (TracerManager.Instance.DirectLogSubmission.Settings.IsIntegrationEnabled(IntegrationId.NLog)
+            var tracerManager = TracerManager.Instance;
+            if (tracerManager.DirectLogSubmission.Settings.IsIntegrationEnabled(IntegrationId.NLog)
              && configuration is not null)
             {
                 // if configuration is not-null, we've already checked that NLog is enabled
-                NLogCommon<TTarget>.AddDatadogTarget(configuration);
+                var wasAdded = NLogCommon<TTarget>.AddDatadogTarget(configuration);
+                if (wasAdded)
+                {
+                    // Not really generating a span, but the point is it's enabled and added
+                    tracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId.NLog);
+                }
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerConfigurationInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/DirectSubmission/LoggerConfigurationInstrumentation.cs
@@ -79,6 +79,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.DirectSu
 
                 var proxy = sink.DuckImplement(targetType);
                 instance.LogEventSinks.Add(proxy);
+                TracerManager.Instance.Telemetry.IntegrationGeneratedSpan(IntegrationId.Serilog);
                 Log.Information("Direct log submission via Serilog enabled");
             }
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -98,8 +98,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 SetEnvironmentVariable("Logging__Datadog__LogLevel__LogsInjection.ILogger.Startup", "Warning");
             }
 
-            var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = MockTracerAgent.Create(Output, agentPort);
+            using var telemetry = this.ConfigureTelemetry();
+            using var agent = EnvironmentHelper.GetMockAgent();
             using var processResult = RunSampleAndWaitForExit(agent, aspNetCorePort: 0);
 
             ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
@@ -134,6 +134,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 .HaveCount(expectedLogCount);
 
             VerifyInstrumentation(processResult.Process);
+            telemetry.AssertIntegrationEnabled(IntegrationId.ILogger);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -160,8 +160,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Log4Net), hostName);
 
-            var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = MockTracerAgent.Create(Output, agentPort);
+            using var telemetry = this.ConfigureTelemetry();
+            using var agent = EnvironmentHelper.GetMockAgent();
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
             ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
@@ -195,6 +195,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             VerifyInstrumentation(processResult.Process);
+            telemetry.AssertIntegrationEnabled(IntegrationId.Log4Net);
         }
 
         private static bool PackageSupportsLogsInjection(string packageVersion)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -158,6 +158,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             SetInstrumentationVerification();
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            SetEnvironmentVariable("INCLUDE_CROSS_DOMAIN_CALL", "false");
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Log4Net), hostName);
 
             using var telemetry = this.ConfigureTelemetry();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -156,6 +156,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             SetInstrumentationVerification();
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            SetEnvironmentVariable("INCLUDE_CROSS_DOMAIN_CALL", "false");
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.NLog), hostName);
 
             using var telemetry = this.ConfigureTelemetry();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -158,8 +158,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.NLog), hostName);
 
-            var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = MockTracerAgent.Create(Output, agentPort);
+            using var telemetry = this.ConfigureTelemetry();
+            using var agent = EnvironmentHelper.GetMockAgent();
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: context);
 
             ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
@@ -196,6 +196,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 };
                 logs.Should().Contain(x => hasProperty(x, CustomContextKey, CustomContextValue));
             }
+
+            telemetry.AssertIntegrationEnabled(IntegrationId.NLog);
         }
 
         private void VerifyContextProperties(LogFileTest[] testFiles, string packageVersion, string context)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -124,6 +124,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetInstrumentationVerification();
             SetSerilogConfiguration(loadFromConfig);
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
+            SetEnvironmentVariable("INCLUDE_CROSS_DOMAIN_CALL", "false");
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Serilog), hostName);
 
             using var telemetry = this.ConfigureTelemetry();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -126,8 +126,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
             EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.Serilog), hostName);
 
-            var agentPort = TcpPortProvider.GetOpenPort();
-            using var agent = MockTracerAgent.Create(Output, agentPort);
+            using var telemetry = this.ConfigureTelemetry();
+            using var agent = EnvironmentHelper.GetMockAgent();
             using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
             ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
@@ -153,6 +153,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.TraceId))
                .And.OnlyContain(x => !string.IsNullOrEmpty(x.SpanId));
             VerifyInstrumentation(processResult.Process);
+            telemetry.AssertIntegrationEnabled(IntegrationId.Serilog);
         }
 
         private void SetSerilogConfiguration(bool loadFromConfig)

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
         {
             var factory = new LoggerFactory();
             var loggerProvider = new DirectSubmissionLoggerProvider(new NullDirectSubmissionLogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug, scopeProvider: null);
-            LoggerFactoryIntegrationCommon<LoggerFactory>.TryAddDirectSubmissionLoggerProvider(factory, loggerProvider);
+            LoggerFactoryIntegrationCommon<LoggerFactory>.TryAddDirectSubmissionLoggerProvider(factory, loggerProvider).Should().BeTrue();
         }
 
         public sealed class DummyOptionsMonitor : IOptionsMonitor<ConsoleLoggerOptions>

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/ILogger/ILoggerDuckTypingTests.cs
@@ -145,7 +145,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.IL
         {
             var factory = new LoggerFactory();
             var loggerProvider = new DirectSubmissionLoggerProvider(new NullDirectSubmissionLogSink(), LogSettingsHelper.GetFormatter(), DirectSubmissionLogLevel.Debug, scopeProvider: null);
-            LoggerFactoryIntegrationCommon<LoggerFactory>.AddDirectSubmissionLoggerProvider(factory, loggerProvider);
+            LoggerFactoryIntegrationCommon<LoggerFactory>.TryAddDirectSubmissionLoggerProvider(factory, loggerProvider);
         }
 
         public sealed class DummyOptionsMonitor : IOptionsMonitor<ConsoleLoggerOptions>

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetDuckTypingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/AutoInstrumentation/Logging/Log4Net/Log4NetDuckTypingTests.cs
@@ -16,10 +16,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Lo
         public void CanIncreaseSizeOfIAppenderArray()
         {
             var appenders = new IAppender[] { };
-            var results = Log4NetCommon<IAppender[]>.AddAppenderToResponse(
+            var success = Log4NetCommon<IAppender[]>.TryAddAppenderToResponse(
                 appenders,
-                new DirectSubmissionLog4NetAppender(null, 0));
+                new DirectSubmissionLog4NetAppender(null, 0),
+                out var results);
 
+            success.Should().BeTrue();
             results.Length.Should().Be(1);
         }
 
@@ -27,10 +29,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests.AutoInstrumentation.Logging.Lo
         public void CanWriteLogToAppender()
         {
             var appenders = new IAppender[] { };
-            var results = Log4NetCommon<IAppender[]>.AddAppenderToResponse(
+            var success = Log4NetCommon<IAppender[]>.TryAddAppenderToResponse(
                 appenders,
-                new DirectSubmissionLog4NetAppender(null, 0));
+                new DirectSubmissionLog4NetAppender(null, 0),
+                out var results);
 
+            success.Should().BeTrue();
             results.Length.Should().Be(1);
 
             foreach (var result in results)

--- a/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
+++ b/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/LoggingMethods.cs
@@ -25,12 +25,21 @@ namespace PluginApplication
         public static int RunLoggingProcedure(Action<string> logAction)
         {
 #if NETFRAMEWORK
-            // Set up the secondary AppDomain first
-            // The plugin application we'll call was built and copied to the ApplicationFiles subdirectory
-            // Create an AppDomain with that directory as the appBasePath
-            var entryDirectory = Directory.GetParent(Assembly.GetEntryAssembly().Location);
-            var applicationFilesDirectory = Path.Combine(entryDirectory.FullName, "ApplicationFiles");
-            var applicationAppDomain = AppDomain.CreateDomain("ApplicationAppDomain", null, applicationFilesDirectory, applicationFilesDirectory, false);
+            var includeCrossDomainCall = Environment.GetEnvironmentVariable("INCLUDE_CROSS_DOMAIN_CALL") != "false";
+            
+            DirectoryInfo entryDirectory;
+            string applicationFilesDirectory;
+            AppDomain applicationAppDomain = null;
+
+            if (includeCrossDomainCall)
+            {
+                // Set up the secondary AppDomain first
+                // The plugin application we'll call was built and copied to the ApplicationFiles subdirectory
+                // Create an AppDomain with that directory as the appBasePath
+                entryDirectory = Directory.GetParent(Assembly.GetEntryAssembly().Location);
+                applicationFilesDirectory = Path.Combine(entryDirectory.FullName, "ApplicationFiles");
+                applicationAppDomain = AppDomain.CreateDomain("ApplicationAppDomain", null, applicationFilesDirectory, applicationFilesDirectory, false);
+            }
 #endif
 
             // Do not explicitly set LogsInjectionEnabled = true, use DD_LOGS_INJECTION environment variable to enable
@@ -54,8 +63,16 @@ namespace PluginApplication
                     // System.Runtime.Remoting.Messaging.CallContext:
                     // System.Runtime.Serialization.SerializationException: Type is not resolved for member 'log4net.Util.PropertiesDictionary,log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a'.
 #if NETFRAMEWORK
-                    logAction("Calling the PluginApplication.Program in a separate AppDomain");
-                    AppDomainProxy.Call(applicationAppDomain, "PluginApplication", "PluginApplication.Program", "Invoke", null);
+                    if (includeCrossDomainCall)
+                    {
+                        logAction("Calling the PluginApplication.Program in a separate AppDomain");
+                        AppDomainProxy.Call(applicationAppDomain, "PluginApplication", "PluginApplication.Program", "Invoke", null);
+                    }
+                    else
+                    {
+                        logAction("Skipping the cross-AppDomain call as INCLUDE_CROSS_DOMAIN_CALL=false");
+                        
+                    }
 #else
                     logAction("Skipping the cross-AppDomain call on .NET Core");
 #endif
@@ -63,7 +80,10 @@ namespace PluginApplication
 
                 logAction($"{ExcludeMessagePrefix}Exited Datadog scope.");
 #if NETFRAMEWORK
-                AppDomain.Unload(applicationAppDomain);
+                if (includeCrossDomainCall)
+                {
+                    AppDomain.Unload(applicationAppDomain);
+                }
 #endif
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary of changes

When we add an appender/sink/target for direct log submission, mark the corresponding integration as enabled.

## Reason for change

For the majority of integrations, we don't mark the integration as enabled until it's generated a span. Given that direct log submission loggers _never_ generate spans, they were never being marked enabled. 

## Implementation details

When the appender/sink/target is successfully added to the logging framework, marks calls `Telemetry.IntegrationGeneratedSpan(IntegrationId)` to mark the integration as enabled.

Note that we _only_ do this for direct log submission, not for log context injection, because
- Apps potentially write a lot of logs on hot paths so we avoid taking the (tiny) perf hit
- Log context injection is enabled/disabled _only_ based on `DD_LOGS_INJECTION_ENABLED`. The context injectors don't check the value of `DD_TRACE_NLog_Enabled` (for example), so it doesn't really make sense to mark the integration as enabled/disabled 

## Test coverage

Updated the existing direct log submission tests to check that the telemetry value is set. Confirmed that each of these tests failed before making the fix (and passed afterwards obvs)
