### PR TITLE
Disable LZMA on Linux

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -34,9 +34,9 @@
 
     <StripSymbols>true</StripSymbols>
 
-    <!-- Don't enable LZMA on Alpine because it randomly crashes with exit code 127
+    <!-- Don't enable LZMA on Linux because it randomly crashes with exit code 127
          We should check the UPX changelog whenever we upgrade to see if there's any relevant fix -->
-    <PublishLzmaCompressed Condition="'$(RuntimeIdentifier)' != 'linux-musl-x64'">true</PublishLzmaCompressed>    
+    <PublishLzmaCompressed Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishLzmaCompressed>    
 
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary of changes

Disable LZMA compression for dd-dotnet on Linux.

## Reason for change

It causes random failures with exit code 127. I initially assumed it only impacted Alpine, but we've seen at least one report of failure on Centos.