### PR TITLE
[CI Visibility] Intelligent Test Runner - Unskippable tests support

### DIFF
--- a/Datadog.Trace.OSX.slnf
+++ b/Datadog.Trace.OSX.slnf
@@ -122,6 +122,7 @@
       "tracer\\test\\test-applications\\integrations\\Samples.WebRequest.NetFramework20\\Samples.WebRequest.NetFramework20.csproj",
       "tracer\\test\\test-applications\\integrations\\Samples.WebRequest\\Samples.WebRequest.csproj",
       "tracer\\test\\test-applications\\integrations\\Samples.XUnitTests\\Samples.XUnitTests.csproj",
+      "tracer\\test\\test-applications\\integrations\\dependency-libs\\ActivitySampleHelper\\ActivitySampleHelper.csproj",
       "tracer\\test\\test-applications\\integrations\\dependency-libs\\LogsInjectionHelper.VersionConflict\\LogsInjectionHelper.VersionConflict.csproj",
       "tracer\\test\\test-applications\\integrations\\dependency-libs\\LogsInjectionHelper\\LogsInjectionHelper.csproj",
       "tracer\\test\\test-applications\\integrations\\dependency-libs\\PluginApplication\\PluginApplication.csproj",

--- a/Datadog.Trace.OSX.slnf
+++ b/Datadog.Trace.OSX.slnf
@@ -42,6 +42,7 @@
       "tracer\\test\\test-applications\\debugger\\Samples.Probes\\Samples.Probes.csproj",
       "tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.External\\Samples.Probes.External.csproj",
       "tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\Samples.Probes.TestRuns.csproj",
+      "tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.Unreferenced.External\\Samples.Probes.Unreferenced.External.csproj",
       "tracer\\test\\test-applications\\instrumentation\\CallTargetNativeTest\\CallTargetNativeTest.csproj",
       "tracer\\test\\test-applications\\instrumentation\\Datadog.Tracer.Native.Checks\\Datadog.Tracer.Native.Checks.csproj",
       "tracer\\test\\test-applications\\integrations\\LogsInjection.ILogger.VersionConflict.2x\\LogsInjection.ILogger.VersionConflict.2x.csproj",

--- a/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tagging/TestSpanTags.cs
@@ -85,4 +85,10 @@ internal partial class TestSpanTags : TestSuiteSpanTags
 
     [Tag(IntelligentTestRunnerTags.SkippedBy)]
     public string SkippedByIntelligentTestRunner { get; set; }
+
+    [Tag(IntelligentTestRunnerTags.UnskippableTag)]
+    public string Unskippable { get; set; }
+
+    [Tag(IntelligentTestRunnerTags.ForcedRunTag)]
+    public string ForcedRun { get; set; }
 }

--- a/tracer/src/Datadog.Trace/Ci/Tags/IntelligentTestRunnerTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/IntelligentTestRunnerTags.cs
@@ -44,4 +44,19 @@ internal static class IntelligentTestRunnerTags
     /// Intelligent Test Runner skipping count
     /// </summary>
     public const string SkippingCount = "test.itr.tests_skipping.count";
+
+    /// <summary>
+    /// Unskippable trait name
+    /// </summary>
+    public const string UnskippableTraitName = "datadog_itr_unskippable";
+
+    /// <summary>
+    /// Unskippable tag name
+    /// </summary>
+    public const string UnskippableTag = "test.itr.unskippable";
+
+    /// <summary>
+    /// Forced run tag name
+    /// </summary>
+    public const string ForcedRunTag = "test.itr.forced_run";
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -62,17 +62,23 @@ internal static class MsTestIntegration
             // Get traits
             if (GetTraits(testMethod) is { } testTraits)
             {
+                // Unskippable tests
+                if (CIVisibility.Settings.IntelligentTestRunnerEnabled)
+                {
+                    ShouldSkip(testMethodInfo, out var isUnskippable, out var isForcedRun, testTraits);
+                    test.SetTag(IntelligentTestRunnerTags.UnskippableTag, isUnskippable ? "true" : "false");
+                    test.SetTag(IntelligentTestRunnerTags.ForcedRunTag, isForcedRun ? "true" : "false");
+                    testTraits.Remove(IntelligentTestRunnerTags.UnskippableTraitName);
+                }
+
                 test.SetTraits(testTraits);
             }
-            else
+            else if (CIVisibility.Settings.IntelligentTestRunnerEnabled)
             {
-                testTraits = null;
+                // Unskippable tests
+                test.SetTag(IntelligentTestRunnerTags.UnskippableTag, "false");
+                test.SetTag(IntelligentTestRunnerTags.ForcedRunTag, "false");
             }
