### PR TITLE
[CI Visibility] Ensure Code Coverage percentage is always a valid number for the backend.

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -346,7 +346,7 @@ namespace Datadog.Trace.Tools.Runner
                             globalCoverage is not null)
                         {
                             // Adds the global code coverage percentage to the session
-                            session.SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.Data[0].ToString(CultureInfo.InvariantCulture));
+                            session.SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.GetTotalPercentage());
                         }
                     }
                     else
@@ -366,8 +366,18 @@ namespace Datadog.Trace.Tools.Runner
                                     // Found using the OpenCover format.
 
                                     // Adds the global code coverage percentage to the session
+                                    var coveragePercentage = Math.Round(seqCovValue, 2);
+                                    if (double.IsNaN(coveragePercentage) || double.IsNegativeInfinity(coveragePercentage))
+                                    {
+                                        coveragePercentage = 0;
+                                    }
+                                    else if (double.IsPositiveInfinity(coveragePercentage))
+                                    {
+                                        coveragePercentage = 100;
+                                    }
+
                                     session.SetTag(CodeCoverageTags.Enabled, "true");
-                                    session.SetTag(CodeCoverageTags.PercentageOfTotalLines, Math.Round(seqCovValue, 2).ToString("F2", CultureInfo.InvariantCulture));
+                                    session.SetTag(CodeCoverageTags.PercentageOfTotalLines, coveragePercentage);
                                     Log.Debug("RunCiCommand: OpenCover code coverage was reported: {Value}", seqCovValue);
                                 }
                                 else if (xmlDoc.SelectSingleNode("/coverage/@line-rate") is { } lineRateAttribute &&
@@ -376,8 +386,18 @@ namespace Datadog.Trace.Tools.Runner
                                     // Found using the Cobertura format.
 
                                     // Adds the global code coverage percentage to the session
+                                    var coveragePercentage = Math.Round(lineRateValue * 100, 2);
+                                    if (double.IsNaN(coveragePercentage) || double.IsNegativeInfinity(coveragePercentage))
+                                    {
+                                        coveragePercentage = 0;
+                                    }
+                                    else if (double.IsPositiveInfinity(coveragePercentage))
+                                    {
+                                        coveragePercentage = 100;
+                                    }
+
                                     session.SetTag(CodeCoverageTags.Enabled, "true");
-                                    session.SetTag(CodeCoverageTags.PercentageOfTotalLines, Math.Round(lineRateValue * 100, 2).ToString("F2", CultureInfo.InvariantCulture));
+                                    session.SetTag(CodeCoverageTags.PercentageOfTotalLines, coveragePercentage);
                                     Log.Debug("RunCiCommand: Cobertura code coverage was reported: {Value}", lineRateAttribute.Value);
                                 }
                                 else

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -15,6 +15,7 @@ using System.Xml;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Spectre.Console;
@@ -366,16 +367,7 @@ namespace Datadog.Trace.Tools.Runner
                                     // Found using the OpenCover format.
 
                                     // Adds the global code coverage percentage to the session
-                                    var coveragePercentage = Math.Round(seqCovValue, 2);
-                                    if (double.IsNaN(coveragePercentage) || double.IsNegativeInfinity(coveragePercentage))
-                                    {
-                                        coveragePercentage = 0;
-                                    }
-                                    else if (double.IsPositiveInfinity(coveragePercentage))
-                                    {
-                                        coveragePercentage = 100;
-                                    }
-
+                                    var coveragePercentage = Math.Round(seqCovValue, 2).ToValidPercentage();
                                     session.SetTag(CodeCoverageTags.Enabled, "true");
                                     session.SetTag(CodeCoverageTags.PercentageOfTotalLines, coveragePercentage);
                                     Log.Debug("RunCiCommand: OpenCover code coverage was reported: {Value}", seqCovValue);
@@ -386,16 +378,7 @@ namespace Datadog.Trace.Tools.Runner
                                     // Found using the Cobertura format.
 
                                     // Adds the global code coverage percentage to the session
-                                    var coveragePercentage = Math.Round(lineRateValue * 100, 2);
-                                    if (double.IsNaN(coveragePercentage) || double.IsNegativeInfinity(coveragePercentage))
-                                    {
-                                        coveragePercentage = 0;
-                                    }
-                                    else if (double.IsPositiveInfinity(coveragePercentage))
-                                    {
-                                        coveragePercentage = 100;
-                                    }
-
+                                    var coveragePercentage = Math.Round(lineRateValue * 100, 2).ToValidPercentage();
                                     session.SetTag(CodeCoverageTags.Enabled, "true");
                                     session.SetTag(CodeCoverageTags.PercentageOfTotalLines, coveragePercentage);
                                     Log.Debug("RunCiCommand: Cobertura code coverage was reported: {Value}", lineRateAttribute.Value);

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Models/Global/CoverageInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Models/Global/CoverageInfo.cs
@@ -6,6 +6,7 @@
 #nullable enable
 
 using System;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Ci.Coverage.Models.Global;
@@ -65,15 +66,7 @@ internal abstract class CoverageInfo
             }
         }
 
