### PR TITLE
[ASM] Limit number of same warning messages in waf benchmarks

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Logging.cs
@@ -25,7 +25,7 @@ internal static partial class ConfigurationKeys
         /// <summary>
         /// Configuration key for setting the number of seconds between,
         /// identical log messages, for Tracer log files.
-        /// Default value is 60s. Setting to 0 disables rate limiting.
+        /// Default value is 0 and setting to 0 disables rate limiting.
         /// </summary>
         public const string LogRateLimit = "DD_TRACE_LOGGING_RATE";
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/EncoderUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/EncoderUnitTests.cs
@@ -120,7 +120,7 @@ public class EncoderUnitTests : WafLibraryRequiredTest
         var root = new Dictionary<string, object>();
         var map = root;
 
-        for (int i = 0; i < nestingDepth; i++)
+        for (var i = 0; i < nestingDepth; i++)
         {
             var nextMap = new Dictionary<string, object>();
             map.Add("item", nextMap);

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -81,17 +81,23 @@ public class AppSecWafBenchmark
     public IEnumerable<NestedMap> Source()
     {
         yield return MakeNestedMap(10);
+        yield return MakeNestedMap(20);
         yield return MakeNestedMap(100);
-        yield return MakeNestedMap(1000);
     }
 
     public IEnumerable<NestedMap> SourceWithAttack()
     {
         yield return MakeNestedMap(10, true);
+        yield return MakeNestedMap(20, true);
         yield return MakeNestedMap(100, true);
-        yield return MakeNestedMap(1000, true);
     }
 
+    /// <summary>
+    /// Generates dummy arguments for the waf
+    /// </summary>
+    /// <param name="nestingDepth">Encoder.cs respects WafConstants.cs limits to process arguments with a max depth of 20 so above depth 20, there shouldn't be much difference of performances.</param>
+    /// <param name="withAttack">an attack present in arguments can slow down waf's run</param>
+    /// <returns></returns>
     private static NestedMap MakeNestedMap(int nestingDepth, bool withAttack = false)
     {
         var root = new Dictionary<string, object>();

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -59,6 +59,7 @@ public class AppSecWafBenchmark
             throw new DirectoryNotFoundException($"The Path: '{path}' doesn't exist.");
         }
 
+        Environment.SetEnvironmentVariable("DD_TRACE_LOGGING_RATE", "60");
         Environment.SetEnvironmentVariable("DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH", path);
         var libInitResult = WafLibraryInvoker.Initialize();
         if (!libInitResult.Success)


### PR DESCRIPTION
## Summary of changes

Add a sample logging rate for waf benchmarks.

## Reason for change

We have too many warning messages, specifying that the arguments tree is too large and that it is going to be trimmed. 
It's normal as the scenarios are a bit extreme to test performances, and it wont happen in real life.

## Implementation details

Change documentation message saying default value is 60 but it's 0

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
