### PR TITLE
Add a GH action for forcing required checks for version-bump PR to success

### DIFF
--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -1,0 +1,38 @@
+name: Override version bump PR checks
+
+on:
+  workflow_dispatch:
+
+jobs:
+  override_checks:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    steps:
+      - name: Fail if branch is not version-bump PR
+        if: ${{ !startsWith(github.ref, 'version-bump-') }}
+        run: |
+          echo "This workflow should only be triggered on the version-bump-x.x.x branch
+          exit 1
+
+      - run: |
+          set -o pipefail
+
+          # These checks won't run automatically on the version bump PR, so need to force this
+          contexts=("code_freeze" "verify_source_generators" "verify_app_trimming_descriptor_generator")
+
+          sha="${{ github.head_ref }}"
+          targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/override_version_bump_pr_checks.yml"
+          state="success"
+          description="Forced override (via GitHub Action)"
+          
+          for context in ${contexts[@]}; do
+            echo "Forcing check check status to $state for $context"
+          
+            curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer ${{ env.github_token }}" \
+              "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
+              -d '{"state":"'"$state"'","context":"'"context"'","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
+          done


### PR DESCRIPTION
## Summary of changes

Allow forcing the checks on the version-bump PR to `success`

## Reason for change

The version-bump PR is created automatically. That means that the standard GitHub Actions _don't_ run automatically, even though they're required for merging. This allows a way around the issue without using admin-mode

## Implementation details

Create a new manual-dispatch workflow that forces the checks. Only allowed on `version-bump*` PRs.

## Test coverage

Can't test this until _after_ I merge it to master 🙄 
