### PR TITLE
Ducktyping `ValueWithType` struct support

### DIFF
--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Fields.cs
@@ -32,6 +32,14 @@ namespace Datadog.Trace.DuckTyping
                 proxyMemberReturnType,
                 Type.EmptyTypes);
 
+            var isValueWithType = false;
+            var originalProxyMemberReturnType = proxyMemberReturnType;
+            if (proxyMemberReturnType.IsGenericType && proxyMemberReturnType.GetGenericTypeDefinition() == typeof(ValueWithType<>))
+            {
+                proxyMemberReturnType = proxyMemberReturnType.GenericTypeArguments[0];
+                isValueWithType = true;
+            }
+
             LazyILGenerator il = new LazyILGenerator(proxyMethod?.GetILGenerator());
             Type returnType = targetField.FieldType;
 
@@ -121,6 +129,13 @@ namespace Datadog.Trace.DuckTyping
                 il.WriteTypeConversion(returnType, proxyMemberReturnType);
             }
 
+            if (isValueWithType)
+            {
+                il.Emit(OpCodes.Ldtoken, returnType);
+                il.EmitCall(OpCodes.Call, GetTypeFromHandleMethodInfo, null!);
+                il.EmitCall(OpCodes.Call, originalProxyMemberReturnType.GetMethod("Create", BindingFlags.Static | BindingFlags.Public)!, null!);
+            }
+
             il.Emit(OpCodes.Ret);
             il.Flush();
             if (proxyMethod is not null)
@@ -160,11 +175,25 @@ namespace Datadog.Trace.DuckTyping
                 }
             }
 
+            var isValueWithType = false;
+            var originalproxyMemberReturnType = proxyMemberReturnType;
+            if (proxyMemberReturnType.IsGenericType && proxyMemberReturnType.GetGenericTypeDefinition() == typeof(ValueWithType<>))
+            {
+                proxyMemberReturnType = proxyMemberReturnType.GenericTypeArguments[0];
+                currentValueType = proxyMemberReturnType;
+                isValueWithType = true;
+            }
+
             // Check if the type can be converted of if we need to enable duck chaining
             if (NeedsDuckChaining(targetField.FieldType, proxyMemberReturnType))
             {
                 // Load the argument and convert it to Duck type
                 il.Emit(OpCodes.Ldarg_1);
+                if (isValueWithType)
+                {
+                    il.Emit(OpCodes.Ldfld, originalproxyMemberReturnType.GetField("Value")!);
+                }
+
                 il.WriteTypeConversion(proxyMemberReturnType, typeof(IDuckType));
 
                 // Call IDuckType.Instance property to get the actual value
@@ -176,6 +205,10 @@ namespace Datadog.Trace.DuckTyping
             {
                 // Load the value into the stack
                 il.Emit(OpCodes.Ldarg_1);
+                if (isValueWithType)
+                {
+                    il.Emit(OpCodes.Ldfld, originalproxyMemberReturnType.GetField("Value")!);
+                }
             }
 
             // We set the field value

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -63,6 +63,14 @@ namespace Datadog.Trace.DuckTyping
                 proxyMemberReturnType,
                 proxyParameterTypes);
 
+            var isValueWithType = false;
+            var originalProxyMemberReturnType = proxyMemberReturnType;
+            if (proxyMemberReturnType.IsGenericType && proxyMemberReturnType.GetGenericTypeDefinition() == typeof(ValueWithType<>))
+            {
+                proxyMemberReturnType = proxyMemberReturnType.GenericTypeArguments[0];
+                isValueWithType = true;
+            }
+
             LazyILGenerator il = new LazyILGenerator(proxyMethod?.GetILGenerator());
             Type returnType = targetProperty.PropertyType;
 
@@ -187,6 +195,13 @@ namespace Datadog.Trace.DuckTyping
                 il.WriteTypeConversion(returnType, proxyMemberReturnType);
             }
 
