### PR TITLE
Make sure Process is not used concurrently

### DIFF
--- a/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static string GetCurrentProcessName()
         {
-            return CurrentProcess.Instance.ProcessName;
+            return CurrentProcess.ProcessName;
         }
 
         /// <summary>
@@ -48,10 +48,9 @@ namespace Datadog.Trace.Util
         [MethodImpl(MethodImplOptions.NoInlining)]
         public static void GetCurrentProcessInformation(out string processName, out string machineName, out int processId)
         {
-            var currentProcess = CurrentProcess.Instance;
-            processName = currentProcess.ProcessName;
-            machineName = currentProcess.MachineName;
-            processId = currentProcess.Id;
+            processName = CurrentProcess.ProcessName;
+            machineName = CurrentProcess.MachineName;
+            processId = CurrentProcess.Pid;
         }
 
         /// <summary>
@@ -174,9 +173,18 @@ namespace Datadog.Trace.Util
         {
             internal static readonly Process Instance;
 
+            internal static readonly string ProcessName;
+            internal static readonly string MachineName;
+            internal static readonly int Pid;
+
             static CurrentProcess()
             {
                 Instance = Process.GetCurrentProcess();
+
+                // Cache the information that won't change
+                ProcessName = Instance.ProcessName;
+                MachineName = Instance.MachineName;
+                Pid = Instance.Id;
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

There were some changes to share a single instance of Process. However, the runtime metrics thread will periodically call `Refresh`, and it's not safe to access the process instance from another thread while it's being refreshed.

The information we might want to access concurrently (process name, machine name, pid) shouldn't change during the lifetime of the process, so the solution is simply to cache them in dedicated fields instead of reading them every time from the Process instance.

## Reason for change

It'll probably crash while I'm on escalation rotation.
