### PR TITLE
[Profiler] Add tests for Wrapper library + pthread_create for alpine

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -119,4 +119,4 @@ enable_testing()
 add_subdirectory(test)
 
 add_custom_target(all-profiler)
-add_dependencies(all-profiler Datadog.Profiler.Native Datadog.Linux.ApiWrapper.x64 Datadog.Profiler.Native.Tests)
+add_dependencies(all-profiler Datadog.Profiler.Native Datadog.Linux.ApiWrapper.x64 profiler-native-tests)

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -124,19 +124,19 @@ int dladdr(const void* addr_arg, Dl_info* info)
 #ifdef DD_ALPINE
 
 /* Function pointers to hold the value of the glibc functions */
-static int (*__real___pthread_create)(pthread_t* restrict res, const pthread_attr_t* restrict attrp, void* (*entry)(void*), void* restrict arg) = NULL;
+static int (*__real_pthread_create)(pthread_t* restrict res, const pthread_attr_t* restrict attrp, void* (*entry)(void*), void* restrict arg) = NULL;
 
-int __pthread_create(pthread_t* restrict res, const pthread_attr_t* restrict attrp, void* (*entry)(void*), void* restrict arg)
+int pthread_create(pthread_t* restrict res, const pthread_attr_t* restrict attrp, void* (*entry)(void*), void* restrict arg)
 {
-    if (__real___pthread_create == NULL)
+    if (__real_pthread_create == NULL)
     {
-        __real___pthread_create = dlsym(RTLD_NEXT, "__pthread_create");
+        __real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
     }
 
     ((char*)&functions_entered_counter)[ENTERED_PTHREAD_CREATE]++;
 
-    // call the real __pthread_create (libc/musl-libc)
-    int result = __real___pthread_create(res, attrp, entry, arg);
+    // call the real pthread_create (libc/musl-libc)
+    int result = __real_pthread_create(res, attrp, entry, arg);
 
     ((char*)&functions_entered_counter)[ENTERED_PTHREAD_CREATE]--;
 

--- a/profiler/test/CMakeLists.txt
+++ b/profiler/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.13.4)
 
 add_subdirectory(Datadog.Profiler.Native.Tests)
+add_subdirectory(Datadog.Linux.ApiWrapper.Tests)
 

--- a/profiler/test/CMakeLists.txt
+++ b/profiler/test/CMakeLists.txt
@@ -3,3 +3,5 @@ cmake_minimum_required(VERSION 3.13.4)
 add_subdirectory(Datadog.Profiler.Native.Tests)
 add_subdirectory(Datadog.Linux.ApiWrapper.Tests)
 
+add_custom_target(profiler-native-tests)
+add_dependencies(profiler-native-tests Datadog.Profiler.Native.Tests Datadog.Linux.ApiWrapper.Tests)

--- a/profiler/test/Datadog.Linux.ApiWrapper.Tests/CMakeLists.txt
+++ b/profiler/test/Datadog.Linux.ApiWrapper.Tests/CMakeLists.txt
@@ -1,0 +1,66 @@
+include(GoogleTest)
+
+
+# ******************************************************
+# Compiler options
+# ******************************************************
+set(CMAKE_CXX_STANDARD 17)
+
+# Sets compiler options
+add_compile_options(-Wc++17-extensions)
+
+if (DEFINED ENV{IsAlpine} AND "$ENV{IsAlpine}" MATCHES "true")
+    add_compile_options(-DDD_ALPINE)
+endif()
+
+if (RUN_ASAN)
+    add_compile_options(-g -fsanitize=address -fno-omit-frame-pointer)
+endif()
+
+if (RUN_UBSAN)
+    add_compile_options(-fsanitize=undefined -g -fno-omit-frame-pointer -fno-sanitize-recover=all)
+endif()
+
+if(ISLINUX)
+    add_compile_options(-stdlib=libstdc++ -DLINUX -Wno-pragmas)
+endif()
+
+SET(TEST_EXECUTABLE_NAME "Datadog.Linux.ApiWrapper.Tests")
+
+SET(TEST_OUTPUT_DIR ${OUTPUT_BUILD_DIR}/bin/${TEST_EXECUTABLE_NAME})
+SET(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${TEST_OUTPUT_DIR})
+SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${TEST_OUTPUT_DIR})
+SET(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${TEST_OUTPUT_DIR})
+
+FILE(GLOB API_WRAPPER_NATIVE_TEST_SRC CONFIGURE_DEPENDS "*.cpp")
+
+add_executable(${TEST_EXECUTABLE_NAME}
+    ${API_WRAPPER_NATIVE_TEST_SRC}
+)
+
+# Define directories includes
+target_include_directories(${TEST_EXECUTABLE_NAME}
+    PUBLIC ${googletest_SOURCE_DIR}/googlemock/include
+    PUBLIC ../../../ # root repository
+)
+
+add_dependencies(${TEST_EXECUTABLE_NAME} gmock gtest)
+
+if (RUN_ASAN)
+    target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=address)
+endif()
+
+if (RUN_UBSAN)
+    target_link_libraries(${TEST_EXECUTABLE_NAME} -fsanitize=undefined)
+endif()
+
+target_link_libraries(${TEST_EXECUTABLE_NAME}
+  gtest_main
+  gmock_main
+  -static-libgcc
+  -static-libstdc++
+  -ldl
+  -Wc++17-extensions
+)
+
+gtest_discover_tests(${TEST_EXECUTABLE_NAME})

--- a/profiler/test/Datadog.Linux.ApiWrapper.Tests/WrappedFunctions.cpp
+++ b/profiler/test/Datadog.Linux.ApiWrapper.Tests/WrappedFunctions.cpp
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gtest/gtest.h"
+
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <link.h>
+#include <pthread.h>
+
+#include "shared/src/native-src/dd_filesystem.hpp"
+
+namespace WrappedFunctionsTest {
+class WrappedFunctionsParametersTests : public ::testing::TestWithParam<void*>
+{
+};
+
+TEST_P(WrappedFunctionsParametersTests, CheckIfFirstResolvedByDynamicLoader)
+{
+    auto* fn = GetParam();
+    Dl_info info;
+    ASSERT_NE(0, dladdr(fn, &info));
+    auto filePath = fs::path(info.dli_fname);
+    ASSERT_STREQ("Datadog.Linux.ApiWrapper.x64.so", filePath.filename().c_str());
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    WrappedFunctionsTest,
+    WrappedFunctionsParametersTests,
+    ::testing::Values(
+#ifdef DD_ALPINE
+        (void*)::pthread_create,
+        (void*)::pthread_attr_init,
+        (void*)::pthread_getattr_default_np,
+        (void*)::pthread_setattr_default_np,
+        (void*)::fork,
+#endif
+        (void*)::dl_iterate_phdr,
+        (void*)::dlopen,
+        (void*)::dladdr));
+
+} // namespace WrappedFunctionsTest


### PR DESCRIPTION
## Summary of changes

Add tests to ensure that the wrapping library (`Datadog.Linux.ApiWrapper.x64.so`) is working correctly + fixing a deadlock on alpine.

## Reason for change
- Add test for the wrapping library
- Fix deadlock on alpine: `__pthread_create` is not the function to wrap but instead `pthread_create`.

## Implementation details

- Add Google tests
- Rename `__pthread_create` into `pthread_create`

## Test coverage

- New test ;)
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
