### PR TITLE
Fix version-bump PR forcer action

### DIFF
--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -20,7 +20,7 @@ jobs:
           # These checks won't run automatically on the version bump PR, so need to force this
           contexts=("code_freeze" "verify_source_generators" "verify_app_trimming_descriptor_generator")
 
-          sha="${{ github.head_ref }}"
+          sha="${{ github.sha }}"
           targetUrl="https://github.com/DataDog/dd-trace-dotnet/actions/workflows/override_version_bump_pr_checks.yml"
           state="success"
           description="Forced override (via GitHub Action)"

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -29,6 +29,7 @@ jobs:
             echo "Forcing check check status to $state for $context"
           
             curl -X POST \
+            --fail-with-body \
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   override_checks:
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
       - name: Fail if branch is not version-bump PR
@@ -32,7 +30,7 @@ jobs:
           
             curl -X POST \
             -H "Accept: application/vnd.github.v3+json" \
-            -H "Authorization: Bearer ${{ env.github_token }}" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
               -d '{"state":"'"$state"'","context":"'"context"'","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
           done

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -33,5 +33,5 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               "https://api.github.com/repos/DataDog/dd-trace-dotnet/statuses/$sha" \
-              -d '{"state":"'"$state"'","context":"'"context"'","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
+              -d '{"state":"'"$state"'","context":"'"$context"'","description":"'"$description"'","target_url":"'"$targetUrl"'"}'
           done

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Fail if branch is not version-bump PR
         if: ${{ !startsWith(github.ref, 'version-bump-') }}
         run: |
-          echo "This workflow should only be triggered on the version-bump-x.x.x branch
+          echo "This workflow should only be triggered on the version-bump-x.x.x branch, but found  ${{ github.ref }}"
           exit 1
 
       - run: |

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Fail if branch is not version-bump PR
-        if: ${{ !startsWith(github.ref, 'version-bump-') }}
+        if: ${{ !startsWith(github.ref, 'refs/heads/version-bump-') }}
         run: |
           echo "This workflow should only be triggered on the version-bump-x.x.x branch, but found  ${{ github.ref }}"
           exit 1


### PR DESCRIPTION
## Summary of changes

Fixes the GH Action introduced in #4556

## Reason for change

You can't test GitHub Actions until they're merged to master for "reasons"

## Implementation details

Fixed various errors in the action

## Test coverage

Tested in [this dummy PR](https://github.com/DataDog/dd-trace-dotnet/pull/4562) and it worked: 

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/6081c04f-b5d2-47ec-966a-3173ae203b5b)


## Other details
Required before next release