+            if (isValueWithType)
+            {
+                il.Emit(OpCodes.Ldtoken, proxyMemberReturnType);
+                il.EmitCall(OpCodes.Call, GetTypeFromHandleMethodInfo, null!);
+                il.EmitCall(OpCodes.Call, originalProxyMemberReturnType.GetMethod("Create", BindingFlags.Static | BindingFlags.Public)!, null!);
+            }
+
             il.Emit(OpCodes.Ret);
             il.Flush();
             if (proxyMethod is not null)
@@ -259,11 +274,23 @@ namespace Datadog.Trace.DuckTyping
                 Type proxyParamType = proxyParameterTypes[pIndex];
                 Type targetParamType = targetParametersTypes[pIndex];
 
+                var isValueWithType = false;
+                var originalProxyParamType = proxyParamType;
+                if (proxyParamType.IsGenericType && proxyParamType.GetGenericTypeDefinition() == typeof(ValueWithType<>))
+                {
+                    proxyParamType = proxyParamType.GenericTypeArguments[0];
+                    isValueWithType = true;
+                }
+
                 // Check if the type can be converted of if we need to enable duck chaining
                 if (needsDuckChaining(targetParamType, proxyParamType))
                 {
                     // Load the argument and cast it as Duck type
                     il.WriteLoadArgument(pIndex, false);
+                    if (isValueWithType)
+                    {
+                        il.Emit(OpCodes.Ldfld, originalProxyParamType.GetField("Value")!);
+                    }
 
                     // If this is a forward duck type, we need to cast to IDuckType and extract the original instance
                     // and set the targetParamType to object
@@ -273,6 +300,10 @@ namespace Datadog.Trace.DuckTyping
                 else
                 {
                     il.WriteLoadArgument(pIndex, false);
+                    if (isValueWithType)
+                    {
+                        il.Emit(OpCodes.Ldfld, originalProxyParamType.GetField("Value")!);
+                    }
                 }
 
                 // If the target parameter type is public or if it's by ref we have to actually use the original target type.

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.Properties.cs
@@ -197,7 +197,7 @@ namespace Datadog.Trace.DuckTyping
 
             if (isValueWithType)
             {
-                il.Emit(OpCodes.Ldtoken, proxyMemberReturnType);
+                il.Emit(OpCodes.Ldtoken, returnType);
                 il.EmitCall(OpCodes.Call, GetTypeFromHandleMethodInfo, null!);
                 il.EmitCall(OpCodes.Call, originalProxyMemberReturnType.GetMethod("Create", BindingFlags.Static | BindingFlags.Public)!, null!);
             }

--- a/tracer/src/Datadog.Trace/DuckTyping/ValueWithType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/ValueWithType.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 using System;
+using System.ComponentModel;
 
 namespace Datadog.Trace.DuckTyping;
 
@@ -12,6 +13,8 @@ namespace Datadog.Trace.DuckTyping;
 /// DuckType return value with original type
 /// </summary>
 /// <typeparam name="TProxy">Type of ducktype proxy</typeparam>
+[Browsable(false)]
+[EditorBrowsable(EditorBrowsableState.Never)]
 public readonly struct ValueWithType<TProxy>
 {
     /// <summary>

--- a/tracer/src/Datadog.Trace/DuckTyping/ValueWithType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/ValueWithType.cs
@@ -1,0 +1,48 @@
+// <copyright file="ValueWithType.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+
+namespace Datadog.Trace.DuckTyping;
+
+/// <summary>
+/// DuckType return value with original type
+/// </summary>
+/// <typeparam name="TProxy">Type of ducktype proxy</typeparam>
+public readonly struct ValueWithType<TProxy>
+{
+    /// <summary>
+    /// Gets the value
+    /// </summary>
+    public readonly TProxy? Value;
+
+    /// <summary>
+    /// Gets the Type of the value
+    /// </summary>
+    public readonly Type Type;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValueWithType{TProxy}"/> struct.
+    /// </summary>
+    /// <param name="value">Value of the proxy instance</param>
+    /// <param name="type">Type of the original value</param>
+    internal ValueWithType(TProxy? value, Type type)
+    {
+        Value = value;
+        Type = type;
+    }
+
+    /// <summary>
+    /// Create Value with original Type
+    /// </summary>
+    /// <param name="value">Value of the proxy instance</param>
+    /// <param name="type">Type of the original value</param>
+    /// <returns>Instance of the value with the original type</returns>
+    public static ValueWithType<TProxy> Create(TProxy? value, Type type)
+    {
+        return new ValueWithType<TProxy>(value, type);
+    }
+}

--- a/tracer/src/Datadog.Trace/DuckTyping/ValueWithType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/ValueWithType.cs
@@ -29,7 +29,7 @@ public readonly struct ValueWithType<TProxy>
     /// </summary>
     /// <param name="value">Value of the proxy instance</param>
     /// <param name="type">Type of the original value</param>
-    internal ValueWithType(TProxy? value, Type type)
+    private ValueWithType(TProxy? value, Type type)
     {
         Value = value;
         Type = type;

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureDuckType.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/IObscureDuckType.cs
@@ -60,5 +60,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 
         [DuckField(Name = "_privateReferenceTypeField")]
         string PrivateReferenceTypeField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicReferenceTypeField")]
+        ValueWithType<string> PublicReferenceTypeFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -60,5 +60,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 
         [DuckField(Name = "_privateReferenceTypeField")]
         public abstract string PrivateReferenceTypeField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicReferenceTypeField")]
+        public abstract ValueWithType<string> PublicReferenceTypeFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -60,5 +60,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType.ProxiesDefinitions
 
         [DuckField(Name = "_privateReferenceTypeField")]
         public virtual string PrivateReferenceTypeField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicReferenceTypeField")]
+        public virtual ValueWithType<string> PublicReferenceTypeFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
@@ -206,6 +206,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("40", duckAbstract.PublicReferenceTypeField);
             Assert.Equal("40", duckVirtual.PublicReferenceTypeField);
 
+            duckInterface.PublicReferenceTypeFieldWithType = ValueWithType<string>.Create("40", typeof(string));
+            Assert.Equal("40", duckInterface.PublicReferenceTypeFieldWithType.Value);
+            Assert.Equal(typeof(string), duckInterface.PublicReferenceTypeFieldWithType.Type);
+            Assert.Equal("40", duckAbstract.PublicReferenceTypeFieldWithType.Value);
+            Assert.Equal(typeof(string), duckAbstract.PublicReferenceTypeFieldWithType.Type);
+            Assert.Equal("40", duckVirtual.PublicReferenceTypeFieldWithType.Value);
+            Assert.Equal(typeof(string), duckVirtual.PublicReferenceTypeFieldWithType.Type);
+
             duckInterface.PublicReferenceTypeField = "42";
             Assert.Equal("42", duckInterface.PublicReferenceTypeField);
             Assert.Equal("42", duckAbstract.PublicReferenceTypeField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureDuckType.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/IObscureDuckType.cs
@@ -60,5 +60,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 
         [DuckField(Name = "_privateSelfTypeField")]
         IDummyFieldObject PrivateSelfTypeField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicSelfTypeField")]
+        ValueWithType<IDummyFieldObject> PublicSelfTypeFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -60,5 +60,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 
         [DuckField(Name = "_privateSelfTypeField")]
         public abstract IDummyFieldObject PrivateSelfTypeField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicSelfTypeField")]
+        public abstract ValueWithType<IDummyFieldObject> PublicSelfTypeFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -60,5 +60,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining.ProxiesDefinitions
 
         [DuckField(Name = "_privateSelfTypeField")]
         public virtual IDummyFieldObject PrivateSelfTypeField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicSelfTypeField")]
+        public virtual ValueWithType<IDummyFieldObject> PublicSelfTypeFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/TypeChainingFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/TypeChaining/TypeChainingFieldTests.cs
@@ -206,6 +206,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.TypeChaining
             Assert.Equal(42, duckAbstract.PublicSelfTypeField.MagicNumber);
             Assert.Equal(42, duckVirtual.PublicSelfTypeField.MagicNumber);
 
+            duckInterface.PublicSelfTypeFieldWithType = ValueWithType<IDummyFieldObject>.Create(newDummy, null!);
+            Assert.Equal(42, duckInterface.PublicSelfTypeFieldWithType.Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckInterface.PublicSelfTypeFieldWithType.Type);
+            Assert.Equal(42, duckAbstract.PublicSelfTypeFieldWithType.Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckAbstract.PublicSelfTypeFieldWithType.Type);
+            Assert.Equal(42, duckVirtual.PublicSelfTypeFieldWithType.Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckVirtual.PublicSelfTypeFieldWithType.Type);
+
             // *
             newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalSelfTypeField = newDummy;

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureDuckType.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/IObscureDuckType.cs
@@ -74,5 +74,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 
         [DuckField(Name = "_privateNullableIntField")]
         int? PrivateNullableIntField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicStaticNullableIntField")]
+        ValueWithType<int?> PublicStaticNullableIntFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -74,5 +74,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 
         [DuckField(Name = "_privateNullableIntField")]
         public abstract int? PrivateNullableIntField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicStaticNullableIntField")]
+        public abstract ValueWithType<int?> PublicStaticNullableIntFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -74,5 +74,10 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType.ProxiesDefinitions
 
         [DuckField(Name = "_privateNullableIntField")]
         public virtual int? PrivateNullableIntField { get; set; }
+
+        // *
+
+        [DuckField(Name = "_publicStaticNullableIntField")]
+        public virtual ValueWithType<int?> PublicStaticNullableIntFieldWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
@@ -298,10 +298,25 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Null(duckAbstract.PublicStaticNullableIntField);
             Assert.Null(duckVirtual.PublicStaticNullableIntField);
 
+            Assert.Null(duckInterface.PublicStaticNullableIntFieldWithType.Value);
+            Assert.Equal(typeof(int?), duckInterface.PublicStaticNullableIntFieldWithType.Type);
+            Assert.Null(duckAbstract.PublicStaticNullableIntFieldWithType.Value);
+            Assert.Equal(typeof(int?), duckAbstract.PublicStaticNullableIntFieldWithType.Type);
+            Assert.Null(duckVirtual.PublicStaticNullableIntFieldWithType.Value);
+            Assert.Equal(typeof(int?), duckVirtual.PublicStaticNullableIntFieldWithType.Type);
+
             duckInterface.PublicStaticNullableIntField = 42;
             Assert.Equal(42, duckInterface.PublicStaticNullableIntField);
             Assert.Equal(42, duckAbstract.PublicStaticNullableIntField);
             Assert.Equal(42, duckVirtual.PublicStaticNullableIntField);
+
+            duckInterface.PublicStaticNullableIntFieldWithType = ValueWithType<int?>.Create(42, null!);
+            Assert.Equal(42, duckInterface.PublicStaticNullableIntFieldWithType.Value);
+            Assert.Equal(typeof(int?), duckInterface.PublicStaticNullableIntFieldWithType.Type);
+            Assert.Equal(42, duckAbstract.PublicStaticNullableIntFieldWithType.Value);
+            Assert.Equal(typeof(int?), duckAbstract.PublicStaticNullableIntFieldWithType.Type);
+            Assert.Equal(42, duckVirtual.PublicStaticNullableIntFieldWithType.Value);
+            Assert.Equal(typeof(int?), duckVirtual.PublicStaticNullableIntFieldWithType.Type);
 
             duckAbstract.PublicStaticNullableIntField = 50;
             Assert.Equal(50, duckInterface.PublicStaticNullableIntField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/MethodTests.cs
@@ -34,6 +34,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             Assert.Equal(20, duckAbstract.Sum(10, 10));
             Assert.Equal(20, duckVirtual.Sum(10, 10));
 
+            // ValueWithType
+            Assert.Equal(20, duckInterface.SumReturnValueWithType(10, 10).Value);
+            Assert.Equal(typeof(int), duckInterface.SumReturnValueWithType(10, 10).Type);
+            Assert.Equal(20, duckAbstract.SumReturnValueWithType(10, 10).Value);
+            Assert.Equal(typeof(int), duckAbstract.SumReturnValueWithType(10, 10).Type);
+            Assert.Equal(20, duckVirtual.SumReturnValueWithType(10, 10).Value);
+            Assert.Equal(typeof(int), duckVirtual.SumReturnValueWithType(10, 10).Type);
+
             // Float
             Assert.Equal(20f, duckInterface.Sum(10f, 10f));
             Assert.Equal(20f, duckAbstract.Sum(10f, 10f));
@@ -64,6 +72,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods
             Assert.Equal(dummy.MagicNumber, duckInterface.Bypass(dummyInt).MagicNumber);
             Assert.Equal(dummy.MagicNumber, duckAbstract.Bypass(dummyInt).MagicNumber);
             Assert.Equal(dummy.MagicNumber, duckVirtual.Bypass(dummyInt).MagicNumber);
+
+            // ValueWithType
+            Assert.Equal(dummy.MagicNumber, duckInterface.BypassReturnValueWithType(dummyInt).Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckInterface.BypassReturnValueWithType(dummyInt).Type);
+            Assert.Equal(dummy.MagicNumber, duckAbstract.BypassReturnValueWithType(dummyInt).Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckAbstract.BypassReturnValueWithType(dummyInt).Type);
+            Assert.Equal(dummy.MagicNumber, duckVirtual.BypassReturnValueWithType(dummyInt).Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckVirtual.BypassReturnValueWithType(dummyInt).Type);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/IObscureDuckType.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/IObscureDuckType.cs
@@ -63,5 +63,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods.ProxiesDefinitions
         bool TryGetPrivateReferenceObject(ref object obj);
 
         IDummyFieldObject Bypass(IDummyFieldObject obj);
+
+        [Duck(Name = "Sum")]
+        ValueWithType<int> SumReturnValueWithType(int a, int b);
+
+        [Duck(Name = "Bypass")]
+        ValueWithType<IDummyFieldObject> BypassReturnValueWithType(IDummyFieldObject obj);
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -64,5 +64,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods.ProxiesDefinitions
         }
 
         public abstract IDummyFieldObject Bypass(IDummyFieldObject obj);
+
+        [Duck(Name = "Sum")]
+        public abstract ValueWithType<int> SumReturnValueWithType(int a, int b);
+
+        [Duck(Name = "Bypass")]
+        public abstract ValueWithType<IDummyFieldObject> BypassReturnValueWithType(IDummyFieldObject obj);
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Methods/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -110,5 +110,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Methods.ProxiesDefinitions
         }
 
         public virtual IDummyFieldObject Bypass(IDummyFieldObject obj) => null;
+
+        [Duck(Name = "Sum")]
+        public virtual ValueWithType<int> SumReturnValueWithType(int a, int b) => default;
+
+        [Duck(Name = "Bypass")]
+        public virtual ValueWithType<IDummyFieldObject> BypassReturnValueWithType(IDummyFieldObject obj) => default;
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/IObscureDuckType.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/IObscureDuckType.cs
@@ -50,6 +50,15 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType.ProxiesDefinit
         [Duck(Name = "PublicStaticGetSetReferenceType")]
         string PublicStaticOnlySet { set; }
 
+        [Duck(Name = "PublicStaticGetSetReferenceType")]
+        ValueWithType<string> PublicStaticOnlySetWithType { set; }
+
+        [Duck(Name = "PublicStaticGetSetReferenceType")]
+        string PublicStaticOnlyGet { get; }
+
+        [Duck(Name = "PublicStaticGetSetReferenceType")]
+        ValueWithType<string> PublicStaticOnlyGetWithType { get; }
+
         // *
 
         string this[string index] { get; set; }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -47,6 +47,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType.ProxiesDefinit
 
         // *
 
+        [Duck(Name = "PublicStaticGetSetReferenceType")]
+        public abstract ValueWithType<string> PublicStaticOnlyGetWithType { get; }
+
+        // *
+
         public abstract string this[string index] { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/ObscureDuckTypeStruct.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/ObscureDuckTypeStruct.cs
@@ -31,5 +31,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType.ProxiesDefinit
         public string InternalGetSetReferenceType;
         public string ProtectedGetSetReferenceType;
         public string PrivateGetSetReferenceType;
+
+        [Duck(Name = "PublicStaticGetSetReferenceType")]
+        public ValueWithType<string> PublicStaticOnlyGetWithType;
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -47,6 +47,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType.ProxiesDefinit
 
         // *
 
+        [Duck(Name = "PublicStaticGetSetReferenceType")]
+        public virtual ValueWithType<string> PublicStaticOnlyGetWithType { get; }
+
+        // *
+
         public virtual string this[string index]
         {
             get => default;

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
@@ -168,6 +168,26 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             Assert.Equal("60", duckVirtual.PrivateStaticGetSetReferenceType);
 
             duckInterface.PrivateStaticGetSetReferenceType = "23";
+
+            duckInterface.PublicStaticOnlySet = "23";
+            Assert.Equal("23", duckInterface.PublicStaticGetSetReferenceType);
+            Assert.Equal("23", duckAbstract.PublicStaticGetSetReferenceType);
+            Assert.Equal("23", duckVirtual.PublicStaticGetSetReferenceType);
+
+            duckInterface.PublicStaticOnlySetWithType = ValueWithType<string>.Create("24", typeof(string));
+            Assert.Equal("24", duckInterface.PublicStaticGetSetReferenceType);
+            Assert.Equal("24", duckAbstract.PublicStaticGetSetReferenceType);
+            Assert.Equal("24", duckVirtual.PublicStaticGetSetReferenceType);
+
+            Assert.Equal("24", duckInterface.PublicStaticOnlyGet);
+            Assert.Equal("24", duckInterface.PublicStaticOnlyGetWithType.Value);
+            Assert.Equal(typeof(string), duckInterface.PublicStaticOnlyGetWithType.Type);
+            Assert.Equal("24", duckAbstract.PublicStaticOnlyGetWithType.Value);
+            Assert.Equal(typeof(string), duckAbstract.PublicStaticOnlyGetWithType.Type);
+            Assert.Equal("24", duckVirtual.PublicStaticOnlyGetWithType.Value);
+            Assert.Equal(typeof(string), duckVirtual.PublicStaticOnlyGetWithType.Type);
+
+            duckInterface.PublicStaticOnlySet = "20";
         }
 
         [Theory]
@@ -351,6 +371,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             Assert.Equal("41", duckStructCopy.InternalGetSetReferenceType);
             Assert.Equal("42", duckStructCopy.ProtectedGetSetReferenceType);
             Assert.Equal("43", duckStructCopy.PrivateGetSetReferenceType);
+
+            Assert.Equal("20", duckStructCopy.PublicStaticOnlyGetWithType.Value);
+            Assert.Equal(typeof(string), duckStructCopy.PublicStaticOnlyGetWithType.Type);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/IObscureDuckType.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/IObscureDuckType.cs
@@ -50,5 +50,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining.ProxiesDefiniti
         // *
 
         IDummyFieldObject PrivateDummyGetSetSelfType { get; set; }
+
+        // *
+        [Duck(Name = "PublicGetSetSelfType")]
+        ValueWithType<IDummyFieldObject> PublicGetSetSelfTypeWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -44,5 +44,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining.ProxiesDefiniti
         public abstract IDummyFieldObject ProtectedGetSetSelfType { get; set; }
 
         public abstract IDummyFieldObject PrivateGetSetSelfType { get; set; }
+
+        // *
+        [Duck(Name = "PublicGetSetSelfType")]
+        public abstract ValueWithType<IDummyFieldObject> PublicGetSetSelfTypeWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ObscureDuckTypeStruct.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ObscureDuckTypeStruct.cs
@@ -29,5 +29,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining.ProxiesDefiniti
         public DummyFieldStruct InternalGetSetSelfType;
         public DummyFieldStruct ProtectedGetSetSelfType;
         public DummyFieldStruct PrivateGetSetSelfType;
+
+        [Duck(Name = "PublicGetSetSelfType")]
+        public ValueWithType<IDummyFieldObject> PublicGetSetSelfTypeWithType;
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -44,5 +44,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining.ProxiesDefiniti
         public virtual IDummyFieldObject ProtectedGetSetSelfType { get; set; }
 
         public virtual IDummyFieldObject PrivateGetSetSelfType { get; set; }
+
+        // *
+        [Duck(Name = "PublicGetSetSelfType")]
+        public virtual ValueWithType<IDummyFieldObject> PublicGetSetSelfTypeWithType { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/TypeChainingPropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/TypeChaining/TypeChainingPropertyTests.cs
@@ -213,6 +213,17 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
             Assert.Equal(42, duckAbstract.PublicGetSetSelfType.MagicNumber);
             Assert.Equal(42, duckVirtual.PublicGetSetSelfType.MagicNumber);
 
+            duckInterface.PublicGetSetSelfTypeWithType = ValueWithType<IDummyFieldObject>.Create(newDummy, null!);
+            Assert.Equal(42, duckInterface.PublicGetSetSelfTypeWithType.Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckInterface.PublicGetSetSelfTypeWithType.Type);
+            Assert.Equal(42, duckAbstract.PublicGetSetSelfTypeWithType.Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckAbstract.PublicGetSetSelfTypeWithType.Type);
+            Assert.Equal(42, duckVirtual.PublicGetSetSelfTypeWithType.Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckVirtual.PublicGetSetSelfTypeWithType.Type);
+
+            newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 42 }).DuckCast<IDummyFieldObject>();
+            duckInterface.PublicGetSetSelfType = newDummy;
+
             // *
             newDummy = (new ObscureObject.DummyFieldObject { MagicNumber = 52 }).DuckCast<IDummyFieldObject>();
             duckInterface.InternalGetSetSelfType = newDummy;
@@ -273,6 +284,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.TypeChaining
             Assert.Equal(42, duckStructCopy.InternalGetSetSelfType.MagicNumber);
             Assert.Equal(42, duckStructCopy.ProtectedGetSetSelfType.MagicNumber);
             Assert.Equal(42, duckStructCopy.PrivateGetSetSelfType.MagicNumber);
+
+            Assert.Equal(42, duckStructCopy.PublicGetSetSelfTypeWithType.Value.MagicNumber);
+            Assert.Equal(typeof(ObscureObject.DummyFieldObject), duckStructCopy.PublicGetSetSelfTypeWithType.Type);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/IObscureDuckType.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/IObscureDuckType.cs
@@ -63,6 +63,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType.ProxiesDefinitions
 
         // *
 
+        [Duck(Name = "PublicGetSetValueType")]
+        ValueWithType<int> PublicGetSetValueTypeWithType { get; set; }
+
+        // *
+
         int this[int index] { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/ObscureDuckTypeAbstractClass.cs
@@ -63,6 +63,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType.ProxiesDefinitions
 
         // *
 
+        [Duck(Name = "PublicGetSetValueType")]
+        public abstract ValueWithType<int> PublicGetSetValueTypeWithType { get; set; }
+
+        // *
+
         public abstract int this[int index] { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/ObscureDuckTypeStruct.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/ObscureDuckTypeStruct.cs
@@ -29,5 +29,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType.ProxiesDefinitions
         public int InternalGetSetValueType;
         public int ProtectedGetSetValueType;
         public int PrivateGetSetValueType;
+
+        [Duck(Name = "PublicGetSetValueType")]
+        public ValueWithType<int> PublicGetSetValueTypeWithType;
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ProxiesDefinitions/ObscureDuckTypeVirtualClass.cs
@@ -67,6 +67,11 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType.ProxiesDefinitions
 
         // *
 
+        [Duck(Name = "PublicGetSetValueType")]
+        public virtual ValueWithType<int> PublicGetSetValueTypeWithType { get; set; }
+
+        // *
+
         public virtual int this[int index]
         {
             get => default;

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
@@ -215,6 +215,14 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             Assert.Equal(40, duckAbstract.PublicGetSetValueType);
             Assert.Equal(40, duckVirtual.PublicGetSetValueType);
 
+            duckInterface.PublicGetSetValueTypeWithType = ValueWithType<int>.Create(40, typeof(int));
+            Assert.Equal(40, duckInterface.PublicGetSetValueTypeWithType.Value);
+            Assert.Equal(typeof(int), duckInterface.PublicGetSetValueTypeWithType.Type);
+            Assert.Equal(40, duckAbstract.PublicGetSetValueTypeWithType.Value);
+            Assert.Equal(typeof(int), duckAbstract.PublicGetSetValueTypeWithType.Type);
+            Assert.Equal(40, duckVirtual.PublicGetSetValueTypeWithType.Value);
+            Assert.Equal(typeof(int), duckVirtual.PublicGetSetValueTypeWithType.Type);
+
             duckInterface.PublicGetSetValueType = 42;
             Assert.Equal(42, duckInterface.PublicGetSetValueType);
             Assert.Equal(42, duckAbstract.PublicGetSetValueType);
@@ -477,6 +485,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             Assert.Equal(41, duckStructCopy.InternalGetSetValueType);
             Assert.Equal(42, duckStructCopy.ProtectedGetSetValueType);
             Assert.Equal(43, duckStructCopy.PrivateGetSetValueType);
+
+            Assert.Equal(40, duckStructCopy.PublicGetSetValueTypeWithType.Value);
+            Assert.Equal(typeof(int), duckStructCopy.PublicGetSetValueTypeWithType.Type);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

This PR adds support for a new `ValueWithType<T>` struct to allow Value and original Type extraction in the ducktype library.

### `ValueWithType<T>` struct

Sometimes we need to get to know the original type of a value we are ducktyping, normally this can be done by just calling `.GetType()` over the returned instance value.
But when there's no instance because the returned ducktyped value is `null` there's no way to extract the original type.

For those cases we can use the `ValueWithType<T>` struct. This will tell the ducktyping machinary to return the value together with the original declared Type of the value.

For example:

```csharp
public interface IProxyMyHandler
{
    string Name { get; set; }

    IProxyMyHandlerConfiguration Configuration { get; }
}
public interface IProxyMyHandlerConfiguration
{
    int MaxConnections { get; set; }
}
```

If the `Configuration` is null then we don't know the original type of configuration, but if we change the proxy to:

```csharp
public interface IProxyMyHandler
{
    string Name { get; set; }

    ValueWithType<IProxyMyHandlerConfiguration> Configuration { get; }
}
public interface IProxyMyHandlerConfiguration
{
    int MaxConnections { get; set; }
}
```

Then we can do:

1. `Configuration.Value`: to retrieve the value as the previous interface. (This works with reference types, values types and duckchaining)
2. `Configuration.Type`: to retrieve the original declared type of the `Configuration` property in the original class.

The structure of the `ValueWithType<T>` class is very simple:

```csharp
public readonly struct ValueWithType<TProxy>
{
    /// <summary>
    /// Gets the value
    /// </summary>
    public readonly TProxy? Value;

    /// <summary>
    /// Gets the Type of the value
    /// </summary>
    public readonly Type Type;
}
```

**This is specially useful when we are ducktyping a `Delegate` class for instrumentation. We will need to get the type of the delegate if the instance is null in order to create a new delegate that follows the same signature. Using this method, the delegate type can be retrieved with `.Type` field.**

**Note:** This struct can be used as `PropertyType`, `FieldType` or Method `ReturnType` in the proxy definition.