### PR TITLE
Update native log verbosity

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1099,8 +1099,8 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                                 const auto caller = GetFunctionInfo(metadata_import, methodDef);
                                 if (!caller.IsValid())
                                 {
-                                    Logger::Warn("    * The caller for the methoddef: ",
-                                                 shared::TokenStr(&parent_token), " is not valid!");
+                                    Logger::Warn("    * Skipping ", shared::TokenStr(&parent_token),
+                                        ": the methoddef is not valid!");
                                     customAttributesIterator = ++customAttributesIterator;
                                     continue;
                                 }
@@ -1111,8 +1111,8 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
                                 auto hr = functionInfo.method_signature.TryParse();
                                 if (FAILED(hr))
                                 {
-                                    Logger::Warn("    * The method signature: ", functionInfo.method_signature.str(),
-                                                 " cannot be parsed.");
+                                    Logger::Warn("    * Skipping ", functionInfo.method_signature.str(),
+                                                 ": the method signature cannot be parsed.");
                                     customAttributesIterator = ++customAttributesIterator;
                                     continue;
                                 }

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -275,7 +275,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     }
     else
     {
-        Logger::Info("JIT Inlining is enabled.");
+        Logger::Debug("JIT Inlining is enabled.");
     }
 
     if (DisableOptimizations())
@@ -286,7 +286,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
 
     if (IsNGENEnabled())
     {
-        Logger::Info("NGEN is enabled.");
+        Logger::Debug("NGEN is enabled.");
         event_mask |= COR_PRF_MONITOR_CACHE_SEARCHES;
     }
     else
@@ -523,7 +523,7 @@ void CorProfiler::RewritingPInvokeMaps(const ModuleMetadata& module_metadata,
                 auto methodDef = *enumIterator;
 
                 const auto& caller = GetFunctionInfo(module_metadata.metadata_import, methodDef);
-                Logger::Info("Rewriting PInvoke method: ", caller.name);
+                Logger::Debug("Rewriting PInvoke method: ", caller.name);
 
                 // Get the current PInvoke map to extract the flags and the entrypoint name
                 DWORD pdwMappingFlags;

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -96,7 +96,9 @@ private:
     //
     // Helper methods
     //
-    static void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const shared::WSTRING& nativemethods_type_name, const shared::WSTRING& library_path = shared::WSTRING());
+    static void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const shared::WSTRING& rewrite_reason,
+                                     const shared::WSTRING& nativemethods_type_name,
+                                     const shared::WSTRING& library_path = shared::WSTRING());
     bool GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleID module_id,
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
     bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
