### PR TITLE
[CIVisibility] Enable GZip compression on agentless mode

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CIVisibilityProtocolPayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CIVisibilityProtocolPayload.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.IO;
 using Datadog.Trace.Ci.Agent.MessagePack;
 using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Vendors.MessagePack;
@@ -35,5 +36,12 @@ namespace Datadog.Trace.Ci.Agent.Payloads
         public override void Reset() => _events.Clear();
 
         public byte[] ToArray() => MessagePackSerializer.Serialize(this, _formatterResolver);
+
+        public int WriteTo(Stream stream)
+        {
+            var buffer = MessagePackSerializer.SerializeUnsafe(this, _formatterResolver);
+            stream.Write(buffer.Array, buffer.Offset, buffer.Count);
+            return buffer.Count;
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR adds support for GZip compression in CI Visibility when running in agentless mode.

## Reason for change

We want to reduce the size of the TestCycle payload on upload.

```log
2023-09-19 00:23:54.005 +02:00 [DBG] Sending (555 events) 94.607 bytes... (1.509.974 bytes uncompressed)
2023-09-19 00:23:54.005 +02:00 [DBG] Sending (612 events) 104.630 bytes... (1.657.160 bytes uncompressed)
2023-09-19 00:23:54.005 +02:00 [DBG] Sending (617 events) 104.552 bytes... (1.672.545 bytes uncompressed)
2023-09-19 00:23:54.005 +02:00 [DBG] Sending (584 events) 100.609 bytes... (1.588.714 bytes uncompressed)
2023-09-19 00:23:55.956 +02:00 [DBG] Sending (171 events) 22.945 bytes... (459.446 bytes uncompressed)
2023-09-19 00:23:55.956 +02:00 [DBG] Sending (188 events) 25.928 bytes... (508.551 bytes uncompressed) 
2023-09-19 00:23:55.962 +02:00 [DBG] Sending (1265 events) 199.052 bytes... (3.482.214 bytes uncompressed) 
2023-09-19 00:23:55.962 +02:00 [DBG] Sending (1351 events) 215.173 bytes... (3.717.688 bytes uncompressed) 
```

## Test coverage
A test was added to make sure the new `WriteTo` method of the CIVisibilityProtocolPayload works correctly. Manual test was made to ensure the gzip encoding is working properly for the backend.
