### PR TITLE
[tracer ] fix replacing spaces in tag names in `DD_TRACE_HEADER_TAGS`

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -1014,12 +1014,12 @@ namespace Datadog.Trace.Configuration
                 {
                     headerTags.Add(headerName.Trim(), string.Empty);
                 }
-                else if (headerTagsNormalizationFixEnabled && providedTagName.TryConvertToNormalizedTagName(normalizePeriods: false, out var normalizedTagName))
+                else if (headerTagsNormalizationFixEnabled && providedTagName.TryConvertToNormalizedTagName(normalizePeriodsAndSpaces: false, out var normalizedTagName))
                 {
                     // If the user has provided a tag name, then we don't normalize periods in the provided tag name
                     headerTags.Add(headerName.Trim(), normalizedTagName);
                 }
-                else if (!headerTagsNormalizationFixEnabled && providedTagName.TryConvertToNormalizedTagName(normalizePeriods: true, out var normalizedTagNameNoPeriods))
+                else if (!headerTagsNormalizationFixEnabled && providedTagName.TryConvertToNormalizedTagName(normalizePeriodsAndSpaces: true, out var normalizedTagNameNoPeriods))
                 {
                     // Back to the previous behaviour if the flag is set
                     headerTags.Add(headerName.Trim(), normalizedTagNameNoPeriods);

--- a/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -87,14 +87,14 @@ namespace Datadog.Trace.ExtensionMethods
         ///    - Colons
         ///    - Slashes
         ///
-        /// 4. Optionally, periods can be replaced by underscores.
+        /// 4. Optionally, periods and spaces can be replaced by underscores.
         /// Note: This method will trim leading/trailing whitespace before checking the requirements.
         /// </summary>
         /// <param name="value">Input string to convert into tag name</param>
-        /// <param name="normalizePeriods">True if we replace dots by underscores</param>
+        /// <param name="normalizePeriodsAndSpaces">True if we replace dots and spaces with underscores</param>
         /// <param name="normalizedTagName">If the method returns true, the normalized tag name</param>
         /// <returns>Returns whether the conversion was successful</returns>
-        public static bool TryConvertToNormalizedTagName(this string value, bool normalizePeriods, out string normalizedTagName)
+        public static bool TryConvertToNormalizedTagName(this string value, bool normalizePeriodsAndSpaces, out string normalizedTagName)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
@@ -118,7 +118,7 @@ namespace Datadog.Trace.ExtensionMethods
                 {
                     case (>= 'a' and <= 'z') or (>= '0' and <= '9') or '_' or ':' or '/' or '-':
                         continue;
-                    case '.' when !normalizePeriods:
+                    case '.' or ' ' when !normalizePeriodsAndSpaces:
                         continue;
                     default:
                         sb[x] = '_';

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -233,7 +233,7 @@ namespace Datadog.Trace.Propagators
                     var cacheKey = new Key(headerName, defaultTagPrefix);
                     var tagNameResult = _defaultTagMappingCache.GetOrAdd(cacheKey, key =>
                     {
-                        if (key.HeaderName.TryConvertToNormalizedTagName(normalizePeriods: true, out var normalizedHeaderTagName))
+                        if (key.HeaderName.TryConvertToNormalizedTagName(normalizePeriodsAndSpaces: true, out var normalizedHeaderTagName))
                         {
                             return key.TagPrefix + "." + normalizedHeaderTagName;
                         }

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
         [InlineData(" original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________", true, "original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________")]
         public void TryConvertToNormalizedTagName(string input, bool expectedConversionSuccess, string expectedTagName)
         {
-            bool actualConversionSuccess = input.TryConvertToNormalizedTagName(normalizePeriods: false, out string actualTagName);
+            bool actualConversionSuccess = input.TryConvertToNormalizedTagName(normalizePeriodsAndSpaces: false, out string actualTagName);
             Assert.Equal(expectedConversionSuccess, actualConversionSuccess);
 
             if (actualConversionSuccess)
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Tests.ExtensionMethods
         [InlineData(" original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________", true, "original_length_201_with_one_leading_whitespace________________________________________________________________________________________________________________________________________________________")]
         public void TryConvertToNormalizedHeaderTagName(string input, bool expectedConversionSuccess, string expectedTagName)
         {
-            bool actualConversionSuccess = input.TryConvertToNormalizedTagName(normalizePeriods: true, out string actualTagName);
+            bool actualConversionSuccess = input.TryConvertToNormalizedTagName(normalizePeriodsAndSpaces: true, out string actualTagName);
             Assert.Equal(expectedConversionSuccess, actualConversionSuccess);
 
             if (actualConversionSuccess)

--- a/tracer/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ExtensionMethods/StringExtensionsTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using Datadog.Trace.ExtensionMethods;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Tests.ExtensionMethods
@@ -45,6 +46,20 @@ namespace Datadog.Trace.Tests.ExtensionMethods
             {
                 Assert.Equal(expectedTagName, actualTagName);
             }
+        }
+
+        [Theory]
+        [InlineData("Some.Header", true, "some_header")]
+        [InlineData("Some Header", true, "some_header")]
+        [InlineData("Some.Header", false, "some.header")]
+        [InlineData("Some Header", false, "some header")]
+        [InlineData(" Some Header ", true, "some_header")]  // always trim whitespace
+        [InlineData(" Some Header ", false, "some header")] // always trim whitespace
+        public void TryConvertToNormalizedTagName_NormalizePeriodsAndSpaces(string input, bool normalizePeriodsAndSpaces, string expectedTagName)
+        {
+            input.TryConvertToNormalizedTagName(normalizePeriodsAndSpaces: normalizePeriodsAndSpaces, out var actualTagName).Should().BeTrue();
+
+            Assert.Equal(expectedTagName, actualTagName);
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes

When users specify a tag name in `DD_TRACE_HEADER_TAGS`, we should not replaces periods or spaces during normalization. Currently we still normalize spaces into underscores.

## Reason for change

.NET Tracer is not currently following the RFC. @mtoffl01 found out with shared tests.

## Implementation details

In `StringExtensions.TryConvertToNormalizedTagName()`, rename the parameter `normalizePeriods` to `normalizePeriodsAndSpaces` and use it to decide if we should replace both characters with underscores.

## Test coverage

Added `StringExtensionsTests.TryConvertToNormalizedTagName_NormalizePeriodsAndSpaces()` with several tests cases.

## Other details
Fixes AIT-8308
