### PR TITLE
Use alpine base for lib-injection image

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -4,7 +4,7 @@ ARG LINUX_PACKAGE
 # The ADD command does more than COPY, so it can directly copy a local directory or it can copy over a `tar.gz` file and automatically extract its contents into the destination
 ADD ${LINUX_PACKAGE} /
 
-FROM busybox
+FROM alpine:3.18.3
 
 ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \


### PR DESCRIPTION
## Summary of changes

Change the base library injection image from `busybox` to `alpine` to make the image more compatible with other software environments.


## Reason for change

`libdl.so.2: cannot open shared object file: No such file or directory` errors have been reported in customer environments which prevents application containers from starting up when using [library injection](https://docs.datadoghq.com/tracing/trace_collection/library_injection_local/?tab=kubernetes#step-3---tag-your-pods-with-unified-service-tags). Likely this is due to some other software such as instrumentation or security that modifies the command run in the container. The modified command fails as the `libdl.so.2` shared library isn't present in the `busybox`-based image.

`busybox` [lacks many standard C libraries](https://github.com/docker-library/busybox/issues/46). `alpine` is a similarly sized image which does provide the standard C libraries and mitigates the issue.

There is little risk in changing the base image to `alpine` as the only command required is to copy files from the image to a volume. However, it is possible that the command that is being added to the container is not compatible with alpine images.


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
