### PR TITLE
Add support for multiple enums in telemetry source generator

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/Sources.cs
@@ -109,7 +109,7 @@ internal partial class Sources
           .Append(
                $$"""
 
-                   private const int _countsLength = {{entryCounts.Sum()}};
+                   private const int {{details.ShortName}}Length = {{entryCounts.Sum()}};
                }
                """);
 
@@ -353,7 +353,7 @@ internal partial class Sources
           .Append(
                $$"""
 
-                   private const int _gaugesLength = {{entryCounts.Sum()}};
+                   private const int {{details.ShortName}}Length = {{entryCounts.Sum()}};
                }
                """);
 
@@ -597,7 +597,7 @@ internal partial class Sources
           .Append(
                $$"""
 
-                   private const int _distributionsLength = {{entryCounts.Sum()}};
+                   private const int {{details.ShortName}}Length = {{entryCounts.Sum()}};
                }
                """);
 
@@ -944,7 +944,7 @@ internal partial class Sources
             $$"""
                   public void Record{{details.ShortName}}{{property}}(int increment = 1)
                   {
-                      Interlocked.Add(ref _buffer.Counts[{{index}}], increment);
+                      Interlocked.Add(ref _buffer.{{details.ShortName}}[{{index}}], increment);
                   }
               """);
     }
@@ -956,7 +956,7 @@ internal partial class Sources
                   public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int increment = 1)
                   {
                       var index = {{index}} + (int)tag;
-                      Interlocked.Add(ref _buffer.Counts[index], increment);
+                      Interlocked.Add(ref _buffer.{{details.ShortName}}[index], increment);
                   }
               """);
     }
@@ -968,7 +968,7 @@ internal partial class Sources
                   public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int increment = 1)
                   {
                       var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
-                      Interlocked.Add(ref _buffer.Counts[index], increment);
+                      Interlocked.Add(ref _buffer.{{details.ShortName}}[index], increment);
                   }
               """);
     }
@@ -979,7 +979,7 @@ internal partial class Sources
             $$"""
                   public void Record{{details.ShortName}}{{property}}(int value)
                   {
-                      Interlocked.Exchange(ref _buffer.Gauges[{{index}}], value);
+                      Interlocked.Exchange(ref _buffer.{{details.ShortName}}[{{index}}], value);
                   }
               """);
     }
@@ -991,7 +991,7 @@ internal partial class Sources
                   public void Record{{details.ShortName}}{{property}}({{tagName}} tag, int value)
                   {
                       var index = {{index}} + (int)tag;
-                      Interlocked.Exchange(ref _buffer.Gauges[index], value);
+                      Interlocked.Exchange(ref _buffer.{{details.ShortName}}[index], value);
                   }
               """);
     }
@@ -1003,7 +1003,7 @@ internal partial class Sources
                   public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, int value)
                   {
                       var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
-                      Interlocked.Exchange(ref _buffer.Gauges[index], value);
+                      Interlocked.Exchange(ref _buffer.{{details.ShortName}}[index], value);
                   }
               """);
     }
@@ -1014,7 +1014,7 @@ internal partial class Sources
             $$"""
                   public void Record{{details.ShortName}}{{property}}(double value)
                   {
-                      _buffer.Distributions[{{index}}].TryEnqueue(value);
+                      _buffer.{{details.ShortName}}[{{index}}].TryEnqueue(value);
                   }
               """);
     }
@@ -1026,7 +1026,7 @@ internal partial class Sources
                   public void Record{{details.ShortName}}{{property}}({{tagName}} tag, double value)
                   {
                       var index = {{index}} + (int)tag;
-                      _buffer.Distributions[index].TryEnqueue(value);
+                      _buffer.{{details.ShortName}}[index].TryEnqueue(value);
                   }
               """);
     }
@@ -1038,7 +1038,7 @@ internal partial class Sources
                   public void Record{{details.ShortName}}{{property}}({{tagName1}} tag1, {{tagName2}} tag2, double value)
                   {
                       var index = {{index}} + ((int)tag1 * {{tag2EntryCount}}) + (int)tag2;
-                      _buffer.Distributions[index].TryEnqueue(value);
+                      _buffer.{{details.ShortName}}[index].TryEnqueue(value);
                   }
               """);
     }

--- a/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/TelemetryMetricGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/TelemetryMetricGenerator.cs
@@ -100,11 +100,11 @@ namespace Datadog.Trace.SourceGenerators.TelemetryMetric
             };
 
             spc.AddSource($"{enumDetails.ShortName}Extensions.g.cs", SourceText.From(enumSource, Encoding.UTF8));
-            spc.AddSource($"MetricsTelemetryCollectorBase_{enumDetails.MetricType}.g.cs", SourceText.From(baseSource, Encoding.UTF8));
-            spc.AddSource($"MetricsTelemetryCollector_{enumDetails.MetricType}.g.cs", SourceText.From(collectorSource, Encoding.UTF8));
-            spc.AddSource($"CiVisibilityMetricsTelemetryCollector_{enumDetails.MetricType}.g.cs", SourceText.From(ciVisibilitySource, Encoding.UTF8));
-            spc.AddSource($"IMetricsTelemetryCollector_{enumDetails.MetricType}.g.cs", SourceText.From(interfaceSource, Encoding.UTF8));
-            spc.AddSource($"NullMetricsTelemetryCollector_{enumDetails.MetricType}.g.cs", SourceText.From(nullSource, Encoding.UTF8));
+            spc.AddSource($"MetricsTelemetryCollectorBase_{enumDetails.ShortName}.g.cs", SourceText.From(baseSource, Encoding.UTF8));
+            spc.AddSource($"MetricsTelemetryCollector_{enumDetails.ShortName}.g.cs", SourceText.From(collectorSource, Encoding.UTF8));
+            spc.AddSource($"CiVisibilityMetricsTelemetryCollector_{enumDetails.ShortName}.g.cs", SourceText.From(ciVisibilitySource, Encoding.UTF8));
+            spc.AddSource($"IMetricsTelemetryCollector_{enumDetails.ShortName}.g.cs", SourceText.From(interfaceSource, Encoding.UTF8));
+            spc.AddSource($"NullMetricsTelemetryCollector_{enumDetails.ShortName}.g.cs", SourceText.From(nullSource, Encoding.UTF8));
 
             static Dictionary<string, EquatableArray<string>> GetEnumDictionary(in EnumDetails details)
             {

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
@@ -13,7 +13,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
@@ -151,147 +151,147 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
@@ -13,70 +13,70 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
@@ -796,5 +796,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] CountEntryCounts { get; }
         = new []{ 4, 171, 57, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 57, 1, 22, 3, 1, 1, 5, 11, 1, 12, 1, 40, 40, 10, 10, 4, 1, 2, 10, 9, 63, 1, 5, 1, 5, 1, 5, 4, 1, 5, 1, 1, 4, 4, 4, 1, 1, };
 
