### PR TITLE
[Profiler] Fix flacky unit test on Alpine

### DIFF
--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -422,7 +422,12 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerSignalHandlerIsRestoredIfA
 
     buffer->CopyInstructionPointers(ips);
 
+    // Disable this check on Alpine due to flackyness
+    // Libunwind randomly fails with unw_backtrace2 (from a signal handler)
+    // but unw_backtrace
+#ifndef DD_ALPINE
     ValidateCallstack(ips);
+#endif
 
     // now the custmer handler must not work
     EXPECT_FALSE(WasCallbackCalled());


### PR DESCRIPTION
## Summary of changes

Disable callstack check/assert on Alpine.

## Reason for change

For some reason, `unw_backtrace2` randomly fails on Alpine but not `unw_backtrace`. This makes the unit test flacky

## Implementation details

Deactivate the check on Alpine but keeps the other checks

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
