### PR TITLE
[Profiler] Check choco exit code and retry if needed

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1481,9 +1481,16 @@ stages:
     steps:
     - powershell: |
         choco install cppcheck -y --version 2.9
+        $errorCode = $LASTEXITCODE
+        if ($errorCode -ne 0)
+        {
+          # something went wrong. Let's retry
+          exit 1
+        }
         Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};C:\Program Files\Cppcheck";
         refreshenv
       displayName: Install CppCheck
+      retryCountOnTaskFailure: 3
 
     - template: steps/clone-repo.yml
       parameters:


### PR DESCRIPTION
## Summary of changes

Make sure we understand why the `static_analysis_profiler` job fails and fix cppcheck installation.

## Reason for change

Time to time, `cppcheck` installation fails, but the step still succeeds because the `refreshenv` call succeeded.  In the next step fails because `choco.exe` was not found.
It's hard at first glance to know what was the issue: was it a cppcheck installation faiilure ? were there errors reported by cppcheck ? ...

## Implementation details
- Fail-fast by checking `cppcheck` installation
- Add retries

## Test coverage

It looks like the current job failed twice the cppcheck installation :) but then succeeded
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
