### PR TITLE
Fix flake in smoke tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -136,7 +136,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
 #if !NET5_0_OR_GREATER
             if (result.StandardOutput.Contains("App completed successfully")
-                && result.ExitCode != expectedExitCode
                 && Regex.IsMatch(result.StandardError, @"open\(/proc/\d+/mem\) FAILED 2 \(No such file or directory\)"))
             {
                 // The above message is the last thing set before we exit.


### PR DESCRIPTION
## Summary of changes

Handle the (known) case where we crash on exit, and then the dump tool crashes

## Reason for change

#4581 tried to fix the flake in smoke tests. That fix failed to fix the flake, because it assumed you would get a non-zero exit code, which apparently is not necessarily the case

## Implementation details

Always skip if we see that crash message

## Test coverage

This is the test
