### PR TITLE
[ASM] Fix waf memory tests flakiness

### DIFF
--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
@@ -25,20 +25,18 @@ namespace Datadog.Trace.Security.Unit.Tests
     {
         public const int TimeoutMicroSeconds = 1_000_000;
 
-        public const int OverheadMargin = 20_000_000; // 20Mb margin
+        public const int OverheadMargin = 40_000_000; // 40Mb margin
 
-        [SkippableFact(Skip = "This is flaky atm")]
         public void InitMemoryLeakCheck()
         {
             if (EnvironmentTools.IsLinux())
             {
-                throw new SkipException("This is flaky on linux, needs investigating");
+                throw new SkipException("This is flaky on linux, because of unreliable PrivateMemorySize64, see https://github.com/dotnet/runtime/issues/72067");
             }
 
             var baseline = GetMemory();
 
-            // Reduced from 1000 to 250 reduce impact in execution time
-            for (int x = 0; x < 250; x++)
+            for (var x = 0; x < 250; x++)
             {
                 Execute(AddressesConstants.RequestBody, "/.adsensepostnottherenonobook", "security_scanner", "crs-913-120");
             }
@@ -48,7 +46,6 @@ namespace Datadog.Trace.Security.Unit.Tests
             current.Should().BeLessThanOrEqualTo(baseline + OverheadMargin);
         }
 
-        [Fact(Skip = "This is flaky atm")]
         public void RunMemoryLeakCheck()
         {
             var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty);
@@ -73,7 +70,6 @@ namespace Datadog.Trace.Security.Unit.Tests
             current.Should().BeLessThanOrEqualTo(baseline + OverheadMargin);
         }
 
-        [Fact(Skip = "This is flaky atm")]
         public void UpdateMemoryLeakCheck()
         {
             var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty);
@@ -117,6 +113,7 @@ namespace Datadog.Trace.Security.Unit.Tests
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
+            GC.WaitForFullGCComplete();
             var proc = Process.GetCurrentProcess();
             proc.Refresh();
             return proc.PrivateMemorySize64;


### PR DESCRIPTION
## Summary of changes

Increase margin as we now work on the managed side

## Reason for change

Previous PR #4302 introduced some flake in memory tests

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
