### PR TITLE
[ASM] Filter `AspNetCore.Correlation.*` cookies vulnerabilities

### DIFF
--- a/tracer/src/Datadog.Trace/IAST/CookieAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/IAST/CookieAnalyzer.cs
@@ -94,7 +94,7 @@ internal static class CookieAnalyzer
 
     private static void AnalyzeCookie(string cookieHeaderValue, IntegrationId integrationId)
     {
-        if (!string.IsNullOrWhiteSpace(cookieHeaderValue))
+        if (!IsExcluded(cookieHeaderValue))
         {
             var cookieHeader = SetCookieHeaderValue.Parse(cookieHeaderValue);
             ReportVulnerabilities(integrationId, cookieHeader);
@@ -127,5 +127,11 @@ internal static class CookieAnalyzer
             IastModule.OnInsecureCookie(integrationId, name);
         }
     }
+
+    private static bool IsExcluded(string cookieName)
+    {
+        return string.IsNullOrWhiteSpace(cookieName) || cookieName.StartsWith(".AspNetCore.Correlation.", StringComparison.OrdinalIgnoreCase);
+    }
+
 #endif
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -359,7 +359,7 @@ public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
     [SkippableTheory]
     [InlineData("/Iast/SafeCookie")]
     [InlineData("/Iast/AllVulnerabilitiesCookie")]
-    public async Task TestIastInsecureCookieRequest(string url)
+    public async Task TestIastCookiesRequest(string url)
     {
         var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
         var filename = $"Security.AspNetCore5.enableIast={IastEnabled}.path ={sanitisedUrl}";

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -272,6 +272,7 @@ namespace Samples.Security.AspNetCore5.Controllers
             var cookieOptions = GetDefaultCookieOptionsInstance();
             cookieOptions.Secure = false;
             Response.Cookies.Append("insecureKey", "insecureValue", cookieOptions);
+            Response.Cookies.Append(".AspNetCore.Correlation.oidc.xxxxxxxxxxxxxxxxxxx", "ExcludedCookieVulnValue", cookieOptions);
             return Content("Sending InsecureCookie");
         }
 
@@ -282,6 +283,7 @@ namespace Samples.Security.AspNetCore5.Controllers
             var cookieOptions = GetDefaultCookieOptionsInstance();
             cookieOptions.HttpOnly = false;
             Response.Cookies.Append("NoHttpOnlyKey", "NoHttpOnlyValue", cookieOptions);
+            Response.Cookies.Append(".AspNetCore.Correlation.oidc.xxxxxxxxxxxxxxxxxxx", "ExcludedCookieVulnValue", cookieOptions);
             return Content("Sending NoHttpOnlyCookie");
         }
 
@@ -292,6 +294,7 @@ namespace Samples.Security.AspNetCore5.Controllers
             var cookieOptions = GetDefaultCookieOptionsInstance();
             cookieOptions.SameSite = SameSiteMode.None;
             Response.Cookies.Append("NoSameSiteKey", "NoSameSiteValue", cookieOptions);
+            Response.Cookies.Append(".AspNetCore.Correlation.oidc.xxxxxxxxxxxxxxxxxxx", "ExcludedCookieVulnValue", cookieOptions);
             var cookieOptionsLax = GetDefaultCookieOptionsInstance();
             cookieOptionsLax.SameSite = SameSiteMode.Lax;
             Response.Cookies.Append("NoSameSiteKeyLax", "NoSameSiteValueLax", cookieOptionsLax);
@@ -328,6 +331,7 @@ namespace Samples.Security.AspNetCore5.Controllers
             cookieOptions.HttpOnly = false;
             cookieOptions.Secure = false;
             Response.Cookies.Append("AllVulnerabilitiesCookieKey", "AllVulnerabilitiesCookieValue", cookieOptions);
+            Response.Cookies.Append(".AspNetCore.Correlation.oidc.xxxxxxxxxxxxxxxxxxx", "ExcludedCookieVulnValue", cookieOptions);
             return Content("Sending AllVulnerabilitiesCookie");
         }
 


### PR DESCRIPTION
## Summary of changes
Exclude `.AspNetCore.Correlation.*` like cookies from vulnerability detection

## Reason for change
This kind of cookies are generated with random names automatically by the AspNet core, creating a lot of false cookie vulnerability positives.

## Implementation details
Filter by cookie name in `CookieAnalyzer`

## Test coverage
Added integration tests
