### PR TITLE
Fix flake in `TracerSettingsTests` due to using environment variables

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsServerlessTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsServerlessTests.cs
@@ -1,0 +1,75 @@
+﻿// <copyright file="TracerSettingsServerlessTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Configuration;
+
+[Collection(nameof(EnvironmentVariablesTestCollection))]
+public class TracerSettingsServerlessTests : SettingsTestsBase
+{
+    // These tests rely on Lambda.Create() which uses environment variables
+    // See TracerSettingsTests for tests which don't rely on any environment variables
+    [Theory]
+    [InlineData("test1,, ,test2", false, false, new[] { "TEST1", "TEST2" })]
+    [InlineData("test1,, ,test2", true, true, new[] { "TEST1", "TEST2" })]
+    [InlineData(null, true, true, new[] { "azuredefault" })]
+    [InlineData(null, false, true, new[] { "/2018-06-01/RUNTIME/INVOCATION/" })]
+    [InlineData(null, false, false, new string[0])]
+    [InlineData("", true, true, new string[0])]
+    public void HttpClientExcludedUrlSubstrings(string value, bool isRunningInAppService, bool isRunningInLambda, string[] expected)
+    {
+        if (expected.Length == 1 && expected[0] == "azuredefault")
+        {
+            expected = ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions.Split(',').Select(s => s.Trim()).ToArray();
+        }
+
+        var previous = isRunningInLambda
+                           ? SetLambdaEnvironmentForTests("functionName", "serviceName::handlerName")
+                           : SetLambdaEnvironmentForTests(null, null);
+        try
+        {
+            var source = CreateConfigurationSource(
+                (ConfigurationKeys.HttpClientExcludedUrlSubstrings, value),
+                (ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, isRunningInAppService ? "1" : "0"));
+
+            var settings = new TracerSettings(source);
+
+            settings.HttpClientExcludedUrlSubstrings.Should().BeEquivalentTo(expected);
+        }
+        finally
+        {
+            foreach (var kvp in previous)
+            {
+                System.Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
+            }
+        }
+    }
+
+    private Dictionary<string, string> SetLambdaEnvironmentForTests(
+        string functionName, string handlerName, [CallerFilePath] string extensionPath = null)
+    {
+        var previous = new Dictionary<string, string>
+        {
+            { LambdaMetadata.FunctionNameEnvVar, System.Environment.GetEnvironmentVariable(LambdaMetadata.FunctionNameEnvVar) },
+            { LambdaMetadata.HandlerEnvVar, System.Environment.GetEnvironmentVariable(LambdaMetadata.HandlerEnvVar) },
+            { LambdaMetadata.ExtensionPathEnvVar, System.Environment.GetEnvironmentVariable(LambdaMetadata.ExtensionPathEnvVar) },
+        };
+
+        System.Environment.SetEnvironmentVariable(LambdaMetadata.FunctionNameEnvVar, functionName);
+        System.Environment.SetEnvironmentVariable(LambdaMetadata.HandlerEnvVar, handlerName);
+        System.Environment.SetEnvironmentVariable(LambdaMetadata.ExtensionPathEnvVar, extensionPath);
+        return previous;
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -7,9 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using Datadog.Trace.Agent;
-using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
@@ -781,41 +779,8 @@ namespace Datadog.Trace.Tests.Configuration
             settings.TraceEnabled.Should().BeFalse();
         }
 
-        [Theory]
-        [InlineData("test1,, ,test2", false, false, new[] { "TEST1", "TEST2" })]
-        [InlineData("test1,, ,test2", true, true, new[] { "TEST1", "TEST2" })]
-        [InlineData(null, true, true, new[] { "azuredefault" })]
-        [InlineData(null, false, true, new[] { "/2018-06-01/RUNTIME/INVOCATION/" })]
-        [InlineData(null, false, false, new string[0])]
-        [InlineData("", true, true, new string[0])]
-        public void HttpClientExcludedUrlSubstrings(string value, bool isRunningInAppService, bool isRunningInLambda, string[] expected)
-        {
-            if (expected.Length == 1 && expected[0] == "azuredefault")
-            {
-                expected = ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions.Split(',').Select(s => s.Trim()).ToArray();
-            }
-
-            var previous = isRunningInLambda
-                               ? SetLambdaEnvironmentForTests("functionName", "serviceName::handlerName")
-                               : SetLambdaEnvironmentForTests(null, null);
-            try
-            {
-                var source = CreateConfigurationSource(
-                    (ConfigurationKeys.HttpClientExcludedUrlSubstrings, value),
-                    (ConfigurationKeys.AzureAppService.AzureAppServicesContextKey, isRunningInAppService ? "1" : "0"));
-
-                var settings = new TracerSettings(source);
-
-                settings.HttpClientExcludedUrlSubstrings.Should().BeEquivalentTo(expected);
-            }
-            finally
-            {
-                foreach (var kvp in previous)
-                {
-                    System.Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
-                }
-            }
-        }
+        // The HttpClientExcludedUrlSubstrings tests rely on Lambda.Create() which uses environment variables
+        // See TracerSettingsServerlessTests for tests which rely on environment variables
 
         [Theory]
         [InlineData("", DbmPropagationLevel.Disabled)]
@@ -920,22 +885,6 @@ namespace Datadog.Trace.Tests.Configuration
             }
 
             Assert.Empty(statusCodes);
