### PR TITLE
Simplify CiVisibility Telemetry check

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.Ci
 
         protected override ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService)
         {
-            return TelemetryFactory.Instance.CreateCiVisibilityTelemetryController(settings, discoveryService);
+            return TelemetryFactory.Instance.CreateCiVisibilityTelemetryController(settings, discoveryService, isAgentAvailable: !_settings.Agentless);
         }
 
         protected override IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager)

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -59,10 +59,10 @@ namespace Datadog.Trace.Telemetry
         public static TelemetryFactory CreateFactory() => new();
 
         public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService)
-            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings), discoveryService, useCiVisibilityTelemetry: false);
+            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings, isAgentAvailable: null), discoveryService, useCiVisibilityTelemetry: false);
 
-        public ITelemetryController CreateCiVisibilityTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService)
-            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings), discoveryService, useCiVisibilityTelemetry: true);
+        public ITelemetryController CreateCiVisibilityTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService, bool isAgentAvailable)
+            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings, isAgentAvailable), discoveryService, useCiVisibilityTelemetry: true);
 
         public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, TelemetrySettings settings, IDiscoveryService discoveryService, bool useCiVisibilityTelemetry)
         {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsTests.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(expected);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.Enabled, "1" }
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
             settings.Agentless.Should().BeNull();
             settings.ConfigurationError.Should().BeNullOrEmpty();
         }
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(DefaultIntakeUrl);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Site, domain },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
 
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be($"https://instrumentation-telemetry-intake.{domain}/");
@@ -94,7 +94,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.Uri, url },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
 
             settings.Agentless.Should().BeNull();
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -114,7 +114,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "some_key" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
 
             settings.Agentless.Should().NotBeNull();
             settings.Agentless.AgentlessUri.Should().Be(DefaultIntakeUrl);
@@ -136,7 +136,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, apiKey },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
             var expectAgentless = enabled && !string.IsNullOrEmpty(apiKey);
 
             if (expectAgentless)
@@ -167,7 +167,7 @@ namespace Datadog.Trace.Tests.Telemetry
             });
             var hasApiKey = !string.IsNullOrEmpty(apiKey);
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
             using var s = new AssertionScope();
 
             settings.TelemetryEnabled.Should().Be(true);
@@ -211,7 +211,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, agentlessEnabled == true ? "SOME_KEY" : null },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
 
             var expectEnabled = enabled != false;
             var expectAgentless = expectEnabled && agentlessEnabled == true;
@@ -244,7 +244,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.Telemetry.AgentProxyEnabled, agentProxyEnabled?.ToString() }
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => agentAvailable, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: agentAvailable, isServerless: false);
 
             settings.AgentProxyEnabled.Should().Be(expected);
         }
@@ -263,7 +263,7 @@ namespace Datadog.Trace.Tests.Telemetry
                 { ConfigurationKeys.ApiKey, "SOME_KEY" },
             });
 
-            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, telemetry: new NullConfigurationTelemetry(), isAgentAvailable: true, isServerless: false);
 
             using var s = new AssertionScope();
             settings.TelemetryEnabled.Should().Be(expected);
@@ -289,7 +289,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public void HeartbeatInterval(string value, double expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.HeartbeatIntervalSeconds, value));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, isAgentAvailable: true, isServerless: false);
 
             settings.HeartbeatInterval.Should().Be(TimeSpan.FromSeconds(expected));
         }
@@ -302,7 +302,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public void V2Enabled_EnabledByDefault(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.V2Enabled, value));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, isAgentAvailable: true, isServerless: false);
 
             settings.V2Enabled.Should().Be(expected);
         }
@@ -320,7 +320,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.Telemetry.V2Enabled, v2Enabled),
                 (ConfigurationKeys.Telemetry.MetricsEnabled, metricsEnabled));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: true);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, isAgentAvailable: true, isServerless: true);
 
             settings.MetricsEnabled.Should().Be(expected);
         }
@@ -338,7 +338,7 @@ namespace Datadog.Trace.Tests.Telemetry
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.Telemetry.MetricsEnabled, metricSettingValue),
                 (ConfigurationKeys.Telemetry.V2Enabled, v2Enabled ? "1" : "0"));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, isAgentAvailable: true, isServerless: false);
 
             settings.MetricsEnabled.Should().Be(expected);
             settings.ConfigurationError.Should().BeNullOrEmpty();
@@ -348,7 +348,7 @@ namespace Datadog.Trace.Tests.Telemetry
         public void MetricsEnabled_TryingToEnableWhenV2DisabledIsConfigError()
         {
             var source = CreateConfigurationSource((ConfigurationKeys.Telemetry.MetricsEnabled, "1"), (ConfigurationKeys.Telemetry.V2Enabled, "0"));
-            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, () => true, isServerless: false);
+            var settings = TelemetrySettings.FromSource(source, NullConfigurationTelemetry.Instance, isAgentAvailable: true, isServerless: false);
 
             settings.MetricsEnabled.Should().Be(false);
             settings.ConfigurationError.Should().NotBeNullOrEmpty();


### PR DESCRIPTION
## Summary of changes

- Tweak how CiVisibility settings interacts with the telemetry settings

## Reason for change

We had some duplication and confusion in the previous implementation

## Implementation details

- We don't need to check `ConfigurationKeys.CIVisibility.AgentlessEnabled` when choosing to enable, agentless: we default to enabling this anyway
- We can pass the `CiVisibilitySettings.Agentless` value directly into the `TelemetrySettings` constructor, because we use different code paths for the telemetry setting creation when doing civisibility vs normal

## Test coverage

Covered by existing tests, just a refactoring

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
