### PR TITLE
[ASM] IAST fix for the 0 line bug

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -277,15 +277,17 @@ internal static class IastModule
         }
 
         // Sometimes we do not have the file/line but we have the method/class.
-        var filename = frameInfo.StackFrame?.GetFileName();
+        var stackFrame = frameInfo.StackFrame;
+        var filename = stackFrame?.GetFileName();
+        var line = string.IsNullOrEmpty(filename) ? 0 : (stackFrame?.GetFileLineNumber() ?? 0);
         var vulnerability = new Vulnerability(
             vulnerabilityType,
             new Location(
                 stackFile: filename,
-                methodName: string.IsNullOrEmpty(filename) ? frameInfo.StackFrame?.GetMethod()?.Name : null,
-                line: !string.IsNullOrEmpty(filename) ? frameInfo.StackFrame?.GetFileLineNumber() : null,
+                methodName: string.IsNullOrEmpty(filename) ? stackFrame?.GetMethod()?.Name : null,
+                line: line > 0 ? line : null,
                 spanId: currentSpan?.SpanId,
-                methodTypeName: string.IsNullOrEmpty(filename) ? GetMethodTypeName(frameInfo.StackFrame) : null),
+                methodTypeName: string.IsNullOrEmpty(filename) ? GetMethodTypeName(stackFrame) : null),
             new Evidence(evidenceValue, tainted?.Ranges),
             integrationId);
 

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -53,6 +53,7 @@ public class InstrumentationTestsBase
     private static MethodInfo _evidenceProperty = _vulnerabilityType.GetProperty("Evidence", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _locationProperty = _vulnerabilityType.GetProperty("Location", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _pathProperty = _locationType.GetProperty("Path", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
+    private static MethodInfo _lineProperty = _locationType.GetProperty("Line", BindingFlags.Public | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _getTaintedObjectsMethod = _taintedObjectsType.GetMethod("Get", BindingFlags.Instance | BindingFlags.Public);
     private static MethodInfo _taintMethod = _taintedObjectsType.GetMethod("Taint", BindingFlags.Instance | BindingFlags.Public);
     private static MethodInfo _enableIastInRequestMethod = _traceContextType.GetMethod("EnableIastInRequest", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -185,6 +186,13 @@ public class InstrumentationTestsBase
         {
             var locationProperty = _locationProperty.Invoke(vulnerability, Array.Empty<object>());
             var path = _pathProperty.Invoke(locationProperty, Array.Empty<object>());
+            var line = _lineProperty.Invoke(locationProperty, Array.Empty<object>());
+
+            if (line != null)
+            {
+                ((int)line).Should().BeGreaterThan(0);
+            }
+
             locations?.Add(path.ToString());
 
             if (!string.IsNullOrEmpty(path as string))


### PR DESCRIPTION
## Summary of changes

When we detect a vulnerability, we consider the line of the file, which comes from frameInfo.StackFrame?.GetFileLineNumber(). According to the documentation of the method, the file line number is returned, or 0 (zero) if the file line number cannot be determined. This means that we need to exclude the 0 return values.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
