### PR TITLE
[ASM] Improve waf benchmarks

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -20,12 +20,7 @@ public class AppSecWafBenchmark
 {
     private const int TimeoutMicroSeconds = 1_000_000;
 
-    // this is necessary, as we use Iteration setup and cleanup which disables the bdn mechanism to estimate the necessary iteration count.Only 1 iteration count will be done with iteration setup and cleanup.
-    // See https://github.com/dotnet/BenchmarkDotNet/pull/1157
-    //Iteration setup and cleanup are necessary as we cant use GlobalCleanup here, the waf needs to flush more often than every 1xx.xxx ops, otherwise OutOfMemory occurs. 
-    private const int WafRuns = 2000;
     private static readonly Waf Waf;
-    private Context _context;
 
     static AppSecWafBenchmark()
     {
@@ -128,7 +123,7 @@ public class AppSecWafBenchmark
                 };
                 map.Add("list", nextList);
             }
-
+        
             var nextMap = new Dictionary<string, object>
             {
                 { "lorem", "ipsum" },
@@ -145,12 +140,6 @@ public class AppSecWafBenchmark
         return new NestedMap(root, nestingDepth, withAttack);
     }
 
-    [IterationSetup]
-    public void Setup() => _context = Waf.CreateContext() as Context;
-
-    [IterationCleanup]
-    public void Cleanup() => _context.Dispose();
-
     [Benchmark]
     [ArgumentsSource(nameof(Source))]
     public void RunWaf(NestedMap args) => RunWafBenchmark(args);
@@ -161,10 +150,9 @@ public class AppSecWafBenchmark
 
     private void RunWafBenchmark(NestedMap args)
     {
-        for (var i = 0; i < WafRuns; i++)
-        {
-            _context.Run(args.Map, TimeoutMicroSeconds);
-        }
+        var context = Waf.CreateContext();
+        context!.Run(args.Map, TimeoutMicroSeconds);
+        context.Dispose();
     }
 
     public record NestedMap(Dictionary<string, object> Map, int NestingDepth, bool IsAttack = false)


### PR DESCRIPTION
## Summary of changes
Get bdn mechanism to estimate the necessary iteration count work again. 

## Reason for change

The way it is now is not quite correct, as attacks are detected only the first time on a brand new context. And here, the same context is used through an iteration with attributes [IterationSetup] [IterationCleanup] which prevents the bdn iteration count estimation mechanism from functioning

## Implementation details
For this, context creation and dispose have to be part of the benchmark. We dont have a choice. If it's in iteration setup, we loose the iteration count mechanism and in case of an attack, all subsequent runs wont return an attack (as it's only returned once). If it's in global setup, waf will run millions of times without being flushed and ends inn out of memory. So after much research, it'sthe best way.
On the other hand context creation and dispose is very minimal. 


## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
