### PR TITLE
Enable v2 telemetry by default

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -144,18 +144,12 @@ namespace Datadog.Trace.Telemetry
 
             var dependencyCollectionEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DependencyCollectionEnabled).AsBool(true);
 
-            var isRunningInAzureAppService = config
-                                        .WithKeys(ConfigurationKeys.AzureAppService.AzureAppServicesContextKey)
-                                        .AsBool(false);
-
-            // Currently enabled by default in AAS, will be flipped to true for all in later versions as part of the rollout
-            var v2Enabled = config.WithKeys(ConfigurationKeys.Telemetry.V2Enabled).AsBool(defaultValue: isRunningInAzureAppService);
+            var v2Enabled = config.WithKeys(ConfigurationKeys.Telemetry.V2Enabled).AsBool(defaultValue: true);
 
             // For testing purposes only
             var debugEnabled = config.WithKeys(ConfigurationKeys.Telemetry.DebugEnabled).AsBool(false);
 
-            // Currently disabled, will be flipped to true in later versions as part of the rollout
-            // Also, will require v2 enabled
+            // Requires v2 enabled
             bool metricsEnabled;
             if (isServerless)
             {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -296,27 +296,12 @@ namespace Datadog.Trace.Tests.Telemetry
 
         [Theory]
         [InlineData("0", false)]
-        [InlineData(null, false)]
-        [InlineData("", false)]
-        [InlineData("1", true)]
-        public void V2Enabled_DisabledByDefault(string value, bool expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.V2Enabled, value));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
-
-            settings.V2Enabled.Should().Be(expected);
-        }
-
-        [Theory]
-        [InlineData("0", false)]
         [InlineData(null, true)]
         [InlineData("", true)]
         [InlineData("1", true)]
-        public void V2Enabled_EnabledByDefaultInAas(string value, bool expected)
+        public void V2Enabled_EnabledByDefault(string value, bool expected)
         {
-            var source = CreateConfigurationSource(
-                (ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, "1"),
-                (ConfigurationKeys.Telemetry.V2Enabled, value));
+            var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.V2Enabled, value));
             var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
 
             settings.V2Enabled.Should().Be(expected);


### PR DESCRIPTION
## Summary of changes

Enable v2 telemetry by default

## Reason for change

We have tested v2 for a while and are happy it's stable, so we want to enable it by default everywhere

## Implementation details

Change the default from `false` to `true`

## Test coverage

Updated the unit tests for settings - the integration tests should automatically now run using v2 metrics

## Other details
Stacked on https://github.com/DataDog/dd-trace-dotnet/pull/4625

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