-    private const int _countsLength = 713;
+    private const int CountLength = 713;
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
@@ -75,5 +75,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] DistributionEntryCounts { get; }
         = new []{ 14, 2, 2, 2, 2, 9, 1, 1, 1, 1, 1, 1, 1, 1, };
 
-    private const int _distributionsLength = 39;
+    private const int DistributionLength = 39;
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
@@ -33,5 +33,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] GaugeEntryCounts { get; }
         = new []{ 1, 6, 1, };
 
-    private const int _gaugesLength = 8;
+    private const int GaugeLength = 8;
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -9,346 +9,346 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
         var index = 0 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 175 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanFinished(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[232], increment);
+        Interlocked.Add(ref _buffer.Count[232], increment);
     }
 
     public void RecordCountSpanEnqueuedForSerialization(Datadog.Trace.Telemetry.Metrics.MetricTags.SpanEnqueueReason tag, int increment = 1)
     {
         var index = 233 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 236 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceSegmentCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceContinuation tag, int increment = 1)
     {
         var index = 240 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkEnqueued(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceChunkEnqueueReason tag, int increment = 1)
     {
         var index = 242 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 244 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkSent(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[248], increment);
+        Interlocked.Add(ref _buffer.Count[248], increment);
     }
 
     public void RecordCountTraceSegmentsClosed(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[249], increment);
+        Interlocked.Add(ref _buffer.Count[249], increment);
     }
 
     public void RecordCountTraceApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[250], increment);
+        Interlocked.Add(ref _buffer.Count[250], increment);
     }
 
     public void RecordCountTraceApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 251 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 273 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTracePartialFlush(Datadog.Trace.Telemetry.Metrics.MetricTags.PartialFlushReason tag, int increment = 1)
     {
         var index = 276 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleInjected(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 278 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleExtracted(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 282 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[286], increment);
+        Interlocked.Add(ref _buffer.Count[286], increment);
     }
 
     public void RecordCountStatsApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 287 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 309 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
         var index = 312 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
         var index = 314 + ((int)tag1 * 22) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
         var index = 358 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[364], increment);
+        Interlocked.Add(ref _buffer.Count[364], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 365 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[422], increment);
+        Interlocked.Add(ref _buffer.Count[422], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 423 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 445 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[448], increment);
+        Interlocked.Add(ref _buffer.Count[448], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[449], increment);
+        Interlocked.Add(ref _buffer.Count[449], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
         var index = 450 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
         var index = 455 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[466], increment);
+        Interlocked.Add(ref _buffer.Count[466], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
         var index = 467 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[479], increment);
+        Interlocked.Add(ref _buffer.Count[479], increment);
     }
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -9,76 +9,76 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionInitTime(Datadog.Trace.Telemetry.Metrics.MetricTags.InitializationComponent tag, double value)
     {
         var index = 0 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -8,17 +8,17 @@ internal partial class MetricsTelemetryCollector
 {
     public void RecordGaugeStatsBuckets(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[0], value);
+        Interlocked.Exchange(ref _buffer.Gauge[0], value);
     }
 
     public void RecordGaugeInstrumentations(Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationComponent tag, int value)
     {
         var index = 1 + (int)tag;
-        Interlocked.Exchange(ref _buffer.Gauges[index], value);
+        Interlocked.Exchange(ref _buffer.Gauge[index], value);
     }
 
     public void RecordGaugeDirectLogQueue(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[7], value);
+        Interlocked.Exchange(ref _buffer.Gauge[7], value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
@@ -13,7 +13,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
@@ -151,147 +151,147 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
@@ -13,70 +13,70 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
@@ -796,5 +796,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] CountEntryCounts { get; }
         = new []{ 4, 171, 57, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 57, 1, 22, 3, 1, 1, 5, 11, 1, 12, 1, 40, 40, 10, 10, 4, 1, 2, 10, 9, 63, 1, 5, 1, 5, 1, 5, 4, 1, 5, 1, 1, 4, 4, 4, 1, 1, };
 
-    private const int _countsLength = 713;
+    private const int CountLength = 713;
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
@@ -75,5 +75,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] DistributionEntryCounts { get; }
         = new []{ 14, 2, 2, 2, 2, 9, 1, 1, 1, 1, 1, 1, 1, 1, };
 
-    private const int _distributionsLength = 39;
+    private const int DistributionLength = 39;
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
@@ -33,5 +33,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] GaugeEntryCounts { get; }
         = new []{ 1, 6, 1, };
 
-    private const int _gaugesLength = 8;
+    private const int GaugeLength = 8;
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -9,346 +9,346 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
         var index = 0 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 175 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanFinished(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[232], increment);
