### PR TITLE
[Dynamic Instrumentation] Improved probe status polling mechanism + fixed snapshot issues

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/DebuggerSettings.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Debugger
         public const int DefaultMaxNumberOfFieldsToCopy = 20;
 
         private const int DefaultUploadBatchSize = 100;
-        private const int DefaultDiagnosticsIntervalSeconds = 5;
+        private const int DefaultDiagnosticsIntervalSeconds = 60 * 60; // 1 hour
         private const int DefaultUploadFlushIntervalMilliseconds = 0;
 
         public DebuggerSettings(IConfigurationSource? source, IConfigurationTelemetry telemetry)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeInfo.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeInfo.cs
@@ -9,6 +9,7 @@ namespace Datadog.Trace.Debugger.Expressions
 {
     internal readonly record struct ProbeInfo(
         string ProbeId,
+        int ProbeVersion,
         ProbeType ProbeType,
         ProbeLocation ProbeLocation,
         EvaluateAt EvaluateAt,
@@ -19,6 +20,8 @@ namespace Datadog.Trace.Debugger.Expressions
         TargetSpan? TargetSpan)
     {
         internal string ProbeId { get; } = ProbeId;
+
+        internal int ProbeVersion { get; } = ProbeVersion;
 
         internal ProbeType ProbeType { get; } = ProbeType;
 

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -69,6 +69,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
             ProbeInfo = new ProbeInfo(
                 probe.Id,
+                probe.Version ?? 0,
                 probeType,
                 location,
                 evaluateAt,
@@ -427,7 +428,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
                     if (!ProbeInfo.IsFullSnapshot)
                     {
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ref info);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
                         LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                         break;
                     }
@@ -446,7 +447,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
                     if (!ProbeInfo.IsFullSnapshot)
                     {
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ref info);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
                         LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                         break;
                     }
@@ -473,7 +474,7 @@ namespace Datadog.Trace.Debugger.Expressions
                             snapshotCreator.CaptureExitMethodEndMarker(ref info);
                         }
 
-                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ref info);
+                        var snapshot = snapshotCreator.FinalizeMethodSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
                         LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                         snapshotCreator.Stop();
                         break;
@@ -512,7 +513,7 @@ namespace Datadog.Trace.Debugger.Expressions
                         snapshotCreator.CaptureEndLine(ref info);
                     }
 
-                    var snapshot = snapshotCreator.FinalizeLineSnapshot(ProbeInfo.ProbeId, ref info);
+                    var snapshot = snapshotCreator.FinalizeLineSnapshot(ProbeInfo.ProbeId, ProbeInfo.ProbeVersion, ref info);
                     LiveDebugger.Instance.AddSnapshot(ProbeInfo.ProbeId, snapshot);
                     snapshotCreator.Stop();
                     break;

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -634,7 +634,7 @@ namespace Datadog.Trace.Debugger.Snapshots
         }
 
         // Finalize snapshot
