### PR TITLE
Fix `HeaderTagsNormalizationFixEnabled` is not saved in settings

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -148,12 +148,12 @@ namespace Datadog.Trace.Configuration
                       // default value (empty)
                       ?? (IDictionary<string, string>)new ConcurrentDictionary<string, string>();
 
-            var headerTagsNormalizationFixEnabled = config
-                                                   .WithKeys(ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled)
-                                                   .AsBool(defaultValue: true);
+            HeaderTagsNormalizationFixEnabled = config
+                                               .WithKeys(ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled)
+                                               .AsBool(defaultValue: true);
 
             // Filter out tags with empty keys or empty values, and trim whitespaces
-            HeaderTagsInternal = InitializeHeaderTags(config, ConfigurationKeys.HeaderTags, headerTagsNormalizationFixEnabled)
+            HeaderTagsInternal = InitializeHeaderTags(config, ConfigurationKeys.HeaderTags, HeaderTagsNormalizationFixEnabled)
                 ?? new Dictionary<string, string>();
 
             PeerServiceTagsEnabled = config

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         TraceSampleRate = .5,
                         // CustomSamplingRules = "[{\"sample_rate\":0.1}]",
                         // ServiceNameMapping = "foo:bar",
-                        TraceHeaderTags = "User-Agent:http_user_agent"
+                        TraceHeaderTags = "User-Agent:http.user_agent"
                     });
 
                 await UpdateAndValidateConfig(


### PR DESCRIPTION
## Summary of changes

Fix that `TracerSettings.HeaderTagsNormalizationFixEnabled` is not initialized

## Reason for change

The value of `DD_TRACE_HEADER_TAG_NORMALIZATION_FIX_ENABLED` is read and used to construct the initial header tags, but it's not saved into the `HeaderTagsNormalizationFixEnabled` property (which is used later as part of dynamic configuration)

## Implementation details

Set the property

## Test coverage

:awkward-monkey:

## Other details

Discovered while thinking about https://github.com/DataDog/dd-trace-dotnet/pull/4599
