### PR TITLE
[Profiler] Avoid returning managed thread with invalid handle

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -225,18 +225,24 @@ std::shared_ptr<ManagedThreadInfo> ManagedThreadList::LoopNext(uint32_t iterator
     }
 
     uint32_t pos = _iterators[iterator];
-    std::shared_ptr<ManagedThreadInfo> pInfo = _threads[pos];
+    std::shared_ptr<ManagedThreadInfo> pInfo = nullptr;
 
-    // move the iterator to the next thread
-    if (pos < activeThreadCount - 1)
+    auto startPos = pos;
+    do
     {
-        pos++;
-    }
-    else // go back to the first thread if the end is reached
-    {
-        pos = 0;
-    }
+        pInfo = _threads[pos];
+        // move the iterator to the next thread and loop
+        // back to the first thread if the end is reached
+        pos = (pos + 1) % activeThreadCount;
+    } while (startPos != pos &&
+        (pInfo->GetOsThreadHandle() == static_cast<HANDLE>(NULL) || pInfo->GetOsThreadHandle() == INVALID_HANDLE_VALUE));
+
     _iterators[iterator] = pos;
+
+    if (startPos == pos)
+    {
+        return nullptr;
+    }
 
     return pInfo;
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ManagedThreadListTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ManagedThreadListTest.cpp
@@ -9,12 +9,18 @@
 #include "ManagedThreadInfo.h"
 
 
+void CreateThread(ManagedThreadList& threadsList, ThreadID threadId, HANDLE handle = NULL)
+{
+    threadsList.GetOrCreateThread(threadId);
+    // for simplicity, use the ThreadID as OS Thread Id
+    threadsList.SetThreadOsInfo(threadId, (DWORD)threadId, handle);
+}
 TEST(ManagedThreadListTest, CheckAdd)
 {
     ManagedThreadList threads(nullptr);
-    threads.GetOrCreateThread(1);
-    threads.GetOrCreateThread(2);
-    threads.GetOrCreateThread(3);
+    CreateThread(threads, 1);
+    CreateThread(threads, 2);
+    CreateThread(threads, 3);
 
     ASSERT_EQ(threads.Count(), 3);
 }
