### PR TITLE
Disable dd_dotnet AOT build in OSX

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -17,7 +17,7 @@
 
     <AssemblyName>dd-dotnet</AssemblyName>
 
-    <PublishAot>true</PublishAot>
+    <PublishAot Condition="!$([MSBuild]::IsOSPlatform('OSX'))">true</PublishAot>
     <OptimizationPreference>Size</OptimizationPreference>
     <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
     <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>


### PR DESCRIPTION
## Summary of changes

This PR disables `dd_dotnet` AOT build for OSX.

## Reason

Build is failing on OSX:

```logs
10:15:23 [DBG]        "/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/Datadog.Trace.sln" (Restore target) (1) ->
10:15:23 [DBG]        (Restore target) -> 
10:15:23 [DBG]          /Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj : error NU1102: Unable to find package runtime.osx-arm64.Microsoft.DotNet.ILCompiler with version (= 7.0.9) [/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/Datadog.Trace.sln]
10:15:23 [DBG]        /Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj : error NU1102:   - Found 8 version(s) in nuget [ Nearest version: 8.0.0-preview.1.23110.8 ] [/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/Datadog.Trace.sln]
10:15:23 [DBG]        /Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj : error NU1102:   - Found 0 version(s) in /usr/local/share/dotnet/library-packs [/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/Datadog.Trace.sln]
10:15:23 [DBG]        /Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj : error NU1102:   - Found 0 version(s) in Azure [/Users/tony.redondo/repos/github/Datadog/dd-trace-dotnet/Datadog.Trace.sln]
```