### PR TITLE
[ASM] Filter azure assemblies in the stack of vulnerabilities

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/StackWalker.cs
+++ b/tracer/src/Datadog.Trace/Iast/StackWalker.cs
@@ -35,6 +35,7 @@ internal static class StackWalker
         "System",
         "System.",
         "xunit.",
+        "Azure."
     };
 
     private static readonly Dictionary<string, bool> ExcludedAssemblyCache = new Dictionary<string, bool>();


### PR DESCRIPTION
## Summary of changes

We need to add a filter in the stack walker in order to exclude the files of the Azure assemblies.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
