### PR TITLE
[ASM] DecompileDelegate lib bugfix

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1035,14 +1035,13 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                     const void* attribute_data = nullptr; // Pointer to receive attribute data, which is not needed for our purposes
                     DWORD data_size = 0;
 
-                    hr = metadata_import->GetCustomAttributeProps(customAttribute, &parent_token, &attribute_ctor_token,
-                                                                  &attribute_data, &data_size);
+                    hr = metadata_import->GetCustomAttributeProps(customAttribute, &parent_token, &attribute_ctor_token, &attribute_data, &data_size);
 
                     // We are only concerned with the trace attribute on method definitions
                     if (TypeFromToken(parent_token) == mdtMethodDef)
                     {
                         mdTypeDef attribute_type_token = mdTypeDefNil;
-                        WCHAR function_name[kNameMaxSize]{};
+                        WCHAR function_name[1024]{};
                         DWORD function_name_len = 0;
 
                         // Get the type name from the constructor

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1035,13 +1035,14 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                     const void* attribute_data = nullptr; // Pointer to receive attribute data, which is not needed for our purposes
                     DWORD data_size = 0;
 
-                    hr = metadata_import->GetCustomAttributeProps(customAttribute, &parent_token, &attribute_ctor_token, &attribute_data, &data_size);
+                    hr = metadata_import->GetCustomAttributeProps(customAttribute, &parent_token, &attribute_ctor_token,
+                                                                  &attribute_data, &data_size);
 
                     // We are only concerned with the trace attribute on method definitions
                     if (TypeFromToken(parent_token) == mdtMethodDef)
                     {
                         mdTypeDef attribute_type_token = mdTypeDefNil;
-                        WCHAR function_name[1024]{};
+                        WCHAR function_name[kNameMaxSize]{};
                         DWORD function_name_len = 0;
 
                         // Get the type name from the constructor

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -78,6 +78,7 @@ static const WSTRING _fixedAssemblyExcludeFilters[] = {
     WStr("vstest.console"),
     WStr("testhost.*"),
     WStr("Oracle.ManagedDataAccess"),
+    WStr("DelegateDecompiler*"),
     LastEntry, // Can't have an empty array. This must be the last element
 };
 static const WSTRING _fixedMethodIncludeFilters[] = {
@@ -103,6 +104,10 @@ static const WSTRING _fixedMethodExcludeFilters[] = {
     WStr("System.ServiceModel*"),
     WStr("System.Web.Http*"),
     WStr("MongoDB.*"),
+    LastEntry, // Can't have an empty array. This must be the last element
+};
+static const WSTRING _fixedMethodAttributeExcludeFilters[] = {
+    WStr("DelegateDecompiler.ComputedAttribute"),
     LastEntry, // Can't have an empty array. This must be the last element
 };
 
@@ -203,6 +208,13 @@ HRESULT Dataflow::Init()
             {
                 _methodExcludeFilters.push_back(_fixedMethodExcludeFilters[x]);
             }
+
+            // Method attribute filters
+            for (int x = 0; _fixedMethodAttributeExcludeFilters[x] != LastEntry; x++)
+            {
+                _methodAttributeExcludeFilters.push_back(_fixedMethodAttributeExcludeFilters[x]);
+            }
+
         //});
     }
     catch (std::exception& err)
@@ -441,10 +453,19 @@ bool Dataflow::IsAssemblyExcluded(const WSTRING& assemblyName, MatchResult* incl
 {
     return IsExcluded(_assemblyIncludeFilters, _assemblyExcludeFilters, assemblyName, includedMatch, excludedMatch);
 }
-bool Dataflow::IsMethodExcluded(const WSTRING& signature, MatchResult* includedMatch, MatchResult* excludedMatch)
+bool Dataflow::IsMethodExcluded(const WSTRING& methodSignature, MatchResult* includedMatch, MatchResult* excludedMatch)
 {
-    return IsExcluded(_methodIncludeFilters, _methodExcludeFilters, signature, includedMatch, excludedMatch);
+    return IsExcluded(_methodIncludeFilters, _methodExcludeFilters, methodSignature, includedMatch, excludedMatch);
 }
+bool Dataflow::IsMethodAttributeExcluded(const WSTRING& attributeName, MatchResult* includedMatch, MatchResult* excludedMatch)
+{
+    return IsExcluded(_methodAttributeIncludeFilters, _methodAttributeExcludeFilters, attributeName, includedMatch, excludedMatch);
+}
+bool Dataflow::HasMethodAttributeExclusions()
+{
+    return _methodAttributeExcludeFilters.size() > 0;
+}
+
 
 ICorProfilerInfo* Dataflow::GetCorProfilerInfo()
 {

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.h
@@ -63,6 +63,8 @@ namespace iast
         std::vector<WSTRING> _assemblyExcludeFilters;
         std::vector<WSTRING> _methodIncludeFilters;
         std::vector<WSTRING> _methodExcludeFilters;
+        std::vector<WSTRING> _methodAttributeIncludeFilters;
+        std::vector<WSTRING> _methodAttributeExcludeFilters;
 
         bool _traceJitMethods = false;
 
@@ -101,8 +103,11 @@ namespace iast
                                  MatchResult* excludedMatch = nullptr);
         bool IsAssemblyExcluded(const WSTRING& assemblyName, MatchResult* includedMatch = nullptr,
                                 MatchResult* excludedMatch = nullptr);
-        bool IsMethodExcluded(const WSTRING& signature, MatchResult* includedMatch = nullptr,
+        bool IsMethodExcluded(const WSTRING& methodSignature, MatchResult* includedMatch = nullptr,
                               MatchResult* excludedMatch = nullptr);
+        bool IsMethodAttributeExcluded(const WSTRING& attributeName, MatchResult* includedMatch = nullptr,
+                              MatchResult* excludedMatch = nullptr);
+        bool HasMethodAttributeExclusions();
 
         AppDomainInfo* GetAppDomain(AppDomainID id);
         ModuleInfo* GetModuleInfo(ModuleID moduleId);

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -255,6 +255,18 @@ namespace iast
         if (_isExcluded < 0)
         {
             _isExcluded = _module->_dataflow->IsMethodExcluded(GetFullName());
+            if (!_isExcluded && _module->_dataflow->HasMethodAttributeExclusions())
+            {
+                for (auto methodAttribute : GetCustomAttributes())
+                {
+                    if (_module->_dataflow->IsMethodAttributeExcluded(methodAttribute))
+                    {
+                        _isExcluded = true;
+                        break;
+                    }
+                }
+            
+            }
         }
         return _isExcluded;
     }
@@ -526,4 +538,10 @@ namespace iast
         _nMethodIL = 0;
         DEL_ARR(_pMethodIL);
     }
+
+    std::vector<WSTRING> MethodInfo::GetCustomAttributes()
+    {
+        return _module->GetCustomAttributes(_id);
+    }
+
 }

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -579,8 +579,7 @@ namespace iast
                 {
                     continue;
                 }
-                auto propAttrs = _module->GetCustomAttributes(property->GetPropertyId());
-                return propAttrs;
+                AddRange(res, _module->GetCustomAttributes(property->GetPropertyId()));
             }
         }
         return res;

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.h
@@ -64,6 +64,7 @@ namespace iast
         virtual SignatureInfo* GetSignature();
         ULONG GetParameterCount();
         CorElementType GetReturnCorType();
