### PR TITLE
[All] Run throughput jobs when they should run

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3625,7 +3625,12 @@ stages:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
 - stage: throughput
-  condition: and(succeeded(), eq(variables.isMainRepository, true))
+  condition: >
+    and(succeeded(), 
+        eq(variables.isMainRepository, true),
+        or(
+          eq(variables.isMainBranch, true),
+          eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')))
   dependsOn: [package_linux, package_arm64, build_windows_tracer, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -3772,7 +3777,12 @@ stages:
       continueOnError: true
 
 - stage: throughput_profiler
-  condition: and(succeeded(), eq(variables.isMainRepository, true))
+  condition: >
+    and(succeeded(), 
+        eq(variables.isMainRepository, true),
+        or(
+          eq(variables.isMainBranch, true),
+          eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')))
   dependsOn: [package_linux, generate_variables, build_windows_tracer, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -3870,7 +3880,12 @@ stages:
       continueOnError: true
 
 - stage: throughput_appsec
-  condition: and(succeeded(), eq(variables.isMainRepository, true))
+  condition: >
+    and(succeeded(), 
+        eq(variables.isMainRepository, true),
+        or(
+          eq(variables.isMainBranch, true),
+          eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')))
   dependsOn: [package_linux, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3772,13 +3772,7 @@ stages:
       continueOnError: true
 
 - stage: throughput_profiler
-  condition: > 
-    and(
-      succeeded(), 
-      ne(variables['isNgenTestBuild'], 'True'),
-      eq(variables.isMainRepository, true),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
-    )
+  condition: and(succeeded(), eq(variables.isMainRepository, true))
   dependsOn: [package_linux, generate_variables, build_windows_tracer, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]


### PR DESCRIPTION
## Summary of changes

Run throughput jobs only when it's needed: *always* on master and on each PR only per product.

## Reason for change

throughput jobs should run when it's needed: when there are changes for products and always on master

## Implementation details

Update the condition on each throughput jobs.

Clean up condition

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
