### PR TITLE
[CIVisibility] `ConfigureCiCommand` fixes.

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
@@ -30,8 +30,12 @@ namespace Datadog.Trace.Tools.Runner
         {
             foreach (var item in environmentVariables)
             {
+                // Declaring variables for Azure Pipelines
                 // https://learn.microsoft.com/en-gb/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#setvariable-initialize-or-modify-the-value-of-a-variable
-                // We cannot use `AnsiConsole.WriteLine` due to the word wrapping and text handling in spectre console, so we use the normal `Console.WriteLine` instead.
+
+                // We cannot use `AnsiConsole.WriteLine` due to the word wrapping and text handling in spectre console that affects the azure command, so we use the normal `Console.WriteLine` instead.
+                // See https://github.com/spectreconsole/spectre.console/issues/1122
+
                 Console.WriteLine($"##vso[task.setvariable variable={item.Key};]{item.Value}");
             }
         }

--- a/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
@@ -29,7 +29,8 @@ namespace Datadog.Trace.Tools.Runner
         {
             foreach (var item in environmentVariables)
             {
-                AnsiConsole.WriteLine($"##vso[task.setvariable variable={item.Key}]{item.Value}");
+                // https://learn.microsoft.com/en-gb/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#setvariable-initialize-or-modify-the-value-of-a-variable
+                AnsiConsole.WriteLine($"##vso[task.setvariable variable={item.Key};]{item.Value}");
             }
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
@@ -31,6 +31,7 @@ namespace Datadog.Trace.Tools.Runner
             foreach (var item in environmentVariables)
             {
                 // https://learn.microsoft.com/en-gb/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#setvariable-initialize-or-modify-the-value-of-a-variable
+                // We cannot use `AnsiConsole.WriteLine` due to the word wrapping and text handling in spectre console, so we use the normal `Console.WriteLine` instead.
                 Console.WriteLine($"##vso[task.setvariable variable={item.Key};]{item.Value}");
             }
         }

--- a/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using Spectre.Console;
 
@@ -30,7 +31,7 @@ namespace Datadog.Trace.Tools.Runner
             foreach (var item in environmentVariables)
             {
                 // https://learn.microsoft.com/en-gb/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#setvariable-initialize-or-modify-the-value-of-a-variable
-                AnsiConsole.WriteLine($"##vso[task.setvariable variable={item.Key};]{item.Value}");
+                Console.WriteLine($"##vso[task.setvariable variable={item.Key};]{item.Value}");
             }
         }
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.Tools.Runner
                 return;
             }
 
-            AnsiConsole.WriteLine("Setting up the environment variables.");
+            Console.WriteLine("Setting up the environment variables.");
 
             if (!CIConfiguration.SetupCIEnvironmentVariables(profilerEnvironmentVariables, ciName))
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Tools.Runner
                 return;
             }
 
-            Console.WriteLine("Setting up the environment variables.");
+            AnsiConsole.WriteLine("Setting up the environment variables.");
 
             if (!CIConfiguration.SetupCIEnvironmentVariables(profilerEnvironmentVariables, ciName))
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Tools.Runner
                 _applicationContext.RunnerFolder,
                 _applicationContext.Platform,
                 _tracerSettings,