+        virtual std::vector<WSTRING> GetCustomAttributes();
 
     private:
         std::atomic<unsigned char> _fullNameCounterLock;
@@ -93,6 +94,21 @@ namespace iast
         FieldInfo(ModuleInfo* pModuleInfo, mdFieldDef fieldDef);
 
         mdFieldDef GetFieldDef();
+    };
+
+    class PropertyInfo : public MemberRefInfo
+    {
+        friend class ILRewriter;
+        friend class ModuleInfo;
+    protected:
+        mdMethodDef _getter;
+        mdMethodDef _setter;
+    public:
+        PropertyInfo(ModuleInfo* pModuleInfo, mdProperty mdProperty);
+
+        inline mdProperty GetPropertyId() { return _id; }
+        inline mdMethodDef GetGetterId() { return _getter; }
+        inline mdMethodDef GetSetterId() { return _setter; }
     };
 
     class MethodInfo : public MemberRefInfo
@@ -148,6 +164,7 @@ namespace iast
 
         void DumpIL(std::string message = "", ULONG pnMethodIL = 0, LPCBYTE pMethodIL = nullptr);
 
-        std::vector<WSTRING> GetCustomAttributes();
+        bool IsPropertyAccessor();
+        std::vector<WSTRING> GetCustomAttributes() override;
     };
 }

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.h
@@ -147,5 +147,7 @@ namespace iast
         void ReJITCompilationFinished();
 
         void DumpIL(std::string message = "", ULONG pnMethodIL = 0, LPCBYTE pMethodIL = nullptr);
