### PR TITLE
Fix runtime metrics bugs + allow DD_TAGS tagging

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -68,12 +68,7 @@ internal class LiveDebuggerFactory
         }
         else
         {
-            var constantTags = new List<string>
-            {
-                $"service:{NormalizerTraceProcessor.NormalizeService(serviceName)}"
-            };
-
-            statsd = TracerManagerFactory.CreateDogStatsdClient(tracerSettings, constantTags, DebuggerSettings.DebuggerMetricPrefix);
+            statsd = TracerManagerFactory.CreateDogStatsdClient(tracerSettings, serviceName, constantTags: null, DebuggerSettings.DebuggerMetricPrefix);
         }
 
         telemetry.ProductChanged(TelemetryProductType.DynamicInstrumentation, enabled: true, error: null);

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -288,6 +288,7 @@ namespace Datadog.Trace
                     ServiceName = NormalizerTraceProcessor.NormalizeService(serviceName),
                     Environment = settings.EnvironmentInternal,
                     ServiceVersion = settings.ServiceVersionInternal,
+                    Advanced = { TelemetryFlushInterval = null }
                 };
 
                 switch (settings.ExporterInternal.MetricsTransport)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -101,6 +101,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_SERVICE", inputServiceName);
             SetEnvironmentVariable("DD_RUNTIME_METRICS_ENABLED", "1");
             SetInstrumentationVerification();
+            SetEnvironmentVariable("DD_TAGS", "some:value"); // Should be added to the metrics
+
             using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
             using var processResult = RunSampleAndWaitForExit(agent);
             var requests = agent.StatsdRequests;
@@ -128,7 +130,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                .OnlyContain(s => s.Contains($"service:{normalizedServiceName}"))
                .And.NotContain(s => s.Contains($"service:{inputServiceName}"))
                .And.OnlyContain(s => Regex.Matches(s, @"env:integration_tests").Count == 1)