-
-            // Unskippable tests
-            ShouldSkip(testMethodInfo, out var isUnskippable, out var isForcedRun, testTraits);
-            test.SetTag(IntelligentTestRunnerTags.UnskippableTag, isUnskippable ? "true" : "false");
-            test.SetTag(IntelligentTestRunnerTags.ForcedRunTag, isForcedRun ? "true" : "false");
 
             // Set test method
             test.SetTestMethodInfo(testMethod);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteIntegration.cs
@@ -52,7 +52,7 @@ public static class TestMethodRunnerExecuteIntegration
             {
                 if (unitTestResult.Outcome is UnitTestResultOutcome.Inconclusive or UnitTestResultOutcome.NotRunnable or UnitTestResultOutcome.Ignored)
                 {
-                    if (!MsTestIntegration.ShouldSkip(instance.TestMethodInfo))
+                    if (!MsTestIntegration.ShouldSkip(instance.TestMethodInfo, out _, out _))
                     {
                         // This instrumentation catches all tests being ignored
                         MsTestIntegration.OnMethodBegin(instance.TestMethodInfo, instance.GetType())?

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestMethodRunnerExecuteTestIntegration.cs
@@ -40,7 +40,7 @@ public static class TestMethodRunnerExecuteTestIntegration
         where TTestMethod : ITestMethod
     {
         // Check if the test should be skipped by ITR
-        if (MsTestIntegration.IsEnabled && MsTestIntegration.ShouldSkip(testMethod))
+        if (MsTestIntegration.IsEnabled && MsTestIntegration.ShouldSkip(testMethod, out _, out _))
         {
             // In order to skip a test we change the Executor to one that returns a valid outcome without calling
             // the MethodInfo of the test

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/UnitTestRunnerRunSingleTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/UnitTestRunnerRunSingleTestIntegration.cs
@@ -56,7 +56,7 @@ public static class UnitTestRunnerRunSingleTestIntegration
             {
                 if (unitTestResult.Outcome is UnitTestResultOutcome.Inconclusive or UnitTestResultOutcome.NotRunnable or UnitTestResultOutcome.Ignored)
                 {
-                    if (!MsTestIntegration.ShouldSkip(testMethodInfo))
+                    if (!MsTestIntegration.ShouldSkip(testMethodInfo, out _, out _))
                     {
                         // This instrumentation catches all tests being ignored
                         MsTestIntegration.OnMethodBegin(testMethodInfo, instance.GetType())?

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -132,7 +132,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
 
         private static void ExtractTraits(ITest currentTest, ref Dictionary<string, List<string>>? traits)
         {
-            if (currentTest.Instance is null)
+            if (currentTest?.Instance is null)
             {
                 return;
             }
@@ -142,33 +142,37 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
                 ExtractTraits(currentTest.Parent, ref traits);
             }
 
-            if (currentTest.Properties is { Keys: { Count: > 0 } } properties)
+            if (currentTest.Properties is { } properties)
             {
-                foreach (var key in properties.Keys)
+                var keys = properties.Keys;
+                if (keys?.Count > 0)
                 {
-                    if (key is SkipReasonKey or "_APPDOMAIN" or "_JOINTYPE" or "_PID" or "_PROVIDERSTACKTRACE")
+                    foreach (var key in keys)
                     {
-                        continue;
-                    }
-
-                    var value = properties[key];
-                    if (value is not null)
-                    {
-                        traits ??= new();
-                        if (!traits.TryGetValue(key, out var lstValues))
+                        if (key is SkipReasonKey or "_APPDOMAIN" or "_JOINTYPE" or "_PID" or "_PROVIDERSTACKTRACE")
                         {
-                            lstValues = new List<string>();
-                            traits[key] = lstValues;
+                            continue;
                         }
 
-                        foreach (var valObj in value)
+                        var value = properties[key];
+                        if (value is not null)
                         {
-                            if (valObj is null)
+                            traits ??= new();
+                            if (!traits.TryGetValue(key, out var lstValues))
                             {
-                                continue;
+                                lstValues = new List<string>();
+                                traits[key] = lstValues;
                             }
 
-                            lstValues.Add(valObj.ToString() ?? string.Empty);
+                            foreach (var valObj in value)
+                            {
+                                if (valObj is null)
+                                {
+                                    continue;
+                                }
+
+                                lstValues.Add(valObj.ToString() ?? string.Empty);
+                            }
                         }
                     }
                 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitWorkItemPerformWorkIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitWorkItemPerformWorkIntegration.cs
@@ -50,7 +50,7 @@ public static class NUnitWorkItemPerformWorkIntegration
                 case "TestFixture" when NUnitIntegration.GetTestSuiteFrom(item) is null && NUnitIntegration.GetTestModuleFrom(item) is { } module:
                     NUnitIntegration.SetTestSuiteTo(item, module.GetOrCreateSuite(item.FullName));
                     break;
-                case "TestMethod" when NUnitIntegration.ShouldSkip(item):
+                case "TestMethod" when NUnitIntegration.ShouldSkip(item, out _, out _):
                     var testMethod = item.Method.MethodInfo;
                     Common.Log.Debug("ITR: Test skipped: {Class}.{Name}", testMethod.DeclaringType?.FullName, testMethod.Name);
                     item.RunState = RunState.Ignored;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -123,10 +123,11 @@ internal static class XUnitIntegration
 
     internal static bool ShouldSkip(ref TestRunnerStruct runnerInstance, out bool isUnskippable, out bool isForcedRun, Dictionary<string, List<string>>? traits = null)
     {
+        isUnskippable = false;
+        isForcedRun = false;
+
         if (CIVisibility.Settings.IntelligentTestRunnerEnabled != true)
         {
-            isUnskippable = false;
-            isForcedRun = false;
             return false;
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -61,11 +61,22 @@ internal static class XUnitIntegration
         // Get traits
         if (runnerInstance.TestCase.Traits is { } traits)
         {
+            // Unskippable tests support
+            if (CIVisibility.Settings.IntelligentTestRunnerEnabled)
+            {
+                ShouldSkip(ref runnerInstance, out var isUnskippable, out var isForcedRun, traits);
+                test.SetTag(IntelligentTestRunnerTags.UnskippableTag, isUnskippable ? "true" : "false");
+                test.SetTag(IntelligentTestRunnerTags.ForcedRunTag, isForcedRun ? "true" : "false");
+                traits.Remove(IntelligentTestRunnerTags.UnskippableTraitName);
+            }
+
             test.SetTraits(traits);
         }
-        else
+        else if (CIVisibility.Settings.IntelligentTestRunnerEnabled)
         {
-            traits = null;
+            // Unskippable tests support
+            test.SetTag(IntelligentTestRunnerTags.UnskippableTag, "false");
+            test.SetTag(IntelligentTestRunnerTags.ForcedRunTag, "false");
         }
 
         // Test code and code owners
@@ -73,11 +84,6 @@ internal static class XUnitIntegration
         {
             test.SetTestMethodInfo(testMethod);
         }
-
-        // Unskippable tests support
-        ShouldSkip(ref runnerInstance, out var isUnskippable, out var isForcedRun, traits);
-        test.SetTag(IntelligentTestRunnerTags.UnskippableTag, isUnskippable ? "true" : "false");
-        test.SetTag(IntelligentTestRunnerTags.ForcedRunTag, isForcedRun ? "true" : "false");
 
         // Telemetry
         Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestRunnerRunAsyncIntegration.cs
@@ -39,7 +39,7 @@ public static class XUnitTestRunnerRunAsyncIntegration
             var runnerInstance = instance.DuckCast<TestRunnerStruct>();
 
             // Check if the test should be skipped by the ITR
-            if (XUnitIntegration.ShouldSkip(ref runnerInstance) && instance.TryDuckCast<ITestRunnerSkippable>(out var skippableRunnerInstance))
+            if (XUnitIntegration.ShouldSkip(ref runnerInstance, out _, out _) && instance.TryDuckCast<ITestRunnerSkippable>(out var skippableRunnerInstance))
             {
                 Common.Log.Debug("ITR: Test skipped: {Class}.{Name}", runnerInstance.TestClass?.FullName ?? string.Empty, runnerInstance.TestMethod?.Name ?? string.Empty);
                 // Refresh values after skip reason change, and create Skip by ITR span.

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
@@ -63,6 +63,18 @@ namespace Datadog.Trace.Ci.Tagging
 #else
         private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
 #endif
+        // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#else
+        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#endif
+        // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#else
+        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -75,6 +87,8 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.traits" => Traits,
                 "test.skip_reason" => SkipReason,
                 "test.skipped_by_itr" => SkippedByIntelligentTestRunner,
+                "test.itr.unskippable" => Unskippable,
+                "test.itr.forced_run" => ForcedRun,
                 _ => base.GetTag(key),
             };
         }
@@ -103,6 +117,12 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.skipped_by_itr": 
                     SkippedByIntelligentTestRunner = value;
+                    break;
+                case "test.itr.unskippable": 
+                    Unskippable = value;
+                    break;
+                case "test.itr.forced_run": 
+                    ForcedRun = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -145,6 +165,16 @@ namespace Datadog.Trace.Ci.Tagging
             if (SkippedByIntelligentTestRunner is not null)
             {
                 processor.Process(new TagItem<string>("test.skipped_by_itr", SkippedByIntelligentTestRunner, SkippedByIntelligentTestRunnerBytes));
+            }
+
+            if (Unskippable is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.unskippable", Unskippable, UnskippableBytes));
+            }
+
+            if (ForcedRun is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.forced_run", ForcedRun, ForcedRunBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -198,6 +228,20 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.skipped_by_itr (tag):")
                   .Append(SkippedByIntelligentTestRunner)
+                  .Append(',');
+            }
+
+            if (Unskippable is not null)
+            {
+                sb.Append("test.itr.unskippable (tag):")
+                  .Append(Unskippable)
+                  .Append(',');
+            }
+
+            if (ForcedRun is not null)
+            {
+                sb.Append("test.itr.forced_run (tag):")
+                  .Append(ForcedRun)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
@@ -63,6 +63,18 @@ namespace Datadog.Trace.Ci.Tagging
 #else
         private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
 #endif
+        // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#else
+        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#endif
+        // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#else
+        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -75,6 +87,8 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.traits" => Traits,
                 "test.skip_reason" => SkipReason,
                 "test.skipped_by_itr" => SkippedByIntelligentTestRunner,
+                "test.itr.unskippable" => Unskippable,
+                "test.itr.forced_run" => ForcedRun,
                 _ => base.GetTag(key),
             };
         }
@@ -103,6 +117,12 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.skipped_by_itr": 
                     SkippedByIntelligentTestRunner = value;
+                    break;
+                case "test.itr.unskippable": 
+                    Unskippable = value;
+                    break;
+                case "test.itr.forced_run": 
+                    ForcedRun = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -145,6 +165,16 @@ namespace Datadog.Trace.Ci.Tagging
             if (SkippedByIntelligentTestRunner is not null)
             {
                 processor.Process(new TagItem<string>("test.skipped_by_itr", SkippedByIntelligentTestRunner, SkippedByIntelligentTestRunnerBytes));
+            }
+
+            if (Unskippable is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.unskippable", Unskippable, UnskippableBytes));
+            }
+
+            if (ForcedRun is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.forced_run", ForcedRun, ForcedRunBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -198,6 +228,20 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.skipped_by_itr (tag):")
                   .Append(SkippedByIntelligentTestRunner)
+                  .Append(',');
+            }
+
+            if (Unskippable is not null)
+            {
+                sb.Append("test.itr.unskippable (tag):")
+                  .Append(Unskippable)
+                  .Append(',');
+            }
+
+            if (ForcedRun is not null)
+            {
+                sb.Append("test.itr.forced_run (tag):")
+                  .Append(ForcedRun)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
@@ -63,6 +63,18 @@ namespace Datadog.Trace.Ci.Tagging
 #else
         private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
 #endif
+        // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#else
+        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#endif
+        // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#else
+        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -75,6 +87,8 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.traits" => Traits,
                 "test.skip_reason" => SkipReason,
                 "test.skipped_by_itr" => SkippedByIntelligentTestRunner,
+                "test.itr.unskippable" => Unskippable,
+                "test.itr.forced_run" => ForcedRun,
                 _ => base.GetTag(key),
             };
         }
@@ -103,6 +117,12 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.skipped_by_itr": 
                     SkippedByIntelligentTestRunner = value;
+                    break;
+                case "test.itr.unskippable": 
+                    Unskippable = value;
+                    break;
+                case "test.itr.forced_run": 
+                    ForcedRun = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -145,6 +165,16 @@ namespace Datadog.Trace.Ci.Tagging
             if (SkippedByIntelligentTestRunner is not null)
             {
                 processor.Process(new TagItem<string>("test.skipped_by_itr", SkippedByIntelligentTestRunner, SkippedByIntelligentTestRunnerBytes));
+            }
+
+            if (Unskippable is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.unskippable", Unskippable, UnskippableBytes));
+            }
+
+            if (ForcedRun is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.forced_run", ForcedRun, ForcedRunBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -198,6 +228,20 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.skipped_by_itr (tag):")
                   .Append(SkippedByIntelligentTestRunner)
+                  .Append(',');
+            }
+
+            if (Unskippable is not null)
+            {
+                sb.Append("test.itr.unskippable (tag):")
+                  .Append(Unskippable)
+                  .Append(',');
+            }
+
+            if (ForcedRun is not null)
+            {
+                sb.Append("test.itr.forced_run (tag):")
+                  .Append(ForcedRun)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.TagsListGenerator.TagListGenerator/TestSpanTags.g.cs
@@ -63,6 +63,18 @@ namespace Datadog.Trace.Ci.Tagging
 #else
         private static readonly byte[] SkippedByIntelligentTestRunnerBytes = new byte[] { 179, 116, 101, 115, 116, 46, 115, 107, 105, 112, 112, 101, 100, 95, 98, 121, 95, 105, 116, 114 };
 #endif
+        // UnskippableBytes = MessagePack.Serialize("test.itr.unskippable");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> UnskippableBytes => new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#else
+        private static readonly byte[] UnskippableBytes = new byte[] { 180, 116, 101, 115, 116, 46, 105, 116, 114, 46, 117, 110, 115, 107, 105, 112, 112, 97, 98, 108, 101 };
+#endif
+        // ForcedRunBytes = MessagePack.Serialize("test.itr.forced_run");
+#if NETCOREAPP
+        private static ReadOnlySpan<byte> ForcedRunBytes => new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#else
+        private static readonly byte[] ForcedRunBytes = new byte[] { 179, 116, 101, 115, 116, 46, 105, 116, 114, 46, 102, 111, 114, 99, 101, 100, 95, 114, 117, 110 };
+#endif
 
         public override string? GetTag(string key)
         {
@@ -75,6 +87,8 @@ namespace Datadog.Trace.Ci.Tagging
                 "test.traits" => Traits,
                 "test.skip_reason" => SkipReason,
                 "test.skipped_by_itr" => SkippedByIntelligentTestRunner,
+                "test.itr.unskippable" => Unskippable,
+                "test.itr.forced_run" => ForcedRun,
                 _ => base.GetTag(key),
             };
         }
@@ -103,6 +117,12 @@ namespace Datadog.Trace.Ci.Tagging
                     break;
                 case "test.skipped_by_itr": 
                     SkippedByIntelligentTestRunner = value;
+                    break;
+                case "test.itr.unskippable": 
+                    Unskippable = value;
+                    break;
+                case "test.itr.forced_run": 
+                    ForcedRun = value;
                     break;
                 default: 
                     base.SetTag(key, value);
@@ -145,6 +165,16 @@ namespace Datadog.Trace.Ci.Tagging
             if (SkippedByIntelligentTestRunner is not null)
             {
                 processor.Process(new TagItem<string>("test.skipped_by_itr", SkippedByIntelligentTestRunner, SkippedByIntelligentTestRunnerBytes));
+            }
+
+            if (Unskippable is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.unskippable", Unskippable, UnskippableBytes));
+            }
+
+            if (ForcedRun is not null)
+            {
+                processor.Process(new TagItem<string>("test.itr.forced_run", ForcedRun, ForcedRunBytes));
             }
 
             base.EnumerateTags(ref processor);
@@ -198,6 +228,20 @@ namespace Datadog.Trace.Ci.Tagging
             {
                 sb.Append("test.skipped_by_itr (tag):")
                   .Append(SkippedByIntelligentTestRunner)
+                  .Append(',');
+            }
+
+            if (Unskippable is not null)
+            {
+                sb.Append("test.itr.unskippable (tag):")
+                  .Append(Unskippable)
+                  .Append(',');
+            }
+
+            if (ForcedRun is not null)
+            {
+                sb.Append("test.itr.forced_run (tag):")
+                  .Append(ForcedRun)
                   .Append(',');
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             var tests = new List<MockCIVisibilityTest>();
             var testSuites = new List<MockCIVisibilityTestSuite>();
             var testModules = new List<MockCIVisibilityTestModule>();
-            var expectedTestCount = version.CompareTo(new Version("2.2.5")) < 0 ? 14 : 16;
+            var expectedTestCount = version.CompareTo(new Version("2.2.5")) < 0 ? 15 : 17;
 
             var sessionId = RandomIdGenerator.Shared.NextSpanId();
             var sessionCommand = "test command";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -170,6 +170,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanEqual(targetTest, TestTags.Command, sessionCommand);
                             AssertTargetSpanEqual(targetTest, TestTags.CommandWorkingDirectory, sessionWorkingDirectory);
 
+                            // Unskippable data
+                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
+                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+
                             // check specific test span
                             switch (targetTest.Meta[TestTags.Name])
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -171,8 +171,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanEqual(targetTest, TestTags.CommandWorkingDirectory, sessionWorkingDirectory);
 
                             // Unskippable data
-                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
-                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            if (targetTest.Meta[TestTags.Name] != "UnskippableTest")
+                            {
+                                AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
+                                AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            }
 
                             // check specific test span
                             switch (targetTest.Meta[TestTags.Name])
@@ -241,6 +244,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                         "{\"metadata\":{},\"arguments\":{\"xValue\":\"1\",\"yValue\":\"0\",\"expectedResult\":\"2\"}}",
                                         "{\"metadata\":{},\"arguments\":{\"xValue\":\"2\",\"yValue\":\"0\",\"expectedResult\":\"4\"}}",
                                         "{\"metadata\":{},\"arguments\":{\"xValue\":\"3\",\"yValue\":\"0\",\"expectedResult\":\"6\"}}");
+                                    break;
+
+                                case "UnskippableTest":
+                                    AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "true");
+                                    AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                                    CheckSimpleTestSpan(targetTest);
                                     break;
                             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -116,8 +116,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanExists(targetSpan, TestTags.CommandWorkingDirectory);
 
                             // Unskippable data
-                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
-                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            if (targetSpan.Tags[TestTags.Name] != "UnskippableTest")
+                            {
+                                AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
+                                AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            }
 
                             // check specific test span
                             switch (targetSpan.Tags[TestTags.Name])
@@ -186,6 +189,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                         "{\"metadata\":{},\"arguments\":{\"xValue\":\"1\",\"yValue\":\"0\",\"expectedResult\":\"2\"}}",
                                         "{\"metadata\":{},\"arguments\":{\"xValue\":\"2\",\"yValue\":\"0\",\"expectedResult\":\"4\"}}",
                                         "{\"metadata\":{},\"arguments\":{\"xValue\":\"3\",\"yValue\":\"0\",\"expectedResult\":\"6\"}}");
+                                    break;
+
+                                case "UnskippableTest":
+                                    AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "true");
+                                    AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                                    CheckSimpleTestSpan(targetSpan);
                                     break;
                             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             var version = string.IsNullOrEmpty(packageVersion) ? new Version("2.2.8") : new Version(packageVersion);
             List<MockSpan> spans = null;
-            var expectedSpanCount = version.CompareTo(new Version("2.2.5")) < 0 ? 14 : 16;
+            var expectedSpanCount = version.CompareTo(new Version("2.2.5")) < 0 ? 15 : 17;
 
             try
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -115,6 +115,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanExists(targetSpan, TestTags.Command);
                             AssertTargetSpanExists(targetSpan, TestTags.CommandWorkingDirectory);
 
+                            // Unskippable data
+                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
+                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+
                             // check specific test span
                             switch (targetSpan.Tags[TestTags.Name])
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -215,6 +215,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanEqual(targetTest, TestTags.Command, sessionCommand);
                             AssertTargetSpanEqual(targetTest, TestTags.CommandWorkingDirectory, sessionWorkingDirectory);
 
+                            // Unskippable data
+                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
+                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+
                             // check specific test span
                             switch (targetTest.Meta[TestTags.Name])
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     public class NUnitEvpTests : TestHelper
     {
-        private const int ExpectedTestCount = 31;
+        private const int ExpectedTestCount = 32;
         private const int ExpectedTestSuiteCount = 9;
 
         private const string TestBundleName = "Samples.NUnitTests";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -24,8 +24,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     public class NUnitEvpTests : TestHelper
     {
-        private const int ExpectedTestCount = 32;
-        private const int ExpectedTestSuiteCount = 9;
+        private const int ExpectedTestCount = 33;
+        private const int ExpectedTestSuiteCount = 10;
 
         private const string TestBundleName = "Samples.NUnitTests";
         private static readonly string[] _testSuiteNames =
@@ -39,6 +39,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             "Samples.NUnitTests.TestSetupError",
             "Samples.NUnitTests.TestTearDownError",
             "Samples.NUnitTests.TestTearDown2Error",
+            "Samples.NUnitTests.UnSkippableSuite",
         };
 
         public NUnitEvpTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -216,8 +216,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanEqual(targetTest, TestTags.CommandWorkingDirectory, sessionWorkingDirectory);
 
                             // Unskippable data
-                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
-                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            if (targetTest.Meta[TestTags.Name] != "UnskippableTest")
+                            {
+                                AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
+                                AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            }
 
                             // check specific test span
                             switch (targetTest.Meta[TestTags.Name])
@@ -308,6 +311,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                 case "Test05" when suite.Contains("SetupError"):
                                 case "IsNull" when suite.Contains("SetupError"):
                                     CheckSetupErrorTest(targetTest);
+                                    break;
+
+                                case "UnskippableTest":
+                                    AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "true");
+                                    AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                                    CheckSimpleTestSpan(targetTest);
                                     break;
                             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -135,6 +135,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanExists(targetSpan, TestTags.Command);
                             AssertTargetSpanExists(targetSpan, TestTags.CommandWorkingDirectory);
 
+                            // Unskippable data
+                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
+                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+
                             // check specific test span
                             switch (targetSpan.Tags[TestTags.Name])
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     public class NUnitTests : TestHelper
     {
-        private const int ExpectedSpanCount = 31;
+        private const int ExpectedSpanCount = 32;
 
         private const string TestBundleName = "Samples.NUnitTests";
         private static string[] _testSuiteNames =

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 {
     public class NUnitTests : TestHelper
     {
-        private const int ExpectedSpanCount = 32;
+        private const int ExpectedSpanCount = 33;
 
         private const string TestBundleName = "Samples.NUnitTests";
         private static string[] _testSuiteNames =
@@ -33,6 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             "Samples.NUnitTests.TestSetupError",
             "Samples.NUnitTests.TestTearDownError",
             "Samples.NUnitTests.TestTearDown2Error",
+            "Samples.NUnitTests.UnSkippableSuite",
         };
 
         public NUnitTests(ITestOutputHelper output)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -136,8 +136,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanExists(targetSpan, TestTags.CommandWorkingDirectory);
 
                             // Unskippable data
-                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
-                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            if (targetSpan.Tags[TestTags.Name] != "UnskippableTest")
+                            {
+                                AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
+                                AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            }
 
                             // check specific test span
                             switch (targetSpan.Tags[TestTags.Name])
@@ -228,6 +231,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                 case "Test05" when suite.Contains("SetupError"):
                                 case "IsNull" when suite.Contains("SetupError"):
                                     CheckSetupErrorTest(targetSpan);
+                                    break;
+
+                                case "UnskippableTest":
+                                    AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "true");
+                                    AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                                    CheckSimpleTestSpan(targetSpan);
                                     break;
                             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -177,6 +177,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanEqual(targetTest, TestTags.Command, sessionCommand);
                             AssertTargetSpanEqual(targetTest, TestTags.CommandWorkingDirectory, sessionWorkingDirectory);
 
+                            // Unskippable data
+                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
+                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+
                             // check specific test span
                             switch (targetTest.Meta[TestTags.Name])
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
     {
         private const string TestBundleName = "Samples.XUnitTests";
         private const string TestSuiteName = "Samples.XUnitTests.TestSuite";
-        private const int ExpectedTestCount = 14;
+        private const int ExpectedTestCount = 15;
 
         public XUnitEvpTests(ITestOutputHelper output)
             : base("XUnitTests", output)
@@ -178,8 +178,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanEqual(targetTest, TestTags.CommandWorkingDirectory, sessionWorkingDirectory);
 
                             // Unskippable data
-                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
-                            AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            if (targetTest.Meta[TestTags.Name] != "UnskippableTest")
+                            {
+                                AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "false");
+                                AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            }
 
                             // check specific test span
                             switch (targetTest.Meta[TestTags.Name])
@@ -248,6 +251,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                         "{\"metadata\":{\"test_name\":\"SimpleErrorParameterizedTest(xValue: 1, yValue: 0, expectedResult: 2)\"},\"arguments\":{\"xValue\":\"1\",\"yValue\":\"0\",\"expectedResult\":\"2\"}}",
                                         "{\"metadata\":{\"test_name\":\"SimpleErrorParameterizedTest(xValue: 2, yValue: 0, expectedResult: 4)\"},\"arguments\":{\"xValue\":\"2\",\"yValue\":\"0\",\"expectedResult\":\"4\"}}",
                                         "{\"metadata\":{\"test_name\":\"SimpleErrorParameterizedTest(xValue: 3, yValue: 0, expectedResult: 6)\"},\"arguments\":{\"xValue\":\"3\",\"yValue\":\"0\",\"expectedResult\":\"6\"}}");
+                                    break;
+
+                                case "UnskippableTest":
+                                    AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.UnskippableTag, "true");
+                                    AssertTargetSpanEqual(targetTest, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                                    CheckSimpleTestSpan(targetTest);
                                     break;
                             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -123,6 +123,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanExists(targetSpan, TestTags.Command);
                             AssertTargetSpanExists(targetSpan, TestTags.CommandWorkingDirectory);
 
+                            // Unskippable data
+                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
+                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+
                             // check specific test span
                             switch (targetSpan.Tags[TestTags.Name])
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
     {
         private const string TestBundleName = "Samples.XUnitTests";
         private const string TestSuiteName = "Samples.XUnitTests.TestSuite";
-        private const int ExpectedSpanCount = 14;
+        private const int ExpectedSpanCount = 15;
 
         public XUnitTests(ITestOutputHelper output)
             : base("XUnitTests", output)
@@ -124,8 +124,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanExists(targetSpan, TestTags.CommandWorkingDirectory);
 
                             // Unskippable data
-                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
-                            AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            if (targetSpan.Tags[TestTags.Name] != "UnskippableTest")
+                            {
+                                AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "false");
+                                AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                            }
 
                             // check specific test span
                             switch (targetSpan.Tags[TestTags.Name])
@@ -194,6 +197,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                                         "{\"metadata\":{\"test_name\":\"SimpleErrorParameterizedTest(xValue: 1, yValue: 0, expectedResult: 2)\"},\"arguments\":{\"xValue\":\"1\",\"yValue\":\"0\",\"expectedResult\":\"2\"}}",
                                         "{\"metadata\":{\"test_name\":\"SimpleErrorParameterizedTest(xValue: 2, yValue: 0, expectedResult: 4)\"},\"arguments\":{\"xValue\":\"2\",\"yValue\":\"0\",\"expectedResult\":\"4\"}}",
                                         "{\"metadata\":{\"test_name\":\"SimpleErrorParameterizedTest(xValue: 3, yValue: 0, expectedResult: 6)\"},\"arguments\":{\"xValue\":\"3\",\"yValue\":\"0\",\"expectedResult\":\"6\"}}");
+                                    break;
+
+                                case "UnskippableTest":
+                                    AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.UnskippableTag, "true");
+                                    AssertTargetSpanEqual(targetSpan, IntelligentTestRunnerTags.ForcedRunTag, "false");
+                                    CheckSimpleTestSpan(targetSpan);
                                     break;
                             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -23,7 +23,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
     {
         private const string TestBundleName = "Samples.XUnitTests";
         private const string TestSuiteName = "Samples.XUnitTests.TestSuite";
-        private const int ExpectedSpanCount = 15;
+        private const string UnSkippableSuiteName = "Samples.XUnitTests.UnSkippableSuite";
+        private const int ExpectedSpanCount = 16;
 
         public XUnitTests(ITestOutputHelper output)
             : base("XUnitTests", output)
@@ -86,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                             AssertTargetSpanEqual(targetSpan, TestTags.Module, TestBundleName);
 
                             // check the suite name
-                            AssertTargetSpanEqual(targetSpan, TestTags.Suite, TestSuiteName);
+                            AssertTargetSpanAnyOf(targetSpan, TestTags.Suite, TestSuiteName, UnSkippableSuiteName);
 
                             // check the test type
                             AssertTargetSpanEqual(targetSpan, TestTags.Type, TestTags.TypeTest);

--- a/tracer/test/test-applications/integrations/Samples.MSTestTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.MSTestTests/TestSuite.cs
@@ -105,5 +105,11 @@ namespace Samples.MSTestTests
         {
             Assert.AreEqual(expectedResult, xValue / yValue);
         }
+
+        [TestMethod]
+        [TestProperty("datadog_itr_unskippable", null)]
+        public void UnskippableTest()
+        {
+        }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/Samples.NUnitTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/Samples.NUnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">3.13.3</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">3.13.1</ApiVersion>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/Samples.NUnitTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/Samples.NUnitTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <OutputType>Library</OutputType>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">3.13.1</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">3.13.3</ApiVersion>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -223,4 +223,13 @@ namespace Samples.NUnitTests
             throw new Exception("TearDown exception.");
         }
     }
