### PR TITLE
[CI Visibility] Remove ApplicationKey requirement from Intelligent Test Runner

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -160,7 +160,7 @@ namespace Datadog.Trace.Tools.Runner
                     Log.Debug("RunCiCommand: EVP proxy was detected.");
                 }
 
-                // If we have api, and the code coverage or the tests skippable environment variables
+                // If we have an api key, and the code coverage or the tests skippable environment variables
                 // are not set when the intelligent test runner is enabled, we query the settings api to check if it should enable coverage or not.
                 if (!ciVisibilitySettings.IntelligentTestRunnerEnabled)
                 {

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -63,7 +63,6 @@ namespace Datadog.Trace.Tools.Runner
             var ciVisibilitySettings = CIVisibility.Settings;
             var agentless = ciVisibilitySettings.Agentless;
             var apiKey = ciVisibilitySettings.ApiKey;
-            var applicationKey = ciVisibilitySettings.ApplicationKey;
 
             var customApiKey = _apiKeyOption.GetValue(context);
 
@@ -107,7 +106,7 @@ namespace Datadog.Trace.Tools.Runner
             var uploadRepositoryChangesTask = Task.CompletedTask;
 
             // Set Agentless configuration from the command line options
-            ciVisibilitySettings.SetAgentlessConfiguration(agentless, apiKey, applicationKey, ciVisibilitySettings.AgentlessUrl);
+            ciVisibilitySettings.SetAgentlessConfiguration(agentless, apiKey, ciVisibilitySettings.AgentlessUrl);
 
             if (!string.IsNullOrEmpty(agentUrl))
             {
@@ -161,21 +160,15 @@ namespace Datadog.Trace.Tools.Runner
                     Log.Debug("RunCiCommand: EVP proxy was detected.");
                 }
 
-                // If we have api and application key, and the code coverage or the tests skippable environment variables
+                // If we have api, and the code coverage or the tests skippable environment variables
                 // are not set when the intelligent test runner is enabled, we query the settings api to check if it should enable coverage or not.
-                var useConfigurationApi = !agentless || !string.IsNullOrEmpty(applicationKey);
-                if (!useConfigurationApi)
-                {
-                    Log.Debug("RunCiCommand: Application key is empty, call to configuration api skipped.");
-                }
-                else if (!ciVisibilitySettings.IntelligentTestRunnerEnabled)
+                if (!ciVisibilitySettings.IntelligentTestRunnerEnabled)
                 {
                     Log.Debug("RunCiCommand: Intelligent test runner is disabled, call to configuration api skipped.");
                 }
 
                 // If we still don't know if we have to enable code coverage or test skipping, then let's request the configuration API
-                if (useConfigurationApi
-                 && ciVisibilitySettings.IntelligentTestRunnerEnabled
+                if (ciVisibilitySettings.IntelligentTestRunnerEnabled
                  && (ciVisibilitySettings.CodeCoverageEnabled == null || ciVisibilitySettings.TestsSkippingEnabled == null))
                 {
                     try

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -23,7 +23,6 @@ namespace Datadog.Trace.Ci.Configuration
             Agentless = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessEnabled).AsBool(false);
             Logs = config.WithKeys(ConfigurationKeys.CIVisibility.Logs).AsBool(false);
             ApiKey = config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
-            ApplicationKey = config.WithKeys(ConfigurationKeys.ApplicationKey).AsRedactedString();
             Site = config.WithKeys(ConfigurationKeys.Site).AsString("datadoghq.com");
             AgentlessUrl = config.WithKeys(ConfigurationKeys.CIVisibility.AgentlessUrl).AsString();
 
@@ -72,11 +71,6 @@ namespace Datadog.Trace.Ci.Configuration
         /// Gets the Api Key to use in Agentless mode
         /// </summary>
         public string? ApiKey { get; private set; }
-
-        /// <summary>
-        /// Gets the Application Key to use in ITR
-        /// </summary>
-        public string? ApplicationKey { get; private set; }
 
         /// <summary>
         /// Gets the Datadog site
@@ -163,11 +157,10 @@ namespace Datadog.Trace.Ci.Configuration
             TestsSkippingEnabled = value;
         }
 
-        internal void SetAgentlessConfiguration(bool enabled, string? apiKey, string? applicationKey, string? agentlessUrl)
+        internal void SetAgentlessConfiguration(bool enabled, string? apiKey, string? agentlessUrl)
         {
             Agentless = enabled;
             ApiKey = apiKey;
-            ApplicationKey = applicationKey;
             AgentlessUrl = agentlessUrl;
         }
 

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -37,9 +37,7 @@ namespace Datadog.Trace.Ci;
 internal class IntelligentTestRunnerClient
 {
     private const string ApiKeyHeader = "DD-API-KEY";
-    private const string ApplicationKeyHeader = "DD-APPLICATION-KEY";
     private const string EvpSubdomainHeader = "X-Datadog-EVP-Subdomain";
-    private const string EvpNeedsApplicationKeyHeader = "X-Datadog-NeedsAppKey";
 
     private const int MaxRetries = 5;
     private const int MaxPackFileSizeInMb = 3;

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -272,11 +272,6 @@ namespace Datadog.Trace.Configuration
         public const string ApiKey = "DD_API_KEY";
 
         /// <summary>
-        /// Configuration key for setting the Application key, used by the ITR.
-        /// </summary>
-        public const string ApplicationKey = "DD_APPLICATION_KEY";
-
-        /// <summary>
         /// Configuration key for setting the default Datadog destination site.
         /// Defaults to "datadoghq.com".
         /// </summary>

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
@@ -55,16 +55,6 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(StringTestCases))]
-        public void ApplicationKey(string value, string expected)
-        {
-            var source = CreateConfigurationSource((ConfigurationKeys.ApplicationKey, value));
-            var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);
-
-            settings.ApplicationKey.Should().Be(expected);
-        }
-
-        [Theory]
         [MemberData(nameof(StringTestCases), "datadoghq.com", Strings.AllowEmpty)]
         public void Site(string value, string expected)
         {


### PR DESCRIPTION
## Summary of changes

This PR removes the usage of the `ApplicationKey` environment variable from the Intelligent Test Runner code as this is no longer required by the API.

## Reason for change

CI Visibility backend removed the ApplicationKey requirement on Intelligent Test Runner http requests. To reduce customers onboarding friction we are removing this requirement from the ITR client.