+        Interlocked.Add(ref _buffer.Count[232], increment);
     }
 
     public void RecordCountSpanEnqueuedForSerialization(Datadog.Trace.Telemetry.Metrics.MetricTags.SpanEnqueueReason tag, int increment = 1)
     {
         var index = 233 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 236 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceSegmentCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceContinuation tag, int increment = 1)
     {
         var index = 240 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkEnqueued(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceChunkEnqueueReason tag, int increment = 1)
     {
         var index = 242 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 244 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkSent(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[248], increment);
+        Interlocked.Add(ref _buffer.Count[248], increment);
     }
 
     public void RecordCountTraceSegmentsClosed(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[249], increment);
+        Interlocked.Add(ref _buffer.Count[249], increment);
     }
 
     public void RecordCountTraceApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[250], increment);
+        Interlocked.Add(ref _buffer.Count[250], increment);
     }
 
     public void RecordCountTraceApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 251 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 273 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTracePartialFlush(Datadog.Trace.Telemetry.Metrics.MetricTags.PartialFlushReason tag, int increment = 1)
     {
         var index = 276 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleInjected(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 278 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleExtracted(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 282 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[286], increment);
+        Interlocked.Add(ref _buffer.Count[286], increment);
     }
 
     public void RecordCountStatsApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 287 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 309 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
         var index = 312 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
         var index = 314 + ((int)tag1 * 22) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
         var index = 358 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[364], increment);
+        Interlocked.Add(ref _buffer.Count[364], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 365 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[422], increment);
+        Interlocked.Add(ref _buffer.Count[422], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 423 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 445 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[448], increment);
+        Interlocked.Add(ref _buffer.Count[448], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[449], increment);
+        Interlocked.Add(ref _buffer.Count[449], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
         var index = 450 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
         var index = 455 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[466], increment);
+        Interlocked.Add(ref _buffer.Count[466], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
         var index = 467 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[479], increment);
+        Interlocked.Add(ref _buffer.Count[479], increment);
     }
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -9,76 +9,76 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionInitTime(Datadog.Trace.Telemetry.Metrics.MetricTags.InitializationComponent tag, double value)
     {
         var index = 0 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -8,17 +8,17 @@ internal partial class MetricsTelemetryCollector
 {
     public void RecordGaugeStatsBuckets(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[0], value);
+        Interlocked.Exchange(ref _buffer.Gauge[0], value);
     }
 
     public void RecordGaugeInstrumentations(Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationComponent tag, int value)
     {
         var index = 1 + (int)tag;
-        Interlocked.Exchange(ref _buffer.Gauges[index], value);
+        Interlocked.Exchange(ref _buffer.Gauge[index], value);
     }
 
     public void RecordGaugeDirectLogQueue(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[7], value);
+        Interlocked.Exchange(ref _buffer.Gauge[7], value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
@@ -13,7 +13,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
@@ -151,147 +151,147 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
@@ -13,70 +13,70 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
@@ -796,5 +796,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] CountEntryCounts { get; }
         = new []{ 4, 171, 57, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 57, 1, 22, 3, 1, 1, 5, 11, 1, 12, 1, 40, 40, 10, 10, 4, 1, 2, 10, 9, 63, 1, 5, 1, 5, 1, 5, 4, 1, 5, 1, 1, 4, 4, 4, 1, 1, };
 
-    private const int _countsLength = 713;
+    private const int CountLength = 713;
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
@@ -75,5 +75,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] DistributionEntryCounts { get; }
         = new []{ 14, 2, 2, 2, 2, 9, 1, 1, 1, 1, 1, 1, 1, 1, };
 
-    private const int _distributionsLength = 39;
+    private const int DistributionLength = 39;
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
@@ -33,5 +33,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] GaugeEntryCounts { get; }
         = new []{ 1, 6, 1, };
 
-    private const int _gaugesLength = 8;
+    private const int GaugeLength = 8;
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -9,346 +9,346 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
         var index = 0 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 175 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanFinished(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[232], increment);
+        Interlocked.Add(ref _buffer.Count[232], increment);
     }
 
     public void RecordCountSpanEnqueuedForSerialization(Datadog.Trace.Telemetry.Metrics.MetricTags.SpanEnqueueReason tag, int increment = 1)
     {
         var index = 233 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 236 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceSegmentCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceContinuation tag, int increment = 1)
     {
         var index = 240 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkEnqueued(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceChunkEnqueueReason tag, int increment = 1)
     {
         var index = 242 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 244 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkSent(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[248], increment);
+        Interlocked.Add(ref _buffer.Count[248], increment);
     }
 
     public void RecordCountTraceSegmentsClosed(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[249], increment);
+        Interlocked.Add(ref _buffer.Count[249], increment);
     }
 
     public void RecordCountTraceApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[250], increment);
+        Interlocked.Add(ref _buffer.Count[250], increment);
     }
 
     public void RecordCountTraceApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 251 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 273 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTracePartialFlush(Datadog.Trace.Telemetry.Metrics.MetricTags.PartialFlushReason tag, int increment = 1)
     {
         var index = 276 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleInjected(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 278 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleExtracted(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 282 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[286], increment);
+        Interlocked.Add(ref _buffer.Count[286], increment);
     }
 
     public void RecordCountStatsApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 287 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 309 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
         var index = 312 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
         var index = 314 + ((int)tag1 * 22) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
         var index = 358 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[364], increment);
+        Interlocked.Add(ref _buffer.Count[364], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 365 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[422], increment);
+        Interlocked.Add(ref _buffer.Count[422], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 423 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 445 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[448], increment);
+        Interlocked.Add(ref _buffer.Count[448], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[449], increment);
+        Interlocked.Add(ref _buffer.Count[449], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
         var index = 450 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
         var index = 455 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[466], increment);
+        Interlocked.Add(ref _buffer.Count[466], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
         var index = 467 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[479], increment);
