### PR TITLE
Refactor `LambdaMetadata` settings creation

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 InitializeTracer(sw);
 
-                InitializeServerless(sw);
+                InitializeServerless(sw, Tracer.Instance.Settings.LambdaMetadata);
             }
 
 #if NETSTANDARD2_0 || NETCOREAPP3_1
@@ -216,7 +216,7 @@ namespace Datadog.Trace.ClrProfiler
 
             InitializeTracer(sw);
 
-            InitializeServerless(sw);
+            InitializeServerless(sw, Tracer.Instance.Settings.LambdaMetadata);
 
             InitializeAppSecLegacy(sw);
 
@@ -403,11 +403,11 @@ namespace Datadog.Trace.ClrProfiler
             }
         }
 
-        private static void InitializeServerless(Stopwatch sw)
+        private static void InitializeServerless(Stopwatch sw, LambdaMetadata metadata)
         {
             try
             {
-                Serverless.InitIfNeeded();
+                Serverless.InitIfNeeded(metadata);
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaMetadata.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/LambdaMetadata.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="LambdaMetadata.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
+
+internal class LambdaMetadata
+{
+    private const string ExtensionEnvName = "_DD_EXTENSION_PATH";
+    private const string ExtensionFullPath = "/opt/extensions/datadog-agent";
+    private const string FunctionEnvame = "AWS_LAMBDA_FUNCTION_NAME";
+    private const string HandlerEnvName = "_HANDLER";
+
+    private LambdaMetadata(bool isRunningInLambda, string functionName, string handlerName, string serviceName)
+    {
+        IsRunningInLambda = isRunningInLambda;
+        FunctionName = functionName;
+        HandlerName = handlerName;
+        ServiceName = serviceName;
+    }
+
+    public bool IsRunningInLambda { get; }
+
+    public string FunctionName { get; }
+
+    public string HandlerName { get; }
+
+    public string ServiceName { get; }
+
+    /// <summary>
+    /// Gets the paths we don't want to trace when running in Lambda
+    /// </summary>
+    internal string DefaultHttpClientExclusions { get; private set; } = "/2018-06-01/runtime/invocation/".ToUpperInvariant();
+
+    public static LambdaMetadata Create(string extensionPath = ExtensionFullPath)
+    {
+        var functionName = EnvironmentHelpers.GetEnvironmentVariable(FunctionEnvame);
+
+        var isRunningInLambda = !string.IsNullOrEmpty(functionName)
+                             && File.Exists(
+                                    EnvironmentHelpers.GetEnvironmentVariable(ExtensionEnvName)
+                                 ?? extensionPath);
+
+        if (!isRunningInLambda)
+        {
+            // the other values are irrelevant, so don't bother setting them
+            return new LambdaMetadata(isRunningInLambda: false, functionName, handlerName: null, serviceName: null);
+        }
+
+        var handlerName = EnvironmentHelpers.GetEnvironmentVariable(HandlerEnvName);
+        var serviceName = handlerName?.IndexOf(LambdaHandler.Separator, StringComparison.Ordinal) switch
+        {
+            null => null, // not provided
+            0 => null, // invalid handler name (no assembly)
+            -1 => handlerName, // top level function style
+            { } i => handlerName.Substring(0, i), // three part function style
+        };
+
+        return new LambdaMetadata(isRunningInLambda: true, functionName, handlerName, serviceName);
+    }
+
+    internal static LambdaMetadata CreateForTests(bool isRunningInLambda, string functionName, string handlerName, string serviceName, string defaultHttpExclusions)
+    {
+        return new LambdaMetadata(isRunningInLambda, functionName, handlerName, serviceName)
+        {
+            DefaultHttpClientExclusions = defaultHttpExclusions
+        };
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
@@ -4,8 +4,6 @@
 // </copyright>
 
 using System;
-using System.IO;
-
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
@@ -146,70 +144,6 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
             {
                 Error("Impossible to get Serverless Definitions", ex);
                 return Array.Empty<NativeCallTargetDefinition>();
-            }
-        }
-
-        internal class LambdaMetadata
-        {
-            private const string ExtensionEnvName = "_DD_EXTENSION_PATH";
-            private const string ExtensionFullPath = "/opt/extensions/datadog-agent";
-            private const string FunctionEnvame = "AWS_LAMBDA_FUNCTION_NAME";
-            private const string HandlerEnvName = "_HANDLER";
-
-            private LambdaMetadata(bool isRunningInLambda, string functionName, string handlerName, string serviceName)
-            {
-                IsRunningInLambda = isRunningInLambda;
-                FunctionName = functionName;
-                HandlerName = handlerName;
-                ServiceName = serviceName;
-            }
-
-            public bool IsRunningInLambda { get; }
-
-            public string FunctionName { get; }
-
-            public string HandlerName { get; }
-
-            public string ServiceName { get; }
-
-            /// <summary>
-            /// Gets the paths we don't want to trace when running in Lambda
-            /// </summary>
-            internal string DefaultHttpClientExclusions { get; private set; } = "/2018-06-01/runtime/invocation/".ToUpperInvariant();
-
-            public static LambdaMetadata Create(string extensionPath = ExtensionFullPath)
-            {
-                var functionName = EnvironmentHelpers.GetEnvironmentVariable(FunctionEnvame);
-
-                var isRunningInLambda = !string.IsNullOrEmpty(functionName)
-                                     && File.Exists(
-                                            EnvironmentHelpers.GetEnvironmentVariable(ExtensionEnvName)
-                                         ?? extensionPath);
-
-                if (!isRunningInLambda)
-                {
-                    // the other values are irrelevant, so don't bother setting them
-                    return new LambdaMetadata(isRunningInLambda: false, functionName, handlerName: null, serviceName: null);
-                }
-
-                var handlerName = EnvironmentHelpers.GetEnvironmentVariable(HandlerEnvName);
-                var serviceName = handlerName?.IndexOf(LambdaHandler.Separator, StringComparison.Ordinal) switch
-                {
-                    null => null, // not provided
-                    0 => null, // invalid handler name (no assembly)
-                    -1 => handlerName, // top level function style
-                    { } i => handlerName.Substring(0, i), // three part function style
-                };
-
-                return new LambdaMetadata(isRunningInLambda: true, functionName, handlerName, serviceName);
-            }
-
-            internal static LambdaMetadata CreateForTests(bool isRunningInLambda, string functionName, string handlerName, string serviceName, string defaultHttpExclusions)
-            {
-                return new LambdaMetadata(isRunningInLambda, functionName, handlerName, serviceName)
-                {
-                    DefaultHttpClientExclusions = defaultHttpExclusions
-                };
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/Serverless.cs
@@ -15,16 +15,9 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation
 
         private static NativeCallTargetDefinition[] callTargetDefinitions = null;
 
-        internal static LambdaMetadata Metadata { get; private set; } = LambdaMetadata.Create();
-
-        internal static void SetMetadataTestsOnly(LambdaMetadata metadata)
+        internal static void InitIfNeeded(LambdaMetadata metadata)
         {
-            Metadata = metadata;
-        }
-
-        internal static void InitIfNeeded()
-        {
-            if (Metadata is { IsRunningInLambda: true, HandlerName: var handlerName })
+            if (metadata is { IsRunningInLambda: true, HandlerName: var handlerName })
             {
                 if (string.IsNullOrEmpty(handlerName))
                 {

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Datadog.Trace.Ci.Tags;
+using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -155,6 +156,7 @@ namespace Datadog.Trace.Configuration
             IsRunningInAzureFunctionsConsumptionPlan = settings.IsRunningInAzureFunctionsConsumptionPlan;
 
             IsRunningInGCPFunctions = settings.IsRunningInGCPFunctions;
+            LambdaMetadata = settings.LambdaMetadata;
 
             TraceId128BitGenerationEnabled = settings.TraceId128BitGenerationEnabled;
             TraceId128BitLoggingEnabled = settings.TraceId128BitLoggingEnabled;
@@ -508,6 +510,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the tracer is running in Google Cloud Functions
         /// </summary>
         internal bool IsRunningInGCPFunctions { get; }
+
+        /// <summary>
+        /// Gets the AWS Lambda settings, including whether we're currently running in Lambda
+        /// </summary>
+        internal LambdaMetadata LambdaMetadata { get; }
 
         /// <summary>
         /// Gets a value indicating whether the tracer should propagate service data in db queries

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -354,6 +354,8 @@ namespace Datadog.Trace.Configuration
 
             IsRunningInGCPFunctions = GCPFunctionSettings.IsGCPFunction;
 
+            LambdaMetadata = LambdaMetadata.Create();
+
             StatsComputationEnabledInternal = config
                                      .WithKeys(ConfigurationKeys.StatsComputationEnabled)
                                      .AsBool(defaultValue: (IsRunningInGCPFunctions || IsRunningInAzureFunctionsConsumptionPlan));
@@ -362,7 +364,7 @@ namespace Datadog.Trace.Configuration
                                    .WithKeys(ConfigurationKeys.HttpClientExcludedUrlSubstrings)
                                    .AsString(
                                         IsRunningInAzureAppService ? ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions :
-                                        Serverless.Metadata is { IsRunningInLambda: true } m ? m.DefaultHttpClientExclusions : string.Empty);
+                                        LambdaMetadata is { IsRunningInLambda: true } m ? m.DefaultHttpClientExclusions : string.Empty);
 
             HttpClientExcludedUrlSubstrings = !string.IsNullOrEmpty(urlSubstringSkips)
                                                   ? TrimSplitString(urlSubstringSkips.ToUpperInvariant(), commaSeparator)
@@ -842,6 +844,11 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating whether the tracer is running in Google Cloud Functions
         /// </summary>
         internal bool IsRunningInGCPFunctions { get; }
+
+        /// <summary>
+        /// Gets the AWS Lambda settings, including whether we're currently running in Lambda
+        /// </summary>
+        internal LambdaMetadata LambdaMetadata { get; }
 
         /// <summary>
         /// Gets a value indicating whether the tracer should propagate service data in db queries

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -363,7 +363,7 @@ namespace Datadog.Trace
                     return settings.AzureAppServiceMetadata.SiteName;
                 }
 
-                if (Serverless.Metadata is { IsRunningInLambda: true, ServiceName: var serviceName })
+                if (settings.LambdaMetadata is { IsRunningInLambda: true, ServiceName: var serviceName })
                 {
                     return serviceName;
                 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -804,7 +804,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 if (isRunningInLambda)
                 {
-                    var metadata = Serverless.LambdaMetadata.CreateForTests(true, "functionName", "handlerName", "serviceName", "serverless");
+                    var metadata = LambdaMetadata.CreateForTests(true, "functionName", "handlerName", "serviceName", "serverless");
                     Serverless.SetMetadataTestsOnly(metadata);
                 }
 

--- a/tracer/test/Datadog.Trace.Tests/ServerlessTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ServerlessTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.Tests
         {
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, string.Empty);
             string path = Directory.GetCurrentDirectory() + "/invalid";
-            var res = Serverless.LambdaMetadata.Create(path);
+            var res = LambdaMetadata.Create(path);
             res.IsRunningInLambda.Should().BeFalse();
         }
 
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Tests
         {
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, "my-test-function");
             string path = Directory.GetCurrentDirectory() + "/invalid";
-            var res = Serverless.LambdaMetadata.Create(path);
+            var res = LambdaMetadata.Create(path);
             res.IsRunningInLambda.Should().BeFalse();
         }
 
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Tests
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, string.Empty);
             string currentDirectory = Directory.GetCurrentDirectory();
             string existingFile = Directory.GetFiles(currentDirectory)[0];
-            var res = Serverless.LambdaMetadata.Create(existingFile);
+            var res = LambdaMetadata.Create(existingFile);
             res.IsRunningInLambda.Should().BeFalse();
         }
 
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests
             Environment.SetEnvironmentVariable(FunctionNameEnvVar, "my-test-function");
             string currentDirectory = Directory.GetCurrentDirectory();
             string existingFile = Directory.GetFiles(currentDirectory)[0];
-            var res = Serverless.LambdaMetadata.Create(existingFile);
+            var res = LambdaMetadata.Create(existingFile);
             res.IsRunningInLambda.Should().BeTrue();
             res.FunctionName.Should().Be("my-test-function");
         }
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Tests
             string currentDirectory = Directory.GetCurrentDirectory();
             string existingFile = Directory.GetFiles(currentDirectory)[0];
 
-            var res = Serverless.LambdaMetadata.Create(existingFile);
+            var res = LambdaMetadata.Create(existingFile);
 
             res.IsRunningInLambda.Should().BeTrue();
             res.FunctionName.Should().Be("my-test-function");
@@ -107,7 +107,7 @@ namespace Datadog.Trace.Tests
             string currentDirectory = Directory.GetCurrentDirectory();
             string existingFile = Directory.GetFiles(currentDirectory)[0];
 
-            var res = Serverless.LambdaMetadata.Create(existingFile);
+            var res = LambdaMetadata.Create(existingFile);
 
             res.IsRunningInLambda.Should().BeTrue();
             res.FunctionName.Should().Be("my-test-function");


### PR DESCRIPTION
## Summary of changes

- Refactors the serverless settings, so we can access the values without relying on statics

## Reason for change

I need to access the lambda metadata in telemetry settings, but don't want to add static globals as it's a pain for testing.

## Implementation details

Moved the creation of the `LambdaMetadata` object to `TracerSettings`, similar to how we do for other types. Note that I didn't change _how_ it reads values (it still only reads from env vars, instead of configuration source). Would could consider adding config telemetry too, but I'll do that in a separate PR if people want it.

## Test coverage

Refactored the existing tests to work with the new approach, and moved some "test only" code into the test project instead

## Other details
Required for subsequent PR to disable telemetry metrics in serverless environments

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