-        _data = new[] { Math.Round((executed / total) * 100, 2), total, executed };
-        if (double.IsNaN(_data[0]) || double.IsNegativeInfinity(_data[0]))
-        {
-            _data[0] = 0;
-        }
-        else if (double.IsPositiveInfinity(_data[0]))
-        {
-            _data[0] = 100;
-        }
+        _data = new[] { Math.Round((executed / total) * 100, 2).ToValidPercentage(), total, executed };
     }
 
     protected void ClearData()
@@ -98,16 +91,6 @@ internal abstract class CoverageInfo
 
     public double GetTotalPercentage()
     {
-        var coveragePercentage = Data[0];
-        if (double.IsNaN(coveragePercentage) || double.IsNegativeInfinity(coveragePercentage))
-        {
-            coveragePercentage = 0;
-        }
-        else if (double.IsPositiveInfinity(coveragePercentage))
-        {
-            coveragePercentage = 100;
-        }
-
-        return coveragePercentage;
+        return Data[0].ToValidPercentage();
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/Coverage/Models/Global/CoverageInfo.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/Models/Global/CoverageInfo.cs
@@ -66,6 +66,14 @@ internal abstract class CoverageInfo
         }
 
         _data = new[] { Math.Round((executed / total) * 100, 2), total, executed };
+        if (double.IsNaN(_data[0]) || double.IsNegativeInfinity(_data[0]))
+        {
+            _data[0] = 0;
+        }
+        else if (double.IsPositiveInfinity(_data[0]))
+        {
+            _data[0] = 100;
+        }
     }
 
     protected void ClearData()
@@ -86,5 +94,20 @@ internal abstract class CoverageInfo
                 component.ClearData();
             }
         }
+    }
+
+    public double GetTotalPercentage()
+    {
+        var coveragePercentage = Data[0];
+        if (double.IsNaN(coveragePercentage) || double.IsNegativeInfinity(coveragePercentage))
+        {
+            coveragePercentage = 0;
+        }
+        else if (double.IsPositiveInfinity(coveragePercentage))
+        {
+            coveragePercentage = 100;
+        }
+
+        return coveragePercentage;
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -423,7 +423,9 @@ public sealed class TestModule
             if (!CIVisibility.HasSkippableTests())
             {
                 // Adds the global code coverage percentage to the module
-                SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.GetTotalPercentage());
+                var codeCoveragePercentage = globalCoverage.GetTotalPercentage();
+                SetTag(CodeCoverageTags.PercentageOfTotalLines, codeCoveragePercentage);
+                _fakeSession?.SetTag(CodeCoverageTags.PercentageOfTotalLines, codeCoveragePercentage);
             }
 
             // If the code coverage path environment variable is set, we store the json file
@@ -459,7 +461,9 @@ public sealed class TestModule
 
         if (CIVisibility.Settings.CodeCoverageEnabled.HasValue)
         {
-            span.SetTag(CodeCoverageTags.Enabled, CIVisibility.Settings.CodeCoverageEnabled.Value ? "true" : "false");
+            var value = CIVisibility.Settings.CodeCoverageEnabled.Value ? "true" : "false";
+            span.SetTag(CodeCoverageTags.Enabled, value);
+            _fakeSession?.SetTag(CodeCoverageTags.Enabled, value);
         }
 
         span.Finish(duration.Value);

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -423,7 +423,7 @@ public sealed class TestModule
             if (!CIVisibility.HasSkippableTests())
             {
                 // Adds the global code coverage percentage to the module
-                span.SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.Data[0].ToString(CultureInfo.InvariantCulture));
+                SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.GetTotalPercentage());
             }
 
             // If the code coverage path environment variable is set, we store the json file

--- a/tracer/src/Datadog.Trace/ExtensionMethods/DoubleExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/DoubleExtensions.cs
@@ -1,0 +1,24 @@
+// <copyright file="DoubleExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.ExtensionMethods;
+
+internal static class DoubleExtensions
+{
+    /// <summary>
+    /// Ensure any double value is a valid percentage number in the range [0,100]
+    /// </summary>
+    /// <param name="value">Original percentage value</param>
+    /// <returns>Sanitized value</returns>
+    public static double ToValidPercentage(this double value)
+    {
+        if (double.IsNaN(value) || value < 0)
+        {
+            return 0;
+        }
+
+        return value > 100 ? 100 : value;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
@@ -111,7 +111,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
 
             testSession.Should().NotBeNull();
             testSession.Meta.Should().Contain(new KeyValuePair<string, string>(CodeCoverageTags.Enabled, "true"));
-            testSession.Meta.Should().Contain(new KeyValuePair<string, string>(CodeCoverageTags.PercentageOfTotalLines, "83.33"));
+            testSession.Metrics.Should().Contain(new KeyValuePair<string, double>(CodeCoverageTags.PercentageOfTotalLines, 83.33));
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR ensures that the Code Coverage percentage tag is always sent as a valid number inside the `metrics` dictionary.
Previously we were converting the value to string, and in some cases the backend couldn't convert the value to a valid number (eg `NaN`)

## Reason for change

We detected an issue in a customer org where the percentage value was invalid.