+        Interlocked.Add(ref _buffer.Count[479], increment);
     }
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -9,76 +9,76 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionInitTime(Datadog.Trace.Telemetry.Metrics.MetricTags.InitializationComponent tag, double value)
     {
         var index = 0 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -8,17 +8,17 @@ internal partial class MetricsTelemetryCollector
 {
     public void RecordGaugeStatsBuckets(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[0], value);
+        Interlocked.Exchange(ref _buffer.Gauge[0], value);
     }
 
     public void RecordGaugeInstrumentations(Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationComponent tag, int value)
     {
         var index = 1 + (int)tag;
-        Interlocked.Exchange(ref _buffer.Gauges[index], value);
+        Interlocked.Exchange(ref _buffer.Gauge[index], value);
     }
 
     public void RecordGaugeDirectLogQueue(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[7], value);
+        Interlocked.Exchange(ref _buffer.Gauge[7], value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_count.g.cs
@@ -13,7 +13,7 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
@@ -151,147 +151,147 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_distribution.g.cs
@@ -13,70 +13,70 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_count.g.cs
@@ -796,5 +796,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] CountEntryCounts { get; }
         = new []{ 4, 171, 57, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 57, 1, 22, 3, 1, 1, 5, 11, 1, 12, 1, 40, 40, 10, 10, 4, 1, 2, 10, 9, 63, 1, 5, 1, 5, 1, 5, 4, 1, 5, 1, 1, 4, 4, 4, 1, 1, };
 
-    private const int _countsLength = 713;
+    private const int CountLength = 713;
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_distribution.g.cs
@@ -75,5 +75,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] DistributionEntryCounts { get; }
         = new []{ 14, 2, 2, 2, 2, 9, 1, 1, 1, 1, 1, 1, 1, 1, };
 
-    private const int _distributionsLength = 39;
+    private const int DistributionLength = 39;
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollectorBase_gauge.g.cs
@@ -33,5 +33,5 @@ internal partial class MetricsTelemetryCollectorBase
     private static int[] GaugeEntryCounts { get; }
         = new []{ 1, 6, 1, };
 
-    private const int _gaugesLength = 8;
+    private const int GaugeLength = 8;
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_count.g.cs
@@ -9,346 +9,346 @@ internal partial class MetricsTelemetryCollector
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
         var index = 0 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIntegrationsError(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationError tag2, int increment = 1)
     {
         var index = 4 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 175 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanFinished(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[232], increment);
+        Interlocked.Add(ref _buffer.Count[232], increment);
     }
 
     public void RecordCountSpanEnqueuedForSerialization(Datadog.Trace.Telemetry.Metrics.MetricTags.SpanEnqueueReason tag, int increment = 1)
     {
         var index = 233 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountSpanDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 236 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceSegmentCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceContinuation tag, int increment = 1)
     {
         var index = 240 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkEnqueued(Datadog.Trace.Telemetry.Metrics.MetricTags.TraceChunkEnqueueReason tag, int increment = 1)
     {
         var index = 242 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkDropped(Datadog.Trace.Telemetry.Metrics.MetricTags.DropReason tag, int increment = 1)
     {
         var index = 244 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceChunkSent(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[248], increment);
+        Interlocked.Add(ref _buffer.Count[248], increment);
     }
 
     public void RecordCountTraceSegmentsClosed(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[249], increment);
+        Interlocked.Add(ref _buffer.Count[249], increment);
     }
 
     public void RecordCountTraceApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[250], increment);
+        Interlocked.Add(ref _buffer.Count[250], increment);
     }
 
     public void RecordCountTraceApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 251 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTraceApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 273 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTracePartialFlush(Datadog.Trace.Telemetry.Metrics.MetricTags.PartialFlushReason tag, int increment = 1)
     {
         var index = 276 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleInjected(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 278 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountContextHeaderStyleExtracted(Datadog.Trace.Telemetry.Metrics.MetricTags.ContextHeaderStyle tag, int increment = 1)
     {
         var index = 282 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[286], increment);
+        Interlocked.Add(ref _buffer.Count[286], increment);
     }
 
     public void RecordCountStatsApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 287 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 309 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
         var index = 312 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
         var index = 314 + ((int)tag1 * 22) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
         var index = 358 + ((int)tag1 * 3) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[364], increment);
+        Interlocked.Add(ref _buffer.Count[364], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
         var index = 365 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[422], increment);
+        Interlocked.Add(ref _buffer.Count[422], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
         var index = 423 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
         var index = 445 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[448], increment);
+        Interlocked.Add(ref _buffer.Count[448], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[449], increment);
+        Interlocked.Add(ref _buffer.Count[449], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
         var index = 450 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
         var index = 455 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[466], increment);
+        Interlocked.Add(ref _buffer.Count[466], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
         var index = 467 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[479], increment);