-               .And.OnlyContain(s => Regex.Matches(s, @"version:1\.0\.0").Count == 1);
+               .And.OnlyContain(s => Regex.Matches(s, @"version:1\.0\.0").Count == 1)
+               .And.OnlyContain(s => Regex.Matches(s, @"some:value").Count == 1);
 
             // Check if .NET Framework or .NET Core 3.1+
             if (!EnvironmentHelper.IsCoreClr()

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -97,7 +97,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         private void RunTest()
         {
             var inputServiceName = "12_$#Samples.$RuntimeMetrics";
-            var normalizedServiceName = "samples._runtimemetrics";
             SetEnvironmentVariable("DD_SERVICE", inputServiceName);
             SetEnvironmentVariable("DD_RUNTIME_METRICS_ENABLED", "1");
             SetInstrumentationVerification();
@@ -127,11 +126,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Assert tags
             metrics
                .Should()
-               .OnlyContain(s => s.Contains($"service:{normalizedServiceName}"))
-               .And.NotContain(s => s.Contains($"service:{inputServiceName}"))
-               .And.OnlyContain(s => Regex.Matches(s, @"env:integration_tests").Count == 1)
-               .And.OnlyContain(s => Regex.Matches(s, @"version:1\.0\.0").Count == 1)
-               .And.OnlyContain(s => Regex.Matches(s, @"some:value").Count == 1);
+               .OnlyContain(s => Regex.Matches(s, @"\bservice:samples\._runtimemetrics").Count == 1)
+               .And.OnlyContain(s => Regex.Matches(s, @"\benv:integration_tests").Count == 1)
+               .And.OnlyContain(s => Regex.Matches(s, @"\bversion:1\.0\.0").Count == 1)
+               .And.OnlyContain(s => Regex.Matches(s, @"\benv:").Count == 1)
+               .And.OnlyContain(s => Regex.Matches(s, @"\bversion:").Count == 1)
+               .And.OnlyContain(s => Regex.Matches(s, @"\bservice:").Count == 1)
+               .And.OnlyContain(s => Regex.Matches(s, @"\bsome:value").Count == 1);
 
             // Check if .NET Framework or .NET Core 3.1+
             if (!EnvironmentHelper.IsCoreClr()

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -597,8 +597,9 @@ public class ProbesTests : TestHelper
         }
         else
         {
+            var normalizedServiceName = EnvironmentHelper.SampleName.ToLowerInvariant();
             var requests = await agent.WaitForStatsdRequests(metricProbes.Length);
-            requests.Should().OnlyContain(s => s.Contains($"service:{EnvironmentHelper.SampleName}"));
+            requests.Should().OnlyContain(s => s.Contains($"service:{normalizedServiceName}"));
 
             var retried = false;
 
@@ -617,7 +618,7 @@ public class ProbesTests : TestHelper
                 }
 
                 Assert.NotNull(req);
-                req.Should().Contain($"service:{EnvironmentHelper.SampleName}");
+                req.Should().Contain($"service:{normalizedServiceName}");
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

- Fixes several bugs in runtime metrics
- Adds tags specified in `DD_TAGS` to runtime metrics

## Reason for change

The `DD_TAGS` feature was requested in https://github.com/DataDog/dd-trace-dotnet/issues/4279. As part of implementing the feature, I discovered a variety of additional bugs:

- Dogstatsd is reading environment variables directly (without wrapping in `try-catch` like our helper does. Currently, haven't done anything about this.
- Dogstatsd was adding duplicate tags, `env:` and `version:` to all metrics, in addition to the tags we add
- Dogstatsd was adding duplicate the `service:` tag, but wasn't normalizing the value. Consequently, all metrics were tagged with _both_ the normalized and unnormalized `service:` tag.
- We were sending "internal" metrics about the stastd client to runtime metrics

```
datadog.dogstatsd.client.metrics
datadog.dogstatsd.client.events
datadog.dogstatsd.client.service_checks
datadog.dogstatsd.client.bytes_sent
datadog.dogstatsd.client.bytes_dropped
datadog.dogstatsd.client.packets_sent
datadog.dogstatsd.client.packets_dropped
datadog.dogstatsd.client.packets_dropped_queue
```

which we don't want

## Implementation details

Dug through the internals of dogstsatsd to make sure we stop sending duplicate values. Basically, if we set the values up-front, dogstatsd _mostly_ doesn't try to load them and re-add them.

Previously, tags looked like this (notice duplicate values + non-normalized servicename):

`runtime.dotnet.gc.pause_time:1.2128|ms|#lang:.NET,lang_interpreter:.NET,lang_version:7.0.9,tracer_version:2.38.0.0,service:samples._runtimemetrics,runtime-id:79819697-3613-4b93-9ef3-acc7401bebec,env:integration_tests,version:1.0.0,service:12_$#Samples.$RuntimeMetrics,env:integration_tests,version:1.0.0`

afterwards, we have this:

`runtime.dotnet.gc.pause_time:1.2128|ms|#lang:.NET,lang_interpreter:.NET,lang_version:7.0.9,tracer_version:2.38.0.0,service:samples._runtimemetrics,runtime-id:79819697-3613-4b93-9ef3-acc7401bebec,env:integration_tests,version:1.0.0`

The `datadog.dogstatsd.client*` metrics were even worse, as they duplicated _all_ the tags 😅 

`datadog.dogstatsd.client.metrics:0|c|#lang:.NET,lang_interpreter:.NET,lang_version:7.0.9,tracer_version:2.38.0.0,service:samples._runtimemetrics,runtime-id:79819697-3613-4b93-9ef3-acc7401bebec,env:integration_tests,version:1.0.0,service:12_$#Samples.$RuntimeMetrics,env:integration_tests,version:1.0.0,client:csharp,client_version:2.38.0.0,client_transport:udp,lang:.NET,lang_interpreter:.NET,lang_version:7.0.9,tracer_version:2.38.0.0,service:samples._runtimemetrics,runtime-id:79819697-3613-4b93-9ef3-acc7401bebec,env:integration_tests,version:1.0.0,service:12_$#Samples.$RuntimeMetrics,env:integration_tests,version:1.0.0`
## Test coverage

Updated the integration tests to do more assertions on the received metrics:
- No internal metrics
- No duplicated env/verison/service
- No unnormalized service names
- Extra tags

## Other details
Fixes: https://github.com/DataDog/dd-trace-dotnet/issues/4279

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
