### PR TITLE
[CI Visibility] LifeTimeManager handling on VSTest

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -33,8 +33,6 @@ namespace Datadog.Trace.Ci
 
         internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(CIVisibility));
 
-        public static event EventHandler? CIVisibilityExit;
-
         public static bool Enabled => _enabledLazy.Value;
 
         public static bool IsRunning => Interlocked.CompareExchange(ref _firstInitialization, 0, 0) == 0;
@@ -260,7 +258,8 @@ namespace Datadog.Trace.Ci
         {
             if (IsRunning)
             {
-                CIVisibilityExit?.Invoke(null, EventArgs.Empty);
+                Log.Information("CI Visibility is exiting.");
+                LifetimeManager.Instance.RunShutdownTasks();
                 Interlocked.Exchange(ref _firstInitialization, 1);
             }
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestAssemblyInfoExecuteAssemblyCleanupIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestAssemblyInfoExecuteAssemblyCleanupIntegration.cs
@@ -59,6 +59,9 @@ public static class TestAssemblyInfoExecuteAssemblyCleanupIntegration
             }
 
             module.Close();
+
+            // Because we are auto-instrumenting a VSTest testhost process we need to manually call the shutdown process
+            CIVisibility.Close();
         }
 
         return CallTargetReturn.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestAssemblyInfoRunAssemblyCleanupIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/TestAssemblyInfoRunAssemblyCleanupIntegration.cs
@@ -66,6 +66,9 @@ public static class TestAssemblyInfoRunAssemblyCleanupIntegration
             }
 
             module.Close();
+
+            // Because we are auto-instrumenting a VSTest testhost process we need to manually call the shutdown process
+            CIVisibility.Close();
         }
 
         return new CallTargetReturn<TReturn>(returnValue);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/UnitTestRunnerRunCleanupIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/UnitTestRunnerRunCleanupIntegration.cs
@@ -40,6 +40,9 @@ public static class UnitTestRunnerRunCleanupIntegration
         if (TestModule.Current is { } module)
         {
             module.Close();
+
+            // Because we are auto-instrumenting a VSTest testhost process we need to manually call the shutdown process
+            CIVisibility.Close();
         }
 
         return new CallTargetReturn<TReturn>(returnValue);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitWorkItemWorkItemCompleteIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitWorkItemWorkItemCompleteIntegration.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.ComponentModel;
+using Datadog.Trace.Ci;
 using Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit;
@@ -38,6 +39,9 @@ public static class NUnitWorkItemWorkItemCompleteIntegration
         {
             case "Assembly" when NUnitIntegration.GetTestModuleFrom(item) is { } module:
                 module.Close();
+                // Because we are auto-instrumenting a VSTest testhost process we need to manually call the shutdown process
+                CIVisibility.Close();
+
                 break;
             case "TestFixture" when NUnitIntegration.GetTestSuiteFrom(item) is { } suite:
                 suite.Close();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerBeforeTestAssemblyFinishedAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerBeforeTestAssemblyFinishedAsyncIntegration.cs
@@ -50,6 +50,9 @@ public static class XUnitTestAssemblyRunnerBeforeTestAssemblyFinishedAsyncIntegr
         if (TestModule.Current is { } testModule)
         {
             await testModule.CloseAsync().ConfigureAwait(false);
+
+            // Because we are auto-instrumenting a VSTest testhost process we need to manually call the shutdown process
+            CIVisibility.Close();
         }
 
         return returnValue;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerRunAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestAssemblyRunnerRunAsyncIntegration.cs
@@ -109,6 +109,9 @@ public static class XUnitTestAssemblyRunnerRunAsyncIntegration
         if (state.State is TestModule testModule)
         {
             await testModule.CloseAsync().ConfigureAwait(false);
+
+            // Because we are auto-instrumenting a VSTest testhost process we need to manually call the shutdown process
+            CIVisibility.Close();
         }
 
         return returnValue;

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Ci;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 
@@ -26,6 +27,7 @@ namespace Datadog.Trace
             // Register callbacks to make sure we flush the traces before exiting
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
             AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
+            CIVisibility.CIVisibilityExit += CiVisibilityExit;
 
             try
             {
@@ -92,6 +94,13 @@ namespace Datadog.Trace
         {
             RunShutdownTasks();
             AppDomain.CurrentDomain.DomainUnload -= CurrentDomain_DomainUnload;
+        }
+
+        private void CiVisibilityExit(object sender, EventArgs e)
+        {
+            Log.Information("CI Visibility is exiting.");
+            RunShutdownTasks();
+            CIVisibility.CIVisibilityExit -= CiVisibilityExit;
         }
 
         private void RunShutdownTasks()

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -27,7 +27,6 @@ namespace Datadog.Trace
             // Register callbacks to make sure we flush the traces before exiting
             AppDomain.CurrentDomain.ProcessExit += CurrentDomain_ProcessExit;
             AppDomain.CurrentDomain.DomainUnload += CurrentDomain_DomainUnload;
-            CIVisibility.CIVisibilityExit += CiVisibilityExit;
 
             try
             {
@@ -96,14 +95,7 @@ namespace Datadog.Trace
             AppDomain.CurrentDomain.DomainUnload -= CurrentDomain_DomainUnload;
         }
 
-        private void CiVisibilityExit(object sender, EventArgs e)
-        {
-            Log.Information("CI Visibility is exiting.");
-            RunShutdownTasks();
-            CIVisibility.CIVisibilityExit -= CiVisibilityExit;
-        }
-
-        private void RunShutdownTasks()
+        public void RunShutdownTasks()
         {
             var current = SynchronizationContext.Current;
             try


### PR DESCRIPTION
## Summary of changes

This PR adds a manual handling for the LifeTimeManager shutdown process on VSTest auto-instrumentation.

## Reason for change

Due to:
- https://github.com/microsoft/vstest/issues/1900#issuecomment-457488472
- https://github.com/Microsoft/vstest/blob/2d4508232b6655a4f363b8bbcc887441c7d1d334/src/Microsoft.TestPlatform.CrossPlatEngine/Client/ProxyOperationManager.cs#L197

The `LifeTimeManager` shutdown process inside a CIVisibility session gets killed after 100ms so any pending requests (eg. Telemetry requests) are cancelled. 

## Implementation details

We want to manually call the shutdown process from the auto-instrumentation after we close the module/assembly a no more test are added. 

