### PR TITLE
Add separate log folder for throughput run

### DIFF
--- a/tracer/build/crank/os.profiles.yml
+++ b/tracer/build/crank/os.profiles.yml
@@ -48,6 +48,7 @@ profiles:
           DD_TRACE_DEBUG: 0
           DD_INTERNAL_TELEMETRY_V2_ENABLED: "{{ telemetry_v2 }}"
           DD_TELEMETRY_METRICS_ENABLED: "{{ enable_metrics }}"
+          DD_TRACE_LOG_DIRECTORY: "{{ linuxProfilerPath }}/{{ commit_hash }}/logs"
         options:
           requiredOperatingSystem: linux
           requiredArchitecture: x64


### PR DESCRIPTION
## Summary of changes

Instead of having to look inside /var/logs/.... and having all mixed logs from all sessions, have isolated log file, and we can look in the right folder.


## Reason for change

Easier to read logs specific to a run 

## Implementation details
just one change in  env variable
## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