+
+    [Property("datadog_itr_unskippable", "")]
+    public class UnSkippableSuite
+    {
+        [Test]
+        public void UnskippableTest()
+        {
+        }
+    }
 }

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -123,7 +123,7 @@ namespace Samples.NUnitTests
         }
 
         [Test]
-        [Property("datadog_itr_unskippable", null)]
+        [Property("datadog_itr_unskippable", "")]
         public void UnskippableTest()
         {
         }

--- a/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.NUnitTests/TestSuite.cs
@@ -121,6 +121,12 @@ namespace Samples.NUnitTests
         public void SkipByITRSimulation()
         {
         }
+
+        [Test]
+        [Property("datadog_itr_unskippable", null)]
+        public void UnskippableTest()
+        {
+        }
     }
 
     [TestFixture("Test01")]

--- a/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
@@ -108,5 +108,11 @@ namespace Samples.XUnitTests
         public void SkipByITRSimulation()
         {
         }
+
+        [Fact]
+        [Trait("datadog_itr_unskippable", null)]
+        public void UnskippableTest()
+        {
+        }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
+++ b/tracer/test/test-applications/integrations/Samples.XUnitTests/TestSuite.cs
@@ -115,4 +115,13 @@ namespace Samples.XUnitTests
         {
         }
     }