-        internal string FinalizeLineSnapshot<T>(string probeId, ref CaptureInfo<T> info)
+        internal string FinalizeLineSnapshot<T>(string probeId, int probeVersion, ref CaptureInfo<T> info)
         {
             using (this)
             {
@@ -649,6 +649,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                 AddEvaluationErrors()
                    .AddProbeInfo(
                         probeId,
+                        probeVersion,
                         info.LineCaptureInfo.LineNumber,
                         info.LineCaptureInfo.ProbeFilePath)
                    .FinalizeSnapshot(
@@ -661,7 +662,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             }
         }
 
-        internal string FinalizeMethodSnapshot<T>(string probeId, ref CaptureInfo<T> info)
+        internal string FinalizeMethodSnapshot<T>(string probeId, int probeVersion, ref CaptureInfo<T> info)
         {
             using (this)
             {
@@ -675,6 +676,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                 AddEvaluationErrors()
                    .AddProbeInfo(
                         probeId,
+                        probeVersion,
                         methodName,
                         typeFullName)
                    .FinalizeSnapshot(
@@ -727,13 +729,16 @@ namespace Datadog.Trace.Debugger.Snapshots
             return this;
         }
 
-        internal DebuggerSnapshotCreator AddProbeInfo<T>(string probeId, T methodNameOrLineNumber, string typeFullNameOrFilePath)
+        internal DebuggerSnapshotCreator AddProbeInfo<T>(string probeId, int probeVersion, T methodNameOrLineNumber, string typeFullNameOrFilePath)
         {
             _jsonWriter.WritePropertyName("probe");
             _jsonWriter.WriteStartObject();
 
             _jsonWriter.WritePropertyName("id");
             _jsonWriter.WriteValue(probeId);
+
+            _jsonWriter.WritePropertyName("version");
+            _jsonWriter.WriteValue(probeVersion);
 
             _jsonWriter.WritePropertyName("location");
             _jsonWriter.WriteStartObject();

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotSerializer.cs
@@ -211,13 +211,14 @@ namespace Datadog.Trace.Debugger.Snapshots
         private static void WriteFieldsInternal(object source, JsonWriter jsonWriter, CancellationTokenSource cts, int currentDepth, IEnumerable<MemberInfo> fields, string fieldsObjectName)
         {
             int index = 0;
+            var isFieldCountReached = false;
             foreach (var field in fields)
             {
                 var fieldOrPropertyName = GetAutoPropertyOrFieldName(field.Name);
 
                 if (index >= _maximumNumberOfFieldsToCopy)
                 {
-                    WriteNotCapturedReason(jsonWriter, NotCapturedReason.fieldCount);
+                    isFieldCountReached = true;
                     break;
                 }
 
@@ -252,6 +253,11 @@ namespace Datadog.Trace.Debugger.Snapshots
             {
                 jsonWriter.WriteEndObject();
             }
+
+            if (isFieldCountReached)
+            {
+                WriteNotCapturedReason(jsonWriter, NotCapturedReason.fieldCount);
+            }
         }
 
         private static void SerializeEnumerable(
@@ -269,8 +275,8 @@ namespace Datadog.Trace.Debugger.Snapshots
                 {
                     jsonWriter.WritePropertyName("type");
                     jsonWriter.WriteValue(type.Name);
-                    jsonWriter.WritePropertyName("value");
-                    jsonWriter.WriteValue($"count: {collection.Count}");
+                    jsonWriter.WritePropertyName("size");
+                    jsonWriter.WriteValue(collection.Count);
                     jsonWriter.WritePropertyName(isDictionary ? "entries" : "elements");
                     jsonWriter.WriteStartArray();
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncCallChain.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncCallChain.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -62,7 +62,8 @@
           "location": {
             "method": "Async1",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncCallChain"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -117,7 +118,8 @@
           "location": {
             "method": "Async2",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncCallChain"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentEntryFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentEntryFullSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -74,7 +74,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.AsyncFieldArgumentEntryFullSnapshot"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentEntryPartialSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentEntryPartialSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": null,
             "type": "Unknown"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentLocalExitFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentLocalExitFullSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -50,7 +50,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.AsyncFieldArgumentLocalExitFullSnapshot"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentLocalExitPartialSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncFieldArgumentLocalExitPartialSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.AsyncFieldArgumentLocalExitPartialSnapshot"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -54,7 +54,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncInstanceMethod"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -111,7 +112,8 @@
             "lines": [
               21
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInterfaceProperties.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInterfaceProperties.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -92,7 +92,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncInterfaceProperties"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -175,7 +176,8 @@
             "lines": [
               34
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -103,8 +103,8 @@
                         "value": "Person"
                       }
                     ],
-                    "type": "List`1",
-                    "value": "count: 1"
+                    "size": 1,
+                    "type": "List`1"
                   },
                   "Id": {
                     "type": "Guid",
@@ -197,8 +197,8 @@
                             "value": "Person"
                           }
                         ],
-                        "type": "List`1",
-                        "value": "count: 1"
+                        "size": 1,
+                        "type": "List`1"
                       },
                       "Id": {
                         "type": "Guid",
@@ -314,8 +314,8 @@
                         "value": "Person"
                       }
                     ],
-                    "type": "List`1",
-                    "value": "count: 1"
+                    "size": 1,
+                    "type": "List`1"
                   },
                   "Id": {
                     "type": "Guid",
@@ -408,8 +408,8 @@
                             "value": "Person"
                           }
                         ],
-                        "type": "List`1",
-                        "value": "count: 1"
+                        "size": 1,
+                        "type": "List`1"
                       },
                       "Id": {
                         "type": "Guid",
@@ -448,7 +448,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest+NestedAsyncGenericStruct"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -543,7 +544,8 @@
             "lines": [
               23
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -638,7 +640,8 @@
             "lines": [
               25
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -733,7 +736,8 @@
             "lines": [
               26
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -794,8 +798,8 @@
                 },
                 "children": {
                   "elements": [],
-                  "type": "List`1",
-                  "value": "count: 0"
+                  "size": 0,
+                  "type": "List`1"
                 },
                 "person": {
                   "isNull": "true",
@@ -829,7 +833,8 @@
             "lines": [
               27
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -949,8 +954,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "isNull": "true",
@@ -984,7 +989,8 @@
             "lines": [
               28
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -1104,8 +1110,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "fields": {
@@ -1201,8 +1207,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1244,7 +1250,8 @@
             "lines": [
               29
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -1365,8 +1372,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1459,8 +1466,8 @@
                               "value": "Person"
                             }
                           ],
-                          "type": "List`1",
-                          "value": "count: 1"
+                          "size": 1,
+                          "type": "List`1"
                         },
                         "Id": {
                           "type": "Guid",
@@ -1498,7 +1505,8 @@
             "lines": [
               45
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -1619,8 +1627,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1713,8 +1721,8 @@
                               "value": "Person"
                             }
                           ],
-                          "type": "List`1",
-                          "value": "count: 1"
+                          "size": 1,
+                          "type": "List`1"
                         },
                         "Id": {
                           "type": "Guid",
@@ -1752,7 +1760,8 @@
             "lines": [
               46
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -1873,8 +1882,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1967,8 +1976,8 @@
                               "value": "Person"
                             }
                           ],
-                          "type": "List`1",
-                          "value": "count: 1"
+                          "size": 1,
+                          "type": "List`1"
                         },
                         "Id": {
                           "type": "Guid",
@@ -2006,7 +2015,8 @@
             "lines": [
               47
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncMethodInsideTaskRun.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncMethodInsideTaskRun"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -101,7 +102,8 @@
           "location": {
             "method": "RunInsideTask",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncMethodInsideTaskRun"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCall.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCall.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCall"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -109,7 +110,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCall"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -172,7 +174,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCall"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCallWithMultipleProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncRecursiveCallWithMultipleProbes.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,70 +46,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
-        },
-        "stack": "ScrubbedValue",
-        "timestamp": "ScrubbedValue"
-      }
-    },
-    "logger": {
-      "method": "Recursive",
-      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes",
-      "thread_id": "ScrubbedValue",
-      "thread_name": "ScrubbedValue",
-      "version": "2"
-    },
-    "message": "ScrubbedValue",
-    "service": "probes"
-  },
-  {
-    "dd.span_id": "ScrubbedValue",
-    "dd.trace_id": "ScrubbedValue",
-    "ddsource": "dd_debugger",
-    "ddtags": "Unknown",
-    "debugger": {
-      "snapshot": {
-        "captures": {
-          "entry": {
-            "arguments": {
-              "i": {
-                "type": "Int32",
-                "value": "0"
-              },
-              "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
-              }
-            }
           },
-          "return": {
-            "arguments": {
-              "i": {
-                "type": "Int32",
-                "value": "1"
-              },
-              "this": {
-                "type": "AsyncRecursiveCallWithMultipleProbes",
-                "value": "AsyncRecursiveCallWithMultipleProbes"
-              }
-            },
-            "locals": {
-              "@return": {
-                "type": "Int32",
-                "value": "3"
-              }
-            }
-          }
-        },
-        "duration": "ScrubbedValue",
-        "id": "ScrubbedValue",
-        "language": "dotnet",
-        "probe": {
-          "id": "ScrubbedValue",
-          "location": {
-            "method": "Recursive",
-            "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -172,7 +110,72 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "i": {
+                "type": "Int32",
+                "value": "0"
+              },
+              "this": {
+                "type": "AsyncRecursiveCallWithMultipleProbes",
+                "value": "AsyncRecursiveCallWithMultipleProbes"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "i": {
+                "type": "Int32",
+                "value": "1"
+              },
+              "this": {
+                "type": "AsyncRecursiveCallWithMultipleProbes",
+                "value": "AsyncRecursiveCallWithMultipleProbes"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "3"
+              }
+            }
           }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -235,7 +238,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -298,7 +302,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -361,7 +366,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -424,7 +430,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -487,7 +494,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -550,7 +558,8 @@
           "location": {
             "method": "Recursive",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncRecursiveCallWithMultipleProbes"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -108,8 +108,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -153,7 +153,8 @@
             "lines": [
               35
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -278,8 +279,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -323,7 +324,8 @@
             "lines": [
               36
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -448,8 +450,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -493,7 +495,8 @@
             "lines": [
               37
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -618,8 +621,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -657,7 +660,8 @@
             "lines": [
               42
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -108,8 +108,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -153,7 +153,8 @@
             "lines": [
               35
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -278,8 +279,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -323,7 +324,8 @@
             "lines": [
               36
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -448,8 +450,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -493,7 +495,8 @@
             "lines": [
               37
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -618,8 +621,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -657,7 +660,8 @@
             "lines": [
               42
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticMethod.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -54,7 +54,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncStaticMethod"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticType.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -58,7 +58,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncStaticType+StaticTypeInner"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -113,7 +114,8 @@
             "lines": [
               28
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,8 +46,8 @@
                     "value": "Room"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 2"
+                "size": 2,
+                "type": "List`1"
               }
             }
           },
@@ -110,8 +110,8 @@
                     "value": "Room"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 2"
+                "size": 2,
+                "type": "List`1"
               }
             }
           }
@@ -124,7 +124,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncTaskReturnTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnWithExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnWithExceptionTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,8 +46,8 @@
                     "value": "Room"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 2"
+                "size": 2,
+                "type": "List`1"
               }
             }
           },
@@ -96,8 +96,8 @@
                     "value": "Room"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 2"
+                "size": 2,
+                "type": "List`1"
               }
             },
             "throwable": {
@@ -115,7 +115,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncTaskReturnWithExceptionTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTemplateArgExitFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTemplateArgExitFullSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -54,7 +54,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.AsyncTemplateArgExitFullSnapshot"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTemplateLocalExitFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTemplateLocalExitFullSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -54,7 +54,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.AsyncTemplateLocalExitFullSnapshot"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -37,7 +37,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncThrowException"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncVoid.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncVoid.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -32,7 +32,8 @@
           "location": {
             "method": "VoidMethod",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncVoid"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -87,7 +88,8 @@
           "location": {
             "method": "VoidTaskMethod",
             "type": "Samples.Probes.TestRuns.SmokeTests.AsyncVoid"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -28,7 +28,8 @@
             "lines": [
               10
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -73,7 +74,8 @@
             "lines": [
               11
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -118,7 +120,8 @@
             "lines": [
               12
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#1..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -86,7 +86,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.ConditionAndTemplateChangeTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -159,7 +160,8 @@
             "lines": [
               70
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#2..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -82,7 +82,8 @@
           "location": {
             "method": "GetInt",
             "type": "Samples.Probes.TestRuns.ExpressionTests.ConditionAndTemplateChangeTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#3..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -56,7 +56,8 @@
             "lines": [
               70
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -84,7 +84,8 @@
             "lines": [
               23
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -185,7 +186,8 @@
             "lines": [
               24
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -286,7 +288,8 @@
             "lines": [
               25
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -353,8 +356,8 @@
                 },
                 "children": {
                   "elements": [],
-                  "type": "List`1",
-                  "value": "count: 0"
+                  "size": 0,
+                  "type": "List`1"
                 },
                 "person": {
                   "isNull": "true",
@@ -388,7 +391,8 @@
             "lines": [
               26
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -514,8 +518,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "isNull": "true",
@@ -549,7 +553,8 @@
             "lines": [
               27
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -675,8 +680,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "fields": {
@@ -772,8 +777,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -815,7 +820,8 @@
             "lines": [
               29
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -941,8 +947,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "fields": {
@@ -1038,8 +1044,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1081,7 +1087,8 @@
             "lines": [
               30
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -1207,8 +1214,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "fields": {
@@ -1304,8 +1311,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1347,7 +1354,8 @@
             "lines": [
               31
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -1473,8 +1481,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "fields": {
@@ -1570,8 +1578,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1613,7 +1621,8 @@
             "lines": [
               32
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -1739,8 +1748,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "fields": {
@@ -1836,8 +1845,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -1879,7 +1888,8 @@
             "lines": [
               34
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -2005,8 +2015,8 @@
                       "value": "Person"
                     }
                   ],
-                  "type": "List`1",
-                  "value": "count: 1"
+                  "size": 1,
+                  "type": "List`1"
                 },
                 "person": {
                   "fields": {
@@ -2102,8 +2112,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -2145,7 +2155,8 @@
             "lines": [
               35
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -166,7 +166,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.GenericMethodWithArguments"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -275,7 +276,8 @@
             "lines": [
               22
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -76,7 +76,8 @@
           "location": {
             "method": "CallMe",
             "type": "Samples.Probes.TestRuns.SmokeTests.GenericRefReturnTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtEntry.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -58,7 +58,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.GreaterThanArgumentTrueAtEntry"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtExit.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanArgumentTrueAtExit.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -40,7 +40,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.GreaterThanArgumentTrueAtExit"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanDuration.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanDuration.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -40,7 +40,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.GreaterThanDuration"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanField.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanField.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -50,7 +50,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.GreaterThanField"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanFieldAsync.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GreaterThanFieldAsync.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -50,7 +50,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.GreaterThanFieldAsync"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasArgumentsAndLocals.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -58,7 +58,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasArgumentsAndLocals"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueInitialized.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -78,7 +78,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasFieldLazyValueInitialized"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasFieldLazyValueNotInitialized.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -70,7 +70,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasFieldLazyValueNotInitialized"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalListOfObjects.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalListOfObjects.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -162,8 +162,8 @@
                     "value": "Person"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 2"
+                "size": 2,
+                "type": "List`1"
               },
               "p": {
                 "fields": {
@@ -308,8 +308,8 @@
                         "value": "Person"
                       }
                     ],
-                    "type": "List`1",
-                    "value": "count: 2"
+                    "size": 2,
+                    "type": "List`1"
                   },
                   "Id": {
                     "type": "Guid",
@@ -450,7 +450,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasLocalListOfObjects"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndArgumentsInGenericNestedType.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -162,8 +162,8 @@
                     "value": "Person"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 2"
+                "size": 2,
+                "type": "List`1"
               },
               "genericVarToString": {
                 "type": "String",
@@ -316,8 +316,8 @@
                         "value": "Person"
                       }
                     ],
-                    "type": "List`1",
-                    "value": "count: 2"
+                    "size": 2,
+                    "type": "List`1"
                   },
                   "Id": {
                     "type": "Guid",
@@ -458,7 +458,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasLocalsAndArgumentsInGenericNestedType+Test`1"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -62,7 +62,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasLocalsAndReturnValue"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -113,7 +114,8 @@
             "lines": [
               16
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -164,7 +166,8 @@
             "lines": [
               17
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -225,7 +228,8 @@
             "lines": [
               25
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasReturnValue.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -50,7 +50,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasReturnValue"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasVarAndMvar.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasVarAndMvar.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -50,8 +50,8 @@
                     "value": "Test`1"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 1"
+                "size": 1,
+                "type": "List`1"
               },
               "kk": {
                 "elements": [
@@ -60,8 +60,8 @@
                     "value": "Test`1"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 1"
+                "size": 1,
+                "type": "List`1"
               },
               "string": {
                 "type": "String",
@@ -74,8 +74,8 @@
                     "value": "Test`1"
                   }
                 ],
-                "type": "List`1",
-                "value": "count: 1"
+                "size": 1,
+                "type": "List`1"
               }
             }
           }
@@ -88,7 +88,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.HasVarAndMvar+Test`1"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.InstanceMethodWithArguments"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -95,7 +96,8 @@
             "lines": [
               18
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceVoidMethod.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -44,7 +44,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.InstanceVoidMethod"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InterfaceProperties.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InterfaceProperties.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -134,7 +134,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.InterfaceProperties"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -245,7 +246,8 @@
             "lines": [
               36
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InvalidCondition.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InvalidCondition.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.InvalidCondition"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionFullSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -44,7 +44,8 @@
             "lines": [
               26
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionPartialSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionPartialSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -16,7 +16,8 @@
             "lines": [
               26
             ]
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -54,7 +54,8 @@
           "location": {
             "method": "MethodToInstrument",
             "type": "Samples.Probes.TestRuns.SmokeTests.LineProbesWithRevertTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -117,7 +118,8 @@
             "lines": [
               41
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -180,7 +182,8 @@
             "lines": [
               55
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -243,7 +246,8 @@
             "lines": [
               56
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
             "lines": [
               41
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -109,7 +110,8 @@
             "lines": [
               55
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -172,7 +174,8 @@
             "lines": [
               56
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -235,7 +238,8 @@
             "lines": [
               57
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -298,7 +302,8 @@
             "lines": [
               58
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
             "lines": [
               46
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -109,7 +110,8 @@
             "lines": [
               46
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -172,7 +174,8 @@
             "lines": [
               46
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -235,7 +238,8 @@
             "lines": [
               59
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
             "lines": [
               55
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
             "lines": [
               46
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -109,7 +110,8 @@
             "lines": [
               46
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -172,7 +174,8 @@
             "lines": [
               46
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplateFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplateFullSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -44,7 +44,8 @@
             "lines": [
               23
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplatePartialSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplatePartialSnapshot.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -16,7 +16,8 @@
             "lines": [
               23
             ]
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -68,7 +68,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MethodThrowExceptionTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -129,7 +130,8 @@
             "lines": [
               26
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MetricCountNonNumeric.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MetricCountNonNumeric.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -20,7 +20,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MetricCountNonNumeric"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -66,7 +66,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MultiProbeTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -125,7 +126,8 @@
             "lines": [
               39
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -186,7 +188,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MultiProbeTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -78,7 +78,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MultiProbeWithSpanTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -147,7 +148,8 @@
             "lines": [
               53
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -216,7 +218,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MultiProbeWithSpanTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -247,7 +250,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MultiProbeWithSpanTest"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -38,7 +38,8 @@
             "lines": [
               25
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -93,7 +94,8 @@
             "lines": [
               25
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -148,7 +150,8 @@
             "lines": [
               32
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -203,7 +206,8 @@
             "lines": [
               32
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultidimensionalArrayTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultidimensionalArrayTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -60,8 +60,8 @@
                         "value": "Error"
                       }
                     ],
-                    "type": "State[]",
-                    "value": "count: 10"
+                    "size": 10,
+                    "type": "State[]"
                   },
                   {
                     "elements": [
@@ -106,12 +106,12 @@
                         "value": "Error"
                       }
                     ],
-                    "type": "State[]",
-                    "value": "count: 10"
+                    "size": 10,
+                    "type": "State[]"
                   }
                 ],
-                "type": "State[][]",
-                "value": "count: 2"
+                "size": 2,
+                "type": "State[][]"
               }
             }
           },
@@ -168,8 +168,8 @@
                         "value": "Error"
                       }
                     ],
-                    "type": "State[]",
-                    "value": "count: 10"
+                    "size": 10,
+                    "type": "State[]"
                   },
                   {
                     "elements": [
@@ -214,12 +214,12 @@
                         "value": "Error"
                       }
                     ],
-                    "type": "State[]",
-                    "value": "count: 10"
+                    "size": 10,
+                    "type": "State[]"
                   }
                 ],
-                "type": "State[][]",
-                "value": "count: 2"
+                "size": 2,
+                "type": "State[][]"
               }
             }
           }
@@ -232,7 +232,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.MultidimensionalArrayTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -40,7 +40,8 @@
           "location": {
             "method": "MethodToInstrument",
             "type": "Samples.Probes.TestRuns.SmokeTests.MultipleLineProbes"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -89,7 +90,8 @@
             "lines": [
               21
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -138,7 +140,8 @@
             "lines": [
               22
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -187,7 +190,8 @@
             "lines": [
               23
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -236,7 +240,8 @@
             "lines": [
               24
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -285,7 +290,8 @@
             "lines": [
               25
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
           "location": {
             "method": "IAmFine",
             "type": "Samples.Probes.TestRuns.SmokeTests.NotSupportedFailureTest+NormalStruct"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -109,7 +110,8 @@
           "location": {
             "method": "IAmFine",
             "type": "Samples.Probes.TestRuns.SmokeTests.NotSupportedFailureTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -160,7 +162,8 @@
             "lines": [
               24
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -211,7 +214,8 @@
             "lines": [
               25
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -262,7 +266,8 @@
             "lines": [
               26
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -313,7 +318,8 @@
             "lines": [
               27
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -364,7 +370,8 @@
             "lines": [
               28
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -413,7 +420,8 @@
             "lines": [
               51
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -462,7 +470,8 @@
             "lines": [
               64
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OpenGenericMethodInDerivedGenericType.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -98,7 +98,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.OpenGenericMethodInDerivedGenericType+Test2`1"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -58,7 +58,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -125,7 +126,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -470,7 +472,8 @@
           "location": {
             "method": "Method",
             "type": "OuterType+OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -533,7 +536,8 @@
           "location": {
             "method": "Method",
             "type": "OuterType+OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -680,7 +684,8 @@
           "location": {
             "method": "Method",
             "type": "Spicing.Things.Up.OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -743,7 +748,8 @@
           "location": {
             "method": "Method",
             "type": "Spicing.Things.Down.OuterType+OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -806,7 +812,8 @@
           "location": {
             "method": "Method",
             "type": "Spicing.Things.Up.OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -879,7 +886,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -942,7 +950,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.OverloadAndSimpleNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotAtEntry.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": null,
             "type": "Samples.Probes.TestRuns.ExpressionTests.PartialSnapshotAtEntry"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotAtExit.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotAtExit.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.PartialSnapshotAtExit"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotWithError.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotWithError.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -20,7 +20,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.PartialSnapshotWithError"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotWithLocalAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotWithLocalAtEntry.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -20,7 +20,8 @@
           "location": {
             "method": null,
             "type": "Samples.Probes.TestRuns.ExpressionTests.PartialSnapshotWithLocalAtEntry"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotWithLocalAtExit.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PartialSnapshotWithLocalAtExit.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.PartialSnapshotWithLocalAtExit"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#1..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": null,
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#2..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -66,7 +66,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#3..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": null,
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleMethodWithLocalsAndArgsTest_#4..verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -66,7 +66,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleMethodWithLocalsAndArgsTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,8 +46,8 @@
                     "value": "SimpleTypeNameTest"
                   }
                 ],
-                "type": "String[]",
-                "value": "count: 3"
+                "size": 3,
+                "type": "String[]"
               }
             },
             "throwable": {
@@ -70,7 +70,8 @@
           "location": {
             "method": "MethodToInstrument",
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleNestedTypeNameInGlobalNamespaceTest+NestedType"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,8 +46,8 @@
                     "value": "SimpleTypeNameTest"
                   }
                 ],
-                "type": "String[]",
-                "value": "count: 3"
+                "size": 3,
+                "type": "String[]"
               }
             },
             "throwable": {
@@ -70,7 +70,8 @@
           "location": {
             "method": "MethodToInstrument",
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleNestedTypeNameTest+NestedType"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,8 +46,8 @@
                     "value": "SimpleTypeNameTest"
                   }
                 ],
-                "type": "String[]",
-                "value": "count: 3"
+                "size": 3,
+                "type": "String[]"
               }
             },
             "throwable": {
@@ -70,7 +70,8 @@
           "location": {
             "method": "MethodToInstrument",
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleTypeNameInGlobalNamespaceTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,8 +46,8 @@
                     "value": "SimpleTypeNameTest"
                   }
                 ],
-                "type": "String[]",
-                "value": "count: 3"
+                "size": 3,
+                "type": "String[]"
               }
             },
             "throwable": {
@@ -70,7 +70,8 @@
           "location": {
             "method": "MethodToInstrument",
             "type": "Samples.Probes.TestRuns.SmokeTests.SimpleTypeNameTest"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -108,8 +108,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -217,8 +217,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -256,7 +256,8 @@
             "lines": [
               32
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -108,8 +108,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -217,8 +217,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -256,7 +256,8 @@
             "lines": [
               33
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -381,8 +382,8 @@
                           "value": "Person"
                         }
                       ],
-                      "type": "List`1",
-                      "value": "count: 1"
+                      "size": 1,
+                      "type": "List`1"
                     },
                     "Id": {
                       "type": "Guid",
@@ -420,7 +421,8 @@
             "lines": [
               38
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticMethodWithArguments.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -38,7 +38,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.StaticMethodWithArguments"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -83,7 +84,8 @@
             "lines": [
               18
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticType.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -58,7 +58,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.StaticType+StaticTypeInner"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -113,7 +114,8 @@
             "lines": [
               23
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticVoidMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticVoidMethod.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -32,7 +32,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.SmokeTests.StaticVoidMethod"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateExceptionValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateExceptionValue.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": "ThrowExceptionMethod",
             "type": "Samples.Probes.TestRuns.ExpressionTests.TemplateExceptionValue"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateNoException.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateNoException.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -14,7 +14,8 @@
           "location": {
             "method": null,
             "type": "Samples.Probes.TestRuns.ExpressionTests.TemplateNoException"
-          }
+          },
+          "version": 0
         },
         "timestamp": "ScrubbedValue"
       }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithDurationAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithDurationAtEntry.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -62,7 +62,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.TemplateWithDurationAtEntry"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtEntry.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtEntry.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -68,7 +68,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.TemplateWithLocalAtEntry"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtExit.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateWithLocalAtExit.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -62,7 +62,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.TemplateWithLocalAtExit"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UnboundProbeBecomesBoundTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UnboundProbeBecomesBoundTest.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -38,7 +38,8 @@
             "lines": [
               11
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -93,7 +94,8 @@
             "lines": [
               12
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UndefinedValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UndefinedValue.verified.txt
@@ -1,4 +1,4 @@
-﻿[
+[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -46,7 +46,8 @@
           "location": {
             "method": "Method",
             "type": "Samples.Probes.TestRuns.ExpressionTests.UndefinedValue"
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSettingsTests.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.Tests.Debugger
                 new NameValueConfigurationSource(new() { { ConfigurationKeys.Debugger.DiagnosticsInterval, value }, }),
                 NullConfigurationTelemetry.Instance);
 
-            settings.DiagnosticsIntervalSeconds.Should().Be(5);
+            settings.DiagnosticsIntervalSeconds.Should().Be(3600);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.Limits_FieldsCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.Limits_FieldsCount.verified.txt
@@ -1,7 +1,6 @@
 ﻿{
   local0: {
     fields: {
-      notCapturedReason: fieldCount,
       _numField1: {
         type: Int32,
         value: 1
@@ -83,6 +82,7 @@
         value: 9
       }
     },
+    notCapturedReason: fieldCount,
     type: ClassWithLotsOFields,
     value: ClassWithLotsOFields
   }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.Limits_LargeCollection.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.Limits_LargeCollection.verified.txt
@@ -403,7 +403,7 @@
       }
     ],
     notCapturedReason: collectionSize,
-    type: Int32[],
-    value: count: 2000
+    size: 2000,
+    type: Int32[]
   }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.ObjectStructure_EmptyArray.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.ObjectStructure_EmptyArray.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   local0: {
     elements: [],
-    type: Int32[],
-    value: count: 0
+    size: 0,
+    type: Int32[]
   }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.ObjectStructure_EmptyList.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerSnapshotCreatorTests.ObjectStructure_EmptyList.verified.txt
@@ -1,7 +1,7 @@
 ﻿{
   local0: {
     elements: [],
-    type: List`1,
-    value: count: 0
+    size: 0,
+    type: List`1
   }
 }


### PR DESCRIPTION
## Summary of changes
- Added 'probe version' in snapshots - to allow the frontend to deprecate old snapshots
- Fixed the positioning of 'noCapturedReason' in the snapshot
- Increased the polling interval of probe statuses and improved its machinery in avoiding dangling statuses.