### PR TITLE
Update CODEOWNERS for serverless

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,5 +43,11 @@ debugger_*.h                               @DataDog/debugger-dotnet
 tracer/src/Datadog.InstrumentedAssemblyGenerator/ @DataDog/debugger-dotnet
 tracer/src/Datadog.InstrumentedAssemblyVerification/ @DataDog/debugger-dotnet
 
+# Serverless
+/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/   @DataDog/tracing-dotnet  @DataDog/serverless-apm
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/       @DataDog/tracing-dotnet  @DataDog/serverless-apm
+/tracer/test/test-applications/azure-functions/                    @DataDog/tracing-dotnet  @DataDog/serverless-apm
+docker-compose.serverless.yml                                      @DataDog/tracing-dotnet  @DataDog/serverless-apm
+
 # Shared code we could move to the root folder
 /tracer/build/                            @DataDog/apm-dotnet


### PR DESCRIPTION
## Summary of changes

Added @DataDog/serverless-apm as co-owners on some serverless paths

## Reason for change

This is primarily maintained by the serverless team, so they should at least be codeowners

## Implementation details

Added tracing as co-owners to hopefully reduce any friction, while keeping both teams informed