-                true);
+                reducePathLength: true);
 
             if (profilerEnvironmentVariables == null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
@@ -61,7 +61,8 @@ namespace Datadog.Trace.Tools.Runner
                 context,
                 _applicationContext.RunnerFolder,
                 _applicationContext.Platform,
-                _tracerSettings);
+                _tracerSettings,
+                true);
 
             if (profilerEnvironmentVariables == null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
@@ -40,7 +40,8 @@ namespace Datadog.Trace.Tools.Runner
                 context,
                 ApplicationContext.RunnerFolder,
                 ApplicationContext.Platform,
-                _legacySettings);
+                _legacySettings,
+                false);
 
             if (profilerEnvironmentVariables is null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tools.Runner
                 ApplicationContext.RunnerFolder,
                 ApplicationContext.Platform,
                 _legacySettings,
-                false);
+                reducePathLength: false);
 
             if (profilerEnvironmentVariables is null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Tools.Runner
                 applicationContext.RunnerFolder,
                 applicationContext.Platform,
                 settings,
-                false);
+                reducePathLength: false);
 
             if (profilerEnvironmentVariables is null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
@@ -16,7 +16,8 @@ namespace Datadog.Trace.Tools.Runner
                 invocationContext,
                 applicationContext.RunnerFolder,
                 applicationContext.Platform,
-                settings);
+                settings,
+                false);
 
             if (profilerEnvironmentVariables is null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -158,9 +158,10 @@ namespace Datadog.Trace.Tools.Runner
             {
                 for (int i = 0; i < paths.Length; i++)
                 {
-                    if (Directory.Exists(paths[i]))
+                    var tmpFolder = Path.GetFullPath(paths[i]);
+                    if (Directory.Exists(tmpFolder))
                     {
-                        folderName = paths[i];
+                        folderName = tmpFolder;
                         break;
                     }
                 }
@@ -177,6 +178,7 @@ namespace Datadog.Trace.Tools.Runner
         {
             try
             {
+                filePath = Path.GetFullPath(filePath);
                 if (!File.Exists(filePath))
                 {
                     WriteError($"Error: The file '{filePath}' can't be found.");
@@ -194,6 +196,7 @@ namespace Datadog.Trace.Tools.Runner
         {
             try
             {
+                filePath = Path.GetFullPath(filePath);
                 if (!File.Exists(filePath))
                 {
                     return null;
@@ -398,7 +401,7 @@ namespace Datadog.Trace.Tools.Runner
             string tracerHome = null;
             if (!string.IsNullOrEmpty(tracerHomeFolder))
             {
-                tracerHome = tracerHomeFolder;
+                tracerHome = Path.GetFullPath(tracerHomeFolder);
                 if (!Directory.Exists(tracerHome))
                 {
                     WriteError("Error: The specified home folder doesn't exist.");

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -26,11 +26,11 @@ namespace Datadog.Trace.Tools.Runner
     {
         public const string Profilerid = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
 
-        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, CommonTracerSettings options)
+        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, CommonTracerSettings options, bool reducePathLength)
         {
             var tracerHomeFolder = options.TracerHome.GetValue(context);
 
-            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, tracerHomeFolder);
+            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, tracerHomeFolder, reducePathLength);
 
             var environment = options.Environment.GetValue(context);
 
@@ -63,9 +63,9 @@ namespace Datadog.Trace.Tools.Runner
             return envVars;
         }
 
-        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, LegacySettings options)
+        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, LegacySettings options, bool reducePathLength)
         {
-            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, options.TracerHomeFolderOption.GetValue(context));
+            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, options.TracerHomeFolderOption.GetValue(context), reducePathLength);
 
             var environment = options.EnvironmentOption.GetValue(context);
 
@@ -390,7 +390,7 @@ namespace Datadog.Trace.Tools.Runner
             return false;
         }
 
-        private static Dictionary<string, string> GetBaseProfilerEnvironmentVariables(string runnerFolder, Platform platform, string tracerHomeFolder)
+        private static Dictionary<string, string> GetBaseProfilerEnvironmentVariables(string runnerFolder, Platform platform, string tracerHomeFolder, bool reducePathLength)
         {
             // In the current nuspec structure RunnerFolder has the following format:
             //  C:\Users\[user]\.dotnet\tools\.store\datadog.trace.tools.runner\[version]\datadog.trace.tools.runner\[version]\tools\netcoreapp3.1\any
@@ -414,6 +414,25 @@ namespace Datadog.Trace.Tools.Runner
             {
                 WriteError("Error: The home directory can't be found. Check that the tool is correctly installed, or use --tracer-home to set a custom path.");
                 return null;
+            }
+
+            if (reducePathLength)
+            {
+                // Due to:
+                // https://developercommunity.visualstudio.com/t/vsotasksetvariable-contains-logging-command-keywor/1249340#T-N1253996
+                // We try to use reduce the length of the path using a temporary folder.
+                var tempFolder = Path.Combine(Path.GetTempPath(), "dd");
+                if (tempFolder.Length < tracerHome.Length)
+                {
+                    try
+                    {
+                        CopyFilesRecursively(tracerHome, tempFolder);
+                        tracerHome = tempFolder;
+                    }
+                    catch
+                    {
+                    }
+                }
             }
 
             string tracerMsBuild = FileExists(Path.Combine(tracerHome, "netstandard2.0", "Datadog.Trace.MSBuild.dll"));
@@ -581,6 +600,21 @@ namespace Datadog.Trace.Tools.Runner
                 }
 
                 return true;
+            }
+        }
+
+        private static void CopyFilesRecursively(string sourcePath, string targetPath)
+        {
+            // Now Create all of the directories
+            foreach (var dirPath in Directory.GetDirectories(sourcePath, "*", SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(dirPath.Replace(sourcePath, targetPath));
+            }
+
+            // Copy all the files & Replaces any files with the same name
+            foreach (var newPath in Directory.GetFiles(sourcePath, "*.*", SearchOption.AllDirectories))
+            {
+                File.Copy(newPath, newPath.Replace(sourcePath, targetPath), true);
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
@@ -53,8 +53,8 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
 
             foreach (var line in helper.StandardOutput.Split(Environment.NewLine))
             {
-                // ##vso[task.setvariable variable=DD_DOTNET_TRACER_HOME]TestTracerHome
-                var match = Regex.Match(line, @"##vso\[task.setvariable variable=(?<name>[A-Z1-9_]+)\](?<value>.*)");
+                // ##vso[task.setvariable variable=DD_DOTNET_TRACER_HOME]TestTracerHome;
+                var match = Regex.Match(line, @"##vso\[task.setvariable variable=(?<name>[A-Z1-9_]+);\](?<value>.*)");
 
                 if (match.Success)
                 {
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
             environmentVariables["DD_ENV"].Should().Be("TestEnv");
             environmentVariables["DD_SERVICE"].Should().Be("TestService");
             environmentVariables["DD_VERSION"].Should().Be("TestVersion");
-            environmentVariables["DD_DOTNET_TRACER_HOME"].Should().Be("TestTracerHome");
+            environmentVariables["DD_DOTNET_TRACER_HOME"].Should().Be(Path.GetFullPath("TestTracerHome"));
             environmentVariables["DD_TRACE_AGENT_URL"].Should().Be("TestAgentUrl");
             environmentVariables["VAR1"].Should().Be("A");
             environmentVariables["VAR2"].Should().Be("B");

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -66,7 +67,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             environmentVariables.Should().Contain("DD_ENV", "TestEnv");
             environmentVariables.Should().Contain("DD_SERVICE", "TestService");
             environmentVariables.Should().Contain("DD_VERSION", "TestVersion");
-            environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME", "TestTracerHome");
+            environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME",  Path.GetFullPath("TestTracerHome"));
             environmentVariables.Should().Contain("DD_TRACE_AGENT_URL", agentUrl);
             environmentVariables.Should().Contain("VAR1", "A");
             environmentVariables.Should().Contain("VAR2", "B");

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/ConfigureCiCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/ConfigureCiCommandTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.RegularExpressions;
 using FluentAssertions;
 using Xunit;
@@ -31,7 +32,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             foreach (var line in console.ReadLines())
             {
                 // ##vso[task.setvariable variable=DD_DOTNET_TRACER_HOME]TestTracerHome
-                var match = Regex.Match(line, @"##vso\[task.setvariable variable=(?<name>[A-Z1-9_]+)\](?<value>.*)");
+                var match = Regex.Match(line, @"##vso\[task.setvariable variable=(?<name>[A-Z1-9_]+);\](?<value>.*)");
 
                 if (match.Success)
                 {
@@ -42,7 +43,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             environmentVariables.Should().Contain("DD_ENV", "TestEnv");
             environmentVariables.Should().Contain("DD_SERVICE", "TestService");
             environmentVariables.Should().Contain("DD_VERSION", "TestVersion");
-            environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME", "TestTracerHome");
+            environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME", Path.GetFullPath("TestTracerHome"));
             environmentVariables.Should().Contain("DD_TRACE_AGENT_URL", "TestAgentUrl");
         }
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/LegacyCommandLineArgumentsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/LegacyCommandLineArgumentsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text.RegularExpressions;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -88,7 +89,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             environmentVariables.Should().Contain("DD_ENV", "TestEnv");
             environmentVariables.Should().Contain("DD_SERVICE", "TestService");
             environmentVariables.Should().Contain("DD_VERSION", "TestVersion");
-            environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME", "TestTracerHome");
+            environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME", Path.GetFullPath("TestTracerHome"));
             environmentVariables.Should().Contain("DD_TRACE_AGENT_URL", agentUrl);
             environmentVariables.Should().Contain("DD_CIVISIBILITY_ENABLED", "1");
             environmentVariables.Should().Contain("VAR1", "A");
@@ -120,7 +121,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
                 foreach (var line in console.ReadLines())
                 {
                     // ##vso[task.setvariable variable=DD_DOTNET_TRACER_HOME]TestTracerHome
-                    var match = Regex.Match(line, @"##vso\[task.setvariable variable=(?<name>[A-Z1-9_]+)\](?<value>.*)");
+                    var match = Regex.Match(line, @"##vso\[task.setvariable variable=(?<name>[A-Z1-9_]+);\](?<value>.*)");
 
                     if (match.Success)
                     {
@@ -131,7 +132,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
                 environmentVariables.Should().Contain("DD_ENV", "TestEnv");
                 environmentVariables.Should().Contain("DD_SERVICE", "TestService");
                 environmentVariables.Should().Contain("DD_VERSION", "TestVersion");
-                environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME", "TestTracerHome");
+                environmentVariables.Should().Contain("DD_DOTNET_TRACER_HOME", Path.GetFullPath("TestTracerHome"));
                 environmentVariables.Should().Contain("DD_TRACE_AGENT_URL", "TestAgentUrl");
                 environmentVariables.Should().Contain("VAR1", "A");
                 environmentVariables.Should().Contain("VAR2", "B");


### PR DESCRIPTION
## Summary of changes

This PR fixes some issues detected when using `dd-trace ci configure` and also makes some small changes in the runner.

#### Changes: 
- [x] Clean clrprofiler paths to absolute paths
- [x] Replace `AnsiConsole` with `Console` when settings the global environment variables for azure ci using logs commands.
- [x] Adds a mechanism to try to reduce the profiler filepath lengths due to a limitation in the azure logs commands length.  

## Reason for change

A customer tried to use `dd-trace ci configure` command and is failing, I was able to reproduce the issue in a sample repo.

