### PR TITLE
[Profiler] Improve integration tests output

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Allocations/AllocationsProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Allocations/AllocationsProfilerTest.cs
@@ -5,17 +5,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Text;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
 using Perftools.Profiles;
 using Xunit;
 using Xunit.Abstractions;
-using static Google.Protobuf.Reflection.SourceCodeInfo.Types;
 
 namespace Datadog.Profiler.IntegrationTests.Allocations
 {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/ApplicationInfoTest.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -9,7 +9,6 @@ using System.Linq;
 using System.Net;
 using System.Text.RegularExpressions;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using Datadog.Trace;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CpuAndWallTime/CpuAndWallTimeTest.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -9,9 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
-using Perftools.Profiles;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/MockDatadogAgent.cs
@@ -5,10 +5,8 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.IO;
 using System.IO.Pipes;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/SamplesHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/SamplesHelper.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Perftools.Profiles;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/StackTrace.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/StackTrace.cs
@@ -4,10 +4,7 @@
 // </copyright>
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using FluentAssertions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestAppFact.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestAppFact.cs
@@ -3,13 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
-using System.Collections.Generic;
 using Xunit;
 using Xunit.Sdk;
 
 namespace Datadog.Profiler.IntegrationTests.Helpers
 {
-    [XunitTestCaseDiscoverer("Datadog.Profiler.SmokeTests.TestAppFrameworkDiscover", "Datadog.Profiler.IntegrationTests")]
+    [XunitTestCaseDiscoverer("Datadog.Profiler.IntegrationTests.Xunit.TestAppFrameworkDiscover", "Datadog.Profiler.IntegrationTests")]
     internal class TestAppFact : FactAttribute
     {
         public TestAppFact(string appAssembly, string[] frameworks = null)

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -39,7 +39,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         {
             _appName = appName;
             _framework = framework;
-            Environment = new EnvironmentHelper(appName, framework, enableTracer);
+            Environment = new EnvironmentHelper(framework, enableTracer);
             _testBaseOutputDir = Environment.GetTestOutputPath();
             _appAssembly = appAssembly;
             _output = output;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -6,7 +6,6 @@
 using System.IO;
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LiveObjects/LiveObjectsProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LiveObjects/LiveObjectsProfilerTest.cs
@@ -5,7 +5,6 @@
 
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Logger/NativeLogger.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Logger/NativeLogger.cs
@@ -6,7 +6,6 @@
 using System.IO;
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/MetricsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/MetricsTest.cs
@@ -5,9 +5,7 @@
 
 using System.Linq;
 using System.Net;
-using System.Threading;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/BuggyBitsTest.cs
@@ -21,7 +21,7 @@ namespace Datadog.Profiler.SmokeTests
         [TestAppFact("Samples.BuggyBits")]
         public void CheckSmoke(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
             runner.RunAndCheck();
         }
 
@@ -29,7 +29,7 @@ namespace Datadog.Profiler.SmokeTests
         [TestAppFact("Samples.BuggyBits")]
         public void CheckSmokeForOldWayToStackWalk(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
             runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/Computer01Test.cs
@@ -3,11 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
-using System.Collections.Generic;
-using System.Linq;
-using Datadog.Profiler.IntegrationTests;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -33,28 +29,28 @@ namespace Datadog.Profiler.SmokeTests
         [TestAppFact("Samples.Computer01")]
         public void CheckAppDomain(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
             runner.RunAndCheck();
         }
 
         [TestAppFact("Samples.Computer01")]
         public void CheckGenerics(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", output: _output);
             runner.RunAndCheck();
         }
 
         [TestAppFact("Samples.Computer01")]
         public void CheckPi(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", output: _output);
             runner.RunAndCheck();
         }
 
         [TestAppFact("Samples.Computer01")]
         public void CheckFibonacci(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", output: _output);
             runner.RunAndCheck();
         }
 
@@ -62,7 +58,7 @@ namespace Datadog.Profiler.SmokeTests
         [TestAppFact("Samples.Computer01")]
         public void CheckAppDomainForOldWayToStackWalk(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
             runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
@@ -71,7 +67,7 @@ namespace Datadog.Profiler.SmokeTests
         [TestAppFact("Samples.Computer01")]
         public void CheckGenericsForOldWayToStackWalk(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 2", output: _output);
             runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
@@ -80,7 +76,7 @@ namespace Datadog.Profiler.SmokeTests
         [TestAppFact("Samples.Computer01")]
         public void CheckPiForOldWayToStackWalk(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 4", output: _output);
             runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }
@@ -89,7 +85,7 @@ namespace Datadog.Profiler.SmokeTests
         [TestAppFact("Samples.Computer01")]
         public void CheckFibonacciForOldWayToStackWalk(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 5", output: _output);
             runner.EnvironmentHelper.CustomEnvironmentVariables[EnvironmentVariables.UseBacktrace2] = "0";
             runner.RunAndCheck();
         }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/CpuLimitTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/CpuLimitTest.cs
@@ -25,7 +25,7 @@ namespace Datadog.Profiler.IntegrationTests.SmokeTests
         [TestAppFact("Samples.BuggyBits")]
         public void CheckCpuLimit(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output);
 
             using var agent = runner.Run();
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
@@ -28,7 +28,7 @@ namespace Datadog.Profiler.SmokeTests
             string appAssembly,
             ITestOutputHelper output,
             TransportType transportType = TransportType.Http)
-            : this(appName, framework, appAssembly, commandLine: null, output, transportType)
+            : this(appName, framework, appAssembly, commandLine: null, output: output, transportType: transportType)
         {
         }
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/TimelineTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/TimelineTest.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
-using Datadog.Profiler.SmokeTests;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/NamedPipeTestcs.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/NamedPipeTestcs.cs
@@ -5,7 +5,6 @@
 
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Datadog.Profiler.IntegrationTests.Helpers;
 using Datadog.Profiler.SmokeTests;
 using FluentAssertions;
@@ -27,7 +26,7 @@ namespace Datadog.Profiler.IntegrationTests.WindowsOnly
         [TestAppFact("Samples.Computer01")]
         public void CheckProfilesSentThroughNamedPipe(string appName, string framework, string appAssembly)
         {
-            new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", _output, TransportType.NamedPipe).RunAndCheck();
+            new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output, transportType: TransportType.NamedPipe).RunAndCheck();
         }
 
         [TestAppFact("Samples.Computer01")]

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerBeforeAfterTestAttribute.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerBeforeAfterTestAttribute.cs
@@ -1,0 +1,23 @@
+// <copyright file="ProfilerBeforeAfterTestAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Datadog.Profiler.IntegrationTests.Xunit
+{
+    internal class ProfilerBeforeAfterTestAttribute : BeforeAfterTestAttribute
+    {
+        public override void After(MethodInfo methodUnderTest)
+        {
+            TestContext.Current.TestName = null;
+        }
+
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            TestContext.Current.TestName = methodUnderTest.DeclaringType.Name + "." + methodUnderTest.Name;
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerTestCase.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerTestCase.cs
@@ -1,0 +1,40 @@
+// <copyright file="ProfilerTestCase.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Datadog.Profiler.IntegrationTests.Xunit
+{
+    internal class ProfilerTestCase : XunitTestCase
+    {
+        [Obsolete]
+        public ProfilerTestCase()
+            : base()
+        {
+        }
+
+        public ProfilerTestCase(
+            IMessageSink diagnosticMessageSink,
+            TestMethodDisplay defaultMethodDisplay,
+            TestMethodDisplayOptions defaultMethodDisplayOptions,
+            ITestMethod testMethod,
+            object[] testMethodArguments = null)
+            : base(diagnosticMessageSink, defaultMethodDisplay, defaultMethodDisplayOptions, testMethod, testMethodArguments)
+        {
+        }
+
+        public override Task<RunSummary> RunAsync(
+            IMessageSink diagnosticMessageSink,
+            IMessageBus messageBus,
+            object[] constructorArguments,
+            ExceptionAggregator aggregator,
+            CancellationTokenSource cancellationTokenSource)
+           => new ProfilerTestCaseRunner(this, DisplayName, SkipReason, constructorArguments, TestMethodArguments, messageBus, aggregator, cancellationTokenSource).RunAsync();
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerTestCaseRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/ProfilerTestCaseRunner.cs
@@ -1,0 +1,26 @@
+// <copyright file="ProfilerTestCaseRunner.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Threading;
+using Xunit.Sdk;
+
+namespace Datadog.Profiler.IntegrationTests.Xunit
+{
+    internal class ProfilerTestCaseRunner : XunitTestCaseRunner
+    {
+        public ProfilerTestCaseRunner(IXunitTestCase testCase, string displayName, string skipReason, object[] constructorArguments, object[] testMethodArguments, IMessageBus messageBus, ExceptionAggregator aggregator, CancellationTokenSource cancellationTokenSource)
+            : base(testCase, displayName, skipReason, constructorArguments, testMethodArguments, messageBus, aggregator, cancellationTokenSource)
+        {
+        }
+
+        protected override List<BeforeAfterTestAttribute> GetBeforeAfterTestAttributes()
+        {
+            var baseList = base.GetBeforeAfterTestAttributes();
+            baseList.Add(new ProfilerBeforeAfterTestAttribute());
+            return baseList;
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/SkippableTestCase.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/SkippableTestCase.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Datadog.Profiler.IntegrationTests.Helpers
+namespace Datadog.Profiler.IntegrationTests.Xunit
 {
     [Serializable]
     public class SkippableTestCase : TestMethodTestCase, IXunitTestCase

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/TestAppFrameworkDiscover.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/TestAppFrameworkDiscover.cs
@@ -3,13 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
 using Xunit.Abstractions;
 using Xunit.Sdk;
 
-namespace Datadog.Profiler.SmokeTests
+namespace Datadog.Profiler.IntegrationTests.Xunit
 {
     /// <summary>
     /// This class allows to discover test cases for smoke application.
@@ -46,13 +47,13 @@ namespace Datadog.Profiler.SmokeTests
                 return results;
             }
 
-            foreach (string folder in System.IO.Directory.GetDirectories(appFolderPath))
+            foreach (var folder in System.IO.Directory.GetDirectories(appFolderPath))
             {
                 var framework = System.IO.Path.GetFileName(folder);
                 if (frameworks == null || frameworks.Contains(framework))
                 {
                     results.Add(
-                        new XunitTestCase(
+                        new ProfilerTestCase(
                                 MessageSink,
                                 TestMethodDisplay.ClassAndMethod,
                                 TestMethodDisplayOptions.All,

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/TestContext.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/TestContext.cs
@@ -1,0 +1,18 @@
+// <copyright file="TestContext.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.Threading;
+
+namespace Datadog.Profiler.IntegrationTests.Xunit
+{
+    internal class TestContext
+    {
+        private static readonly AsyncLocal<TestContext> _context = new();
+
+        public static TestContext Current => _context.Value ??= new TestContext();
+
+        public string TestName { get; internal set; }
+    }
+}


### PR DESCRIPTION
## Summary of changes

The goal is to improve the profiler integration tests output, to simplify failing test artifacts.

## Reason for change
Today, when the profiler integration tests run, they produce log files and pprof files. As you can see in the screenshot below, `Before` is the current layout which makes things hard to locate failing tests log/pprof files:
You have to go to the job console, look for the `kind of id of the test`, the framework and you can locate you artifact.

With this PR, it will be easier to locate failing tests artifacts: As shown in the image below, with the `After`, knowing the failing test (class name and method name and framework), we can quickly get the log/pprof files.

![image](https://github.com/DataDog/dd-trace-dotnet/assets/17292193/dce94b25-4031-4e02-8b0d-4dff7b998bc2)
## Implementation details

In xUnit 2, there is no `TestContext` (coming with xUnit 3), so we implemented a lightweight `TestContext` class which will be filled by the `ProfilerAfterBeforeTestAttribute`.

To avoid modifying all the tests, we implemented a `ProfilerTestCaseRunner` class, overrided the `GetBeforeAfterTestAttributes` to get the ones from the base class, and injecting our `ProfilerAfterBeforeTestAttribute`.
In order to use our runner, we lightly implemented a `ProfilerTestCase` to create an instance of our `ProfilerTestCaseRunner` class to run the test.

We replaced the instantiation of a `XunitTestCase` by our `ProfilerTestCase` in our (already existing) `TestAppFrameworkDiscover` class.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
