### PR TITLE
Fix race-condition in DuckType

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -14,6 +14,7 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Threading;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.DuckTyping
@@ -1263,7 +1264,8 @@ namespace Datadog.Trace.DuckTyping
         /// <typeparam name="T">Type of proxy definition</typeparam>
         public static class CreateCache<T>
         {
-            private static CreateTypeResult _fastPath = default;
+            // Because CreateTypeResult is a struct, it needs to be boxed for safe concurrent access
+            private static StrongBox<CreateTypeResult>? _fastPath;
 
             /// <summary>
             /// Gets the type of T
@@ -1279,19 +1281,16 @@ namespace Datadog.Trace.DuckTyping
             public static CreateTypeResult GetProxy(Type targetType)
             {
                 // We set a fast path for the first proxy type for a proxy definition. (It's likely to have a proxy definition just for one target type)
-                CreateTypeResult fastPath = _fastPath;
-                if (fastPath.TargetType == targetType)
+                var fastPath = Volatile.Read(ref _fastPath);
+
+                if (fastPath?.Value.TargetType == targetType)
                 {
-                    return fastPath;
+                    return fastPath.Value;
                 }
 
                 CreateTypeResult result = GetOrCreateProxyType(Type, targetType);
 
-                fastPath = _fastPath;
-                if (fastPath.TargetType is null)
-                {
-                    _fastPath = result;
-                }
+                _fastPath ??= new(result);
 
                 return result;
             }
@@ -1373,19 +1372,16 @@ namespace Datadog.Trace.DuckTyping
             public static CreateTypeResult GetReverseProxy(Type targetType)
             {
                 // We set a fast path for the first proxy type for a proxy definition. (It's likely to have a proxy definition just for one target type)
-                CreateTypeResult fastPath = _fastPath;
-                if (fastPath.TargetType == targetType)
+                var fastPath = Volatile.Read(ref _fastPath);
+
+                if (fastPath?.Value.TargetType == targetType)
                 {
-                    return fastPath;
+                    return fastPath.Value;
                 }
 
                 CreateTypeResult result = GetOrCreateReverseProxyType(Type, targetType);
 
-                fastPath = _fastPath;
-                if (fastPath.TargetType is null)
-                {
-                    _fastPath = result;
-                }
+                _fastPath ??= new(result);
 
                 return result;
             }


### PR DESCRIPTION
## Summary of changes

`CreateTypeResult` is a struct bigger than a pointer, so writing it is not atomic. The code in `CreateCache<T>.GetProxy` and  `CreateCache<T>.GetReverseProxy` write that value concurrently, which is unsafe.

This PR fixes the thread-safety issue by boxing the `CreateTypeResult` instance.

## Reason for change

Rare failure detected in the CI.

## Implementation details

Using `StrongBox<T>` for strongly-typed boxing.

## Test coverage

Since the issue was detected in a test, I guess we have coverage.