@@ -22,9 +28,9 @@ TEST(ManagedThreadListTest, CheckAdd)
 TEST(ManagedThreadListTest, CheckRemove)
 {
     ManagedThreadList threads(nullptr);
-    threads.GetOrCreateThread(1);
-    threads.GetOrCreateThread(2);
-    threads.GetOrCreateThread(3);
+    CreateThread(threads, 1);
+    CreateThread(threads, 2);
+    CreateThread(threads, 3);
 
     ASSERT_EQ(threads.Count(), 3);
 
@@ -46,9 +52,9 @@ TEST(ManagedThreadListTest, CheckLoopNext)
     ManagedThreadList threads(nullptr);
     auto iterator = threads.CreateIterator();
 
-    threads.GetOrCreateThread(1);
-    threads.GetOrCreateThread(2);
-    threads.GetOrCreateThread(3);
+    CreateThread(threads, 1, (HANDLE)1);
+    CreateThread(threads, 2, (HANDLE)2);
+    CreateThread(threads, 3, (HANDLE)3);
 
     // check iterator
     std::shared_ptr<ManagedThreadInfo> pInfo = nullptr;
@@ -76,15 +82,16 @@ TEST(ManagedThreadListTest, CheckLoopNextWhenAdd)
 {
     ManagedThreadList threads(nullptr);
     auto iterator = threads.CreateIterator();
-    threads.GetOrCreateThread(1);
-    threads.GetOrCreateThread(2);
-    threads.GetOrCreateThread(3);
+
+    CreateThread(threads, 1, (HANDLE)1);
+    CreateThread(threads, 2, (HANDLE)2);
+    CreateThread(threads, 3, (HANDLE)3);
 
     // add during iteration
     std::shared_ptr<ManagedThreadInfo> pInfo = nullptr;
     pInfo = threads.LoopNext(iterator);
     pInfo = threads.LoopNext(iterator);
-    threads.GetOrCreateThread(4);
+    CreateThread(threads, 4, (HANDLE)4);
 
     pInfo = threads.LoopNext(iterator);
     ASSERT_TRUE(pInfo != nullptr);
@@ -98,11 +105,11 @@ TEST(ManagedThreadListTest, CheckLoopNextWhenRemove)
 {
     ManagedThreadList threads(nullptr);
     auto iterator = threads.CreateIterator();
-    threads.GetOrCreateThread(1);
-    threads.GetOrCreateThread(2);
-    threads.GetOrCreateThread(3);
-    threads.GetOrCreateThread(4);
-    threads.GetOrCreateThread(5);
+    CreateThread(threads, 1, (HANDLE)1);
+    CreateThread(threads, 2, (HANDLE)2);
+    CreateThread(threads, 3, (HANDLE)3);
+    CreateThread(threads, 4, (HANDLE)4);
+    CreateThread(threads, 5, (HANDLE)5);
 
     std::shared_ptr<ManagedThreadInfo> pInfo = nullptr;
     pInfo = threads.LoopNext(iterator);
@@ -143,13 +150,67 @@ TEST(ManagedThreadListTest, CheckLoopNextWhenRemove)
     //                    ^
 }
 
+TEST(ManagedThreadListTest, CheckLoopNextSkipThreadWithInvalidHandle)
+{
+    ManagedThreadList threads(nullptr);
+    auto iterator = threads.CreateIterator();
+    CreateThread(threads, 1, (HANDLE)1);
+    CreateThread(threads, 2, (HANDLE)2);
+    // Thread 3 has no valid HANDLE
+    CreateThread(threads, 3);
+    CreateThread(threads, 4, (HANDLE)4);
+    CreateThread(threads, 5, (HANDLE)5);
+
+    std::shared_ptr<ManagedThreadInfo> pInfo = nullptr;
+
+    //
+    // see what happens when an element is removed after and before the current position
+    //    1   2   3   4   5
+    //    ^
+    pInfo = threads.LoopNext(iterator);
+    ASSERT_TRUE(pInfo != nullptr);
+    ASSERT_EQ(pInfo->GetClrThreadId(), 1);
+
+    //    1   2   3   4   5
+    //        ^
+    pInfo = threads.LoopNext(iterator);
+    ASSERT_TRUE(pInfo != nullptr);
+    ASSERT_EQ(pInfo->GetClrThreadId(), 2);
+
+    // The next call to LoopNext will go directly to thread 4,
+    // because thread 3 has an invalid HANDLE
+    //    1   2   3   4   5
+    //                ^
+    pInfo = threads.LoopNext(iterator);
+    ASSERT_TRUE(pInfo != nullptr);
+    ASSERT_EQ(pInfo->GetClrThreadId(), 4);
+
+    //    1   2   3   4   5
+    //                    ^
+    pInfo = threads.LoopNext(iterator);
+    ASSERT_TRUE(pInfo != nullptr);
+    ASSERT_EQ(pInfo->GetClrThreadId(), 5);
+}
+
+TEST(ManagedThreadListTest, CheckLoopNextReturnNullptrIfNoThreadWithValidHandle)
+{
+    ManagedThreadList threads(nullptr);
+    auto iterator = threads.CreateIterator();
+    CreateThread(threads, 1);
+    CreateThread(threads, 2, INVALID_HANDLE_VALUE);
+    CreateThread(threads, 3);
+    CreateThread(threads, 4, INVALID_HANDLE_VALUE);
+
+    ASSERT_EQ(nullptr, threads.LoopNext(iterator));
+}
+
 TEST(ManagedThreadListTest, CheckLoopNextWhenRemoveLastThread)
 {
     ManagedThreadList threads(nullptr);
     auto iterator = threads.CreateIterator();
-    threads.GetOrCreateThread(1);
-    threads.GetOrCreateThread(2);
-    threads.GetOrCreateThread(3);
+    CreateThread(threads, 1, (HANDLE)1);
+    CreateThread(threads, 2, (HANDLE)2);
+    CreateThread(threads, 3, (HANDLE)3);
 
     std::shared_ptr<ManagedThreadInfo> pInfo = nullptr;
     pInfo = threads.LoopNext(iterator);
@@ -209,11 +270,12 @@ void WorkOnIterator(MultipleIteratorsParams* parameters)
 TEST(ManagedThreadListTest, CheckMultipleIterators)
 {
     ManagedThreadList threads(nullptr);
-    threads.GetOrCreateThread(1);
-    threads.GetOrCreateThread(2);
-    threads.GetOrCreateThread(3);
-    threads.GetOrCreateThread(4);
-    threads.GetOrCreateThread(5);
+    CreateThread(threads, 1, (HANDLE)1);
+    CreateThread(threads, 2, (HANDLE)2);
+    CreateThread(threads, 3, (HANDLE)3);
+    CreateThread(threads, 4, (HANDLE)4);
+    CreateThread(threads, 5, (HANDLE)5);
+
     MultipleIteratorsParams params1(threads, threads.CreateIterator());
     MultipleIteratorsParams params2(threads, threads.CreateIterator());
 


### PR DESCRIPTION
## Summary of changes

Avoid returning a managed thread which does not have a valid handle.

## Reason for change

Cleaner code.

And also because, we may be in a situation where the `ManagedThreadList` contains managed threads that have no valid handle yet. For example: `Kestrel Timer` thread was created and the `StackSamplerLoop` trying to sample it before it has a valid handle (call to `ThreadAssignedToOSThread` is made).

## Implementation details

In `LoopNext`, we look for the next thread that would have a valid handle.

## Test coverage

Add new unit tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
