### PR TITLE
Fix flake in telemetry metric unit test

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollector.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
 {
     private readonly TimeSpan _aggregationInterval;
+    private readonly Action? _aggregationNotification;
     private readonly string[] _unknownWafVersionTags = { "waf_version:unknown" };
     private readonly Lazy<AggregatedMetrics> _aggregated = new();
     private readonly Task _aggregateTask;
@@ -31,9 +32,10 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
     {
     }
 
-    internal MetricsTelemetryCollector(TimeSpan aggregationInterval)
+    internal MetricsTelemetryCollector(TimeSpan aggregationInterval, Action? aggregationNotification = null)
     {
         _aggregationInterval = aggregationInterval;
+        _aggregationNotification = aggregationNotification;
         _aggregateTask = Task.Run(AggregateMetricsLoopAsync);
     }
 
@@ -296,6 +298,7 @@ internal partial class MetricsTelemetryCollector : IMetricsTelemetryCollector
 
             // The process may have exited, but we want to do a final aggregation before process end anyway
             AggregateMetrics();
+            _aggregationNotification?.Invoke();
 
             if (_processExit.Task.IsCompleted)
             {


### PR DESCRIPTION
## Summary of changes

- Add check that aggregation task hasn't faulted in unit tests
- Remove timing requirement from test to reduce flake

## Reason for change

On ARM64 the test that verifies the aggregation task runs periodically was flaky. This is likely down to the ci machines being overloaded, but it was annoying. Kevin also pointed out that we couldn't be _sure_ that this was the case, and it was possible that that the aggregation task had faulted, so added `await` to the task in all unit tests

## Implementation details

Added an optional "aggregation notification" that we can use in unit tests to wait for an aggregation to occur. Also added `await collector.DisposeAsync()` to all unit tests.

## Test coverage

Covered by existing