### PR TITLE
Box DuckType `CreateTypeResult` cache to avoid race condition

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -1263,7 +1263,7 @@ namespace Datadog.Trace.DuckTyping
         /// <typeparam name="T">Type of proxy definition</typeparam>
         public static class CreateCache<T>
         {
-            private static CreateTypeResult _fastPath = default;
+            private static StrongBox<CreateTypeResult> _fastPath = new(default);
 
             /// <summary>
             /// Gets the type of T
@@ -1279,7 +1279,8 @@ namespace Datadog.Trace.DuckTyping
             public static CreateTypeResult GetProxy(Type targetType)
             {
                 // We set a fast path for the first proxy type for a proxy definition. (It's likely to have a proxy definition just for one target type)
-                CreateTypeResult fastPath = _fastPath;
+                var boxedFastPath = _fastPath;
+                var fastPath = boxedFastPath.Value;
                 if (fastPath.TargetType == targetType)
                 {
                     return fastPath;
@@ -1287,10 +1288,11 @@ namespace Datadog.Trace.DuckTyping
 
                 CreateTypeResult result = GetOrCreateProxyType(Type, targetType);
 
-                fastPath = _fastPath;
+                boxedFastPath = _fastPath;
+                fastPath = boxedFastPath.Value;
                 if (fastPath.TargetType is null)
                 {
-                    _fastPath = result;
+                    _fastPath = new StrongBox<CreateTypeResult>(result);
                 }
 
                 return result;
@@ -1373,7 +1375,8 @@ namespace Datadog.Trace.DuckTyping
             public static CreateTypeResult GetReverseProxy(Type targetType)
             {
                 // We set a fast path for the first proxy type for a proxy definition. (It's likely to have a proxy definition just for one target type)
-                CreateTypeResult fastPath = _fastPath;
+                var boxedFastPath = _fastPath;
+                var fastPath = boxedFastPath.Value;
                 if (fastPath.TargetType == targetType)
                 {
                     return fastPath;
@@ -1381,10 +1384,11 @@ namespace Datadog.Trace.DuckTyping
 
                 CreateTypeResult result = GetOrCreateReverseProxyType(Type, targetType);
 
-                fastPath = _fastPath;
+                boxedFastPath = _fastPath;
+                fastPath = boxedFastPath.Value;
                 if (fastPath.TargetType is null)
                 {
-                    _fastPath = result;
+                    _fastPath = new StrongBox<CreateTypeResult>(result);
                 }
 
                 return result;


### PR DESCRIPTION
## Summary of changes

This PR boxes the `CreateTypeResult` _fastpath cache to avoid any type of race condition while copying the struct to the stack.

## Reason for change

This is the only feasible explanation we found to a one-time exception that appeared in ci:

```log
10:10:46 [ERR] 10:08:09 [Error] Exception occurred when calling the CallTarget integration continuation. System.NullReferenceException: The activator for this proxy type is null, check if the type can be created by calling 'CanCreate()'
   at Datadog.Trace.Util.ThrowHelper.ThrowNullReferenceException(String message) in /project/tracer/src/Datadog.Trace/Util/ThrowHelper.cs:line 79
   at Datadog.Trace.DuckTyping.DuckType.CreateTypeResult.CreateInstance[T](Object instance) in /project/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs:line 1209
   at Confluent_Kafka__12C514CA49093D1E.Confluent_Kafka_ConsumeResult`2\[\[System_String\, System_Private_CoreLib\, Version=4_0_0_0\, Culture=neutral\, PublicKeyToken=7cec85d7bea7798e\]\,\[System_String\, System_Private_CoreLib\, Version=4_0_0_0\, Culture=neutral\, PublicKeyToken=7cec85d7bea7798e\]\].Datadog_Trace_ClrProfiler_AutoInstrumentation_Kafka_IConsumeResult_6.get_Message()
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaConsumerConsumeIntegration.OnMethodEnd[TTarget,TResponse](TTarget instance, TResponse response, Exception exception, CallTargetState& state) in /project/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs:line 68
   at KafkaConsumerConsumeIntegration.OnMethodEnd.Object.ConsumeResult`2(Object , ConsumeResult`2 , Exception , CallTargetState& )
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.EndMethodHandler`3.Invoke(TTarget instance, TReturn returnValue, Exception exception, CallTargetState& state)
   at Confluent.Kafka.Consumer`2.Consume(Int32 millisecondsTimeout)
 { MachineName: ".", Process: "[7282 dotnet]", AppDomain: "[1 Samples.Kafka]", TracerVersion: "2.38.0.0" }
```