### PR TITLE
[Serverless][AWS] Fix serialization to use `JsonConverter`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
@@ -267,11 +267,11 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
 
                 if (objectType == typeof(MemoryStream))
                 {
-                    contract.Converter = new MemoryStreamJsonConverter();
+                    contract.Converter = MemoryStreamConverter;
                 }
                 else if (objectType == typeof(DateTime))
                 {
-                    contract.Converter = new DateTimeJsonConverter();
+                    contract.Converter = DateTimeConverter;
                 }
 
                 return contract;

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
         private const string PlaceholderOperationName = "placeholder-operation";
         private const string DefaultJson = "{}";
         private const double ServerlessMaxWaitingFlushTime = 3;
+        private static readonly DateTime Epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         private static readonly DateTimeJsonConverter DateTimeConverter = new();
         private static readonly MemoryStreamJsonConverter MemoryStreamConverter = new();
@@ -220,7 +221,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
             }
         }
 
-        private static string SerializeObject<T>(T obj)
+        internal static string SerializeObject<T>(T obj)
         {
             try
             {
@@ -314,7 +315,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
         {
             public override void WriteJson(JsonWriter writer, DateTime value, JsonSerializer serializer)
             {
-                var elapsedTime = value - DateTime.UnixEpoch;
+                var elapsedTime = value - Epoch;
                 // `.TotalSeconds` includes milliseconds in the
                 // decimals, which is what the Extension expects.
                 var timestamp = elapsedTime.TotalSeconds;


### PR DESCRIPTION
## Summary of changes

Add `JsonSerializerSettings` to the method `SerializeObject` to properly handle requests with `MemoryStream` and `DateTime`.

Allowing to properly send payload to the Datadog Extension for correct inferred span creation.
![Screenshot 2023-08-29 at 1 13 25 PM](https://github.com/DataDog/dd-trace-dotnet/assets/30836115/61577791-fd87-49a9-b48b-9f6c8e03e716)

## Reason for change

Serialization fails for requests where `DateTime` and `MemoryStream` fields exist.

## Implementation details

Added `JsonConverter` classes for said types.
Added a contract to cache the converter per type.

## Test coverage

- [x] Unit tests
- [x] Manual tested in AWS Lambda

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