+
+        std::vector<WSTRING> GetCustomAttributes();
     };
 }

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -835,4 +835,122 @@ mdToken ModuleInfo::DefineMemberRef(const WSTRING& moduleName, const WSTRING& ty
         return 0;
     }
 }
+
+std::vector<WSTRING> ModuleInfo::GetCustomAttributes(mdToken token)
+{
+    std::vector<WSTRING> res;
+
+    HCORENUM hCorEnum = nullptr;
+    mdCustomAttribute enumeratedElements[64];
+    ULONG enumCount;
+
+    while (_metadataImport->EnumCustomAttributes(&hCorEnum, token, mdTokenNil, enumeratedElements,
+                                                sizeof(enumeratedElements) / sizeof(enumeratedElements[0]),
+                                                &enumCount) == S_OK)
+    {
+        mdToken attributeParentToken = mdTokenNil;
+        mdToken attributeCtorToken = mdTokenNil;
+        const void* attribute_data = nullptr; // Pointer to receive attribute data, which is not needed for our purposes
+        DWORD data_size = 0;
+
+        for (ULONG i = 0; i < enumCount; i++)
+        {
+            HRESULT hr = _metadataImport->GetCustomAttributeProps(enumeratedElements[i], &attributeParentToken,
+                                                                 &attributeCtorToken, &attribute_data, &data_size);
+            if (SUCCEEDED(hr))
+            {
+                auto attrCtor = GetMemberRefInfo(attributeCtorToken);
+                res.push_back(attrCtor->GetTypeName());
+            }
+        }
+    }
+
+    _metadataImport->CloseEnum(hCorEnum);
+    return res;
+
+    /*
+
+            // Now we enumerate all custom attributes in this method
+            auto metadata_import = _module->_metadataImport;
+            auto enumCustomAttributes = Enumerator<mdCustomAttribute>(
+                [&metadata_import](HCORENUM* ptr, mdCustomAttribute arr[], ULONG max, ULONG* cnt) -> HRESULT {
+                    return metadata_import->EnumCustomAttributes(ptr, mdTokenNil, mdTokenNil, arr, max, cnt);
+                },
+                [&metadata_import](HCORENUM ptr) -> void { metadata_import->CloseEnum(ptr); });
+            auto customAttributesIterator = enumCustomAttributes.begin();
+
+            while (customAttributesIterator != enumCustomAttributes.end())
+            {
+                mdCustomAttribute customAttribute = *customAttributesIterator;
+
+                // Check if the typeref matches
+                mdToken parent_token = mdTokenNil;
+                mdToken attribute_ctor_token = mdTokenNil;
+                const void* attribute_data = nullptr; // Pointer to receive attribute data, which is not needed for our
+       purposes DWORD data_size = 0;
+
+                HRESULT hr = metadata_import->GetCustomAttributeProps(customAttribute, &parent_token,
+       &attribute_ctor_token, &attribute_data, &data_size);
+
+                // We are only concerned with the trace attribute on method definitions
+                if (TypeFromToken(parent_token) == mdtMethodDef)
+                {
+                    mdTypeDef attribute_type_token = mdTypeDefNil;
+                    WCHAR function_name[1024]{};
+                    DWORD function_name_len = 0;
+
+                    // Get the type name from the constructor
+                    const auto attribute_ctor_token_type = TypeFromToken(attribute_ctor_token);
+                    if (attribute_ctor_token_type == mdtMemberRef)
+                    {
+                        hr = metadata_import->GetMemberRefProps(attribute_ctor_token, &attribute_type_token,
+       function_name, 1024, &function_name_len, nullptr, nullptr);
+                    }
+                    else if (attribute_ctor_token_type == mdtMethodDef)
+                    {
+                        hr = metadata_import->GetMemberProps(attribute_ctor_token, &attribute_type_token, function_name,
+       1024, &function_name_len, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+                    }
+                    else
+                    {
+                        hr = E_FAIL;
+                    }
+
+                    if (SUCCEEDED(hr))
+                    {
+                        mdToken resolution_token = mdTokenNil;
+                        WCHAR type_name[1024]{};
+                        DWORD type_name_len = 0;
+
+                        const auto token_type = TypeFromToken(attribute_type_token);
+                        if (token_type == mdtTypeDef)
+                        {
+                            DWORD type_flags;
+                            mdToken type_extends = mdTokenNil;
+                            hr = metadata_import->GetTypeDefProps(attribute_type_token, type_name, 1024, &type_name_len,
+       &type_flags, &type_extends);
+                        }
+                        else if (token_type == mdtTypeRef)
+                        {
+                            hr = metadata_import->GetTypeRefProps(attribute_type_token, &resolution_token, type_name,
+       1024, &type_name_len);
+                        }
+                        else
+                        {
+                            type_name_len = 0;
+                        }
+
+                        WSTRING attributeName = type_name;
+                        res.push_back(attributeName);
+                    }
+                }
+
+                customAttributesIterator = ++customAttributesIterator;
+            }
+
+            return res;
+    */
+}
+
+
 } // namespace iast

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.h
@@ -17,6 +17,7 @@ namespace iast
     class MethodSpec;
     class MethodInfo;
     class FieldInfo;
