### PR TITLE
Try to fix GitLab build

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -241,6 +241,9 @@ partial class Build
             // If we're building for x64, build for x86 too
             var platforms = ArchitecturesForPlatformForTracer;
 
+            // Gitlab has issues with memory usage...
+            var isGitlab = Nuke.Common.CI.GitLab.GitLab.Instance is not null;
+
             // Can't use dotnet msbuild, as needs to use the VS version of MSBuild
             // Build native tracer assets
             MSBuild(s => s
@@ -249,7 +252,7 @@ partial class Build
                 .SetMSBuildPath()
                 .SetTargets("BuildCppSrc")
                 .DisableRestore()
-                .SetMaxCpuCount(null)
+                .SetMaxCpuCount(isGitlab ? 1 : null)
                 .CombineWith(platforms, (m, platform) => m
                     .SetTargetPlatform(platform)));
         });


### PR DESCRIPTION
## Summary of changes

- Disable building in parallel in GitLab

## Reason for change

We often run out of heap space in the gitlab build

## Implementation details

set MaxCPU to 1 when running in GitLab

## Test coverage

I ran it once 🤷‍♂️ 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