@@ -78,7 +78,7 @@ ULONG DebuggerRejitPreprocessor::PreprocessLineProbes(
             const auto caller = GetFunctionInfo(metadataImport, methodDef);
             if (!caller.IsValid())
             {
-                Logger::Warn("    * The caller for the methoddef: ", shared::TokenStr(&methodDef), " is not valid!");
+                Logger::Warn("    * Skipping ", shared::TokenStr(&methodDef), ": the methoddef is not valid!");
                 continue;
             }
 
@@ -88,7 +88,7 @@ ULONG DebuggerRejitPreprocessor::PreprocessLineProbes(
             auto hr = functionInfo.method_signature.TryParse();
             if (FAILED(hr))
             {
-                Logger::Warn("    * The method signature: ", functionInfo.method_signature.str(), " cannot be parsed.");
+                Logger::Warn("    * Skipping ", functionInfo.method_signature.str(), ": the method signature cannot be parsed.");
                 continue;
             }
 
@@ -386,7 +386,7 @@ std::tuple<HRESULT, mdMethodDef, FunctionInfo> DebuggerRejitPreprocessor::Transf
     auto caller = GetFunctionInfo(metadataImport, moveNextMethod);
     if (!caller.IsValid())
     {
-        Logger::Error("DebuggerRejitPreprocessor::TransformKickOffToMoveNext: The caller for the methoddef: ",
+        Logger::Error("DebuggerRejitPreprocessor::TransformKickOffToMoveNext: The methoddef: ",
                       shared::TokenStr(&moveNextMethod), " is not valid!");
         return {E_FAIL, mdMethodDefNil, FunctionInfo()};
     }

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.cpp
@@ -107,7 +107,7 @@ ULONG DebuggerRejitPreprocessor::PreprocessLineProbes(
                     moduleInfo.assembly.app_domain_id, pCorAssemblyProperty, enable_by_ref_instrumentation,
                     enable_calltarget_state_by_ref);
 
-                Logger::Info("ReJIT handler stored metadata for ", moduleInfo.id, " ", moduleInfo.assembly.name,
+                Logger::Debug("ReJIT handler stored metadata for ", moduleInfo.id, " ", moduleInfo.assembly.name,
                              " AppDomain ", moduleInfo.assembly.app_domain_id, " ",
                              moduleInfo.assembly.app_domain_name);
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -58,8 +58,11 @@ bool RejitHandlerModuleMethod::RequestRejitForInlinersInModule(ModuleID moduleId
     ModuleID currentModuleId = m_module->GetModuleId();
     mdMethodDef currentMethodDef = m_methodDef;
 
+#if DEBUG
+    // We generate this log hundreds of times, and isn't typically useful in escalations 
     Logger::Debug("RejitHandlerModuleMethod::RequestRejitForInlinersInModule for ",
                   "[ModuleInliner=", moduleId , ", ModuleId=", currentModuleId, ", MethodDef=", currentMethodDef, "]");
+#endif
 
     RejitHandler* handler = m_module->GetHandler();
     ICorProfilerInfo7* pInfo = handler->GetCorProfilerInfo();

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -194,7 +194,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
                                    moduleInfo.assembly.app_domain_id, pCorAssemblyProperty,
                                    enable_by_ref_instrumentation, enable_calltarget_state_by_ref);
 
-            Logger::Info("ReJIT handler stored metadata for ", moduleInfo.id, " ", moduleInfo.assembly.name,
+            Logger::Debug("ReJIT handler stored metadata for ", moduleInfo.id, " ", moduleInfo.assembly.name,
                          " AppDomain ", moduleInfo.assembly.app_domain_id, " ", moduleInfo.assembly.app_domain_name);
 
             moduleHandler->SetModuleMetadata(moduleMetadata);

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -113,7 +113,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
         const auto caller = GetFunctionInfo(metadataImport, methodDef);
         if (!caller.IsValid())
         {
-            Logger::Warn("    * The caller for the methoddef: ", shared::TokenStr(&methodDef), " is not valid!");
+            Logger::Warn("    * Skipping ", shared::TokenStr(&methodDef), ": the methoddef is not valid!");
             continue;
         }
 
@@ -123,7 +123,8 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
         auto hr = functionInfo.method_signature.TryParse();
         if (FAILED(hr))
         {
-            Logger::Warn("    * The method signature: ", functionInfo.method_signature.str(), " cannot be parsed.");
+            Logger::Warn("    * Skipping ", functionInfo.method_signature.str(),
+                ": the method signature cannot be parsed.");
             continue;
         }
 
@@ -148,8 +149,8 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
             // instrumentation target
             if (numOfArgs != target_method.signature_types.size() - 1)
             {
-                Logger::Info("    * The caller for the methoddef: ", caller.name,
-                              " doesn't have the right number of arguments (", numOfArgs, " arguments).");
+                Logger::Info("    * Skipping ", caller.type.name, ".", caller.name,
+                    ": the methoddef doesn't have the right number of arguments (", numOfArgs, " arguments).");
                 continue;
             }
 
@@ -171,8 +172,8 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
             }
             if (argumentsMismatch)
             {
-                Logger::Info("    * The caller for the methoddef: ", target_method.method_name,
-                              " doesn't have the right type of arguments.");
+                Logger::Info("    * Skipping ", target_method.method_name,
+                    ": the methoddef doesn't have the right type of arguments.");
                 continue;
             }
         }
@@ -201,7 +202,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
         }
 
         Logger::Info("Method enqueued for ReJIT for ", target_method.type.name, ".", target_method.method_name,
-                  "(", (target_method.signature_types.size() - 1), " params)'.");
+                  "(", (target_method.signature_types.size() - 1), " params).");
         EnqueueNewMethod(definition, metadataImport, metadataEmit, moduleInfo, typeDef, rejitRequests, methodDef,
                          functionInfo, moduleHandler);
 

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.cpp
@@ -148,7 +148,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
             // instrumentation target
             if (numOfArgs != target_method.signature_types.size() - 1)
             {
-                Logger::Debug("    * The caller for the methoddef: ", caller.name,
+                Logger::Info("    * The caller for the methoddef: ", caller.name,
                               " doesn't have the right number of arguments (", numOfArgs, " arguments).");
                 continue;
             }
@@ -171,7 +171,7 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
             }
             if (argumentsMismatch)
             {
-                Logger::Debug("    * The caller for the methoddef: ", target_method.method_name,
+                Logger::Info("    * The caller for the methoddef: ", target_method.method_name,
                               " doesn't have the right type of arguments.");
                 continue;
             }
@@ -200,6 +200,8 @@ void RejitPreprocessor<RejitRequestDefinition>::ProcessTypeDefForRejit(const Rej
             moduleHandler->SetModuleMetadata(moduleMetadata);
         }
 
+        Logger::Info("Method enqueued for ReJIT for ", target_method.type.name, ".", target_method.method_name,
+                  "(", (target_method.signature_types.size() - 1), " params)'.");
         EnqueueNewMethod(definition, metadataImport, metadataEmit, moduleInfo, typeDef, rejitRequests, methodDef,
                          functionInfo, moduleHandler);
 


### PR DESCRIPTION
## Summary of changes

- Move some `Info` level logs to `Debug`
- Move one `Debug` log to only be in `#if Debug` builds
- Move the `Debug` level log that describes rejitted methods to `Info`
- Reword some log messages
- Add "origin" of rewriting to some messages

## Reason for change

We currently generate a _lot_ of logs in the native tracer when in Debug mode. _Most_ of these aren't particularly useful when working on investigations, but some of them are. To reduce the need to enable debug logs (especially as it relates to forthcoming automatic log collections with a flare), this PR updates some of the log levels.

## Implementation details

- `JIT Inlining is enabled` -> Debug - this is the default, we have a log if it's disabled, so probably don't need it in the Info logs
- `NGEN is enabled` -> Debug - same argument
- `Rewriting PInvoke method` -> Debug - these happen every time, and aren't particularly useful unless they go wrong (which we already log)
- `ReJIT handler stored metadata for` -> Debug - meh
- `RejitHandlerModuleMethod::RequestRejitForInlinersInModule` -> `#if DEBUG` - this is written _hundreds_ of times, and probably isn't very useful
- `The caller for the methoddef X doesn't have the right number of arguments` -> `info` - these are the calls that I look for typically in the native logs, so we know when instrumenting succeeded or failed
-  `Method enqueued for ReJIT for X` -> Info - the counterpart to "failed to rejit" which we can't deduce in info logs currently

## Test coverage

Did some line/file size comparisons. Instrumented a small aspnetcore app, made some requests and shutdown. It had version conflict as it turns out.

|----State----|   Debug?   |  File Size |  Log lines  |    
|---|---|---:|---:|
|Before changes| Enabled |    552KB| 3,002 |
|               | Disabled  |  12KB| 96 |
|Reduced Logs  | Enabled |    277KB| 1,511 |
|               | Disabled  |  7 KB|  51 |
| Extra info Log | Disabled |  12KB|  83 |

So overall, we have ~half the number of logs in debug mode, and reduced the logs in info mode, despite introducing some useful log lines:

<details>
<summary>The final (non-debug) logs are shown here</summary>
<pre><code>09/07/23 11:06:54.492 AM [19984|13416] [info] Datadog CLR Profiler 2.38.0 on Windows (amd64)
09/07/23 11:06:54.493 AM [19984|13416] [info] ProcessName: telemetrytest.exe
09/07/23 11:06:54.493 AM [19984|13416] [info] Process CommandLine: ".\telemetrytest.exe" --environment Development --urls http://*:8083
09/07/23 11:06:54.493 AM [19984|13416] [info] Environment variables:
09/07/23 11:06:54.493 AM [19984|13416] [info]   DD_DOTNET_TRACER_HOME=C:\repos\dd-trace-dotnet\shared\bin\monitoring-home
09/07/23 11:06:54.493 AM [19984|13416] [info]   DD_ENV=andrew
09/07/23 11:06:54.493 AM [19984|13416] [info] Runtime Information: .NET 7.0.9
09/07/23 11:06:54.493 AM [19984|28188] [info] Initializing ReJIT request thread.
09/07/23 11:06:54.494 AM [19984|13416] [info] IAST Callsite instrumentation is disabled.
09/07/23 11:06:54.494 AM [19984|13416] [info] Profiler filepath: C:\repos\dd-trace-dotnet\shared\bin\monitoring-home\win-x64\Datadog.Tracer.Native.dll
09/07/23 11:06:54.494 AM [19984|13416] [info] Profiler attached.
09/07/23 11:06:54.508 AM [19984|13416] [info] COR library: System.Private.CoreLib 7.0.0
09/07/23 11:06:54.533 AM [19984|13416] [info] JITCompilationStarted: Startup hook registered in function_id=140705667411808 token=100663302 name=Program.<Main>$(), assembly_name=telemetrytest app_domain_id=2456999042608 domain_neutral=0
09/07/23 11:06:54.545 AM [19984|13416] [info] ModuleLoadFinished: Datadog.Trace.ClrProfiler.Managed.Loader loaded into AppDomain 2456999042608 clrhost
09/07/23 11:06:54.597 AM [19984|13416] [info] ModuleLoadFinished: Datadog.Trace v2.38.0.0 - Fix PInvoke maps
09/07/23 11:06:54.597 AM [19984|13416] [info] Rewriting PInvokes to native for windows: C:\repos\dd-trace-dotnet\shared\bin\monitoring-home\win-x64\Datadog.Tracer.Native.dll
09/07/23 11:06:54.599 AM [19984|13416] [info] Rewriting PInvokes to native for debugger: C:\repos\dd-trace-dotnet\shared\bin\monitoring-home\win-x64\Datadog.Tracer.Native.dll
09/07/23 11:06:54.599 AM [19984|13416] [info] Rewriting PInvokes to native for native loader: C:\repos\dd-trace-dotnet\shared\bin\monitoring-home\win-x64\Datadog.Trace.ClrProfiler.Native.dll
09/07/23 11:06:54.603 AM [19984|13416] [info] Successfully added method DistributedTracer.__GetInstanceForProfiler__ for ModuleID=140705668719056
09/07/23 11:06:54.604 AM [19984|13416] [info] Rewriting Instrumentation.GetNativeTracerVersion() => PROFILER_VERSION
09/07/23 11:06:54.604 AM [19984|13416] [info] AssemblyLoadFinished: Datadog.Trace.dll v2.38.0.0 matched profiler version v2.38.0.0
09/07/23 11:06:54.604 AM [19984|13416] [info] ByRef Instrumentation enabled.
09/07/23 11:06:54.604 AM [19984|13416] [info] CallTargetState ByRef enabled.
09/07/23 11:06:54.604 AM [19984|13416] [info] AddTraceAttributeInstrumentation: Initialized assembly=Datadog.Trace, Version=2.38.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, type=Datadog.Trace.ClrProfiler.AutoInstrumentation.TraceAnnotations.TraceAnnotationsIntegration
09/07/23 11:06:54.945 AM [19984|13416] [info] Total number of modules to analyze: 20
09/07/23 11:06:54.952 AM [19984|28188] [info] Method enqueued for ReJIT for System.Diagnostics.Process.Start(0 params)'.
09/07/23 11:06:54.952 AM [19984|28188] [info]     * Skipping System.Diagnostics.Process.Start: the methoddef doesn't have the right number of arguments (1 arguments).
09/07/23 11:06:54.952 AM [19984|28188] [info]     * Skipping System.Diagnostics.Process.Start: the methoddef doesn't have the right number of arguments (2 arguments).
09/07/23 11:06:54.952 AM [19984|28188] [info]     * Skipping System.Diagnostics.Process.Start: the methoddef doesn't have the right number of arguments (2 arguments).
09/07/23 11:06:54.952 AM [19984|28188] [info]     * Skipping System.Diagnostics.Process.Start: the methoddef doesn't have the right number of arguments (1 arguments).
09/07/23 11:06:54.953 AM [19984|28188] [info]     * Skipping System.Diagnostics.Process.Start: the methoddef doesn't have the right number of arguments (4 arguments).
09/07/23 11:06:54.953 AM [19984|28188] [info]     * Skipping System.Diagnostics.Process.Start: the methoddef doesn't have the right number of arguments (5 arguments).
09/07/23 11:06:54.961 AM [19984|28188] [info] Method enqueued for ReJIT for System.Net.Http.HttpClientHandler.Send(2 params)'.
09/07/23 11:06:54.961 AM [19984|28188] [info] Method enqueued for ReJIT for System.Net.Http.HttpClientHandler.SendAsync(2 params)'.
09/07/23 11:06:54.961 AM [19984|28188] [info] Method enqueued for ReJIT for System.Net.Http.SocketsHttpHandler.Send(2 params)'.
09/07/23 11:06:54.961 AM [19984|28188] [info] Method enqueued for ReJIT for System.Net.Http.SocketsHttpHandler.SendAsync(2 params)'.
09/07/23 11:06:54.967 AM [19984|28188] [info] Request ReJIT done for 5 methods
09/07/23 11:06:54.967 AM [19984|13416] [info] RegisterCallTargetDefinitions: Added 374 call targets (enabled: 350, enabled categories: 1) 
09/07/23 11:06:54.968 AM [19984|48392] [info] NGEN:: Processed with 1 inliners [ModuleId=140705673483408,MethodDef=100663888]
09/07/23 11:06:54.968 AM [19984|28188] [info] Request ReJIT done for 1 methods
09/07/23 11:06:54.987 AM [19984|28188] [info]     * Skipping Microsoft.Extensions.Logging.LoggerFactory..ctor: the methoddef doesn't have the right number of arguments (0 arguments).
09/07/23 11:06:54.987 AM [19984|28188] [info]     * Skipping Microsoft.Extensions.Logging.LoggerFactory..ctor: the methoddef doesn't have the right number of arguments (1 arguments).
09/07/23 11:06:54.987 AM [19984|28188] [info]     * Skipping Microsoft.Extensions.Logging.LoggerFactory..ctor: the methoddef doesn't have the right number of arguments (2 arguments).
09/07/23 11:06:54.987 AM [19984|28188] [info]     * Skipping Microsoft.Extensions.Logging.LoggerFactory..ctor: the methoddef doesn't have the right number of arguments (2 arguments).
09/07/23 11:06:54.987 AM [19984|28188] [info]     * Skipping Microsoft.Extensions.Logging.LoggerFactory..ctor: the methoddef doesn't have the right number of arguments (3 arguments).
09/07/23 11:06:54.987 AM [19984|28188] [info] Method enqueued for ReJIT for Microsoft.Extensions.Logging.LoggerFactory..ctor(4 params)'.
09/07/23 11:06:54.987 AM [19984|28188] [info] Method enqueued for ReJIT for Microsoft.Extensions.Logging.LoggerFactoryScopeProvider.ForEachScope(2 params)'.
09/07/23 11:06:54.987 AM [19984|28188] [info] Request ReJIT done for 2 methods
09/07/23 11:06:55.001 AM [19984|28188] [info] Method enqueued for ReJIT for Microsoft.Extensions.Logging.LoggerExternalScopeProvider.ForEachScope(2 params)'.
09/07/23 11:06:55.002 AM [19984|28188] [info] Request ReJIT done for 1 methods
09/07/23 11:06:55.010 AM [19984|28188] [info] Method enqueued for ReJIT for System.Data.Common.DbCommand.ExecuteDbDataReader(1 params)'.
09/07/23 11:06:55.011 AM [19984|28188] [info] Method enqueued for ReJIT for System.Data.Common.DbCommand.ExecuteDbDataReaderAsync(2 params)'.
09/07/23 11:06:55.011 AM [19984|28188] [info] Method enqueued for ReJIT for System.Data.Common.DbCommand.ExecuteNonQuery(0 params)'.
09/07/23 11:06:55.011 AM [19984|28188] [info]     * Skipping System.Data.Common.DbCommand.ExecuteNonQueryAsync: the methoddef doesn't have the right number of arguments (0 arguments).
09/07/23 11:06:55.011 AM [19984|28188] [info] Method enqueued for ReJIT for System.Data.Common.DbCommand.ExecuteNonQueryAsync(1 params)'.
09/07/23 11:06:55.012 AM [19984|28188] [info] Method enqueued for ReJIT for System.Data.Common.DbCommand.ExecuteScalar(0 params)'.
09/07/23 11:06:55.012 AM [19984|28188] [info]     * Skipping System.Data.Common.DbCommand.ExecuteScalarAsync: the methoddef doesn't have the right number of arguments (0 arguments).
09/07/23 11:06:55.012 AM [19984|28188] [info] Method enqueued for ReJIT for System.Data.Common.DbCommand.ExecuteScalarAsync(1 params)'.
09/07/23 11:06:55.012 AM [19984|28188] [info] Request ReJIT done for 6 methods
09/07/23 11:06:55.083 AM [19984|28188] [info] Method enqueued for ReJIT for Microsoft.AspNetCore.Builder.ApplicationBuilder.Build(0 params)'.
09/07/23 11:06:55.084 AM [19984|28188] [info] Request ReJIT done for 1 methods
09/07/23 11:06:55.141 AM [19984|13416] [info] *** CallTarget_RewriterCallback() Finished: Microsoft.Extensions.Logging.LoggerFactory..ctor() [IsVoid=1, IsStatic=0, IntegrationType=Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger.DirectSubmission.LoggerFactoryConstructorNet7Integration, Arguments=4]
09/07/23 11:06:55.146 AM [19984|44664] [info] *** CallTarget_RewriterCallback() Finished: System.Net.Http.HttpClientHandler.SendAsync() [IsVoid=0, IsStatic=0, IntegrationType=Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.HttpClientHandler.HttpClientHandlerIntegration, Arguments=2]
09/07/23 11:06:55.183 AM [19984|44664] [info] *** CallTarget_RewriterCallback() Finished: System.Net.Http.SocketsHttpHandler.SendAsync() [IsVoid=0, IsStatic=0, IntegrationType=Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient.SocketsHttpHandler.SocketsHttpHandlerIntegration, Arguments=2]
09/07/23 11:06:55.187 AM [19984|28188] [info]     * Skipping Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions.SignInAsync: the methoddef doesn't have the right number of arguments (3 arguments).
09/07/23 11:06:55.187 AM [19984|28188] [info]     * Skipping Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions.SignInAsync: the methoddef doesn't have the right number of arguments (2 arguments).
09/07/23 11:06:55.187 AM [19984|28188] [info]     * Skipping Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions.SignInAsync: the methoddef doesn't have the right number of arguments (3 arguments).
09/07/23 11:06:55.187 AM [19984|28188] [info] Method enqueued for ReJIT for Microsoft.AspNetCore.Authentication.AuthenticationHttpContextExtensions.SignInAsync(4 params)'.
09/07/23 11:06:55.187 AM [19984|28188] [info] Request ReJIT done for 1 methods
09/07/23 11:06:55.188 AM [19984|13416] [info] NGEN:: Processed with 3 inliners [ModuleId=140705680900184,MethodDef=100663333]
09/07/23 11:06:55.188 AM [19984|28188] [info] Request ReJIT done for 3 methods
09/07/23 11:06:55.194 AM [19984|13416] [info] *** CallTarget_RewriterCallback() Finished: Microsoft.AspNetCore.Builder.ApplicationBuilder.Build() [IsVoid=0, IsStatic=0, IntegrationType=Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.AspNetCoreBlockMiddlewareIntegrationEnd, Arguments=0]
09/07/23 11:06:59.256 AM [19984|28116] [info] ModuleLoadFinished: Datadog.Trace v2.35.0.0 - Fix PInvoke maps
09/07/23 11:06:59.257 AM [19984|28116] [info] Rewriting PInvokes to native for windows: C:\repos\dd-trace-dotnet\shared\bin\monitoring-home\win-x64\Datadog.Tracer.Native.dll
09/07/23 11:06:59.259 AM [19984|28116] [info] Rewriting PInvokes to native for debugger: C:\repos\dd-trace-dotnet\shared\bin\monitoring-home\win-x64\Datadog.Tracer.Native.dll
09/07/23 11:06:59.259 AM [19984|28116] [info] Rewriting PInvokes to native for native loader: C:\repos\dd-trace-dotnet\shared\bin\monitoring-home\win-x64\Datadog.Trace.ClrProfiler.Native.dll
09/07/23 11:06:59.264 AM [19984|28116] [info] Successfully added method DistributedTracer.__GetInstanceForProfiler__ for ModuleID=140705685291848
09/07/23 11:06:59.264 AM [19984|28116] [info] Rewriting GetDistributedTracer->[AutoInstrumentation]__GetInstanceForProfiler__
09/07/23 11:06:59.266 AM [19984|28116] [info] Rewriting Instrumentation.GetNativeTracerVersion() => PROFILER_VERSION
09/07/23 11:06:59.266 AM [19984|28116] [warning] AssemblyLoadFinished: Datadog.Trace.dll v2.35.0.0 did not match profiler version v2.38.0.0
09/07/23 11:07:05.052 AM [19984|28188] [info] Exiting ReJIT request thread.
09/07/23 11:07:05.052 AM [19984|13416] [info] Exiting...
09/07/23 11:07:05.052 AM [19984|13416] [info] Stats: Total time: 10559ms | Total time in Callbacks: 470ms [Initialize=1ms, ModuleLoadFinished=104ms/139, CallTargetRequestRejit=61ms/55, CallTargetRewriter=1ms/4, AssemblyLoadFinished=0ms/139, ModuleUnloadStarted=0ms/0, JitCompilationStarted=112ms/11133, JitInlining=3ms/12952, JitCacheFunctionSearchStarted=184ms/7337, InitializeProfiler=0ms/0]
</code></pre>
</detail>