+    class PropertyInfo;
     class DataflowAspect;
     class DataflowAspectReference;
     class AspectFilter;

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.h
@@ -53,6 +53,7 @@ namespace iast
         std::unordered_map<mdMemberRef, MemberRefInfo*> _members;
         std::unordered_map<mdMethodDef, MethodInfo*> _methods;
         std::unordered_map<mdMethodDef, FieldInfo*> _fields;
+        std::unordered_map<mdProperty, PropertyInfo*> _properties;
         std::unordered_map<mdMethodSpec, MethodSpec*> _specs;
         std::unordered_map<mdSignature, SignatureInfo*> _signatures;
 
@@ -119,6 +120,7 @@ namespace iast
         MemberRefInfo* GetMemberRefInfo(mdMemberRef token);
         MethodInfo* GetMethodInfo(mdMethodDef methodDef);
         FieldInfo* GetFieldInfo(mdFieldDef fieldDef);
+        PropertyInfo* GetPropertyInfo(mdProperty propId);
         MethodSpec* GetMethodSpec(mdMethodSpec methodSpec);
         SignatureInfo* GetSignature(mdSignature sigToken);
         WSTRING GetUserString(mdString token);
@@ -127,6 +129,8 @@ namespace iast
         std::vector<MethodInfo*> GetMethods(mdTypeDef typeDef, const WSTRING& name);
         std::vector<MethodInfo*> GetMethods(mdTypeDef typeDef, const WSTRING& methodName, ULONG paramCount);
         std::vector<MethodInfo*> GetMethods(const WSTRING& typeName, const WSTRING& methodName);
+
+        std::vector<PropertyInfo*> GetProperties(mdTypeDef typeDef);
 
         MethodInfo* GetMethod(const WSTRING& typeName, const WSTRING& methodName, PCCOR_SIGNATURE pSignature, ULONG nSignature);
         MethodInfo* GetMethod(mdTypeDef typeDef, const WSTRING& methodName, PCCOR_SIGNATURE pSignature, ULONG nSignature);

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.h
@@ -30,10 +30,12 @@ namespace iast
         friend class Dataflow;
         friend class ILRewriter;
         friend class TypeInfo;
+        friend class MemberInfo;
         friend class MemberRefInfo;
         friend class MethodSpec;
         friend class MethodInfo;
         friend class FieldInfo;
+        friend class PropertyInfo;
         friend class DataflowAspectClass;
         friend class DataflowAspect;
         friend class DataflowAspectReference;
@@ -142,5 +144,7 @@ namespace iast
 
         HRESULT FindMemberRefsByName(mdTypeRef typeRef, const WSTRING& memberName, std::vector<mdMemberRef>& members);
         HRESULT GetAssemblyTypeRef(const WSTRING& assemblyName, const WSTRING& typeName, mdTypeRef* typeRef);
+
+        std::vector<WSTRING> GetCustomAttributes(mdToken token);
     };
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="DelegateDecompiler" Version="0.32.0" />
     <PackageReference Include="FluentAssertions" Version="6.4.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSDKVersion)" />

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/TestClasses.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/TestClasses.cs
@@ -5,4 +5,11 @@ public class Book
     public string Id { get; set; }
     public string Title { get; set; }
     public string Author { get; set; }
+
+    [DelegateDecompiler.Computed]
+    public string FullTitle
+    {
+        [DelegateDecompiler.Computed]
+        get => Title + "_";
+    }
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/TestClasses.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/TestClasses.cs
@@ -7,9 +7,20 @@ public class Book
     public string Author { get; set; }
 
     [DelegateDecompiler.Computed]
