### PR TITLE
[ASM] bugfix - stop misreporting RC update failure

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticFeatureResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticFeatureResult.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="DiagnosticFeatureResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.ExtensionMethods;
+
+namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
+
+internal class DiagnosticFeatureResult
+{
+    private DiagnosticFeatureResult(IReadOnlyList<string> loaded, IReadOnlyList<string> failed, IReadOnlyDictionary<string, object> errors)
+    {
+        Loaded = loaded;
+        Failed = failed;
+        Errors = errors;
+    }
+
+    public IReadOnlyList<string> Loaded { get; }
+
+    public IReadOnlyList<string> Failed { get; }
+
+    public IReadOnlyDictionary<string, object> Errors { get; }
+
+    public static DiagnosticFeatureResult? From(string key, Dictionary<string, object> diagObject)
+    {
+        if (diagObject.TryGetValue(key, out var subKeysObj) && subKeysObj is Dictionary<string, object> subKeys)
+        {
+            var loaded = GetListKey(subKeys, "loaded");
+            var failed = GetListKey(subKeys, "failed");
+            var errors = GetDictionaryKey(subKeys, "errors");
+            return new DiagnosticFeatureResult(loaded, failed, errors);
+        }
+
+        return null;
+    }
+
+    private static IReadOnlyList<string> GetListKey(Dictionary<string, object> diagObject, string key)
+    {
+        if (diagObject.TryGetValue(key, out var listObj) && listObj is object[] list)
+        {
+            return list.Cast<string>().ToList();
+        }
+
+        return new List<string>();
+    }
+
+    private static IReadOnlyDictionary<string, object> GetDictionaryKey(Dictionary<string, object> diagObject, string key)
+    {
+        if (diagObject.TryGetValue(key, out var dictObj) && dictObj is Dictionary<string, object> dict)
+        {
+            return dict;
+        }
+
+        return new Dictionary<string, object>();
+    }
+}

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResult.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="DiagnosticResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
+
+internal class DiagnosticResult
+{
+    private readonly Dictionary<string, object> _diagnosticsData;
+    private readonly Lazy<DiagnosticFeatureResult?> _customRules;
+    private readonly Lazy<DiagnosticFeatureResult?> _exclusions;
+    private readonly Lazy<DiagnosticFeatureResult?> _rules;
+    private readonly Lazy<DiagnosticFeatureResult?> _rulesData;
+    private readonly Lazy<DiagnosticFeatureResult?> _rulesOverride;
+
+    public DiagnosticResult(Obj diagObject)
+    {
+        _diagnosticsData = (Dictionary<string, object>)Encoder.Decode(diagObject);
+        _customRules = MakeLazy("custom_rules");
+        _exclusions = MakeLazy("exclusions");
+        _rules = MakeLazy("rules");
+        _rulesData = MakeLazy("rules_data");
+        _rulesOverride = MakeLazy("rules_override");
+    }
+
+    public DiagnosticFeatureResult? CustomRules => _customRules.Value;
+
+    public DiagnosticFeatureResult? Exclusions => _exclusions.Value;
+
+    public DiagnosticFeatureResult? Rules => _rules.Value;
+
+    public DiagnosticFeatureResult? RulesData => _rulesData.Value;
+
+    public DiagnosticFeatureResult? RulesOverride => _rulesOverride.Value;
+
+    public string? RulesVersion => _diagnosticsData["ruleset_version"] as string;
+
+    private Lazy<DiagnosticFeatureResult?> MakeLazy(string key)
+        => new Lazy<DiagnosticFeatureResult?>(() => DiagnosticFeatureResult.From(key, _diagnosticsData));
+}

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResultUtils.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResultUtils.cs
@@ -35,7 +35,7 @@ internal static class DiagnosticResultUtils
             {
                 if (noRuleDiagnoticsIsError)
                 {
-                    errors = new Dictionary<string, object> { { "diagnostics-error", "Waf could not provide diagnostics on rules in the correct format" } };
+                    errors = new Dictionary<string, object> { { "diagnostics-error", "Waf could not provide diagnostics on rules or diagnostic format is incorrect" } };
                 }
 
                 return new ReportedDiagnostics { FailedCount = failedCount, LoadedCount = loadedCount, RulesetVersion = rulesetVersion, Errors = errors };

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResultUtils.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/DiagnosticResultUtils.cs
@@ -1,0 +1,69 @@
+﻿// <copyright file="DiagnosticResultUtils.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Vendors.Serilog;
+
+namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed;
+
+#pragma warning disable SA1402 // File may only contain a single type
+
+internal static class DiagnosticResultUtils
+{
+    internal static ReportedDiagnostics ExtractReportedDiagnostics(Obj diagObject, bool noRuleDiagnoticsIsError)
+    {
+        ushort failedCount = 0;
+        ushort loadedCount = 0;
+        string rulesetVersion = string.Empty;
+        IReadOnlyDictionary<string, object>? errors = null;
+        try
+        {
+            if (diagObject.ArgsType == ObjType.Invalid)
+            {
+                errors = new Dictionary<string, object> { { "diagnostics-error", "Waf didn't provide a valid diagnostics object at initialization, most likely due to an older waf version < 1.11.0" } };
+                return new ReportedDiagnostics { FailedCount = failedCount, LoadedCount = loadedCount, RulesetVersion = rulesetVersion, Errors = errors };
+            }
+
+            var diagResult = new DiagnosticResult(diagObject);
+
+            var rules = diagResult.Rules;
+            if (rules == null)
+            {
+                if (noRuleDiagnoticsIsError)
+                {
+                    errors = new Dictionary<string, object> { { "diagnostics-error", "Waf could not provide diagnostics on rules in the correct format" } };
+                }
+
+                return new ReportedDiagnostics { FailedCount = failedCount, LoadedCount = loadedCount, RulesetVersion = rulesetVersion, Errors = errors };
+            }
+
+            failedCount = (ushort)rules.Failed.Count;
+            loadedCount = (ushort)rules.Loaded.Count;
+            errors = rules.Errors;
+            rulesetVersion = diagResult.RulesVersion ?? string.Empty;
+        }
+        catch (Exception err)
+        {
+            Log.Error(err, "AppSec could not read Waf diagnostics. Disabling AppSec");
+            var localErrors = errors as Dictionary<string, object> ?? new Dictionary<string, object>();
+            localErrors.Add("diagnostics-error", err.Message);
+            errors = localErrors;
+        }
+
+        return new ReportedDiagnostics { FailedCount = failedCount, LoadedCount = loadedCount, RulesetVersion = rulesetVersion, Errors = errors };
+    }
+}
+
+#pragma warning disable SA1201
+
+internal struct ReportedDiagnostics
+{
+    public ushort FailedCount;
+    public ushort LoadedCount;
+    public string RulesetVersion;
+    public IReadOnlyDictionary<string, object>? Errors;
+}

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/UpdateResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/UpdateResult.cs
@@ -16,46 +16,12 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
         {
             if (diagObject != null)
             {
-                Dictionary<string, object>? rules = null;
-                if (diagObject.ArgsType == ObjType.Invalid)
-                {
-                    Errors = new Dictionary<string, object> { { "diagnostics-error", "Waf didn't provide a valid diagnostics object at initialization, most likely due to an older waf version < 1.11.0" } };
-                }
-                else
-                {
-                    var diagnosticsData = (Dictionary<string, object>)Encoder.Decode(diagObject);
-                    if (diagnosticsData.Count > 0)
-                    {
-                        object? rulesObj = null;
-                        var valueExist = diagnosticsData.TryGetValue("rules", out rulesObj);
-                        if (!valueExist)
-                        {
-                            valueExist = diagnosticsData.TryGetValue("rules_override", out rulesObj);
-                            if (!valueExist)
-                            {
-                                Errors = new Dictionary<string, object> { { "diagnostics-error", "Waf could not provide diagnostics on rules or rule_overrides" } };
-                            }
-                        }
+                var reportedDiag = DiagnosticResultUtils.ExtractReportedDiagnostics(diagObject, false);
 
-                        if (rulesObj != null)
-                        {
-                            rules = rulesObj as Dictionary<string, object>;
-                            if (rules == null)
-                            {
-                                Errors = new Dictionary<string, object> { { "diagnostics-error", "Waf could not provide diagnostics on rules as a dictionary key-value" } };
-                            }
-                        }
-
-                        if (diagnosticsData.TryGetValue("ruleset_version", out var ruleFileVersion))
-                        {
-                            RuleFileVersion = Convert.ToString(ruleFileVersion);
-                        }
-                    }
-                }
-
-                FailedToLoadRules = (ushort)(rules != null ? ((object[])rules["failed"]).Length : 0);
-                LoadedRules = (ushort)(rules != null ? ((object[])rules["loaded"]).Length : 0);
-                Errors = Errors ?? (Dictionary<string, object>)rules!["errors"];
+                FailedToLoadRules = reportedDiag.FailedCount;
+                LoadedRules = reportedDiag.LoadedCount;
+                Errors = reportedDiag.Errors;
+                RuleFileVersion = reportedDiag.RulesetVersion;
 
                 if (Errors != null && Errors.Count > 0)
                 {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/UpdateResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/UpdateResult.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
 
         internal string? ErrorMessage { get; }
 
-        internal bool? HasErrors { get; }
+        internal bool HasErrors { get; }
 
         internal string? RuleFileVersion { get; }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Datadog.Trace.Security.Unit.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Datadog.Trace.Security.Unit.Tests.csproj
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
@@ -10,7 +13,7 @@
       <Link>rule-set.json</Link>
     </Content>
   </ItemGroup>
-  
+
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #nullable enable
+using System;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Xunit;
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafErrorsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafErrorsTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Waf;
@@ -54,9 +55,9 @@ namespace Datadog.Trace.Security.Unit.Tests
             initResult.Success.Should().BeFalse();
             initResult.FailedToLoadRules.Should().Be(0);
             initResult.LoadedRules.Should().Be(0);
-            initResult.Errors.Should().BeEmpty();
-            initResult.HasErrors.Should().BeFalse();
-            initResult.ErrorMessage.Should().BeNullOrEmpty();
+            initResult.Errors.Should().Equal(new Dictionary<string, object> { { "diagnostics-error", "Waf could not provide diagnostics on rules or diagnostic format is incorrect" } });
+            initResult.HasErrors.Should().BeTrue();
+            initResult.ErrorMessage.Should().Be("{\"diagnostics-error\":\"Waf could not provide diagnostics on rules or diagnostic format is incorrect\"}");
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
@@ -93,6 +93,7 @@ namespace Datadog.Trace.Security.Unit.Tests
                 configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafRulesOverridesKey);
                 var result = waf!.UpdateWafFromConfigurationStatus(configurationStatus);
                 result.Success.Should().BeTrue();
+                result.HasErrors.Should().BeFalse();
 
                 Execute(waf, AddressesConstants.RequestBody, "/.adsensepostnottherenonobook", "security_scanner", "crs-913-120", enabled);
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
@@ -70,6 +70,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafRulesOverridesKey);
             var result = waf!.UpdateWafFromConfigurationStatus(configurationStatus);
             result.Success.Should().BeTrue();
+            result.HasErrors.Should().BeFalse();
             Execute(waf, attackParts1, false);
             Execute(waf, attackParts2, true);
 
@@ -77,6 +78,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             configurationStatus.RulesOverridesByFile["test"] = ruleOverrides.ToArray();
             result = waf!.UpdateWafFromConfigurationStatus(configurationStatus);
             result.Success.Should().BeTrue();
+            result.HasErrors.Should().BeFalse();
             Execute(waf, attackParts1, false);
             Execute(waf, attackParts2, false);
 
@@ -85,6 +87,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             configurationStatus.RulesOverridesByFile["test"] = ruleOverrides.ToArray();
             result = waf!.UpdateWafFromConfigurationStatus(configurationStatus);
             result.Success.Should().BeTrue();
+            result.HasErrors.Should().BeFalse();
             Execute(waf, attackParts1, false);
             Execute(waf, attackParts2, true);
 
@@ -93,7 +96,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             configurationStatus.RulesOverridesByFile["test"] = ruleOverrides.ToArray();
             result = waf!.UpdateWafFromConfigurationStatus(configurationStatus);
             result.Success.Should().BeTrue();
-            result.Success.Should().BeTrue();
+            result.HasErrors.Should().BeFalse();
             Execute(waf, attackParts1, true);
             Execute(waf, attackParts2, true);
         }
@@ -122,6 +125,7 @@ namespace Datadog.Trace.Security.Unit.Tests
                 configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafRulesOverridesKey);
                 var result = waf!.UpdateWafFromConfigurationStatus(configurationStatus);
                 result.Success.Should().BeTrue();
+                result.HasErrors.Should().BeFalse();
                 Execute(waf, attackParts1, true, "block");
                 Execute(waf, attackParts2, true);
             }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
@@ -31,6 +31,8 @@ namespace Datadog.Trace.Security.Unit.Tests
             var configurationStatus = new ConfigurationStatus(string.Empty) { RulesDataByFile = { ["test"] = rulesData!.ToArray() } };
             configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafRulesDataKey);
             var res = initResult.Waf!.UpdateWafFromConfigurationStatus(configurationStatus);
+            res.Success.Should().BeTrue();
+            res.HasErrors.Should().BeFalse();
             using var context = waf.CreateContext()!;
             var result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.UserId, "user3" } },


### PR DESCRIPTION
## Summary of changes

Diagnostic data from the WAF, which has recently changed format, was being misinterpreted. This led to errors being reported by remote config when a change had been correctly applied.

## Test coverage

Added assertions to all WAF unit tests to check the error status of the update.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