+        Interlocked.Add(ref _buffer.Count[479], increment);
     }
 
     public void RecordCountCIVisibilityEventCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 480 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmark tag2, int increment = 1)
     {
         var index = 520 + ((int)tag1 * 8) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageStarted(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 560 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageFinished(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestFramework tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCoverageLibrary tag2, int increment = 1)
     {
         var index = 570 + ((int)tag1 * 2) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityManualApiEvent(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 580 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEventsEnqueueForSerialization(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[584], increment);
+        Interlocked.Add(ref _buffer.Count[584], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, int increment = 1)
     {
         var index = 585 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityEndpointPayloadRequestsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag2, int increment = 1)
     {
         var index = 587 + ((int)tag1 * 5) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommand(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, int increment = 1)
     {
         var index = 597 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitCommandErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityExitCodes tag2, int increment = 1)
     {
         var index = 606 + ((int)tag1 * 7) + (int)tag2;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommits(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[669], increment);
+        Interlocked.Add(ref _buffer.Count[669], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSearchCommitsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 670 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPack(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[675], increment);
+        Interlocked.Add(ref _buffer.Count[675], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsObjectsPackErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 676 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettings(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[681], increment);
+        Interlocked.Add(ref _buffer.Count[681], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 682 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityGitRequestsSettingsResponse(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityITRSettingsResponse tag, int increment = 1)
     {
         var index = 687 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequest(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[691], increment);
+        Interlocked.Add(ref _buffer.Count[691], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsRequestErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityErrorType tag, int increment = 1)
     {
         var index = 692 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseTests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[697], increment);
+        Interlocked.Add(ref _buffer.Count[697], increment);
     }
 
     public void RecordCountCIVisibilityITRSkippableTestsResponseSuites(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[698], increment);
+        Interlocked.Add(ref _buffer.Count[698], increment);
     }
 
     public void RecordCountCIVisibilityITRSkipped(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 699 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRUnskippable(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 703 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityITRForcedRun(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityTestingEventType tag, int increment = 1)
     {
         var index = 707 + (int)tag;
-        Interlocked.Add(ref _buffer.Counts[index], increment);
+        Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageIsEmpty(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[711], increment);
+        Interlocked.Add(ref _buffer.Count[711], increment);
     }
 
     public void RecordCountCIVisibilityCodeCoverageErrors(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Counts[712], increment);
+        Interlocked.Add(ref _buffer.Count[712], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_distribution.g.cs
@@ -9,76 +9,76 @@ internal partial class MetricsTelemetryCollector
     public void RecordDistributionInitTime(Datadog.Trace.Telemetry.Metrics.MetricTags.InitializationComponent tag, double value)
     {
         var index = 0 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadBytes(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 14 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadRequestsMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 16 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointPayloadEventsCount(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 18 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityEndpointEventsSerializationMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityEndpoints tag, double value)
     {
         var index = 20 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitCommandMs(Datadog.Trace.Telemetry.Metrics.MetricTags.CIVisibilityCommands tag, double value)
     {
         var index = 22 + (int)tag;
-        _buffer.Distributions[index].TryEnqueue(value);
+        _buffer.Distribution[index].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSearchCommitsMs(double value)
     {
-        _buffer.Distributions[31].TryEnqueue(value);
+        _buffer.Distribution[31].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackMs(double value)
     {
-        _buffer.Distributions[32].TryEnqueue(value);
+        _buffer.Distribution[32].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackBytes(double value)
     {
-        _buffer.Distributions[33].TryEnqueue(value);
+        _buffer.Distribution[33].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsObjectsPackFiles(double value)
     {
-        _buffer.Distributions[34].TryEnqueue(value);
+        _buffer.Distribution[34].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityGitRequestsSettingsMs(double value)
     {
-        _buffer.Distributions[35].TryEnqueue(value);
+        _buffer.Distribution[35].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsRequestMs(double value)
     {
-        _buffer.Distributions[36].TryEnqueue(value);
+        _buffer.Distribution[36].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(double value)
     {
-        _buffer.Distributions[37].TryEnqueue(value);
+        _buffer.Distribution[37].TryEnqueue(value);
     }
 
     public void RecordDistributionCIVisibilityCodeCoverageFiles(double value)
     {
-        _buffer.Distributions[38].TryEnqueue(value);
+        _buffer.Distribution[38].TryEnqueue(value);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TelemetryMetric.TelemetryMetricGenerator/MetricsTelemetryCollector_gauge.g.cs
@@ -8,17 +8,17 @@ internal partial class MetricsTelemetryCollector
 {
     public void RecordGaugeStatsBuckets(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[0], value);
+        Interlocked.Exchange(ref _buffer.Gauge[0], value);
     }
 
     public void RecordGaugeInstrumentations(Datadog.Trace.Telemetry.Metrics.MetricTags.InstrumentationComponent tag, int value)
     {
         var index = 1 + (int)tag;
-        Interlocked.Exchange(ref _buffer.Gauges[index], value);
+        Interlocked.Exchange(ref _buffer.Gauge[index], value);
     }
 
     public void RecordGaugeDirectLogQueue(int value)
     {
-        Interlocked.Exchange(ref _buffer.Gauges[7], value);
+        Interlocked.Exchange(ref _buffer.Gauge[7], value);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollectorBase.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollectorBase.cs
@@ -96,9 +96,9 @@ internal abstract partial class MetricsTelemetryCollectorBase
         {
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             AggregateMetric(buffer.PublicApiCounts, timestamp, aggregated.PublicApiCounts);
-            AggregateMetric(buffer.Counts, timestamp, aggregated.Counts);
-            AggregateMetric(buffer.Gauges, timestamp, aggregated.Gauges);
-            AggregateDistribution(buffer.Distributions, aggregated.Distributions);
+            AggregateMetric(buffer.Count, timestamp, aggregated.Counts);
+            AggregateMetric(buffer.Gauge, timestamp, aggregated.Gauges);
+            AggregateDistribution(buffer.Distribution, aggregated.Distributions);
         }
 
         // prepare the buffer for next time
@@ -418,21 +418,21 @@ internal abstract partial class MetricsTelemetryCollectorBase
     {
 #pragma warning disable SA1401 // fields should be private
         public readonly int[] PublicApiCounts;
-        public readonly int[] Counts;
-        public readonly int[] Gauges;
-        public readonly BoundedConcurrentQueue<double>[] Distributions;
+        public readonly int[] Count;
+        public readonly int[] Gauge;
+        public readonly BoundedConcurrentQueue<double>[] Distribution;
 
 #pragma warning restore SA1401
 
         public MetricBuffer()
         {
             PublicApiCounts = new int[PublicApiUsageExtensions.Length];
-            Counts = new int[_countsLength];
-            Gauges = new int[_gaugesLength];
-            Distributions = new BoundedConcurrentQueue<double>[_distributionsLength];
-            for (var i = _distributionsLength - 1; i >= 0; i--)
+            Count = new int[CountLength];
+            Gauge = new int[GaugeLength];
+            Distribution = new BoundedConcurrentQueue<double>[DistributionLength];
+            for (var i = DistributionLength - 1; i >= 0; i--)
             {
-                Distributions[i] = new BoundedConcurrentQueue<double>(queueLimit: 1000);
+                Distribution[i] = new BoundedConcurrentQueue<double>(queueLimit: 1000);
             }
         }
 
@@ -443,19 +443,19 @@ internal abstract partial class MetricsTelemetryCollectorBase
                 PublicApiCounts[i] = 0;
             }
 
-            for (var i = 0; i < Counts.Length; i++)
+            for (var i = 0; i < Count.Length; i++)
             {
-                Counts[i] = 0;
+                Count[i] = 0;
             }
 
-            for (var i = 0; i < Gauges.Length; i++)
+            for (var i = 0; i < Gauge.Length; i++)
             {
-                Gauges[i] = 0;
+                Gauge[i] = 0;
             }
 
-            for (var i = 0; i < Distributions.Length; i++)
+            for (var i = 0; i < Distribution.Length; i++)
             {
-                while (Distributions[i].TryDequeue(out _)) { }
+                while (Distribution[i].TryDequeue(out _)) { }
             }
         }
     }

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/TelemetryMetricGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/TelemetryMetricGeneratorTests.cs
@@ -98,7 +98,7 @@ public class TelemetryMetricGeneratorTests
                 private static int[] TestMetricEntryCounts { get; }
                     = new []{ };
 
-                private const int _countsLength = 0;
+                private const int TestMetricLength = 0;
             }
             """;
 
@@ -294,7 +294,7 @@ public class TelemetryMetricGeneratorTests
                 private static int[] TestMetricEntryCounts { get; }
                     = new []{ 1, 4, 12, 1, };
 
-                private const int _countsLength = 18;
+                private const int TestMetricLength = 18;
             }
             """;
 
@@ -309,24 +309,24 @@ public class TelemetryMetricGeneratorTests
             {
                 public void RecordTestMetricZeroTagMetric(int increment = 1)
                 {
-                    Interlocked.Add(ref _buffer.Counts[0], increment);
+                    Interlocked.Add(ref _buffer.TestMetric[0], increment);
                 }
 
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, int increment = 1)
                 {
                     var index = 1 + (int)tag;
-                    Interlocked.Add(ref _buffer.Counts[index], increment);
+                    Interlocked.Add(ref _buffer.TestMetric[index], increment);
                 }
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, int increment = 1)
                 {
                     var index = 5 + ((int)tag1 * 3) + (int)tag2;
-                    Interlocked.Add(ref _buffer.Counts[index], increment);
+                    Interlocked.Add(ref _buffer.TestMetric[index], increment);
                 }
 
                 public void RecordTestMetricZeroAgainTagMetric(int increment = 1)
                 {
-                    Interlocked.Add(ref _buffer.Counts[17], increment);
+                    Interlocked.Add(ref _buffer.TestMetric[17], increment);
                 }
             }
             """;
@@ -342,7 +342,7 @@ public class TelemetryMetricGeneratorTests
             {
                 public void RecordTestMetricZeroTagMetric(int increment = 1)
                 {
-                    Interlocked.Add(ref _buffer.Counts[0], increment);
+                    Interlocked.Add(ref _buffer.TestMetric[0], increment);
                 }
 
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, int increment = 1)
@@ -553,7 +553,7 @@ public class TelemetryMetricGeneratorTests
                 private static int[] TestMetricEntryCounts { get; }
                     = new []{ 1, 4, 12, 1, };
 
-                private const int _gaugesLength = 18;
+                private const int TestMetricLength = 18;
             }
             """;
 
@@ -568,24 +568,24 @@ public class TelemetryMetricGeneratorTests
             {
                 public void RecordTestMetricZeroTagMetric(int value)
                 {
-                    Interlocked.Exchange(ref _buffer.Gauges[0], value);
+                    Interlocked.Exchange(ref _buffer.TestMetric[0], value);
                 }
 
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, int value)
                 {
                     var index = 1 + (int)tag;
-                    Interlocked.Exchange(ref _buffer.Gauges[index], value);
+                    Interlocked.Exchange(ref _buffer.TestMetric[index], value);
                 }
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, int value)
                 {
                     var index = 5 + ((int)tag1 * 3) + (int)tag2;
-                    Interlocked.Exchange(ref _buffer.Gauges[index], value);
+                    Interlocked.Exchange(ref _buffer.TestMetric[index], value);
                 }
 
                 public void RecordTestMetricZeroAgainTagMetric(int value)
                 {
-                    Interlocked.Exchange(ref _buffer.Gauges[17], value);
+                    Interlocked.Exchange(ref _buffer.TestMetric[17], value);
                 }
             }
             """;
@@ -601,7 +601,7 @@ public class TelemetryMetricGeneratorTests
             {
                 public void RecordTestMetricZeroTagMetric(int value)
                 {
-                    Interlocked.Exchange(ref _buffer.Gauges[0], value);
+                    Interlocked.Exchange(ref _buffer.TestMetric[0], value);
                 }
 
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, int value)
@@ -812,7 +812,7 @@ public class TelemetryMetricGeneratorTests
                 private static int[] TestMetricEntryCounts { get; }
                     = new []{ 1, 4, 12, 1, };
 
-                private const int _distributionsLength = 18;
+                private const int TestMetricLength = 18;
             }
             """;
 
@@ -827,24 +827,24 @@ public class TelemetryMetricGeneratorTests
             {
                 public void RecordTestMetricZeroTagMetric(double value)
                 {
-                    _buffer.Distributions[0].TryEnqueue(value);
+                    _buffer.TestMetric[0].TryEnqueue(value);
                 }
 
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, double value)
                 {
                     var index = 1 + (int)tag;
-                    _buffer.Distributions[index].TryEnqueue(value);
+                    _buffer.TestMetric[index].TryEnqueue(value);
                 }
 
                 public void RecordTestMetricTwoTagMetric(MyTests.TestMetricNameSpace.LogLevel tag1, MyTests.TestMetricNameSpace.ErrorType tag2, double value)
                 {
                     var index = 5 + ((int)tag1 * 3) + (int)tag2;
-                    _buffer.Distributions[index].TryEnqueue(value);
+                    _buffer.TestMetric[index].TryEnqueue(value);
                 }
 
                 public void RecordTestMetricZeroAgainTagMetric(double value)
                 {
-                    _buffer.Distributions[17].TryEnqueue(value);
+                    _buffer.TestMetric[17].TryEnqueue(value);
                 }
             }
             """;
@@ -860,7 +860,7 @@ public class TelemetryMetricGeneratorTests
             {
                 public void RecordTestMetricZeroTagMetric(double value)
                 {
-                    _buffer.Distributions[0].TryEnqueue(value);
+                    _buffer.TestMetric[0].TryEnqueue(value);
                 }
 
                 public void RecordTestMetricOneTagMetric(MyTests.TestMetricNameSpace.LogLevel tag, double value)
@@ -929,6 +929,319 @@ public class TelemetryMetricGeneratorTests
         trees[4].Should().Be(expectedCiVisibility);
         trees[5].Should().Be(expectedInterface);
         trees[6].Should().Be(expectedNull);
+    }
+
+    [Fact]
+    public void CanGenerateForMultipleMetricsOfSameType()
+    {
+        const string input = """
+            using Datadog.Trace.SourceGenerators;
+            using System.ComponentModel;
+
+            namespace MyTests.TestMetricNameSpace;
+
+            [TelemetryMetricType("count")]
+            public enum Count
+            { 
+                [TelemetryMetric("metric.zero")]
+                ZeroTagMetric,
+            }
+
+            [TelemetryMetricType("count")]
+            public enum CountCi
+            { 
+                [TelemetryMetric("metric.other", true, "civisibility")]
+                OtherMetric,
+            }
+            """;
+
+        const string expectedCountEnum = """
+            // <auto-generated/>
+            #nullable enable
+            
+            namespace MyTests.TestMetricNameSpace;
+            internal static partial class CountExtensions
+            {
+                /// <summary>
+                /// The number of separate metrics in the <see cref="MyTests.TestMetricNameSpace.Count" /> metric.
+                /// </summary>
+                public const int Length = 1;
+            
+                /// <summary>
+                /// Gets the metric name for the provided metric
+                /// </summary>
+                /// <param name="metric">The metric to get the name for</param>
+                /// <returns>The datadog metric name</returns>
+                public static string GetName(this MyTests.TestMetricNameSpace.Count metric)
+                    => metric switch
+                    {
+                        MyTests.TestMetricNameSpace.Count.ZeroTagMetric => "metric.zero",
+                        _ => null!,
+                    };
+            
+                /// <summary>
+                /// Gets whether the metric is a "common" metric, used by all tracers
+                /// </summary>
+                /// <param name="metric">The metric to check</param>
+                /// <returns>True if the metric is a "common" metric, used by all languages</returns>
+                public static bool IsCommon(this MyTests.TestMetricNameSpace.Count metric)
+                    => metric switch
+                    {
+                        _ => true,
+                    };
+            
+                /// <summary>
+                /// Gets the custom namespace for the provided metric
+                /// </summary>
+                /// <param name="metric">The metric to get the name for</param>
+                /// <returns>The datadog metric name</returns>
+                public static string? GetNamespace(this MyTests.TestMetricNameSpace.Count metric)
+                    => metric switch
+                    {
+                        _ => null,
+                    };
+            }
+            """;
+
+        const string expectedCountBase = """
+            // <auto-generated/>
+            #nullable enable
+            
+            using System.Threading;
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class MetricsTelemetryCollectorBase
+            {
+                /// <summary>
+                /// Creates the buffer for the <see cref="MyTests.TestMetricNameSpace.Count" /> values.
+                /// </summary>
+                private static AggregatedMetric[] GetCountBuffer()
+                    => new AggregatedMetric[]
+                    {
+                        // metric.zero, index = 0
+                        new(null),
+                    };
+            
+                /// <summary>
+                /// Gets an array of metric counts, indexed by integer value of the <see cref="MyTests.TestMetricNameSpace.Count" />.
+                /// Each value represents the number of unique entries in the buffer returned by <see cref="GetCountBuffer()" />
+                /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
+                /// </summary>
+                private static int[] CountEntryCounts { get; }
+                    = new []{ 1, };
+            
+                private const int CountLength = 1;
+            }
+            """;
+
+        const string expectedCountCollector = """
+            // <auto-generated/>
+            #nullable enable
+            
+            using System.Threading;
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class MetricsTelemetryCollector
+            {
+                public void RecordCountZeroTagMetric(int increment = 1)
+                {
+                    Interlocked.Add(ref _buffer.Count[0], increment);
+                }
+            }
+            """;
+
+        const string expectedCountCiVisibility = """
+            // <auto-generated/>
+            #nullable enable
+            
+            using System.Threading;
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class CiVisibilityMetricsTelemetryCollector
+            {
+                public void RecordCountZeroTagMetric(int increment = 1)
+                {
+                }
+            }
+            """;
+
+        const string expectedCountInterface = """
+            // <auto-generated/>
+            #nullable enable
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial interface IMetricsTelemetryCollector
+            {
+                public void RecordCountZeroTagMetric(int increment = 1);
+            }
+            """;
+
+        const string expectedCountNull = """
+            // <auto-generated/>
+            #nullable enable
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class NullMetricsTelemetryCollector
+            {
+                public void RecordCountZeroTagMetric(int increment = 1)
+                {
+                }
+            }
+            """;
+
+        const string expectedCountCiEnum = """
+            // <auto-generated/>
+            #nullable enable
+            
+            namespace MyTests.TestMetricNameSpace;
+            internal static partial class CountCiExtensions
+            {
+                /// <summary>
+                /// The number of separate metrics in the <see cref="MyTests.TestMetricNameSpace.CountCi" /> metric.
+                /// </summary>
+                public const int Length = 1;
+            
+                /// <summary>
+                /// Gets the metric name for the provided metric
+                /// </summary>
+                /// <param name="metric">The metric to get the name for</param>
+                /// <returns>The datadog metric name</returns>
+                public static string GetName(this MyTests.TestMetricNameSpace.CountCi metric)
+                    => metric switch
+                    {
+                        MyTests.TestMetricNameSpace.CountCi.OtherMetric => "metric.other",
+                        _ => null!,
+                    };
+            
+                /// <summary>
+                /// Gets whether the metric is a "common" metric, used by all tracers
+                /// </summary>
+                /// <param name="metric">The metric to check</param>
+                /// <returns>True if the metric is a "common" metric, used by all languages</returns>
+                public static bool IsCommon(this MyTests.TestMetricNameSpace.CountCi metric)
+                    => metric switch
+                    {
+                        _ => true,
+                    };
+            
+                /// <summary>
+                /// Gets the custom namespace for the provided metric
+                /// </summary>
+                /// <param name="metric">The metric to get the name for</param>
+                /// <returns>The datadog metric name</returns>
+                public static string? GetNamespace(this MyTests.TestMetricNameSpace.CountCi metric)
+                    => metric switch
+                    {
+                        MyTests.TestMetricNameSpace.CountCi.OtherMetric => "civisibility",
+                        _ => null,
+                    };
+            }
+            """;
+
+        const string expectedCountCiBase = """
+            // <auto-generated/>
+            #nullable enable
+            
+            using System.Threading;
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class MetricsTelemetryCollectorBase
+            {
+                /// <summary>
+                /// Creates the buffer for the <see cref="MyTests.TestMetricNameSpace.CountCi" /> values.
+                /// </summary>
+                private static AggregatedMetric[] GetCountCiBuffer()
+                    => new AggregatedMetric[]
+                    {
+                        // metric.other, index = 0
+                        new(null),
+                    };
+            
+                /// <summary>
+                /// Gets an array of metric counts, indexed by integer value of the <see cref="MyTests.TestMetricNameSpace.CountCi" />.
+                /// Each value represents the number of unique entries in the buffer returned by <see cref="GetCountCiBuffer()" />
+                /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
+                /// </summary>
+                private static int[] CountCiEntryCounts { get; }
+                    = new []{ 1, };
+            
+                private const int CountCiLength = 1;
+            }
+            """;
+
+        const string expectedCountCiCollector = """
+            // <auto-generated/>
+            #nullable enable
+            
+            using System.Threading;
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class MetricsTelemetryCollector
+            {
+                public void RecordCountCiOtherMetric(int increment = 1)
+                {
+                    Interlocked.Add(ref _buffer.CountCi[0], increment);
+                }
+            }
+            """;
+
+        const string expectedCountCiCiVisibility = """
+            // <auto-generated/>
+            #nullable enable
+            
+            using System.Threading;
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class CiVisibilityMetricsTelemetryCollector
+            {
+                public void RecordCountCiOtherMetric(int increment = 1)
+                {
+                    Interlocked.Add(ref _buffer.CountCi[0], increment);
+                }
+            }
+            """;
+
+        const string expectedCountCiInterface = """
+            // <auto-generated/>
+            #nullable enable
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial interface IMetricsTelemetryCollector
+            {
+                public void RecordCountCiOtherMetric(int increment = 1);
+            }
+            """;
+
+        const string expectedCountCiNull = """
+            // <auto-generated/>
+            #nullable enable
+            
+            namespace Datadog.Trace.Telemetry;
+            internal partial class NullMetricsTelemetryCollector
+            {
+                public void RecordCountCiOtherMetric(int increment = 1)
+                {
+                }
+            }
+            """;
+        var (diagnostics, trees) = TestHelpers.GetGeneratedTrees<TelemetryMetricGenerator>(input);
+        using var scope = new AssertionScope();
+        diagnostics.Should().BeEmpty();
+        trees.Length.Should().Be(13);
+        // tree 0 is the attributes
+        trees[1].Should().Be(expectedCountEnum);
+        trees[2].Should().Be(expectedCountBase);
+        trees[3].Should().Be(expectedCountCollector);
+        trees[4].Should().Be(expectedCountCiVisibility);
+        trees[5].Should().Be(expectedCountInterface);
+        trees[6].Should().Be(expectedCountNull);
+
+        trees[7].Should().Be(expectedCountCiEnum);
+        trees[8].Should().Be(expectedCountCiBase);
+        trees[9].Should().Be(expectedCountCiCollector);
+        trees[10].Should().Be(expectedCountCiCiVisibility);
+        trees[11].Should().Be(expectedCountCiInterface);
+        trees[12].Should().Be(expectedCountCiNull);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary of changes

- Add proper support for having multiple telemetry enums of the same type, e.g. two different `count` enums

## Reason for change

With the changes in https://github.com/DataDog/dd-trace-dotnet/pull/4596, our tags array is getting pretty large. What's more, we know that some of the these metrics are never going to be called outside of ciapp, and vice versa. 

The changes in this PR a first step to splitting out the ci visibility metrics, so that we can improve allocations etc for both scenarios (APM + ciapp)

## Implementation details

We already had partial support for this, we just weren't generating unique names for some properties.

## Test coverage

Added an additional unit test

## Other details

This is just step one in a multi-part process 😄 
Stacked on https://github.com/DataDog/dd-trace-dotnet/pull/4596
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
