### PR TITLE
[Profiler] POC for named pipes based IPC

### DIFF
--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.cpp
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.cpp
@@ -1,0 +1,351 @@
+// Inspired by https://github.com/zodiacon/Win10SysProgBookSamples/blob/master/Chapter18/CalculatorSvr/CalculatorSvr.cpp
+// Another implementation without using ThreadPool API - https://learn.microsoft.com/en-us/windows/win32/ipc/multithreaded-pipe-server
+#include <windows.h>
+
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "..\shared\Protocol.h"
+
+bool ParseCommandLine(int argc, char* argv[], int& pid, char*& pipe)
+{
+    bool success = false;
+    for (size_t i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-pid") == 0)
+        {
+            if (i == argc - 1)
+            {
+                return false;
+            }
+
+            // atoi is fine because we don't expect 0 to be a valid pid
+            pid = atoi(argv[i+1]);
+            success = (pid != 0);
+        }
+        else
+        if (strcmp(argv[i], "-pipe") == 0)
+        {
+            if (i == argc - 1)
+            {
+                return false;
+            }
+
+            pipe = argv[i + 1];
+            success = true;
+        }
+    }
+
+    return success;
+}
+
+int ShowLastError(const char* msg, DWORD error = ::GetLastError())
+{
+    printf("%s (%u)\n", msg, error);
+    return -2;
+}
+
+bool WriteErrorResponse(HANDLE hPipe)
+{
+    DWORD written;
+    if (!::WriteFile(hPipe, &ErrorResponse, sizeof(ErrorResponse), &written, nullptr))
+    {
+        printf("Failed to send error response...\n");
+        return false;
+    }
+    ::FlushFileBuffers(hPipe);
+}
+
+bool WriteSuccessResponse(HANDLE hPipe)
+{
+    DWORD written;
+    if (!::WriteFile(hPipe, &SuccessResponse, sizeof(SuccessResponse), &written, nullptr))
+    {
+        printf("Failed to send success response...\n");
+        return false;
+    }
+    ::FlushFileBuffers(hPipe);
+}
+
+bool ReadEvents(HANDLE hPipe, uint8_t* pBuffer, DWORD bufferSize, DWORD& readSize)
+{
+    bool success = true;
+    auto pMessage = reinterpret_cast<ClrEventsMessage*>(pBuffer);
+    DWORD totalReadSize = 0;
+    DWORD lastError = ERROR_SUCCESS;
+
+    while (totalReadSize < bufferSize)
+    {
+        success = ::ReadFile(hPipe, &(pBuffer[totalReadSize]), bufferSize - totalReadSize, &readSize, nullptr);
+
+        if (!success || readSize == 0)
+        {
+            lastError = ::GetLastError();
+
+            if (lastError == ERROR_MORE_DATA)
+            {
+                totalReadSize += readSize;
+                if (totalReadSize == bufferSize)
+                {
+                    std::cout << "Read buffer was too small...\n";
+                    return false;
+                }
+
+                continue;
+            }
+            else
+            {
+                if (lastError == ERROR_BROKEN_PIPE)
+                {
+                    std::cout << "Disconnected client...\n";
+                }
+                else
+                {
+                    std::cout << "Error reading from pipe (" << lastError << ")...\n ";
+                }
+                return false;
+            }
+        }
+        else
+        {
+            if (!IsMessageValid(pMessage))
+            {
+                WriteErrorResponse(hPipe);
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    // too big for the buffer
+    return false;
+}
+
+void ProcessEvents(HANDLE hPipe)
+{
+    DWORD bufferSize = (1 << 16) + sizeof(IpcHeader);
+    auto buffer = std::make_unique<uint8_t[]>(bufferSize);
+    auto message = reinterpret_cast<ClrEventsMessage*>(buffer.get());
+
+    DWORD readSize;
+    for (;;)
+    {
+        //if (!::ReadFile(hPipe, buffer.get(), bufferSize, &read, nullptr) || read == 0)
+        //{
+        //    auto lastError = ::GetLastError();
+        //    if (lastError == ERROR_BROKEN_PIPE)
+        //    {
+        //        std::cout << "Disconnected client...\n";
+        //    }
+        //    else
+        //    {
+        //        std::cout << "Error reading from pipe (" << lastError << ")...\n ";
+        //    }
+
+        //    break;
+        //}
+
+        //if (!IsMessageValid(message))
+        //{
+        //    DWORD written;
+        //    if (!::WriteFile(hPipe, &ErrorResponse, sizeof(ErrorResponse), &written, nullptr))
+        //    {
+        //        printf("Failed to send error response...\n");
+        //        continue;
+        //    }
+        //    ::FlushFileBuffers(hPipe);
+
+        //    break;
+        //}
+        if (!ReadEvents(hPipe, buffer.get(), bufferSize, readSize))
+        {
+            break;
+        }
+
+        // check the message based on the expected command
+        if (message->CommandId == Commands::ClrEvents)
+        {
+            std::cout << "Events received: " << message->Size - sizeof(IpcHeader) << " / " << readSize << " bytes\n";
+
+            WriteSuccessResponse(hPipe);
+        }
+        else
+        {
+            std::cout << "Invalid command (" << message->CommandId << ")...\n";
+
+            WriteErrorResponse(hPipe);
+            break;
+        }
+    }
+
+    ::DisconnectNamedPipe(hPipe);
+    ::CloseHandle(hPipe);
+}
+
+
+int RunServer(int pid)
+{
+    std::stringstream buffer;
+    buffer << "\\\\.\\pipe\\DD_ETW_CLIENT_";
+    buffer << pid;
+    std::string pipeName = buffer.str();
+    std::cout << "Exposing " << pipeName << "\n";
+
+    // we are expecting only one "client" connecting: the Datadog Agent
+    HANDLE hNamedPipe =
+        ::CreateNamedPipeA(
+            pipeName.c_str(),
+            PIPE_ACCESS_DUPLEX,  // TODO: do we really need to send a response to the Agent?
+            PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+            1,
+            sizeof(SuccessResponse),
+            (1 << 16) + sizeof(IpcHeader),
+            0,
+            nullptr);
+
+    if (hNamedPipe == INVALID_HANDLE_VALUE)
+    {
+        return ShowLastError("Failed to create named pipe");
+    }
+
+    std::cout << "Listening...\n";
+
+    if (!::ConnectNamedPipe(hNamedPipe, nullptr) && ::GetLastError() != ERROR_PIPE_CONNECTED)
+    {
+        return ShowLastError("ConnectNamedPipe failed...");
+    }
+
+    // process events as they are received
+    ProcessEvents(hNamedPipe);
+
+    return 0;
+}
+
+void CALLBACK RunServerCallback(PTP_CALLBACK_INSTANCE instance, PVOID context)
+{
+    int pid = reinterpret_cast<int>(context);
+    RunServer(pid);
+}
+
+void StartServerAsync(int pid)
+{
+    // let a threadpool thread run the named pipe server
+    if (!::TrySubmitThreadpoolCallback(RunServerCallback, reinterpret_cast<PVOID>(pid), nullptr))
+    {
+        ShowLastError("Impossible to run the server into the threadpool...");
+    }
+}
+
+void SendRegistrationCommand(HANDLE hPipe, int pid, bool add)
+{
+    RegistrationProcessMessage message;
+    if (add)
+    {
+        SetupRegisterCommand(message, pid);
+    }
+    else
+    {
+        SetupUnregisterCommand(message, pid);
+    }
+
+	DWORD written;
+    if (!::WriteFile(hPipe, &message, sizeof(message), &written, nullptr))
+    {
+        ShowLastError("Failed to write to pipe");
+        return;
+    }
+    ::FlushFileBuffers(hPipe);
+
+    IpcHeader response;
+    DWORD read;
+    if (!::ReadFile(hPipe, &response, sizeof(response), &read, nullptr))
+    {
+        DWORD lastError = ::GetLastError();
+        if (lastError == ERROR_PIPE_NOT_CONNECTED)
+        {
+            // expected after unregistration (i.e. !add) because the pipe will be closed by the Agent
+            if (add)
+            {
+                std::cout << "Pipe no more connected: registration failed...\n";
+            }
+        }
+        else
+        {
+            ShowLastError("Failed to read result");
+            if (add)
+            {
+                std::cout << "Registration failed...\n";
+            }
+            else
+            {
+                std::cout << "Unregistration failed...\n";
+            }
+        }
+    }
+    else
+    {
+        if (add)
+        {
+            std::cout << "Registered!\n";
+        }
+        else
+        {
+            std::cout << "Unregistered!\n";
+        }
+    }
+
+}
+
+int main(int argc, char* argv[])
+{
+    int pid = -1;
+    char* pipe = nullptr;
+    if (!ParseCommandLine(argc, argv, pid, pipe))
+    {
+        if (pid == -1)
+        {
+            std::cout << "Missing -p <pid>...\n";
+        }
+        if (pipe == nullptr)
+        {
+            std::cout << "Missing -pipe <server name>...\n";
+        }
+
+        return -1;
+    }
+
+    std::cout << "\n";
+
+    // start the server part to receive proxied ETW events
+    StartServerAsync(pid);
+
+    std::string pipeName = "\\\\.\\pipe\\";
+    pipeName += pipe;
+    std::cout << "Contacting " << pipeName << "...\n";
+
+    // 500 ms timeout but should we use the server-defined one?
+    // NMPWAIT_USE_DEFAULT_WAIT in that case
+    HANDLE hPipe = CheckEndpoint(pipeName, 500);
+    if (hPipe == INVALID_HANDLE_VALUE)
+    {
+        return ShowLastError("Impossible to connect to the ETW server...");
+    }
+
+    SendRegistrationCommand(hPipe, pid, true);
+
+    std::cout << "Press ENTER to unregister...\n";
+    std::string input;
+    std::getline(std::cin, input);
+    SendRegistrationCommand(hPipe, pid, false);
+
+    ::CloseHandle(hPipe);
+
+    return 0;
+}
+
+
+
+

--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.vcxproj
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.vcxproj
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{97dd3e31-0922-455e-a308-e0c798e84476}</ProjectGuid>
+    <RootNamespace>ddprofetwclient</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\shared\Protocol.cpp" />
+    <ClCompile Include="dd-prof-etw-client.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\shared\Protocol.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.vcxproj.filters
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.vcxproj.filters
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dd-prof-etw-client.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\shared\Protocol.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\shared\Protocol.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-collector/dd-prof-etw-collector.cpp
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-collector/dd-prof-etw-collector.cpp
@@ -1,0 +1,252 @@
+// Inspired by https://github.com/zodiacon/Win10SysProgBookSamples/blob/master/Chapter18/CalculatorSvr/CalculatorSvr.cpp
+// Another implementation without using ThreadPool API - https://learn.microsoft.com/en-us/windows/win32/ipc/multithreaded-pipe-server
+#include <windows.h>
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+#include "..\shared\Protocol.h"
+
+
+bool ParseCommandLine(int argc, char* argv[], char*& pipe)
+{
+    bool success = false;
+    for (size_t i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-pipe") == 0)
+        {
+            if (i == argc - 1)
+            {
+                return false;
+            }
+
+            pipe = argv[i + 1];
+            success = true;
+        }
+    }
+
+    return success;
+}
+
+int ShowLastError(const char* msg, DWORD error = ::GetLastError())
+{
+    printf("%s (%u)\n", msg, error);
+    return 1;
+}
+
+bool IsSuccessResponse(HANDLE hPipe)
+{
+    IpcHeader response;
+    DWORD read;
+    if (!::ReadFile(hPipe, &response, sizeof(response), &read, nullptr))
+    {
+        ShowLastError("Failed to get response...");
+        return false;
+    }
+
+    if (read != sizeof(response))
+    {
+        std::cout << "invalid response size\n";
+        return false;
+    }
+
+    if (!IsMessageValid(&response))
+    {
+        return false;
+    }
+
+    return (response.ResponseCode == (uint8_t)ResponseId::OK);
+}
+
+void SendClrEvents(PTP_CALLBACK_INSTANCE instance, PVOID context)
+{
+    int pid = reinterpret_cast<int>(context);
+
+    // check the profiled application is listening
+    std::stringstream sBuffer;
+    sBuffer << "\\\\.\\pipe\\DD_ETW_CLIENT_";
+    sBuffer << pid;
+    std::string pipeName = sBuffer.str();
+    HANDLE hPipe = CheckEndpoint(pipeName, 500);
+    if (hPipe == INVALID_HANDLE_VALUE)
+    {
+        ShowLastError("Impossible to connect to the profiled application...");
+        return;
+    }
+
+    std::cout << "Connected to " << pipeName << "\n ";
+
+
+    // send messages with different sizes and payload
+    auto buffer = std::make_unique<byte[]>((1 << 16) + sizeof(IpcHeader));
+    ClrEventsMessage* pMessage = reinterpret_cast<ClrEventsMessage*>(buffer.get());
+
+    DWORD written;
+    DWORD messageSize;
+
+    SetupSendEventsCommand(pMessage, 1024);
+    messageSize = pMessage->Size;
+    buffer[sizeof(IpcHeader)] = 1;
+    if (!::WriteFile(hPipe, pMessage, messageSize, &written, nullptr))
+    {
+        ShowLastError("Failed to send CLR events...");
+        ::CloseHandle(hPipe);
+        return;
+    }
+    ::FlushFileBuffers(hPipe);
+
+    if (!IsSuccessResponse(hPipe))
+    {
+        std::cout << "Error after sending CLR events\n ";
+        return;
+    }
+
+    SetupSendEventsCommand(pMessage, 2048);
+    messageSize = pMessage->Size;
+    buffer[sizeof(IpcHeader)] = 2;
+    if (!::WriteFile(hPipe, pMessage, messageSize, &written, nullptr))
+    {
+        ShowLastError("Failed to send CLR events...");
+        ::CloseHandle(hPipe);
+        return;
+    }
+    ::FlushFileBuffers(hPipe);
+
+    if (!IsSuccessResponse(hPipe))
+    {
+        std::cout << "Error after sending CLR events\n ";
+        return;
+    }
+
+    // TODO: sync with the unregister command to stop the pipe only at that time
+    //::CloseHandle(hPipe);
+}
+
+void SendClrEventsAsync(int pid)
+{
+    if (!::TrySubmitThreadpoolCallback(SendClrEvents, reinterpret_cast<PVOID>(pid), nullptr))
+    {
+        ShowLastError("Impossible to add the send CLR events callback into the threadpool...");
+    }
+}
+
+void CALLBACK CommandCallback(PTP_CALLBACK_INSTANCE instance, PVOID context)
+{
+    uint8_t buffer[sizeof(RegistrationProcessMessage)];
+    auto hPipe = static_cast<HANDLE>(context);
+    uint64_t unregisteredPid = -1;
+
+    DWORD read;
+    for (;;)
+    {
+        if (!::ReadFile(hPipe, buffer, sizeof(buffer), &read, nullptr) || read == 0)
+        {
+            auto lastError = ::GetLastError();
+            if (lastError == ERROR_BROKEN_PIPE)
+            {
+                std::cout << "Disconnected client...\n";
+            }
+            else
+            {
+                std::cout << "Error reading from pipe (" << lastError << ")...\n ";
+            }
+
+            break;
+        }
+
+        // process the command
+        auto message = reinterpret_cast<RegistrationProcessMessage*>(buffer);
+        if (!IsMessageValid(message))
+        {
+            std::cout << "Invalid received message...\n";
+            break;
+        }
+
+        // check the expected commands
+        if (message->CommandId == Commands::Register)
+        {
+            std::cout << "pid " << message->Pid << " has been registered\n";
+
+            SendClrEventsAsync(message->Pid);
+        }
+        else
+        if (message->CommandId == Commands::Unregister)
+        {
+            unregisteredPid = message->Pid;
+            std::cout << "pid " << unregisteredPid << " has been unregistered\n";
+            break;
+        }
+        else
+        {
+            std::cout << "Invalid command (" << message->CommandId << ")...\n";
+
+            // TODO: don't exit but send an error response
+            break;
+        }
+
+        // send the response
+        DWORD written;
+        if (!::WriteFile(hPipe, &SuccessResponse, sizeof(SuccessResponse), &written, nullptr))
+        {
+            printf("Failed to send result!\n");
+            continue;
+        }
+   }
+
+    std::cout << "Disconnecting from " << unregisteredPid << "\n";
+    ::DisconnectNamedPipe(hPipe);
+    ::CloseHandle(hPipe);
+}
+
+
+int main(int argc, char* argv[])
+{
+    char* pipe = nullptr;
+    if (!ParseCommandLine(argc, argv, pipe))
+    {
+        std::cout << "Missing pipe...\n";
+        return -1;
+    }
+
+    std::cout << "\n";
+
+    std::string pipeName = "\\\\.\\pipe\\";
+    pipeName += pipe;
+    std::cout << "Exposing " << pipeName << "\n";
+
+    while (true)
+    {
+        HANDLE hNamedPipe =
+            ::CreateNamedPipeA(
+                pipeName.c_str(),
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS,
+                PIPE_UNLIMITED_INSTANCES, // in real world, limit to a max number of profiled applications (255 anyway)
+                sizeof(SuccessResponse),
+                sizeof(RegistrationProcessMessage),
+                0,
+                nullptr
+                );
+
+        if (hNamedPipe == INVALID_HANDLE_VALUE)
+        {
+            return ShowLastError("Failed to create named pipe");
+        }
+
+        std::cout << "Listening...\n";
+
+        if (!::ConnectNamedPipe(hNamedPipe, nullptr) && ::GetLastError() != ERROR_PIPE_CONNECTED)
+        {
+            return ShowLastError("ConnectNamedPipe failed...");
+        }
+
+        // let a threadpool thread process the command; allowing the server to process more incoming commands
+        if (!::TrySubmitThreadpoolCallback(CommandCallback, hNamedPipe, nullptr))
+        {
+            return ShowLastError("Impossible to add a command callback into the threadpool...");
+        }
+    }
+
+    return 0;
+}

--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-collector/dd-prof-etw-collector.vcxproj
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-collector/dd-prof-etw-collector.vcxproj
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{3fd8a994-8edc-4edd-95c5-e664d205a401}</ProjectGuid>
+    <RootNamespace>ddprofetwcollector</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="dd-prof-etw-collector.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-collector/dd-prof-etw-collector.vcxproj.filters
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-collector/dd-prof-etw-collector.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="dd-prof-etw-collector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw.sln
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34003.232
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dd-prof-etw-client", "dd-prof-etw-client\dd-prof-etw-client.vcxproj", "{97DD3E31-0922-455E-A308-E0C798E84476}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "dd-prof-etw-collector", "dd-prof-etw-collector\dd-prof-etw-collector.vcxproj", "{3FD8A994-8EDC-4EDD-95C5-E664D205A401}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Debug|x64.ActiveCfg = Debug|x64
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Debug|x64.Build.0 = Debug|x64
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Debug|x86.ActiveCfg = Debug|Win32
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Debug|x86.Build.0 = Debug|Win32
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Release|x64.ActiveCfg = Release|x64
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Release|x64.Build.0 = Release|x64
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Release|x86.ActiveCfg = Release|Win32
+		{97DD3E31-0922-455E-A308-E0C798E84476}.Release|x86.Build.0 = Release|Win32
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Debug|x64.ActiveCfg = Debug|x64
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Debug|x64.Build.0 = Debug|x64
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Debug|x86.ActiveCfg = Debug|Win32
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Debug|x86.Build.0 = Debug|Win32
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Release|x64.ActiveCfg = Release|x64
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Release|x64.Build.0 = Release|x64
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Release|x86.ActiveCfg = Release|Win32
+		{3FD8A994-8EDC-4EDD-95C5-E664D205A401}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E470B257-4B23-4191-B966-B11EF32CF684}
+	EndGlobalSection
+EndGlobal

--- a/profiler/src/Tools/ETW/dd-prof-etw/shared/Protocol.cpp
+++ b/profiler/src/Tools/ETW/dd-prof-etw/shared/Protocol.cpp
@@ -1,0 +1,3 @@
+#include "Protocol.h"
+
+

--- a/profiler/src/Tools/ETW/dd-prof-etw/shared/Protocol.h
+++ b/profiler/src/Tools/ETW/dd-prof-etw/shared/Protocol.h
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <Windows.h>
+
+
+enum Commands : uint8_t
+{
+    // 0 is not a valid command id
+
+    // commands sent by the profiler
+    Register    = 1,
+    Unregister  = 2,
+
+    // commands sent by the Agent
+    ClrEvents  = 16,
+};
+
+enum class ResponseId : uint8_t
+{
+    OK = 0x00,
+    // future
+    Error = 0xFF,
+};
+
+struct MagicVersion
+{
+    uint8_t Magic[14];
+};
+const MagicVersion DD_Ipc_Magic_V1 = {"DD_ETW_IPC_V1"}; // 14 bytes long (including final 0)
+
+// The header to be associated with every command and response
+#pragma pack(1)
+struct IpcHeader
+{
+    union
+    {
+        MagicVersion _magic;
+        uint8_t Magic[14]; // Magic Version number; a 0 terminated char array
+    };
+
+    // TODO: do we need blocks larger than 64KB?
+    uint16_t Size; // The size of the incoming packet, size = header size + payload size
+    union
+    {
+        uint8_t CommandId;    // The command being sent (TODO: do we need to add a group/set of commands?)
+        uint8_t ResponseCode; // 0x00 in case of success and 0xFF in case of error
+    };
+};  // size of header = 17 bytes
+
+
+// Messages for commands
+//
+//
+#pragma pack(1)
+struct RegistrationProcessMessage : public IpcHeader
+{
+    uint64_t Pid;
+};
+
+inline void SetupRegistrationCommand(RegistrationProcessMessage& message, uint64_t pid)
+{
+    memcpy(message.Magic, &DD_Ipc_Magic_V1, sizeof(DD_Ipc_Magic_V1));
+    message.Size = sizeof(RegistrationProcessMessage);
+    message.Pid = pid;
+}
+
+inline void SetupRegisterCommand(RegistrationProcessMessage& message, uint64_t pid)
+{
+    SetupRegistrationCommand(message, pid);
+    message.CommandId = Commands::Register;
+}
+
+inline void SetupUnregisterCommand(RegistrationProcessMessage& message, uint64_t pid)
+{
+    SetupRegistrationCommand(message, pid);
+    message.CommandId = Commands::Unregister;
+}
+
+#pragma pack(1)
+struct ClrEventsMessage : public IpcHeader
+{
+    // the size of this payload is given by (message.size - sizeof(IpcHeader))
+    uint8_t payload[1];
+};
+
+// the given message will probably be dynamically allocated
+// Also, the given size is the size of the payload only
+inline void SetupSendEventsCommand(ClrEventsMessage* pMessage, uint16_t size)
+{
+    memcpy(pMessage->Magic, &DD_Ipc_Magic_V1, sizeof(DD_Ipc_Magic_V1));
+    pMessage->Size = size + sizeof(IpcHeader);
+    pMessage->CommandId = Commands::ClrEvents;
+}
+
+
+// predefined headers for responses
+//
+//
+const IpcHeader SuccessResponse =
+{
+    { DD_Ipc_Magic_V1 },
+    (uint16_t)sizeof(IpcHeader),
+    (uint8_t)ResponseId::OK
+};
+
+const IpcHeader ErrorResponse =
+{
+    { DD_Ipc_Magic_V1 },
+    (uint16_t)sizeof(IpcHeader),
+    (uint8_t)ResponseId::Error
+};
+
+
+// helpers
+//
+//
+inline bool IsMessageValid(IpcHeader* pMessage)
+{
+    if (memcmp(&DD_Ipc_Magic_V1, pMessage->Magic, sizeof(DD_Ipc_Magic_V1)) != 0)
+    {
+        std::cout << "Invalid Magic signature...\n";
+        return false;
+    }
+
+    return true;
+}
+
+inline HANDLE CheckEndpoint(const std::string& pipeName, DWORD timeoutMS)
+{
+    bool success = ::WaitNamedPipeA(pipeName.c_str(), timeoutMS);
+    if (!success)
+    {
+        std::cout << "Timeout when trying to connect to" << pipeName << "...\n";
+    }
+
+    HANDLE hPipe = ::CreateFileA(
+        pipeName.c_str(),
+        GENERIC_READ | GENERIC_WRITE,
+        0,
+        nullptr,
+        OPEN_EXISTING,
+        0,
+        nullptr);
+
+    return hPipe;
+}


### PR DESCRIPTION
## Summary of changes
Implement named pipes IPC mechanisms in a new tool 

## Reason for change
To support .NET Framework, the Datadog Agent will collect the CLR events via ETW and proxy them to the profiled applications. To ease the Agent implementation and tests, a tool will simulate a profiled application and dump the exchanged messages via named pipe.

## Implementation details
A named pipe server is implemented by the tool to receive the events via a message-based protocol.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