+    public string FullId
+    {
+        get => Id + "-" + Title + "-" + Author;
+    }
+
     public string FullTitle
     {
-        // [DelegateDecompiler.Computed]
+        [DelegateDecompiler.Computed]
         get => Title + "_";
     }
+
+    public string FullAuthor
+    {
+        get => "_" + Author;
+    }
+
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/TestClasses.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/DabaseHelpers/TestClasses.cs
@@ -9,7 +9,7 @@ public class Book
     [DelegateDecompiler.Computed]
     public string FullTitle
     {
-        [DelegateDecompiler.Computed]
+        // [DelegateDecompiler.Computed]
         get => Title + "_";
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFTests.cs
@@ -4,6 +4,7 @@ using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Infrastructure;
 using System.Data.SqlClient;
 using System.Linq;
+using DelegateDecompiler;
 using FluentAssertions;
 using Xunit;
 
@@ -51,5 +52,21 @@ public class EFTests : EFBaseTests
         var query = new EntityCommand(queryString, conn);
         return query;
     }
+
+    [Fact]
+    public void TestDelegateDecompileLibBug()
+    {
+        var book = new Book { Id = "id", Title = "title", Author = "author" };
+        var ft = book.FullTitle;
+        var books = (db as ApplicationDbContext).Books;
+        var decompiled = books.Decompile();
+        var any = decompiled.Any(x => x.FullTitle != ft);
+        //var data = (db as ApplicationDbContext).Books.Decompile().Where(x => x.FullTitle != "eeef").ToList();
+        if (any)
+        {
+
+        }
+    }
+
 }
 #endif

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFTests.cs
@@ -1,4 +1,5 @@
 #if !NETCOREAPP2_1
+using System;
 using System.Data;
 using System.Data.Entity.Core.EntityClient;
 using System.Data.Entity.Infrastructure;
@@ -54,19 +55,47 @@ public class EFTests : EFBaseTests
     }
 
     [Fact]
-    public void TestDelegateDecompileLibBug()
+    public void TestDelegateDecompileLibBug_PropertyAttribute()
     {
-        var book = new Book { Id = "id", Title = "title", Author = "author" };
-        var ft = book.FullTitle;
-        var books = (db as ApplicationDbContext).Books;
-        var decompiled = books.Decompile();
-        var any = decompiled.Any(x => x.FullTitle != ft);
-        //var data = (db as ApplicationDbContext).Books.Decompile().Where(x => x.FullTitle != "eeef").ToList();
-        if (any)
-        {
-
-        }
+        var all = (db as ApplicationDbContext).Books.ToList();
+        all.Count.Should().Be(2);
+        var book = all[1];
+        var txt = book.FullId;
+        var res = (db as ApplicationDbContext).Books.Decompile().Where(x => x.FullId == txt).ToList();
+        res.Count().Should().Be(1);
     }
+
+    [Fact]
+    public void TestDelegateDecompileLibBug_PropertyGetterAttribute()
+    {
+        // DecompileDelegate does not support the use of the attribute only on the getter
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var all = (db as ApplicationDbContext).Books.ToList();
+            all.Count.Should().Be(2);
+            var book = all[1];
+            var txt = book.FullTitle;
+            var res = (db as ApplicationDbContext).Books.Decompile().Where(x => x.FullTitle == txt).ToList();
+            res.Count().Should().Be(1);
+        });
+    }
+
+
+    [Fact]
+    public void TestDelegateDecompileLibBug_NoAttribute()
+    {
+        // We don't support this scenario
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            var all = (db as ApplicationDbContext).Books.ToList();
+            all.Count.Should().Be(2);
+            var book = all[1];
+            var txt = book.FullAuthor;
+            var res = (db as ApplicationDbContext).Books.Decompile().Where(x => x.FullAuthor == txt).ToList();
+            res.Count().Should().Be(1);
+        });
+    }
+
 
 }
 #endif


### PR DESCRIPTION
## Summary of changes

Added the capability to exclude methods from Dataflow based on their decoration attributes 

## Reason for change

A nasty bug found on SpotFreight client, while making a LINQ to Entities query. It crashed with an "unsupported exception" because we replaced the system Concat function with out own aspect.

## Implementation details

The solution consist in ignoring the methods (or properties) decorated with the `DelegateDecompiler.ComputedAttribute` attribute, so the `DelegateDecompiler` library does not crash.

## Test coverage

Added a test case reproducing the bug

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
