### PR TITLE
Disable telemetry metrics when running in serverless environment

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -59,10 +59,10 @@ namespace Datadog.Trace.Telemetry
         public static TelemetryFactory CreateFactory() => new();
 
         public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService)
-            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config), discoveryService, useCiVisibilityTelemetry: false);
+            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings), discoveryService, useCiVisibilityTelemetry: false);
 
         public ITelemetryController CreateCiVisibilityTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService)
-            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config), discoveryService, useCiVisibilityTelemetry: true);
+            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings), discoveryService, useCiVisibilityTelemetry: true);
 
         public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, TelemetrySettings settings, IDiscoveryService discoveryService, bool useCiVisibilityTelemetry)
         {

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Telemetry
         public bool MetricsEnabled { get; }
 
         public static TelemetrySettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry, ImmutableTracerSettings tracerSettings)
-            => FromSource(source, telemetry, IsAgentAvailable, isServerless: tracerSettings.LambdaMetadata.IsRunningInLambda || tracerSettings.IsRunningInAzureFunctionsConsumptionPlan);
+            => FromSource(source, telemetry, IsAgentAvailable, isServerless: tracerSettings.LambdaMetadata.IsRunningInLambda || tracerSettings.IsRunningInAzureFunctionsConsumptionPlan || tracerSettings.IsRunningInGCPFunctions);
 
         public static TelemetrySettings FromSource(IConfigurationSource source, IConfigurationTelemetry telemetry, Func<bool?> isAgentAvailable, bool isServerless)
         {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(expected);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.Enabled, "1" }
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
             settings.Agentless.Should().BeNull();
             settings.ConfigurationError.Should().BeNullOrEmpty();
         }
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(DefaultIntakeUrl);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Site, domain },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
 
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be($"https://instrumentation-telemetry-intake.{domain}/");
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.Uri, url },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
 
             settings.Agentless.Should().BeNull();
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -114,7 +114,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
 
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(DefaultIntakeUrl);
@@ -136,7 +136,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, apiKey },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
             var expectAgentless = enabled && !string.IsNullOrEmpty(apiKey);
 
             if (expectAgentless)
@@ -167,7 +167,7 @@ namespace Datadog.Trace.Tests.Telemetry
             });
             var hasApiKey = !string.IsNullOrEmpty(apiKey);
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
             using var s = new AssertionScope();
 
             settings.TelemetryEnabled.Should().Be(true);
@@ -211,7 +211,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, agentlessEnabled == true ? "SOME_KEY" : null },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
 
             var expectEnabled = enabled != false;
             var expectAgentless = expectEnabled && agentlessEnabled == true;
@@ -244,7 +244,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.AgentProxyEnabled, agentProxyEnabled?.ToString() }
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => agentAvailable, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => agentAvailable, isServerless: false);
 
             settings.AgentProxyEnabled.Should().Be(expected);
         }
@@ -263,7 +263,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "SOME_KEY" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, isAgentAvailable: () => true, telemetry: new NullConfigurationTelemetry());
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
 
             using var s = new AssertionScope();
             settings.TelemetryEnabled.Should().Be(expected);
@@ -289,7 +289,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public void HeartbeatInterval(string value, double expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds, value));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
 
             settings.HeartbeatInterval.Should().Be(TimeSpan.FromSeconds(expected));
         }
@@ -302,7 +302,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public void V2Enabled_DisabledByDefault(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.V2Enabled, value));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
 
             settings.V2Enabled.Should().Be(expected);
         }
@@ -312,14 +312,32 @@ namespace Datadog.Trace.Tests.Telemetry
         [InlineData(null, true)]
         [InlineData("", true)]
         [InlineData("1", true)]
-        public void V2Enabled_DisabledByDefaultInAas(string value, bool expected)
+        public void V2Enabled_EnabledByDefaultInAas(string value, bool expected)
         {
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1"),
                 (ConfigurationKeys.Telemetry.V2Enabled, value));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
 
             settings.V2Enabled.Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData("0", "1", false)]
+        [InlineData(null, "1", false)]
+        [InlineData("", "1", false)]
+        [InlineData("1", "0", false)]
+        [InlineData("1", null, false)]
+        [InlineData("1", "", false)]
+        [InlineData("1", "1", false)]
+        public void V2Metrics_DisabledInServerless(string v2Enabled, string metricsEnabled, bool expected)
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.Telemetry.V2Enabled, v2Enabled),
+                (ConfigurationKeys.Telemetry.MetricsEnabled, metricsEnabled));
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: true);
+
+            settings.MetricsEnabled.Should().Be(expected);
         }
 
         [Theory]
@@ -335,7 +353,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.Telemetry.MetricsEnabled, metricSettingValue),
                 (ConfigurationKeys.Telemetry.V2Enabled, v2Enabled ? "1" : "0"));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
 
             settings.MetricsEnabled.Should().Be(expected);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -345,7 +363,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public void MetricsEnabled_TryingToEnableWhenV2DisabledIsConfigError()
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.MetricsEnabled, "1"), (ConfigurationKeys.Telemetry.V2Enabled, "0"));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
 
             settings.MetricsEnabled.Should().Be(false);
             settings.ConfigurationError.Should().NotBeNullOrEmpty();


### PR DESCRIPTION
## Summary of changes

Disables telemetry metrics when running AWS Lambda or AAS consumption plan

## Reason for change

We can't trust these environments to provide reliable timers, which we need for our aggregations. This isn't _necessarily_ a big issue, but we'd rather disable for now, and re-enable them at a later date, rather than knowingly push potentially dubious data. 

At a later date, we can consider adding an explicit `lambda` tag to the generated metrics, so that we can separate the data if necessary

## Implementation details

Added a check for whether we're running in a serverless environment. If so, we explicitly disable metrics. Otherwise we fallback to the existing behaviour

## Test coverage

Updated unit tests to handle new behavior, and added new test for serverless behaviour.

## Other details
Stacked on #4624

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
