### PR TITLE
[CI Visibility] `dd-trace ci configure` improvements

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
@@ -5,19 +5,35 @@
 
 using System;
 using System.Collections.Generic;
+using Datadog.Trace.Logging;
 using Spectre.Console;
 
 namespace Datadog.Trace.Tools.Runner
 {
     internal static class CIConfiguration
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(CIConfiguration));
+
         public static bool SetupCIEnvironmentVariables(Dictionary<string, string> environmentVariables, CIName? ci)
         {
+            Log.Information("Detecting CI provider...");
             ci ??= AutodetectCi();
 
             switch (ci)
             {
                 case CIName.AzurePipelines:
+                    Log.Information("Setting up the environment variables for auto-instrumentation for Azure Pipelines.");
+                    // Excluding powershell.exe due to interference in the azure agent making that subsequence script tasks fail.
+                    if (environmentVariables.TryGetValue("DD_PROFILER_EXCLUDE_PROCESSES", out var excludeProcesses))
+                    {
+                        excludeProcesses += ";powershell.exe";
+                    }
+                    else
+                    {
+                        excludeProcesses = "powershell.exe";
+                    }
+
+                    environmentVariables["DD_PROFILER_EXCLUDE_PROCESSES"] = excludeProcesses;
                     SetupAzureEnvironmentVariables(environmentVariables);
                     return true;
             }

--- a/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CIConfiguration.cs
@@ -23,14 +23,14 @@ namespace Datadog.Trace.Tools.Runner
             {
                 case CIName.AzurePipelines:
                     Log.Information("Setting up the environment variables for auto-instrumentation for Azure Pipelines.");
-                    // Excluding powershell.exe due to interference in the azure agent making that subsequence script tasks fail.
+                    // Excluding powershell.exe and DTAExecutionHost.exe due to interference in the azure agent making that subsequence script tasks fail.
                     if (environmentVariables.TryGetValue("DD_PROFILER_EXCLUDE_PROCESSES", out var excludeProcesses))
                     {
-                        excludeProcesses += ";powershell.exe";
+                        excludeProcesses += ";DTAExecutionHost.exe;powershell.exe";
                     }
                     else
                     {
-                        excludeProcesses = "powershell.exe";
+                        excludeProcesses = "DTAExecutionHost.exe;powershell.exe";
                     }
 
                     environmentVariables["DD_PROFILER_EXCLUDE_PROCESSES"] = excludeProcesses;


### PR DESCRIPTION
## Summary of changes

This PR contains a couple of CI Visibility improvements: 

- Log stderr on git pack errors.
- Add a logs into the SetupCIEnvironmentVariables method to ensure the log folder is created.
- Add powershell.exe as an exclude process when using dd-trace ci configure azp due to incompatibilities.