+
+    [Trait("datadog_itr_unskippable", null)]
+    public class UnSkippableSuite
+    {
+        [Fact]
+        public void UnskippableTest()
+        {
+        }
+    }
 }


### PR DESCRIPTION
## Summary of changes

This PR adds support for Unskippable tests for the Intelligent Test Runner feature.

This features allows to tag any test with the `datadog_itr_unskippable` trait to make sure the test always run even with the Intelligent Test Runner enabled.

### How it works?

#### XUnit:
You must decorate the test or class with a `TraitAttribute`:

```csharp
        [Fact]
        [Trait("datadog_itr_unskippable", null)]
        public void UnskippableTest()
        {
             ...
        }
```
or
```csharp
    [Trait("datadog_itr_unskippable", null)]
    public class UnSkippableSuite
    {
        [Fact]
        public void UnskippableTest()
        {
             ...
        }
    }
```

#### NUnit:
You must decorate the test or class with a `PropertyAttribute`:

```csharp
        [Test]
        [Property("datadog_itr_unskippable", "")]
        public void UnskippableTest()
        {
             ...
        }
```
or
```csharp
    [Property("datadog_itr_unskippable", "")]
    public class UnSkippableSuite
    {
        [Test]
        public void UnskippableTest()
        {
             ...
        }
    }
```

#### MSTest:
You must decorate the test with a `TestPropertyAttribute`:

```csharp
        [TestMethod]
        [TestProperty("datadog_itr_unskippable", null)]
        public void UnskippableTest()
        {
             ...
        }
```

At the execution time, test decorated with these attributes will be not considered as skippable in an Intelligent Test Runner session.

The RFC of the feature can be found [here](https://docs.google.com/document/d/16nM4stwXk4N4anlSS7LK76AldBn7-5k9eve8SEbfMck/edit).

## Test coverage

All testing framework cases adds a new test case marked with the attribute, and an assertion to the tags added to the resulting payload by the feature.