-        }
-
-        private Dictionary<string, string> SetLambdaEnvironmentForTests(
-            string functionName, string handlerName, [CallerFilePath] string extensionPath = null)
-        {
-            var previous = new Dictionary<string, string>
-            {
-                { LambdaMetadata.FunctionNameEnvVar, System.Environment.GetEnvironmentVariable(LambdaMetadata.FunctionNameEnvVar) },
-                { LambdaMetadata.HandlerEnvVar, System.Environment.GetEnvironmentVariable(LambdaMetadata.HandlerEnvVar) },
-                { LambdaMetadata.ExtensionPathEnvVar, System.Environment.GetEnvironmentVariable(LambdaMetadata.ExtensionPathEnvVar) },
-            };
-
-            System.Environment.SetEnvironmentVariable(LambdaMetadata.FunctionNameEnvVar, functionName);
-            System.Environment.SetEnvironmentVariable(LambdaMetadata.HandlerEnvVar, handlerName);
-            System.Environment.SetEnvironmentVariable(LambdaMetadata.ExtensionPathEnvVar, extensionPath);
-            return previous;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/EnvironmentVariablesTestCollection.cs
+++ b/tracer/test/Datadog.Trace.Tests/EnvironmentVariablesTestCollection.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="EnvironmentVariablesTestCollection.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Xunit;
+
+namespace Datadog.Trace.Tests;
+
+/// <summary>
+/// Used to indicate a test modifies environment variables, so shouldn't be run in parallel with other similar tests
+/// </summary>
+[CollectionDefinition(nameof(EnvironmentVariablesTestCollection), DisableParallelization = true)]
+public class EnvironmentVariablesTestCollection
+{
+}

--- a/tracer/test/Datadog.Trace.Tests/ServerlessTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ServerlessTests.cs
@@ -13,10 +13,11 @@ using Xunit;
 
 namespace Datadog.Trace.Tests
 {
+    [Collection(nameof(EnvironmentVariablesTestCollection))]
     public class ServerlessTests : IDisposable
     {
-        private const string FunctionNameEnvVar = "AWS_LAMBDA_FUNCTION_NAME";
-        private const string HandlerEnvVar = "_HANDLER";
+        private const string FunctionNameEnvVar = LambdaMetadata.FunctionNameEnvVar;
+        private const string HandlerEnvVar = LambdaMetadata.HandlerEnvVar;
         private readonly Dictionary<string, string> _originalEnvVars;
 
         public ServerlessTests()


### PR DESCRIPTION
## Summary of changes

Fix flake in unit tests

## Reason for change

We don't like flake

## Implementation details

The `Lambda.Create()` method is called in the `TracerSettings` constructor. This method relies explicitly on environment variables (not `IConfigurationSource`). This makes it flaky in unit tests if run in parallel with tests that manipulate environment variables. 

To allow running the remainder of the `TracerSettingsTests` in parallel, removed only the flaky tests to a separate class, and decorated all applicable tests with a non-parallelizing collection

## Test coverage

Same coverage, just shuffled some things

## Other details
This flaked on mac, but "luckily" we automatically re-run mac tests because they're so flaky... So it was only caught in ci-visibility!

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
