### PR TITLE
[Tracing] Unify the manual Tracer instance and the automatic Tracer instance - Part 1: Automatic Refactoring

### DIFF
--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.MSBuild
 
             try
             {
-                _tracer = Tracer.Instance;
+                _tracer = Tracer.InternalInstance;
 
                 // Attach to the eventSource events only if we successfully get the tracer instance.
                 eventSource.BuildStarted += EventSource_BuildStarted;

--- a/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.OpenTracing
         /// <param name="isDebugEnabled">Turns on all debug logging (this may have an impact on application performance).</param>
         /// <returns>A Datadog compatible ITracer implementation</returns>
         [PublicApi]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DD0002:Incorrect usage of public API", Justification = "We must access the tracer via the public Tracer.Instance accessor because this API is only ever used for manual instrumentation.")]
         public static global::OpenTracing.ITracer CreateTracer(Uri agentEndpoint = null, string defaultServiceName = null, bool isDebugEnabled = false)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.OpenTracingTracerFactory_CreateTracer);

--- a/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Crank/Importer.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Tools.Runner.Crank
                     var fileName = Path.GetFileName(jsonFilePath);
 
                     CIVisibility.Initialize();
-                    Tracer tracer = Tracer.Instance;
+                    Tracer tracer = Tracer.InternalInstance;
 
                     foreach (var jobItem in result.JobResults.Jobs)
                     {

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -27,8 +27,8 @@ namespace Datadog.Trace.Activity.Handlers
         public static void ActivityStarted<T>(string sourceName, T activity, ITags? tags, out ActivityMapping activityMapping)
             where T : IActivity
         {
-            Tracer.Instance.TracerManager.Telemetry.IntegrationRunning(IntegrationId);
-            var activeSpan = Tracer.Instance.ActiveScope?.Span as Span;
+            Tracer.InternalInstance.TracerManager.Telemetry.IntegrationRunning(IntegrationId);
+            var activeSpan = Tracer.InternalInstance.ActiveScope?.Span as Span;
 
             // Propagate Trace and Parent Span ids
             SpanContext? parent = null;
@@ -71,7 +71,7 @@ namespace Datadog.Trace.Activity.Handlers
                             _ = HexString.TryParseTraceId(activityTraceId, out var newActivityTraceId);
                             _ = HexString.TryParseUInt64(parentSpanId, out var newActivitySpanId);
 
-                            parent = Tracer.Instance.CreateSpanContext(
+                            parent = Tracer.InternalInstance.CreateSpanContext(
                                 SpanContext.None,
                                 traceId: newActivityTraceId,
                                 spanId: newActivitySpanId,
@@ -162,7 +162,7 @@ namespace Datadog.Trace.Activity.Handlers
 
             static Scope CreateScopeFromActivity(T activity, ITags? tags, SpanContext? parent, TraceId traceId, ulong spanId, string? rawTraceId, string? rawSpanId)
             {
-                var span = Tracer.Instance.StartSpan(
+                var span = Tracer.InternalInstance.StartSpan(
                     activity.OperationName,
                     tags: tags,
                     parent: parent,
@@ -172,8 +172,8 @@ namespace Datadog.Trace.Activity.Handlers
                     rawTraceId: rawTraceId,
                     rawSpanId: rawSpanId);
 
-                Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
-                return Tracer.Instance.ActivateSpan(span, finishOnClose: false);
+                Tracer.InternalInstance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
+                return Tracer.InternalInstance.ActivateSpan(span, finishOnClose: false);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Activity/Handlers/AzureServiceBusActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/AzureServiceBusActivityHandler.cs
@@ -27,15 +27,15 @@ namespace Datadog.Trace.Activity.Handlers
         public void ActivityStarted<T>(string sourceName, T activity)
             where T : IActivity
         {
-            var tags = Tracer.Instance.CurrentTraceSettings.Schema.Client.CreateAzureServiceBusTags();
+            var tags = Tracer.InternalInstance.CurrentTraceSettings.Schema.Client.CreateAzureServiceBusTags();
             ActivityHandlerCommon.ActivityStarted(sourceName, activity, tags: tags, out var activityMapping);
         }
 
         public void ActivityStopped<T>(string sourceName, T activity)
             where T : IActivity
         {
-            var dataStreamsManager = Tracer.Instance.TracerManager.DataStreamsManager;
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
+            var dataStreamsManager = Tracer.InternalInstance.TracerManager.DataStreamsManager;
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
                 && dataStreamsManager.IsEnabled
                 && activity.Instance is not null
                 && activity.OperationName == "Message"

--- a/tracer/src/Datadog.Trace/Activity/Handlers/IgnoreActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/IgnoreActivityHandler.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Activity.Handlers
             where T : IActivity
         {
             // Propagate Trace and Parent Span ids
-            IgnoreActivity(activity, (Span?)Tracer.Instance.ActiveScope?.Span);
+            IgnoreActivity(activity, (Span?)Tracer.InternalInstance.ActiveScope?.Span);
         }
 
         public void ActivityStopped<T>(string sourceName, T activity)

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Activity
             }
 
             // Fixup "version" tag
-            if (Tracer.Instance.Settings.ServiceVersionInternal is null
+            if (Tracer.InternalInstance.Settings.ServiceVersionInternal is null
                 && span.GetTag("service.version") is { Length: > 1 } otelServiceVersion)
             {
                 span.SetTag(Tags.Version, otelServiceVersion);
@@ -156,7 +156,7 @@ namespace Datadog.Trace.Activity
             {
                 // Later: Support config 'span_name_as_resource_name'
                 // Later: Support config 'span_name_remappings'
-                if (Tracer.Instance.Settings.OpenTelemetryLegacyOperationNameEnabled && activity5 is not null)
+                if (Tracer.InternalInstance.Settings.OpenTelemetryLegacyOperationNameEnabled && activity5 is not null)
                 {
                     span.OperationName = activity5.Source.Name switch
                     {

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -95,7 +95,7 @@ internal readonly partial struct SecurityCoordinator
 
         if (status is not null)
         {
-            _localRootSpan.SetHttpStatusCode(status.Value, isServer: true, Tracer.Instance.Settings);
+            _localRootSpan.SetHttpStatusCode(status.Value, isServer: true, Tracer.InternalInstance.Settings);
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
+++ b/tracer/src/Datadog.Trace/AppSec/EventTrackingSdk.cs
@@ -25,7 +25,7 @@ public static class EventTrackingSdk
         public static void TrackUserLoginSuccessEvent(string userId)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.EventTrackingSdk_TrackUserLoginSuccessEvent);
-            TrackUserLoginSuccessEvent(userId, null, Tracer.Instance);
+            TrackUserLoginSuccessEvent(userId, null, Tracer.InternalInstance);
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ public static class EventTrackingSdk
         public static void TrackUserLoginSuccessEvent(string userId, IDictionary<string, string> metadata)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.EventTrackingSdk_TrackUserLoginSuccessEvent_Metadata);
-            TrackUserLoginSuccessEvent(userId, metadata, Tracer.Instance);
+            TrackUserLoginSuccessEvent(userId, metadata, Tracer.InternalInstance);
         }
 
         internal static void TrackUserLoginSuccessEvent(string userId, IDictionary<string, string> metadata, Tracer tracer)
@@ -83,7 +83,7 @@ public static class EventTrackingSdk
         public static void TrackUserLoginFailureEvent(string userId, bool exists)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.EventTrackingSdk_TrackUserLoginFailureEvent);
-            TrackUserLoginFailureEvent(userId, exists, null, Tracer.Instance);
+            TrackUserLoginFailureEvent(userId, exists, null, Tracer.InternalInstance);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ public static class EventTrackingSdk
         public static void TrackUserLoginFailureEvent(string userId, bool exists, IDictionary<string, string> metadata)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.EventTrackingSdk_TrackUserLoginFailureEvent_Metadata);
-            TrackUserLoginFailureEvent(userId, exists, metadata, Tracer.Instance);
+            TrackUserLoginFailureEvent(userId, exists, metadata, Tracer.InternalInstance);
         }
 
         internal static void TrackUserLoginFailureEvent(string userId, bool exists, IDictionary<string, string> metadata, Tracer tracer)
@@ -142,7 +142,7 @@ public static class EventTrackingSdk
         public static void TrackCustomEvent(string eventName)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.EventTrackingSdk_TrackCustomEvent);
-            TrackCustomEvent(eventName, null, Tracer.Instance);
+            TrackCustomEvent(eventName, null, Tracer.InternalInstance);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ public static class EventTrackingSdk
         public static void TrackCustomEvent(string eventName, IDictionary<string, string> metadata)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.EventTrackingSdk_TrackCustomEvent_Metadata);
-            TrackCustomEvent(eventName, metadata, Tracer.Instance);
+            TrackCustomEvent(eventName, metadata, Tracer.InternalInstance);
         }
 
         internal static void TrackCustomEvent(string eventName, IDictionary<string, string> metadata, Tracer tracer)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -78,14 +78,14 @@ namespace Datadog.Trace.AspNet
 
         internal static void AddHeaderTagsFromHttpResponse(HttpContext httpContext, Scope scope)
         {
-            if (!Tracer.Instance.Settings.HeaderTagsInternal.IsNullOrEmpty() &&
+            if (!Tracer.InternalInstance.Settings.HeaderTagsInternal.IsNullOrEmpty() &&
                 httpContext != null &&
                 HttpRuntime.UsingIntegratedPipeline &&
                 _canReadHttpResponseHeaders)
             {
                 try
                 {
-                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTagsInternal, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.InternalInstance.Settings.HeaderTagsInternal, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 }
                 catch (PlatformNotSupportedException ex)
                 {
@@ -106,7 +106,7 @@ namespace Datadog.Trace.AspNet
             bool shouldDisposeScope = true;
             try
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
 
                 if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
                 {
@@ -222,7 +222,7 @@ namespace Datadog.Trace.AspNet
 
             try
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
                 {
                     // integration disabled
@@ -302,12 +302,12 @@ namespace Datadog.Trace.AspNet
                                 status = 400;
                             }
 
-                            rootSpan.SetHttpStatusCode(status, isServer: true, Tracer.Instance.Settings);
+                            rootSpan.SetHttpStatusCode(status, isServer: true, Tracer.InternalInstance.Settings);
                             AddHeaderTagsFromHttpResponse(app.Context, rootScope);
 
                             if (scope.Span != rootSpan)
                             {
-                                scope.Span.SetHttpStatusCode(status, isServer: true, Tracer.Instance.Settings);
+                                scope.Span.SetHttpStatusCode(status, isServer: true, Tracer.InternalInstance.Settings);
                                 AddHeaderTagsFromHttpResponse(app.Context, scope);
                             }
                         }
@@ -351,7 +351,7 @@ namespace Datadog.Trace.AspNet
         {
             try
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
 
                 if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
                 {

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Ci
         {
             get
             {
-                if (Tracer.Instance.TracerManager is CITracerManager cITracerManager)
+                if (Tracer.InternalInstance.TracerManager is CITracerManager cITracerManager)
                 {
                     return cITracerManager;
                 }
@@ -110,7 +110,7 @@ namespace Datadog.Trace.Ci
             // Initialize Tracer
             Log.Information("Initialize Test Tracer instance");
             TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings, true), new CITracerManagerFactory(settings, discoveryService, eventPlatformProxyEnabled, UseLockedTracerManager));
-            _ = Tracer.Instance;
+            _ = Tracer.InternalInstance;
 
             // Initialize FrameworkDescription
             _ = FrameworkDescription.Instance;
@@ -175,7 +175,7 @@ namespace Datadog.Trace.Ci
             // Initialize Tracer
             Log.Information("Initialize Test Tracer instance");
             TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings, true), new CITracerManagerFactory(settings, discoveryService, eventPlatformProxyEnabled, UseLockedTracerManager));
-            _ = Tracer.Instance;
+            _ = Tracer.InternalInstance;
 
             // Initialize FrameworkDescription
             _ = FrameworkDescription.Instance;
@@ -230,12 +230,12 @@ namespace Datadog.Trace.Ci
                 if (Settings.Logs)
                 {
                     await Task.WhenAll(
-                        Tracer.Instance.FlushAsync(),
-                        Tracer.Instance.TracerManager.DirectLogSubmission.Sink.FlushAsync()).ConfigureAwait(false);
+                        Tracer.InternalInstance.FlushAsync(),
+                        Tracer.InternalInstance.TracerManager.DirectLogSubmission.Sink.FlushAsync()).ConfigureAwait(false);
                 }
                 else
                 {
-                    await Tracer.Instance.FlushAsync().ConfigureAwait(false);
+                    await Tracer.InternalInstance.FlushAsync().ConfigureAwait(false);
                 }
 
                 Log.Debug("Integration flushed.");

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -38,7 +38,7 @@ public sealed class Test
         var module = suite.Module;
 
         var tags = new TestSpanTags(Suite.Tags, name);
-        var tracer = Tracer.Instance;
+        var tracer = Tracer.InternalInstance;
         var span = tracer.StartSpan(
             string.IsNullOrEmpty(module.Framework) ? "test" : $"{module.Framework!.ToLowerInvariant()}.test",
             tags: tags,

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -158,7 +158,7 @@ public sealed class TestModule
         // Check if Intelligent Test Runner has skippable tests and set the flag according to that
         tags.TestsSkipped = CIVisibility.HasSkippableTests() ? "true" : "false";
 
-        var span = Tracer.Instance.StartSpan(
+        var span = Tracer.InternalInstance.StartSpan(
             string.IsNullOrEmpty(framework) ? "test_module" : $"{framework!.ToLowerInvariant()}.test_module",
             tags: tags,
             startTime: startDate);

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -52,7 +52,7 @@ public sealed class TestSession
 
         tags.SetCIEnvironmentValues(environment);
 
-        var span = Tracer.Instance.StartSpan(
+        var span = Tracer.InternalInstance.StartSpan(
             string.IsNullOrEmpty(framework) ? "test_session" : $"{framework!.ToLowerInvariant()}.test_session",
             tags: tags,
             startTime: startDate);

--- a/tracer/src/Datadog.Trace/Ci/TestSuite.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSuite.cs
@@ -30,7 +30,7 @@ public sealed class TestSuite
         Name = name;
 
         var tags = new TestSuiteSpanTags(module.Tags, name);
-        var span = Tracer.Instance.StartSpan(
+        var span = Tracer.InternalInstance.StartSpan(
             string.IsNullOrEmpty(module.Framework) ? "test_suite" : $"{module.Framework!.ToLowerInvariant()}.test_suite",
             tags: tags,
             startTime: startDate);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchGetItemAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchGetItemAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagBatchRequest(request, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchGetItemIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchGetItemIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagBatchRequest(request, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchWriteItemAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchWriteItemAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagBatchRequest(request, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchWriteItemIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/BatchWriteItemIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagBatchRequest(request, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/DeleteItemAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/DeleteItemAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/DeleteItemIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/DeleteItemIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/GetItemAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/GetItemAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/GetItemIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/GetItemIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/PutItemAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/PutItemAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/PutItemIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/PutItemIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/ScanAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/ScanAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/ScanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/ScanIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/UpdateItemAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/UpdateItemAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/UpdateItemIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/DynamoDb/UpdateItemIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.DynamoDb
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsDynamoDbCommon.CreateScope(Tracer.Instance, Operation, out AwsDynamoDbTags tags);
+            var scope = AwsDynamoDbCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsDynamoDbTags tags);
             AwsDynamoDbCommon.TagTableNameAndResourceName(request.TableName, tags, scope);
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
+            var scope = AwsKinesisCommon.CreateScope(Tracer.InternalInstance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
             if (scope?.Span.Context != null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
+            var scope = AwsKinesisCommon.CreateScope(Tracer.InternalInstance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
             if (scope?.Span.Context != null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
+            var scope = AwsKinesisCommon.CreateScope(Tracer.InternalInstance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
             if (scope?.Span.Context != null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Kinesis/PutRecordsIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Kinesis
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsKinesisCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
+            var scope = AwsKinesisCommon.CreateScope(Tracer.InternalInstance, Operation, SpanKinds.Producer, null, out AwsKinesisTags tags);
             tags.StreamName = request.StreamName;
 
             if (scope?.Span.Context != null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeAsyncIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                 return CallTargetState.GetDefault();
             }
 
-            var scope = Tracer.Instance.InternalActiveScope;
+            var scope = Tracer.InternalInstance.InternalActiveScope;
             if (scope?.Span.Tags is AwsSdkTags tags)
             {
                 tags.Region = executionContext.RequestContext.ClientConfig.RegionEndpoint?.SystemName;
@@ -87,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                 }
 
                 tags.RequestId = response.ResponseMetadata.RequestId;
-                state.Scope.Span.SetHttpStatusCode((int)response.HttpStatusCode, false, Tracer.Instance.Settings);
+                state.Scope.Span.SetHttpStatusCode((int)response.HttpStatusCode, false, Tracer.InternalInstance.Settings);
             }
 
             // Do not dispose the scope (if present) when exiting.

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/RuntimePipelineInvokeSyncIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                 return CallTargetState.GetDefault();
             }
 
-            var scope = Tracer.Instance.InternalActiveScope;
+            var scope = Tracer.InternalInstance.InternalActiveScope;
             if (scope?.Span.Tags is AwsSdkTags tags)
             {
                 tags.Region = executionContext.RequestContext.ClientConfig.RegionEndpoint?.SystemName;
@@ -87,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK
                 }
 
                 tags.RequestId = responseContext.Response.ResponseMetadata.RequestId;
-                state.Scope.Span.SetHttpStatusCode((int)responseContext.Response.HttpStatusCode, false, Tracer.Instance.Settings);
+                state.Scope.Span.SetHttpStatusCode((int)responseContext.Response.HttpStatusCode, false, Tracer.InternalInstance.Settings);
             }
 
             // Do not dispose the scope (if present) when exiting.

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 
             var requestProxy = request.DuckCast<IPublishRequest>();
 
-            var scope = AwsSnsCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, out AwsSnsTags tags);
+            var scope = AwsSnsCommon.CreateScope(Tracer.InternalInstance, Operation, SpanKinds.Producer, out AwsSnsTags tags);
             tags.TopicArn = requestProxy.TopicArn;
             tags.TopicName = AwsSnsCommon.GetTopicName(requestProxy.TopicArn);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueName = request.QueueName;
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueName = request.QueueName;
 
             return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageAsyncIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Consumer);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Consumer);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Consumer);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Consumer);
             tags.QueueUrl = request.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
 
             var requestProxy = request.DuckCast<ISendMessageRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
             tags.QueueUrl = requestProxy.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
 
             var requestProxy = request.DuckCast<ISendMessageBatchRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
             tags.QueueUrl = requestProxy.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
 
             var requestProxy = request.DuckCast<ISendMessageBatchRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
             tags.QueueUrl = requestProxy.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
 
             var requestProxy = request.DuckCast<ISendMessageRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
+            var scope = AwsSqsCommon.CreateScope(Tracer.InternalInstance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
             tags.QueueUrl = requestProxy.QueueUrl;
             tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteNonQueryAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteNonQueryAsyncIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteNonQueryIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteNonQueryIntegration.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteNonQueryWithBehaviorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteNonQueryWithBehaviorIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderAsyncIntegration.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderIntegration.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorAndCancellationAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorAndCancellationAsyncIntegration.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior, CancellationToken cancellationToken)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorAsyncIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithBehaviorIntegration.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithCancellationAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWithCancellationAsyncIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarAsyncIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, CancellationToken cancellationToken)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarIntegration.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarWithBehaviorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarWithBehaviorIntegration.cs
@@ -28,7 +28,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TBehavior>(TTarget instance, TBehavior commandBehavior)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/AsyncCommandIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/AsyncCommandIntegration.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Aerospike
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(AerospikeCommon.CreateScope(Tracer.Instance, instance));
+            return new CallTargetState(AerospikeCommon.CreateScope(Tracer.InternalInstance, instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/SyncCommandIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/SyncCommandIntegration.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Aerospike
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(AerospikeCommon.CreateScope(Tracer.Instance, instance));
+            return new CallTargetState(AerospikeCommon.CreateScope(Tracer.InternalInstance, instance));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ApiController_ExecuteAsync_Integration.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
             else
             {
                 HttpContextHelper.AddHeaderTagsFromHttpResponse(HttpContext.Current, scope);
-                scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true, Tracer.Instance.Settings);
+                scope.Span.SetHttpStatusCode(responseMessage.DuckCast<HttpResponseMessageStruct>().StatusCode, isServer: true, Tracer.InternalInstance.Settings);
                 scope.Dispose();
             }
 
@@ -136,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         private static void OnRequestCompletedAfterException(HttpContext httpContext, Scope scope, DateTimeOffset finishTime)
         {
             HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
-            scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.Settings);
+            scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.InternalInstance.Settings);
             scope.Span.Finish(finishTime);
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
                 Span span = null;
                 // integration enabled, go create a scope!
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 if (tracer.Settings.IsIntegrationEnabled(IntegrationId))
                 {
                     var newResourceNamesEnabled = tracer.Settings.RouteTemplateResourceNamesEnabled;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetWebApi2Integration.cs
@@ -40,13 +40,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
             try
             {
-                if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+                if (!Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId))
                 {
                     // integration disabled, don't create a scope, skip this trace
                     return null;
                 }
 
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 var request = controllerContext.Request;
                 SpanContext propagatedContext = null;
                 HttpHeadersCollection? headersCollection = null;
@@ -119,7 +119,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         {
             try
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 var tracerSettings = tracer.Settings;
                 var newResourceNamesEnabled = tracerSettings.RouteTemplateResourceNamesEnabled;
                 var request = controllerContext.Request;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AsyncControllerActionInvoker_EndInvokeAction_Integration.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                 else
                 {
                     HttpContextHelper.AddHeaderTagsFromHttpResponse(httpContext, scope);
-                    scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.Settings);
+                    scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.InternalInstance.Settings);
                     scope.Dispose();
                 }
             }
@@ -102,11 +102,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
             {
                 // in classic mode, the exception won't cause the correct status code to be set
                 // even though a 500 response will be sent, so set it manually instead
-                scope.Span.SetHttpStatusCode(500, isServer: true, Tracer.Instance.Settings);
+                scope.Span.SetHttpStatusCode(500, isServer: true, Tracer.InternalInstance.Settings);
             }
             else
             {
-                scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.Instance.Settings);
+                scope.Span.SetHttpStatusCode(httpContext.Response.StatusCode, isServer: true, Tracer.InternalInstance.Settings);
             }
 
             scope.Span.Finish(finishTime);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ExceptionHandlerExtensions_HandleAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ExceptionHandlerExtensions_HandleAsync_Integration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         internal static CallTargetState OnMethodBegin<TTarget, TExceptionHandler, TExceptionContext>(TTarget instance, TExceptionHandler handler, TExceptionContext context, CancellationToken cancellationToken)
             where TExceptionContext : IExceptionContext
         {
-            var scope = Tracer.Instance.ActiveScope;
+            var scope = Tracer.InternalInstance.ActiveScope;
             var exception = context.Exception;
 
             if (scope is not null && exception is not null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/HttpContextHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/HttpContextHelper.cs
@@ -19,11 +19,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
 
         internal static void AddHeaderTagsFromHttpResponse(System.Web.HttpContext httpContext, Scope scope)
         {
-            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && _canReadHttpResponseHeaders && !Tracer.Instance.Settings.HeaderTagsInternal.IsNullOrEmpty())
+            if (httpContext != null && HttpRuntime.UsingIntegratedPipeline && _canReadHttpResponseHeaders && !Tracer.InternalInstance.Settings.HeaderTagsInternal.IsNullOrEmpty())
             {
                 try
                 {
-                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.Instance.Settings.HeaderTagsInternal, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
+                    scope.Span.SetHeaderTags(httpContext.Response.Headers.Wrap(), Tracer.InternalInstance.Settings.HeaderTagsInternal, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 }
                 catch (PlatformNotSupportedException ex)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
             where TTarget : IThreadContext
         {
             var httpContext = instance.HttpContext;
-            if (httpContext.Items[HttpContextScopeKey] is Scope scope && Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
+            if (httpContext.Items[HttpContextScopeKey] is Scope scope && Tracer.InternalInstance.ScopeManager is IScopeRawAccess rawAccess)
             {
                 rawAccess.Active = scope;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_DisassociateFromCurrentThread_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_DisassociateFromCurrentThread_Integration.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
             where TTarget : IThreadContext
         {
-            if (Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
+            if (Tracer.InternalInstance.ScopeManager is IScopeRawAccess rawAccess)
             {
                 rawAccess.Active = null;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
@@ -79,7 +79,7 @@ internal class BlockingMiddleware
 
         if (security.Enabled)
         {
-            if (Tracer.Instance?.ActiveScope?.Span is Span span)
+            if (Tracer.InternalInstance?.ActiveScope?.Span is Span span)
             {
                 var securityCoordinator = new SecurityCoordinator(security, context, span);
                 if (_endPipeline && !context.Response.HasStarted)
@@ -120,7 +120,7 @@ internal class BlockingMiddleware
                 await WriteResponse(action, context, out endedResponse).ConfigureAwait(false);
                 if (security.Enabled)
                 {
-                    if (Tracer.Instance?.ActiveScope?.Span is Span span)
+                    if (Tracer.InternalInstance?.ActiveScope?.Span is Span span)
                     {
                         var securityCoordinator = new SecurityCoordinator(security, context, span);
                         if (!blockException.Reported)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/FireOnStartCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/FireOnStartCommon.cs
@@ -69,7 +69,7 @@ public static class FireOnStartCommon
             {
                 if (security.Enabled)
                 {
-                    var span = Tracer.Instance.InternalActiveScope?.Root?.Span;
+                    var span = Tracer.InternalInstance.InternalActiveScope?.Root?.Span;
 
                     if (span is not null)
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/AuthenticationHttpContextExtensionsIntegration.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.UserEvents
             var security = Security.Instance;
             if (security.TrackUserEvents)
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 var scope = tracer.InternalActiveScope;
                 return new CallTargetState(scope, claimPrincipal);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInIntegration.cs
@@ -50,7 +50,7 @@ public static class SignInManagerPasswordSignInIntegration
         var security = Security.Instance;
         if (security.TrackUserEvents)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             var scope = tracer.InternalActiveScope;
             return new CallTargetState(scope, user);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/SignInManagerPasswordSignInUserIntegration.cs
@@ -51,7 +51,7 @@ public static class SignInManagerPasswordSignInUserIntegration
         var security = Security.Instance;
         if (security.TrackUserEvents)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             var scope = tracer.InternalActiveScope;
             return new CallTargetState(scope, user);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/UserEvents/UserManagerCreateIntegration.cs
@@ -50,7 +50,7 @@ public static class UserManagerCreateIntegration
         var security = Security.Instance;
         if (security.TrackUserEvents)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             var scope = tracer.InternalActiveScope;
             return new CallTargetState(scope, user);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         public static CallTargetState OnFunctionExecutionBegin<TTarget, TFunction>(TTarget instance, TFunction instanceParam)
             where TFunction : IFunctionInstance
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
@@ -178,7 +178,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         public static CallTargetState OnIsolatedFunctionBegin<T>(T functionContext)
             where T : IFunctionContext
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/FunctionInvocationMiddlewareInvokeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/FunctionInvocationMiddlewareInvokeIntegration.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, HttpContext httpContext)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (tracer.Settings.IsIntegrationEnabled(AzureFunctionsCommon.IntegrationId))
             {
@@ -71,7 +71,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
         {
             if (state.Scope is { } scope)
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 var security = Security.Instance;
                 var httpContext = state.State as HttpContext;
                 try

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/GrpcMessageConversionExtensionsToRpcHttpIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/Isolated/GrpcMessageConversionExtensionsToRpcHttpIntegration.cs
@@ -40,7 +40,7 @@ public class GrpcMessageConversionExtensionsToRpcHttpIntegration
     internal static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget nullInstance, TReturn returnValue, Exception exception, in CallTargetState state)
         where TReturn : ITypedData
     {
-        AzureFunctionsCommon.OverridePropagatedContext<TTarget, TReturn>(Tracer.Instance, returnValue, state.State as string);
+        AzureFunctionsCommon.OverridePropagatedContext<TTarget, TReturn>(Tracer.InternalInstance, returnValue, state.State as string);
         return returnValue;
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/InstrumentMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/InstrumentMessageIntegration.cs
@@ -41,8 +41,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.ServiceBus
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, IDictionary<string, object> properties, string activityName, ref string traceparent, ref string tracestate)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
-                && Tracer.Instance.TracerManager.DataStreamsManager.IsEnabled)
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
+                && Tracer.InternalInstance.TracerManager.DataStreamsManager.IsEnabled)
             {
                 // Adding DSM to the send operation of IReadOnlyCollection<ServiceBusMessage>|ServiceBusMessageBatch - Step Two:
                 // In between the OnMethodBegin and OnMethodEnd, a new Activity will be created to represent

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/ProcessMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/ProcessMessageIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.ServiceBus
             // when the following requirements are met:
             // - AzureServiceBus integration enabled
             // - DD_TRACE_OTEL_ENABLED=true
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             var dataStreamsManager = tracer.TracerManager.DataStreamsManager;
 
             if (tracer.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/SendServiceBusMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/SendServiceBusMessageBatchIntegration.cs
@@ -42,8 +42,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.ServiceBus
         internal static CallTargetState OnMethodBegin<TTarget, TMessage>(TTarget instance, TMessage message)
             where TMessage : IServiceBusMessage
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
-                && Tracer.Instance.TracerManager.DataStreamsManager.IsEnabled)
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
+                && Tracer.InternalInstance.TracerManager.DataStreamsManager.IsEnabled)
             {
                 // Adding DSM to the send operation of ServiceBusMessageBatch - Step One:
                 // While we have access to the message object itself, create a mapping from the

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/SendServiceBusMessagesIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/ServiceBus/SendServiceBusMessagesIntegration.cs
@@ -44,8 +44,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.ServiceBus
         internal static CallTargetState OnMethodBegin<TTarget, TOperation>(TTarget instance, IEnumerable messages, string activityName, TOperation operation)
             where TTarget : ITransportSender, IDuckType
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
-                && Tracer.Instance.TracerManager.DataStreamsManager.IsEnabled)
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId.AzureServiceBus)
+                && Tracer.InternalInstance.TracerManager.DataStreamsManager.IsEnabled)
             {
                 if (messages is not null)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CosmosDb/CosmosCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CosmosDb/CosmosCommon.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.CosmosDb
 
         private static CallTargetState CreateCosmosDbCallState<TTarget, TQueryDefinition>(TTarget instance, TQueryDefinition queryDefinition, string containerId, string databaseId, Uri endpoint)
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (!Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // integration disabled, don't create a scope, skip this trace
                 return CallTargetState.GetDefault();
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.CosmosDb
                     query = queryDefinitionObj.QueryText;
                 }
 
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
 
                 var parent = tracer.ActiveScope?.Span;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Couchbase/CouchbaseCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Couchbase/CouchbaseCommon.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Couchbase
 
         internal static CallTargetState CommonOnMethodBeginV3<TOperation>(TOperation tOperation, IClusterNode clusterNode)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId) || tOperation == null)
             {
                 // integration disabled, don't create a scope, skip this trace
@@ -59,7 +59,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Couchbase
 
         internal static CallTargetState CommonOnMethodBegin<TOperation>(TOperation tOperation, string normalizedSeedNodes)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId) || tOperation == null)
             {
                 // integration disabled, don't create a scope, skip this trace

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearchAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearchAsync_Integration.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V5
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TRequestData>(TTarget instance, TRequestData requestData, CancellationToken cancellationToken)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV5Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV5(requestData));
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.InternalInstance, ElasticsearchV5Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV5(requestData));
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearch_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V5/RequestPipeline_CallElasticsearch_Integration.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V5
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TRequestData>(TTarget instance, TRequestData requestData)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV5Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV5(requestData));
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.InternalInstance, ElasticsearchV5Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV5(requestData));
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearchAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearchAsync_Integration.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V6
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TRequestData>(TTarget instance, TRequestData requestData, CancellationToken cancellationToken)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV6Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV6(requestData));
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.InternalInstance, ElasticsearchV6Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV6(requestData));
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearch_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V6/RequestPipeline_CallElasticsearch_Integration.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V6
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TRequestData>(TTarget instance, TRequestData requestData)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV6Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV6(requestData));
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.InternalInstance, ElasticsearchV6Constants.IntegrationId, instance.DuckCast<RequestPipelineStruct>(), new RequestDataV6(requestData));
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_RequestAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_RequestAsync_Integration.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, THttpMethod, TPostData, TRequestParameters>(TTarget instance, THttpMethod method, string path, CancellationToken cancellationToken, TPostData postData, TRequestParameters requestParameters)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV7Constants.IntegrationId, path, method.ToString(), requestParameters, out var tags);
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.InternalInstance, ElasticsearchV7Constants.IntegrationId, path, method.ToString(), requestParameters, out var tags);
 
             return new CallTargetState(scope, tags);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_Request_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_Request_Integration.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, THttpMethod, TPostData, TRequestParameters>(TTarget instance, THttpMethod method, string path, TPostData postData, TRequestParameters requestParameters)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV7Constants.IntegrationId, path, method.ToString(), requestParameters, out var tags);
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.InternalInstance, ElasticsearchV7Constants.IntegrationId, path, method.ToString(), requestParameters, out var tags);
 
             return new CallTargetState(scope, tags);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegration.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
         internal static CallTargetState OnMethodBegin<TTarget, TQueyRequest>(TTarget instance, TQueyRequest request, in CancellationToken token)
             where TQueyRequest : IQueryRequest
         {
-            return new CallTargetState(scope: HotChocolateCommon.CreateScopeFromExecuteAsync(Tracer.Instance, request));
+            return new CallTargetState(scope: HotChocolateCommon.CreateScopeFromExecuteAsync(Tracer.InternalInstance, request));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegrationExtra.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegrationExtra.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
             var operationType = HotChocolateCommon.GetOperation(operation.OperationType);
             var operationName = GetNameStringValue(operation.Name.Value);
 
-            HotChocolateCommon.UpdateScopeFromExecuteAsync(Tracer.Instance, operationType, operationName);
+            HotChocolateCommon.UpdateScopeFromExecuteAsync(Tracer.InternalInstance, operationType, operationName);
             return CallTargetState.GetDefault();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegrationExtraV13.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegrationExtraV13.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
             var operationType = HotChocolateCommon.GetOperation(operation.OperationType);
             var operationName = operation.Name;
 
-            HotChocolateCommon.UpdateScopeFromExecuteAsync(Tracer.Instance, operationType, operationName);
+            HotChocolateCommon.UpdateScopeFromExecuteAsync(Tracer.InternalInstance, operationType, operationName);
             return CallTargetState.GetDefault();
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegrationV13.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/HotChocolate/ExecuteAsyncIntegrationV13.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.HotChocolate
         internal static CallTargetState OnMethodBegin<TTarget, TQueyRequest>(TTarget instance, TQueyRequest request, in CancellationToken token)
             where TQueyRequest : IQueryRequest
         {
-            return new CallTargetState(scope: HotChocolateCommon.CreateScopeFromExecuteAsync(Tracer.Instance, request));
+            return new CallTargetState(scope: HotChocolateCommon.CreateScopeFromExecuteAsync(Tracer.InternalInstance, request));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ExecuteAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ExecuteAsyncIntegration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
         internal static CallTargetState OnMethodBegin<TTarget, TContext>(TTarget instance, TContext context)
             where TContext : IExecutionContext
         {
-            return new CallTargetState(scope: GraphQLCommon.CreateScopeFromExecuteAsync(Tracer.Instance, context), state: context);
+            return new CallTargetState(scope: GraphQLCommon.CreateScopeFromExecuteAsync(Tracer.InternalInstance, context), state: context);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ExecuteAsyncIntegrationV5AndV7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ExecuteAsyncIntegrationV5AndV7.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
         internal static CallTargetState OnMethodBegin<TTarget, TContext>(TTarget instance, TContext context)
             where TContext : IExecutionContextV5AndV7
         {
-            return new CallTargetState(scope: GraphQLCommon.CreateScopeFromExecuteAsyncV5AndV7(Tracer.Instance, context), state: context);
+            return new CallTargetState(scope: GraphQLCommon.CreateScopeFromExecuteAsyncV5AndV7(Tracer.InternalInstance, context), state: context);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateAsyncIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
         internal static CallTargetState OnMethodBegin<TTarget, TSchema, TDocument, TRules, TUserContext, TInputs>(TTarget instance, string originalQuery, TSchema schema, TDocument document, TRules rules, TUserContext userContext, TInputs inputs)
             where TDocument : IDocument
         {
-            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.Instance, document.OriginalQuery));
+            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.InternalInstance, document.OriginalQuery));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateAsyncIntegrationV4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateAsyncIntegrationV4.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
         internal static CallTargetState OnMethodBegin<TTarget, TSchema, TDocument, TVariables, TRules, TUserContext, TInputs>(TTarget instance, TSchema schema, TDocument document, TVariables variables, TRules rules, TUserContext userContext, TInputs inputs)
             where TDocument : IDocument
         {
-            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.Instance, document.OriginalQuery));
+            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.InternalInstance, document.OriginalQuery));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateAsyncIntegrationV5AndV7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateAsyncIntegrationV5AndV7.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
         internal static CallTargetState OnMethodBegin<TTarget, TValidationContext, TRules>(TTarget instance, TValidationContext validationContext, TRules rules)
             where TValidationContext : IValidationContext
         {
-            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.Instance, validationContext.Document.Source?.ToString()));
+            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.InternalInstance, validationContext.Document.Source?.ToString()));
         }
 
         internal static TValidationResult OnAsyncMethodEnd<TTarget, TValidationResult>(TTarget instance, TValidationResult validationResult, Exception exception, in CallTargetState state)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/Net/ValidateIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.GraphQL.Net
         internal static CallTargetState OnMethodBegin<TTarget, TSchema, TDocument, TRules, TUserContext, TInputs>(TTarget instance, string originalQuery, TSchema schema, TDocument document, TRules rules, TUserContext userContext, TInputs inputs)
             where TDocument : IDocument
         {
-            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.Instance, document.OriginalQuery));
+            return new CallTargetState(GraphQLCommon.CreateScopeFromValidate(Tracer.InternalInstance, document.OriginalQuery));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcProtocolHelpersBuildHttpErrorResponseIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcProtocolHelpersBuildHttpErrorResponseIntegration.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin(HttpResponse response, int httpStatusCode, int grpcStatusCode, string message)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (GrpcCoreApiVersionHelper.IsSupported
              && tracer.Settings.IsIntegrationEnabled(IntegrationId.Grpc)
              && tracer.ActiveScope?.Span is Span { Tags: GrpcServerTags } span)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/HttpContextServerCallContextLogCallEndIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/HttpContextServerCallContextLogCallEndIntegration.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (GrpcCoreApiVersionHelper.IsSupported
              && tracer.Settings.IsIntegrationEnabled(IntegrationId.Grpc)
              && tracer.ActiveScope?.Span is Span { Tags: GrpcServerTags } span)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/ServerCallHandlerBaseHandleCallAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/ServerCallHandlerBaseHandleCallAsyncIntegration.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
         {
             if (GrpcCoreApiVersionHelper.IsSupported)
             {
-                var scope = GrpcDotNetServerCommon.CreateServerSpan(Tracer.Instance, instance, httpContext.Request);
+                var scope = GrpcDotNetServerCommon.CreateServerSpan(Tracer.InternalInstance, instance, httpContext.Request);
                 return new CallTargetState(scope);
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcCallFinishCallIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcCallFinishCallIntegration.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcNetC
             where TStatus : IStatus
         {
             // always supported, as only applies in v2.43.0+
-            GrpcDotNetClientCommon.RecordResponseMetadataAndStatus(Tracer.Instance, instance, status.StatusCode, status.Detail, status.DebugException);
+            GrpcDotNetClientCommon.RecordResponseMetadataAndStatus(Tracer.InternalInstance, instance, status.StatusCode, status.Detail, status.DebugException);
             return CallTargetState.GetDefault();
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcCallFinishCallPre243Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcCallFinishCallPre243Integration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcNetC
                 // Technically, status _should_ be a Nullable<Status>, but due to nullable weirdness,
                 // if it has a value, then it isn't, and it _always_ has a value here AFAICT
                 var statusValue = status.DuckCast<StatusStruct>();
-                GrpcDotNetClientCommon.RecordResponseMetadataAndStatus(Tracer.Instance, instance, statusValue.StatusCode, statusValue.Detail, statusValue.DebugException);
+                GrpcDotNetClientCommon.RecordResponseMetadataAndStatus(Tracer.InternalInstance, instance, statusValue.StatusCode, statusValue.Detail, statusValue.DebugException);
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcCallRunCallIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcCallRunCallIntegration.cs
@@ -43,7 +43,7 @@ public class GrpcCallRunCallIntegration
     {
         if (GrpcCoreApiVersionHelper.IsSupported)
         {
-            var scope = GrpcDotNetClientCommon.CreateClientSpan(Tracer.Instance, instance, requestMessage);
+            var scope = GrpcDotNetClientCommon.CreateClientSpan(Tracer.InternalInstance, instance, requestMessage);
             return new CallTargetState(scope);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcNetClient/GrpcDotNetClientCommon.cs
@@ -105,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcNetC
                 span.SetHeaderTags(metadata, tracer.Settings.GrpcTagsInternal, defaultTagPrefix: GrpcCommon.ResponseMetadataTagPrefix);
             }
 
-            GrpcCommon.RecordFinalClientSpanStatus(Tracer.Instance, grpcStatusCode, errorMessage, ex);
+            GrpcCommon.RecordFinalClientSpanStatus(Tracer.InternalInstance, grpcStatusCode, errorMessage, ex);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/AsyncCallHandleFinishedInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/AsyncCallHandleFinishedInstrumentation.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
     {
         internal static CallTargetState OnMethodBegin<TTarget, TStatus>(TTarget instance, bool success, in TStatus clientSideStatus)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (GrpcCoreApiVersionHelper.IsSupported && tracer.Settings.IsIntegrationEnabled(IntegrationId.Grpc))
             {
                 var asyncCall = instance.DuckCast<AsyncCallStruct>();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/AsyncCallHandleUnaryResponseInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/AsyncCallHandleUnaryResponseInstrumentation.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
         {
             // receivedStatus can change in the middle of this method, so we need to wait for the method to finish,
             // to grab the final status.
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (GrpcCoreApiVersionHelper.IsSupported && tracer.Settings.IsIntegrationEnabled(IntegrationId.Grpc))
             {
                 // using CreateFrom to avoid boxing ClientSideStatus struct

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/DefaultCallInvokerInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/DefaultCallInvokerInstrumentation.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
             // Need to inject _everything_ required to recreate the span later, in the "finished" integrations
             if (GrpcCoreApiVersionHelper.IsSupported)
             {
-                GrpcLegacyClientCommon.InjectHeaders(Tracer.Instance, method, ref callOptions);
+                GrpcLegacyClientCommon.InjectHeaders(Tracer.InternalInstance, method, ref callOptions);
             }
 
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/MetadataArraySafeHandleCreateInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/MetadataArraySafeHandleCreateInstrumentation.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
         /// </summary>
         internal static CallTargetState OnMethodBegin<TInstance, TMetadata>(TInstance instance, TMetadata metadataInstance)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (!GrpcCoreApiVersionHelper.IsSupported || !tracer.Settings.IsIntegrationEnabled(IntegrationId.Grpc) || metadataInstance is null)
             {
                 return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/AsyncCallServerSendInitialMetadataAsyncInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/AsyncCallServerSendInitialMetadataAsyncInstrumentation.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
     {
         internal static CallTargetState OnMethodBegin<TTarget, TMetadata>(TTarget instance, in TMetadata? headers)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (tracer.ActiveScope is Scope { Span: { Tags: GrpcServerTags } span } && headers is not null)
             {
                 var metadata = headers.DuckCast<IMetadata>();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/AsyncCallServerSendStatusFromServerAsyncInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/AsyncCallServerSendStatusFromServerAsyncInstrumentation.cs
@@ -31,7 +31,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
     {
         internal static CallTargetState OnMethodBegin<TTarget, TStatus, TMetadata, TResponse>(TTarget instance, in TStatus status, in TMetadata trailers, in TResponse response)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (tracer.ActiveScope is Scope { Span: { Tags: GrpcServerTags } span })
             {
                 // Use CreateFrom to avoid boxing

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/ServerCallHandlerInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Server/ServerCallHandlerInstrumentation.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Server
         internal static CallTargetState OnMethodBegin<TTarget, TServerRpc, TCompletionQueue>(TTarget instance, TServerRpc serverRpc, in TCompletionQueue completionQueue)
             where TServerRpc : IServerRpcNew
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (GrpcCoreApiVersionHelper.IsSupported && tracer.Settings.IsIntegrationEnabled(IntegrationId.Grpc))
             {
                 var scope = GrpcLegacyServerCommon.CreateServerSpan(tracer, instance, serverRpc.RequestMetadata);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/HttpMessageHandlerCommon.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
                 return CallTargetState.GetDefault();
             }
 
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             var headers = requestMessage.Headers;
             if (IsTracingEnabled(headers, implementationIntegrationId) &&
                 ScopeFactory.CreateOutboundHttpScope(tracer, requestMessage.Method.Method, requestMessage.RequestUri, integrationId, out var tags) is { } scope)
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
             {
                 if (responseMessage.Instance is not null)
                 {
-                    scope.Span.SetHttpStatusCode(responseMessage.StatusCode, false, Tracer.Instance.Settings);
+                    scope.Span.SetHttpStatusCode(responseMessage.StatusCode, false, Tracer.InternalInstance.Settings);
                 }
 
                 if (exception != null)
@@ -73,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.HttpClient
 
         private static bool IsTracingEnabled(IRequestHeaders headers, IntegrationId? implementationIntegrationId)
         {
-            if (implementationIntegrationId != null && !Tracer.Instance.Settings.IsIntegrationEnabled(implementationIntegrationId.Value))
+            if (implementationIntegrationId != null && !Tracer.InternalInstance.Settings.IsIntegrationEnabled(implementationIntegrationId.Value))
             {
                 return false;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
         {
             if (instance is HttpWebRequest request && WebRequestCommon.IsTracingEnabled(request))
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
 
                 if (tracer.Settings.IsIntegrationEnabled(WebRequestCommon.IntegrationId))
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
         {
             if (instance is HttpWebRequest request && WebRequestCommon.IsTracingEnabled(request))
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
 
                 // We may have already set headers
                 if (request.Headers.Get(HttpHeaderNames.TraceId) is null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -68,14 +68,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 var existingSpanContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
 
                 // If this operation creates the trace, then we need to re-apply the sampling priority
-                bool setSamplingPriority = existingSpanContext?.SamplingPriority != null && Tracer.Instance.ActiveScope == null;
+                bool setSamplingPriority = existingSpanContext?.SamplingPriority != null && Tracer.InternalInstance.ActiveScope == null;
 
                 Scope scope = null;
 
                 try
                 {
                     scope = ScopeFactory.CreateOutboundHttpScope(
-                        Tracer.Instance,
+                        Tracer.InternalInstance,
                         request.Method,
                         request.RequestUri,
                         WebRequestCommon.IntegrationId,
@@ -93,7 +93,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
 
                         if (returnValue is HttpWebResponse response)
                         {
-                            scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.Instance.Settings);
+                            scope.Span.SetHttpStatusCode((int)response.StatusCode, isServer: false, Tracer.InternalInstance.Settings);
                             scope.Dispose();
                         }
                         else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
@@ -102,7 +102,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                             // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
                             scope.Span.SetExceptionTags(exception);
 
-                            scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.Instance.Settings);
+                            scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, isServer: false, Tracer.InternalInstance.Settings);
                             scope.Dispose();
                         }
                         else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
         {
             if (instance is HttpWebRequest request && WebRequestCommon.IsTracingEnabled(request))
             {
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
 
                 if (tracer.Settings.IsIntegrationEnabled(WebRequestCommon.IntegrationId))
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetResponse_Integration.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
             {
                 if (returnValue is HttpWebResponse response)
                 {
-                    state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.Instance.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, Tracer.InternalInstance.Settings);
                     state.Scope.Dispose();
                 }
                 else if (exception is WebException { Status: WebExceptionStatus.ProtocolError, Response: HttpWebResponse exceptionResponse })
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                     // SetHttpStatusCode will mark the span with an error if the StatusCode is within the configured range
                     state.Scope.Span.SetExceptionTags(exception);
 
-                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.Instance.Settings);
+                    state.Scope.Span.SetHttpStatusCode((int)exceptionResponse.StatusCode, false, Tracer.InternalInstance.Settings);
                     state.Scope.Dispose();
                 }
                 else

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequestCommon.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 var spanContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
 
                 // If this operation creates the trace, then we need to re-apply the sampling priority
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 bool setSamplingPriority = spanContext?.SamplingPriority != null && tracer.ActiveScope == null;
 
                 Scope scope = null;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/WebRequest_GetResponseAsync_Integration.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
         {
             if (state.Scope != null)
             {
-                Tracer tracer = Tracer.Instance;
+                Tracer tracer = Tracer.InternalInstance;
                 if (returnValue is HttpWebResponse response)
                 {
                     state.Scope.Span.SetHttpStatusCode((int)response.StatusCode, false, tracer.Settings);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerCloseIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerCloseIntegration.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
             // If we are already in a consumer scope, close it.
-            KafkaHelper.CloseConsumerScope(Tracer.Instance);
+            KafkaHelper.CloseConsumerScope(Tracer.InternalInstance);
             return CallTargetState.GetDefault();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConstructorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConstructorIntegration.cs
@@ -28,7 +28,7 @@ public class KafkaConsumerConstructorIntegration
     internal static CallTargetState OnMethodBegin<TTarget, TConsumerBuilder>(TTarget instance, TConsumerBuilder consumer)
         where TConsumerBuilder : IConsumerBuilder
     {
-        if (Tracer.Instance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId))
+        if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId))
         {
             string groupId = null;
             string bootstrapServers = null;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, int millisecondsTimeout)
         {
             // If we are already in a consumer scope, close it, and start a new one on method exit.
-            KafkaHelper.CloseConsumerScope(Tracer.Instance);
+            KafkaHelper.CloseConsumerScope(Tracer.InternalInstance);
             return CallTargetState.GetDefault();
         }
 
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             {
                 // This sets the span as active and either disposes it immediately
                 // or disposes it on the next call to Consumer.Consume()
-                var tracer = Tracer.Instance;
+                var tracer = Tracer.InternalInstance;
                 Scope scope = KafkaHelper.CreateConsumerScope(
                     tracer,
                     tracer.TracerManager.DataStreamsManager,
@@ -74,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                     consumeResult.Offset,
                     consumeResult.Message);
 
-                if (!Tracer.Instance.Settings.KafkaCreateConsumerScopeEnabledInternal)
+                if (!Tracer.InternalInstance.Settings.KafkaCreateConsumerScopeEnabledInternal)
                 {
                     // Close and dispose the scope immediately
                     scope.DisposeWithException(exception);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerDisposeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerDisposeIntegration.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
             // If we are already in a consumer scope, close it.
-            KafkaHelper.CloseConsumerScope(Tracer.Instance);
+            KafkaHelper.CloseConsumerScope(Tracer.InternalInstance);
             return CallTargetState.GetDefault();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerUnsubscribeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerUnsubscribeIntegration.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
             // If we are already in a consumer scope, close it.
-            KafkaHelper.CloseConsumerScope(Tracer.Instance);
+            KafkaHelper.CloseConsumerScope(Tracer.InternalInstance);
             return CallTargetState.GetDefault();
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceAsyncIntegration.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         {
             var partition = topicPartition.DuckCast<ITopicPartition>();
             Scope scope = KafkaHelper.CreateProducerScope(
-                Tracer.Instance,
+                Tracer.InternalInstance,
                 instance,
                 partition,
                 isTombstone: message.Value is null,
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             {
                 KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
                     scope.Span,
-                    Tracer.Instance.TracerManager.DataStreamsManager,
+                    Tracer.InternalInstance.TracerManager.DataStreamsManager,
                     partition?.Topic,
                     message);
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncDeliveryHandlerIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncDeliveryHandlerIntegration.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 // The current span should be started in KafkaProduceSyncIntegration.OnMethodBegin
                 // The OnMethodBegin and OnMethodEnd of this integration happens between KafkaProduceSyncIntegration.OnMethodBegin
                 // and KafkaProduceSyncIntegration.OnMethodEnd, so the consumer span is active for the duration of this integration
-                var activeScope = Tracer.Instance?.InternalActiveScope;
+                var activeScope = Tracer.InternalInstance?.InternalActiveScope;
                 var span = activeScope?.Span;
                 if (span is null)
                 {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProduceSyncIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             // as a generic parameter, for injecting headers
             var partition = topicPartition.DuckCast<ITopicPartition>();
             Scope scope = KafkaHelper.CreateProducerScope(
-                Tracer.Instance,
+                Tracer.InternalInstance,
                 instance,
                 partition,
                 isTombstone: message.Value is null,
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             {
                 KafkaHelper.TryInjectHeaders<TTopicPartition, TMessage>(
                     scope.Span,
-                    Tracer.Instance.TracerManager.DataStreamsManager,
+                    Tracer.InternalInstance.TracerManager.DataStreamsManager,
                     partition?.Topic,
                     message);
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaProducerConstructorIntegration.cs
@@ -28,7 +28,7 @@ public class KafkaProducerConstructorIntegration
     internal static CallTargetState OnMethodBegin<TTarget, TProducerBuilder>(TTarget instance, TProducerBuilder consumer)
         where TProducerBuilder : IProducerBuilder
     {
-        if (Tracer.Instance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId))
+        if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(KafkaConstants.IntegrationId))
         {
             foreach (var kvp in consumer.Config)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/DatadogLoggingScope.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/DatadogLoggingScope.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
         private readonly string _cachedFormat;
 
         public DatadogLoggingScope()
-            : this(Tracer.Instance)
+            : this(Tracer.InternalInstance)
         {
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/LoggerExternalScopeProviderForEachScopeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/LoggerExternalScopeProviderForEachScopeIntegration.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TAction, TState>(TTarget instance, TAction callback, TState state)
         {
-            LoggerIntegrationCommon.AddScope(Tracer.Instance, callback, state);
+            LoggerIntegrationCommon.AddScope(Tracer.InternalInstance, callback, state);
             return new CallTargetState(scope: null, state: null);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/LoggerFactoryScopeProviderForEachScopeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/LoggerFactoryScopeProviderForEachScopeIntegration.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TAction, TState>(TTarget instance, TAction callback, TState state)
         {
-            LoggerIntegrationCommon.AddScope(Tracer.Instance, callback, state);
+            LoggerIntegrationCommon.AddScope(Tracer.InternalInstance, callback, state);
             return new CallTargetState(scope: null, state: null);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
         internal static CallTargetState OnMethodBegin<TTarget, TLoggingEvent>(TTarget instance, TLoggingEvent loggingEvent)
             where TLoggingEvent : ILoggingEvent
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (tracer.Settings.LogsInjectionEnabledInternal &&
                 !loggingEvent.Properties.Contains(CorrelationIdentifier.ServiceKey))

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegrationV4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegrationV4.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjecti
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TTargets, TLogEventInfo, TLogFactory>(TTarget instance, Type loggerType, TTargets targetsForLevel, TLogEventInfo logEvent, TLogFactory factory)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (tracer.Settings.LogsInjectionEnabledInternal)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegrationV5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/LoggerImplWriteIntegrationV5.cs
@@ -40,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjecti
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TTargets, TLogEventInfo, TLogFactory>(TTarget instance, Type loggerType, TTargets targetsForLevel, TLogEventInfo logEvent, TLogFactory factory)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (tracer.Settings.LogsInjectionEnabledInternal)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.LogsInje
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TLogEvent>(TTarget instance, TLogEvent loggingEvent)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (tracer.Settings.LogsInjectionEnabledInternal)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/MongoDbIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/MongoDbIntegration.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.MongoDb
         internal static Scope CreateScope<TConnection>(object wireProtocol, TConnection connection)
             where TConnection : IConnection
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_Purge_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_Purge_Integration.cs
@@ -35,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         internal static CallTargetState OnMethodBegin<TMessageQueue>(TMessageQueue instance)
             where TMessageQueue : IMessageQueue
         {
-            var scope = MsmqCommon.CreateScope(Tracer.Instance, Command, SpanKinds.Client, instance);
+            var scope = MsmqCommon.CreateScope(Tracer.InternalInstance, Command, SpanKinds.Client, instance);
             return new CallTargetState(scope);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_ReceiveCurrent_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_ReceiveCurrent_Integration.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         internal static CallTargetState OnMethodBegin<TMessageQueue>(TMessageQueue instance, TimeSpan timeout, int action, object cursorHandle, object messagePropertyFilter, object messageQueueTransaction, MessageQueueTransactionType messageQueueTransactionType)
             where TMessageQueue : IMessageQueue
         {
-            var scope = MsmqCommon.CreateScope(Tracer.Instance, action != 0 ? CommandPeek : CommandReceive, SpanKinds.Consumer, instance);
+            var scope = MsmqCommon.CreateScope(Tracer.InternalInstance, action != 0 ? CommandPeek : CommandReceive, SpanKinds.Consumer, instance);
             return new CallTargetState(scope);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_SendInternal_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_SendInternal_Integration.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         internal static CallTargetState OnMethodBegin<TMessageQueue>(TMessageQueue instance, object message, object messageQueueTransaction, MessageQueueTransactionType messageQueueTransactionType)
             where TMessageQueue : IMessageQueue
         {
-            var scope = MsmqCommon.CreateScope(Tracer.Instance, Command, SpanKinds.Producer, instance, messageQueueTransaction != null || messageQueueTransactionType != MessageQueueTransactionType.None);
+            var scope = MsmqCommon.CreateScope(Tracer.InternalInstance, Command, SpanKinds.Producer, instance, messageQueueTransaction != null || messageQueueTransactionType != MessageQueueTransactionType.None);
             return new CallTargetState(scope);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/StartRootSpanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/StartRootSpanIntegration.cs
@@ -45,9 +45,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTracer, TSpanKind, TSpanAttributes, TLinks>(TTracer instance, string name, TSpanKind kind, TSpanAttributes spanAttributes, TLinks links, DateTimeOffset startTimeinstance)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId))
             {
-                return new CallTargetState(Tracer.Instance.InternalActiveScope);
+                return new CallTargetState(Tracer.InternalInstance.InternalActiveScope);
             }
 
             // integration disabled, don't create a scope, skip this trace
@@ -66,10 +66,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
         /// <returns>CallTargetReturn</returns>
         internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // If the integration created a new scope, dispose it
-                var currentScope = Tracer.Instance.InternalActiveScope;
+                var currentScope = Tracer.InternalInstance.InternalActiveScope;
                 if (state.Scope != currentScope)
                 {
                     currentScope.Dispose();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/StartSpanIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/StartSpanIntegration.cs
@@ -47,9 +47,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTracer, TSpanKind, TSpanContext, TSpanAttributes, TLinks>(TTracer instance, string name, TSpanKind kind, in TSpanContext parentContext, TSpanAttributes spanAttributes, TLinks links, DateTimeOffset startTimeinstance)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId))
             {
-                return new CallTargetState(Tracer.Instance.InternalActiveScope);
+                return new CallTargetState(Tracer.InternalInstance.InternalActiveScope);
             }
 
             // integration disabled, don't create a scope, skip this trace
@@ -68,10 +68,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
         /// <returns>CallTargetReturn</returns>
         internal static CallTargetReturn<TReturn> OnMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // If the integration created a new scope, dispose it
-                var currentScope = Tracer.Instance.InternalActiveScope;
+                var currentScope = Tracer.InternalInstance.InternalActiveScope;
                 if (state.Scope != currentScope)
                 {
                     currentScope.Dispose();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/TracerProviderBuilderIntegration.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.OpenTelemetry
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TTracerProviderBuilder>(TTarget instance, TTracerProviderBuilder tracerProviderBuilder)
         {
-            if (Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId))
+            if (Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 if (_cachedAddProcessorDelegate is not null
                     && _cachedProcessorType is not null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/ProcessStartCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/ProcessStartCommon.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Process
 
         private static Scope? CreateScope(string filename, IDictionary<string, string?>? environmentVariables, bool useShellExecute, string arguments, Collection<string>? argumentList = null)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
                 // integration disabled, don't create a scope, skip this span
@@ -87,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Process
             };
 
             // Don't populate further with command line information if shell collection is disabled
-            if (!Tracer.Instance.Settings.CommandsCollectionEnabled)
+            if (!Tracer.InternalInstance.Settings.CommandsCollectionEnabled)
             {
                 return tags;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicConsumeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicConsumeIntegration.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         internal static CallTargetState OnMethodBegin<TTarget, TConsumer>(TTarget instance, string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, TConsumer consumer)
         {
             QueueHelper.SetQueue(consumer, queue);
-            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Consumer, queue: queue));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.InternalInstance, out _, Command, SpanKinds.Consumer, queue: queue));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            using (var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
+            using (var scope = RabbitMQIntegration.CreateScope(Tracer.InternalInstance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
             {
                 if (scope != null)
                 {
@@ -106,7 +106,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                     if (basicProperties != null)
                     {
                         RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(
-                            Tracer.Instance,
+                            Tracer.InternalInstance,
                             scope.Span,
                             tags,
                             basicProperties.Headers,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicPublishIntegration.cs
@@ -51,8 +51,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             where TBody : IBody, IDuckType // Versions < 6.0.0: TBody is byte[] // Versions >= 6.0.0: TBody is ReadOnlyMemory<byte>
             where TTarget : IModelBase
         {
-            var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey, host: instance?.Session.Connection.Endpoint.HostName);
-            Tracer.Instance.CurrentTraceSettings.Schema.RemapPeerService(tags);
+            var scope = RabbitMQIntegration.CreateScope(Tracer.InternalInstance, out RabbitMQTags tags, Command, spanKind: SpanKinds.Producer, exchange: exchange, routingKey: routingKey, host: instance?.Session.Connection.Endpoint.HostName);
+            Tracer.InternalInstance.CurrentTraceSettings.Schema.RemapPeerService(tags);
 
             if (scope != null)
             {
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
                     SpanContextPropagator.Instance.Inject(scope.Span.Context, basicProperties.Headers, default(ContextPropagation));
                     RabbitMQIntegration.SetDataStreamsCheckpointOnProduce(
-                        Tracer.Instance,
+                        Tracer.InternalInstance,
                         scope.Span,
                         tags,
                         basicProperties.Headers,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
             where TTarget : IModelBase
         {
-            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange, host: instance?.Session.Connection.Endpoint.HostName));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.InternalInstance, out _, Command, SpanKinds.Client, exchange: exchange, host: instance?.Session.Connection.Endpoint.HostName));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
             where TTarget : IModelBase
         {
-            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey, host: instance?.Session.Connection.Endpoint.HostName));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.InternalInstance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey, host: instance?.Session.Connection.Endpoint.HostName));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
             where TTarget : IModelBase
         {
-            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, host: instance?.Session.Connection.Endpoint.HostName));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.InternalInstance, out _, Command, SpanKinds.Client, queue: queue, host: instance?.Session.Connection.Endpoint.HostName));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
@@ -162,7 +162,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             where TBasicProperties : IBasicProperties
             where TBody : IBody // ReadOnlyMemory<byte> body in 6.0.0
         {
-            if (IsActiveScopeRabbitMQ(Tracer.Instance))
+            if (IsActiveScopeRabbitMQ(Tracer.InternalInstance))
             {
                 // we are already instrumenting this,
                 // don't instrument nested methods that belong to the same stacktrace
@@ -192,7 +192,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, "basic.deliver", parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, exchange: exchange, routingKey: routingKey);
+            var scope = RabbitMQIntegration.CreateScope(Tracer.InternalInstance, out RabbitMQTags tags, "basic.deliver", parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, exchange: exchange, routingKey: routingKey);
             if (tags != null)
             {
                 tags.MessageSize = body?.Length.ToString() ?? "0";
@@ -200,7 +200,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 
             var timeInQueue = basicProperties != null && basicProperties.Timestamp.UnixTime != 0 ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - basicProperties.Timestamp.UnixTime : 0;
             RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(
-                Tracer.Instance,
+                Tracer.InternalInstance,
                 scope.Span,
                 tags,
                 basicProperties?.Headers,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/RedisHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/RedisHelper.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
 
         internal static Scope CreateScope(Tracer tracer, IntegrationId integrationId, string integrationName, string host, string port, string rawCommand, long? databaseIndex)
         {
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(integrationId))
+            if (!Tracer.InternalInstance.Settings.IsIntegrationEnabled(integrationId))
             {
                 // integration disabled, don't create a scope, skip this trace
                 return null;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/ServiceStack/RedisNativeClientSendReceiveIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/ServiceStack/RedisNativeClientSendReceiveIntegration.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.ServiceStack
         internal static CallTargetState OnMethodBegin<TTarget, TFunc, TAction>(TTarget instance, byte[][] cmdWithBinaryArgs, TFunc fn, TAction completePipelineFn, bool sendWithoutRead)
             where TTarget : IRedisNativeClient
         {
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, IntegrationId, IntegrationName, instance.Host ?? string.Empty, instance.Port.ToString(CultureInfo.InvariantCulture), RedisHelper.GetRawCommand(cmdWithBinaryArgs), instance.Db);
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, IntegrationId, IntegrationName, instance.Host ?? string.Empty, instance.Port.ToString(CultureInfo.InvariantCulture), RedisHelper.GetRawCommand(cmdWithBinaryArgs), instance.Db);
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/ServiceStack/RedisNativeClientSendReceiveIntegration_6_2_0.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/ServiceStack/RedisNativeClientSendReceiveIntegration_6_2_0.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.ServiceStack
         internal static CallTargetState OnMethodBegin<TTarget, TFunc, TAction>(TTarget instance, byte[][] cmdWithBinaryArgs, TFunc fn, TAction completePipelineFn, bool sendWithoutRead, string operation)
             where TTarget : IRedisNativeClient
         {
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, IntegrationId, IntegrationName, instance.Host ?? string.Empty, instance.Port.ToString(CultureInfo.InvariantCulture), RedisHelper.GetRawCommand(cmdWithBinaryArgs), instance.Db);
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, IntegrationId, IntegrationName, instance.Host ?? string.Empty, instance.Port.ToString(CultureInfo.InvariantCulture), RedisHelper.GetRawCommand(cmdWithBinaryArgs), instance.Db);
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration.cs
@@ -55,7 +55,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
             string rawCommand = message.CommandAndKey ?? "COMMAND";
             StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration_2_6_45.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration_2_6_45.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
             string rawCommand = message.CommandAndKey ?? "COMMAND";
             StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
             string rawCommand = message.CommandAndKey ?? "COMMAND";
             StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration_2_6_45.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration_2_6_45.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
             string rawCommand = message.CommandAndKey ?? "COMMAND";
             StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerSelectServerIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerSelectServerIntegration.cs
@@ -29,7 +29,7 @@ public class ConnectionMultiplexerSelectServerIntegration
 {
     internal static CallTargetReturn<TResult> OnMethodEnd<TTarget, TResult>(TTarget instance, TResult result, Exception exception, in CallTargetState state)
     {
-        var span = Tracer.Instance.InternalActiveScope?.Span;
+        var span = Tracer.InternalInstance.InternalActiveScope?.Span;
 
         if (result is not null
             && span is { Type: SpanTypes.Redis, Tags: RedisTags { InstrumentationName: StackExchangeRedisHelper.IntegrationName } tags })

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
             string rawCommand = message.CommandAndKey ?? "COMMAND";
             StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Multiplexer.Configuration);
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration_2_6_48.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration_2_6_48.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
             string rawCommand = message.CommandAndKey ?? "COMMAND";
             StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Multiplexer.Configuration);
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteSyncIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
             string rawCommand = message.CommandAndKey ?? "COMMAND";
             StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Multiplexer.Configuration);
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            Scope scope = RedisHelper.CreateScope(Tracer.InternalInstance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/MsTestV2/MsTestIntegration.cs
@@ -23,7 +23,7 @@ internal static class MsTestIntegration
 
     internal static readonly ThreadLocal<object> IsTestMethodRunnableThreadLocal = new();
 
-    internal static bool IsEnabled => CIVisibility.IsRunning && Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId);
+    internal static bool IsEnabled => CIVisibility.IsRunning && Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId);
 
     internal static Test OnMethodBegin<TTestMethod>(TTestMethod testMethodInfo, Type type)
         where TTestMethod : ITestMethod

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/NUnit/NUnitIntegration.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
         internal const string SkipReasonKey = "_SKIPREASON";
         internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(NUnitIntegration));
 
-        internal static bool IsEnabled => CIVisibility.IsRunning && Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId);
+        internal static bool IsEnabled => CIVisibility.IsRunning && Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId);
 
         internal static Test? CreateTest(ITest currentTest)
         {
@@ -117,7 +117,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.NUnit
             test.SetTestMethodInfo(testMethod);
 
             // Telemetry
-            Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
+            Tracer.InternalInstance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
 
             // Skip tests
             if (skipReason is not null)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitIntegration.cs
@@ -17,7 +17,7 @@ internal static class XUnitIntegration
     internal const string IntegrationName = nameof(IntegrationId.XUnit);
     internal const IntegrationId IntegrationId = Configuration.IntegrationId.XUnit;
 
-    internal static bool IsEnabled => CIVisibility.IsRunning && Tracer.Instance.Settings.IsIntegrationEnabled(IntegrationId);
+    internal static bool IsEnabled => CIVisibility.IsRunning && Tracer.InternalInstance.Settings.IsIntegrationEnabled(IntegrationId);
 
     internal static Test? CreateTest(ref TestRunnerStruct runnerInstance, Type targetType)
     {
@@ -86,7 +86,7 @@ internal static class XUnitIntegration
         }
 
         // Telemetry
-        Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
+        Tracer.InternalInstance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
 
         // Skip tests
         if (runnerInstance.SkipReason is { } skipReason)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/XUnit/XUnitTestOutputHelperQueueTestOutputIntegration.cs
@@ -44,7 +44,7 @@ public static class XUnitTestOutputHelperQueueTestOutputIntegration
             return CallTargetState.GetDefault();
         }
 
-        var tracer = Tracer.Instance;
+        var tracer = Tracer.InternalInstance;
         if (tracer.TracerManager.DirectLogSubmission.Settings.MinimumLevel < DirectSubmissionLogLevel.Information)
         {
             return CallTargetState.GetDefault();

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/TraceAnnotationsIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/TraceAnnotationsIntegration.cs
@@ -41,9 +41,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.TraceAnnotations
                 key => TraceAnnotationInfoFactory.Create(MethodBase.GetMethodFromHandle(key.MethodHandle, key.TypeHandle)));
 
             var tags = new TraceAnnotationTags();
-            var scope = Tracer.Instance.StartActiveInternal(info.OperationName, tags: tags);
+            var scope = Tracer.InternalInstance.StartActiveInternal(info.OperationName, tags: tags);
             scope.Span.ResourceName = info.ResourceName;
-            Tracer.Instance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
+            Tracer.InternalInstance.TracerManager.Telemetry.IntegrationGeneratedSpan(IntegrationId);
             return new CallTargetState(scope);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/AsyncMethodInvoker_InvokeBegin_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/AsyncMethodInvoker_InvokeBegin_Integration.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
             //
             // context.IncomingMessageProperties contains:
             // - ["httpRequest"] key to find distributed tracing headers
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(WcfCommon.IntegrationId) || !Tracer.Instance.Settings.DelayWcfInstrumentationEnabled || WcfCommon.GetCurrentOperationContext is null)
+            if (!Tracer.InternalInstance.Settings.IsIntegrationEnabled(WcfCommon.IntegrationId) || !Tracer.InternalInstance.Settings.DelayWcfInstrumentationEnabled || WcfCommon.GetCurrentOperationContext is null)
             {
                 return CallTargetState.GetDefault();
             }
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                 var requestContext = operationContextProxy.RequestContext;
 
                 // First, capture the active scope
-                var activeScope = Tracer.Instance.InternalActiveScope;
+                var activeScope = Tracer.InternalInstance.InternalActiveScope;
                 var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
 
                 // Then, create the new scope
@@ -88,7 +88,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
             {
                 // InvokeBegin should have started an async operation that will ultimately call InvokeEnd
                 // The current thread will be reused by WCF to process other requests so we need to restore the old scope
-                if (Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
+                if (Tracer.InternalInstance.ScopeManager is IScopeRawAccess rawAccess)
                 {
                     rawAccess.Active = state.PreviousScope;
                     DistributedTracer.Instance.SetSpanContext(state.PreviousDistributedSpanContext);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/ChannelHandlerIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/ChannelHandlerIntegration.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
         internal static CallTargetState OnMethodBegin<TTarget, TRequestContext, TOperationContext>(TTarget instance, TRequestContext request, TOperationContext currentOperationContext)
             where TRequestContext : IRequestContext, IDuckType
         {
-            if (Tracer.Instance.Settings.DelayWcfInstrumentationEnabled || request.Instance is null)
+            if (Tracer.InternalInstance.Settings.DelayWcfInstrumentationEnabled || request.Instance is null)
             {
                 return CallTargetState.GetDefault();
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/SyncMethodInvokerIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/SyncMethodInvokerIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
             //
             // context.IncomingMessageProperties contains:
             // - ["httpRequest"] key to find distributed tracing headers
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(WcfCommon.IntegrationId) || !Tracer.Instance.Settings.DelayWcfInstrumentationEnabled || WcfCommon.GetCurrentOperationContext is null)
+            if (!Tracer.InternalInstance.Settings.IsIntegrationEnabled(WcfCommon.IntegrationId) || !Tracer.InternalInstance.Settings.DelayWcfInstrumentationEnabled || WcfCommon.GetCurrentOperationContext is null)
             {
                 return CallTargetState.GetDefault();
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/TaskMethodInvokerIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/TaskMethodInvokerIntegration.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
             //
             // context.IncomingMessageProperties contains:
             // - ["httpRequest"] key to find distributed tracing headers
-            if (!Tracer.Instance.Settings.IsIntegrationEnabled(WcfCommon.IntegrationId) || !Tracer.Instance.Settings.DelayWcfInstrumentationEnabled || WcfCommon.GetCurrentOperationContext is null)
+            if (!Tracer.InternalInstance.Settings.IsIntegrationEnabled(WcfCommon.IntegrationId) || !Tracer.InternalInstance.Settings.DelayWcfInstrumentationEnabled || WcfCommon.GetCurrentOperationContext is null)
             {
                 return CallTargetState.GetDefault();
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
@@ -44,7 +44,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                 return null;
             }
 
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (!tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
@@ -164,7 +164,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                 return action;
             }
 
-            if (Tracer.Instance.Settings.WcfObfuscationEnabled)
+            if (Tracer.InternalInstance.Settings.WcfObfuscationEnabled)
             {
                 return UriHelpers.GetCleanUriPath(requestHeaders.To?.LocalPath);
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler
 
         public object GetAutomaticActiveScope()
         {
-            return Tracer.Instance.InternalActiveScope;
+            return Tracer.InternalInstance.InternalActiveScope;
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler
             // This is a compromise: we add an additional asynclocal read for the manual tracer when there is no parent trace,
             // but it allows us to remove the asynclocal write for the automatic tracer when running without manual instrumentation.
 
-            return DistributedTrace.Value ?? Tracer.Instance.InternalActiveScope?.Span?.Context;
+            return DistributedTrace.Value ?? Tracer.InternalInstance.InternalActiveScope?.Span?.Context;
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler.cs
@@ -42,8 +42,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`1.cs
@@ -43,8 +43,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`2.cs
@@ -44,8 +44,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`3.cs
@@ -45,8 +45,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`4.cs
@@ -46,8 +46,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`5.cs
@@ -47,8 +47,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`6.cs
@@ -48,8 +48,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`7.cs
@@ -49,8 +49,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodHandler`8.cs
@@ -50,8 +50,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5, ref TArg6 arg6, ref TArg7 arg7, ref TArg8 arg8)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, ref arg1, ref arg2, ref arg3, ref arg4, ref arg5, ref arg6, ref arg7, ref arg8));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/BeginMethodSlowHandler.cs
@@ -41,8 +41,8 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static CallTargetState Invoke(TTarget instance, object[] arguments)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
-            // We don't use Tracer.Instance.DistributedSpanContext directly because we already retrieved the
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
+            // We don't use Tracer.InternalInstance.DistributedSpanContext directly because we already retrieved the
             // active scope from an AsyncLocal instance, and we want to avoid retrieving twice.
             var spanContextRaw = DistributedTracer.Instance.GetSpanContextRaw() ?? activeScope?.Span?.Context;
             return new CallTargetState(activeScope, spanContextRaw, _invokeDelegate(instance, arguments));

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/EndMethodHandler`1.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
                 // Restore previous scope and the previous DistributedTrace if there is a continuation
                 // This is used to mimic the ExecutionContext copy from the StateMachine
-                if (Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
+                if (Tracer.InternalInstance.ScopeManager is IScopeRawAccess rawAccess)
                 {
                     rawAccess.Active = state.PreviousScope;
                     DistributedTracer.Instance.SetSpanContext(state.PreviousDistributedSpanContext);

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationOptions.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationOptions.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                 if (_integrationId.Value is { } integrationId)
                 {
                     TelemetryFactory.Metrics.RecordCountSharedIntegrationsError(integrationId.GetMetricTag(), MetricTags.InstrumentationError.DuckTyping);
-                    Tracer.Instance.TracerManager.Telemetry.IntegrationDisabledDueToError(integrationId, nameof(DuckTypeException));
+                    Tracer.InternalInstance.TracerManager.Telemetry.IntegrationDisabledDueToError(integrationId, nameof(DuckTypeException));
                 }
 
                 _disableIntegration = true;
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
                 if (_integrationId.Value is { } integrationId)
                 {
                     TelemetryFactory.Metrics.RecordCountSharedIntegrationsError(integrationId.GetMetricTag(), MetricTags.InstrumentationError.Invoker);
-                    Tracer.Instance.TracerManager.Telemetry.IntegrationDisabledDueToError(integrationId, nameof(CallTargetInvokerException));
+                    Tracer.InternalInstance.TracerManager.Telemetry.IntegrationDisabledDueToError(integrationId, nameof(CallTargetInvokerException));
                 }
 
                 _disableIntegration = true;
@@ -67,7 +67,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         {
             if (_integrationId.Value is not null)
             {
-                Tracer.Instance.TracerManager.Telemetry.IntegrationRunning(_integrationId.Value.Value);
+                Tracer.InternalInstance.TracerManager.Telemetry.IntegrationRunning(_integrationId.Value.Value);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -15,12 +15,12 @@ namespace Datadog.Trace.ClrProfiler
     {
         public int? GetSamplingPriority()
         {
-            return Tracer.Instance.InternalActiveScope?.Span.Context.TraceContext?.SamplingPriority;
+            return Tracer.InternalInstance.InternalActiveScope?.Span.Context.TraceContext?.SamplingPriority;
         }
 
         public void SetSamplingPriority(int? samplingPriority)
         {
-            Tracer.Instance.InternalActiveScope?.Span.Context.TraceContext
+            Tracer.InternalInstance.InternalActiveScope?.Span.Context.TraceContext
                  ?.SetSamplingPriority(samplingPriority, notifyDistributedTracer: false);
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -136,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler
 
                 InitializeTracer(sw);
 
-                InitializeServerless(sw, Tracer.Instance.Settings.LambdaMetadata);
+                InitializeServerless(sw, Tracer.InternalInstance.Settings.LambdaMetadata);
             }
 
 #if NETSTANDARD2_0 || NETCOREAPP3_1
@@ -216,7 +216,7 @@ namespace Datadog.Trace.ClrProfiler
 
             InitializeTracer(sw);
 
-            InitializeServerless(sw, Tracer.Instance.Settings.LambdaMetadata);
+            InitializeServerless(sw, Tracer.InternalInstance.Settings.LambdaMetadata);
 
             InitializeAppSecLegacy(sw);
 
@@ -338,7 +338,7 @@ namespace Datadog.Trace.ClrProfiler
 
             try
             {
-                if (Tracer.Instance.Settings.IsActivityListenerEnabled)
+                if (Tracer.InternalInstance.Settings.IsActivityListenerEnabled)
                 {
                     Log.Debug("Initializing activity listener.");
                     Activity.ActivityListener.Initialize();
@@ -351,10 +351,10 @@ namespace Datadog.Trace.ClrProfiler
 
             Log.Debug("Initialization of non native parts finished.");
 
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (tracer is null)
             {
-                Log.Debug("Tracer.Instance is null after InitializeNoNativeParts was invoked");
+                Log.Debug("Tracer.InternalInstance is null after InitializeNoNativeParts was invoked");
             }
 
             if (sw != null)
@@ -366,10 +366,10 @@ namespace Datadog.Trace.ClrProfiler
 
         private static void InitializeTracer(Stopwatch sw)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
             if (tracer is null)
             {
-                Log.Debug("Skipping TraceMethods initialization because Tracer.Instance was null after InitializeNoNativeParts was invoked");
+                Log.Debug("Skipping TraceMethods initialization because Tracer.InternalInstance was null after InitializeNoNativeParts was invoked");
             }
             else
             {
@@ -454,7 +454,7 @@ namespace Datadog.Trace.ClrProfiler
         {
             var observers = new List<DiagnosticObserver>();
 
-            if (Tracer.Instance.Settings.AzureAppServiceMetadata?.IsFunctionsApp is not true)
+            if (Tracer.InternalInstance.Settings.AzureAppServiceMetadata?.IsFunctionsApp is not true)
             {
                 // Not adding the `AspNetCoreDiagnosticObserver` is particularly important for Azure Functions.
                 // The AspNetCoreDiagnosticObserver will be loaded in a separate Assembly Load Context, breaking the connection of AsyncLocal

--- a/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/AWS/LambdaCommon.cs
@@ -87,7 +87,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
 
             try
             {
-                await Tracer.Instance.TracerManager.AgentWriter.FlushTracesAsync()
+                await Tracer.InternalInstance.TracerManager.AgentWriter.FlushTracesAsync()
                             .WaitAsync(TimeSpan.FromSeconds(ServerlessMaxWaitingFlushTime))
                             .ConfigureAwait(false);
             }
@@ -151,7 +151,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
             var samplingPriority = response.Headers.Get(HttpHeaderNames.SamplingPriority);
             if (ValidateOKStatus(response))
             {
-                return CreatePlaceholderScope(Tracer.Instance, traceId, samplingPriority);
+                return CreatePlaceholderScope(Tracer.InternalInstance, traceId, samplingPriority);
             }
 
             return null;
@@ -212,7 +212,7 @@ namespace Datadog.Trace.ClrProfiler.ServerlessInstrumentation.AWS
                 // here we need a sync flush, since the lambda environment can be destroy after each invocation
                 // 3 seconds is enough to send payload to the extension (via localhost)
                 AsyncUtil.RunSync(
-                    () => Tracer.Instance.TracerManager.AgentWriter.FlushTracesAsync()
+                    () => Tracer.InternalInstance.TracerManager.AgentWriter.FlushTracesAsync()
                                 .WaitAsync(TimeSpan.FromSeconds(ServerlessMaxWaitingFlushTime)));
             }
             catch (Exception ex)

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Configuration
 
         private static void OnConfigurationChanged(ConfigurationBuilder settings)
         {
-            var oldSettings = Tracer.Instance.Settings;
+            var oldSettings = Tracer.InternalInstance.Settings;
 
             var headerTags = TracerSettings.InitializeHeaderTags(settings, ConfigurationKeys.HeaderTags, oldSettings.HeaderTagsNormalizationFixEnabled);
             // var serviceNameMappings = TracerSettings.InitializeServiceNameMappings(settings, ConfigurationKeys.ServiceNameMappings);

--- a/tracer/src/Datadog.Trace/CorrelationIdentifier.cs
+++ b/tracer/src/Datadog.Trace/CorrelationIdentifier.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the name of the service
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DD0002:Incorrect usage of public API", Justification = "We must access the tracer via the public Tracer.Instance accessor because this API is only ever used for manual instrumentation.")]
         public static string Service
         {
             get
@@ -42,6 +43,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the version of the service
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DD0002:Incorrect usage of public API", Justification = "We must access the tracer via the public Tracer.Instance accessor because this API is only ever used for manual instrumentation.")]
         public static string Version
         {
             get
@@ -54,6 +56,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the environment name of the service
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DD0002:Incorrect usage of public API", Justification = "We must access the tracer via the public Tracer.Instance accessor because this API is only ever used for manual instrumentation.")]
         public static string Env
         {
             get
@@ -67,6 +70,7 @@ namespace Datadog.Trace
         /// Gets the id of the active trace.
         /// </summary>
         /// <returns>The id of the active trace. If there is no active trace, returns zero.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DD0002:Incorrect usage of public API", Justification = "We must access the tracer via the public Tracer.Instance accessor because this API is only ever used for manual instrumentation.")]
         public static ulong TraceId
         {
             get
@@ -80,6 +84,7 @@ namespace Datadog.Trace
         /// Gets the id of the active span.
         /// </summary>
         /// <returns>The id of the active span. If there is no active span, returns zero.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("CodeQuality", "DD0002:Incorrect usage of public API", Justification = "We must access the tracer via the public Tracer.Instance accessor because this API is only ever used for manual instrumentation.")]
         public static ulong SpanId
         {
             get

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -324,28 +324,28 @@ namespace Datadog.Trace.Debugger.Expressions
                 switch (ProbeInfo.TargetSpan)
                 {
                     case TargetSpan.Root:
-                        Tracer.Instance.ScopeManager.Active.Root.Span.SetTag(decoration.TagName, decoration.Value);
-                        Tracer.Instance.ScopeManager.Active.Root.Span.SetTag(probeIdTag, ProbeInfo.ProbeId);
+                        Tracer.InternalInstance.ScopeManager.Active.Root.Span.SetTag(decoration.TagName, decoration.Value);
+                        Tracer.InternalInstance.ScopeManager.Active.Root.Span.SetTag(probeIdTag, ProbeInfo.ProbeId);
                         if (decoration.Errors?.Length > 0)
                         {
-                            Tracer.Instance.ScopeManager.Active.Root.Span.SetTag(evaluationErrorTag, string.Join(";", decoration.Errors));
+                            Tracer.InternalInstance.ScopeManager.Active.Root.Span.SetTag(evaluationErrorTag, string.Join(";", decoration.Errors));
                         }
-                        else if (Tracer.Instance.ScopeManager.Active.Span.GetTag(evaluationErrorTag) != null)
+                        else if (Tracer.InternalInstance.ScopeManager.Active.Span.GetTag(evaluationErrorTag) != null)
                         {
-                            Tracer.Instance.ScopeManager.Active.Root.Span.SetTag(evaluationErrorTag, null);
+                            Tracer.InternalInstance.ScopeManager.Active.Root.Span.SetTag(evaluationErrorTag, null);
                         }
 
                         break;
                     case TargetSpan.Active:
-                        Tracer.Instance.ScopeManager.Active.Span.SetTag(decoration.TagName, decoration.Value);
-                        Tracer.Instance.ScopeManager.Active.Span.SetTag(probeIdTag, ProbeInfo.ProbeId);
+                        Tracer.InternalInstance.ScopeManager.Active.Span.SetTag(decoration.TagName, decoration.Value);
+                        Tracer.InternalInstance.ScopeManager.Active.Span.SetTag(probeIdTag, ProbeInfo.ProbeId);
                         if (decoration.Errors?.Length > 0)
                         {
-                            Tracer.Instance.ScopeManager.Active.Span.SetTag(evaluationErrorTag, string.Join(";", decoration.Errors));
+                            Tracer.InternalInstance.ScopeManager.Active.Span.SetTag(evaluationErrorTag, string.Join(";", decoration.Errors));
                         }
-                        else if (Tracer.Instance.ScopeManager.Active.Span.GetTag(evaluationErrorTag) != null)
+                        else if (Tracer.InternalInstance.ScopeManager.Active.Span.GetTag(evaluationErrorTag) != null)
                         {
-                            Tracer.Instance.ScopeManager.Active.Span.SetTag(evaluationErrorTag, null);
+                            Tracer.InternalInstance.ScopeManager.Active.Span.SetTag(evaluationErrorTag, null);
                         }
 
                         break;

--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/SpanDebuggerInvoker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/SpanDebuggerInvoker.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
             var tags = new CommonTags();
             tags.SetTag("debugger.probeid", probeId);
             tags.SetTag("component", "trace");
-            var scope = Tracer.Instance.StartActiveInternal(operationName, tags: tags);
+            var scope = Tracer.InternalInstance.StartActiveInternal(operationName, tags: tags);
             scope.Span.ResourceName = resourceName;
             TelemetryFactory.Metrics.RecordCountSpanCreated(MetricTags.IntegrationName.DebuggerSpanProbe);
             return new SpanDebuggerState(scope);

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -689,7 +689,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
         internal void FinalizeSnapshot(string methodName, string typeFullName, string probeFilePath)
         {
-            var activeScope = Tracer.Instance.InternalActiveScope;
+            var activeScope = Tracer.InternalInstance.InternalActiveScope;
 
             // TODO: support 128-bit trace ids?
             var traceId = activeScope?.Span.TraceId128.Lower.ToString(CultureInfo.InvariantCulture);

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.DiagnosticListeners
 
         protected override string ListenerName => DiagnosticListenerName;
 
-        private Tracer CurrentTracer => _tracer ?? Tracer.Instance;
+        private Tracer CurrentTracer => _tracer ?? Tracer.InternalInstance;
 
         private Security CurrentSecurity => _security ?? Security.Instance;
 

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -231,7 +231,7 @@ internal static class IastModule
             return null;
         }
 
-        var currentSpan = (Tracer.Instance.ActiveScope as Scope)?.Span;
+        var currentSpan = (Tracer.InternalInstance.ActiveScope as Scope)?.Span;
         var traceContext = currentSpan?.Context?.TraceContext;
         return traceContext?.IastRequestContext;
     }
@@ -244,7 +244,7 @@ internal static class IastModule
     // This method adds web vulnerabilities, with no location, only on web environments
     private static Scope? AddWebVulnerability(string evidenceValue, IntegrationId integrationId, string vulnerabilityType, int hashId)
     {
-        var tracer = Tracer.Instance;
+        var tracer = Tracer.InternalInstance;
         if (!iastSettings.Enabled || !tracer.Settings.IsIntegrationEnabled(integrationId))
         {
             // integration disabled, don't create a scope, skip this span
@@ -278,7 +278,7 @@ internal static class IastModule
 
     public static bool AddRequestVulnerabilitiesAllowed()
     {
-        var currentSpan = (Tracer.Instance.ActiveScope as Scope)?.Span;
+        var currentSpan = (Tracer.InternalInstance.ActiveScope as Scope)?.Span;
         var traceContext = currentSpan?.Context?.TraceContext;
         var isRequest = traceContext?.RootSpan?.Type == SpanTypes.Web;
         return isRequest && traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed() == true;
@@ -286,7 +286,7 @@ internal static class IastModule
 
     private static Scope? GetScope(string evidenceValue, IntegrationId integrationId, string vulnerabilityType, string operationName, bool taintedFromEvidenceRequired = false)
     {
-        var tracer = Tracer.Instance;
+        var tracer = Tracer.InternalInstance;
         if (!iastSettings.Enabled || !tracer.Settings.IsIntegrationEnabled(integrationId))
         {
             // integration disabled, don't create a scope, skip this span

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingClient.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ServiceFabric
         /// <param name="e">The event arguments.</param>
         private static void ServiceRemotingClientEvents_SendRequest(object? sender, EventArgs? e)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (!_initialized || !tracer.Settings.IsIntegrationEnabled(ServiceRemotingConstants.IntegrationId))
             {
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ServiceFabric
         /// or <c>IServiceRemotingFailedResponseEventArgs</c> on failure.</param>
         private static void ServiceRemotingClientEvents_ReceiveResponse(object? sender, EventArgs? e)
         {
-            if (!_initialized || !Tracer.Instance.Settings.IsIntegrationEnabled(ServiceRemotingConstants.IntegrationId))
+            if (!_initialized || !Tracer.InternalInstance.Settings.IsIntegrationEnabled(ServiceRemotingConstants.IntegrationId))
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingHelpers.cs
@@ -144,7 +144,7 @@ namespace Datadog.Trace.ServiceFabric
         {
             try
             {
-                var scope = Tracer.Instance.InternalActiveScope;
+                var scope = Tracer.InternalInstance.InternalActiveScope;
 
                 if (scope == null)
                 {
@@ -152,7 +152,7 @@ namespace Datadog.Trace.ServiceFabric
                     return;
                 }
 
-                string expectedSpanName = GetOperationName(Tracer.Instance, spanKind);
+                string expectedSpanName = GetOperationName(Tracer.InternalInstance, spanKind);
 
                 if (expectedSpanName != scope.Span.OperationName)
                 {

--- a/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingService.cs
+++ b/tracer/src/Datadog.Trace/ServiceFabric/ServiceRemotingService.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ServiceFabric
         /// <param name="e">The event arguments.</param>
         private static void ServiceRemotingServiceEvents_ReceiveRequest(object? sender, EventArgs? e)
         {
-            var tracer = Tracer.Instance;
+            var tracer = Tracer.InternalInstance;
 
             if (!_initialized || !tracer.Settings.IsIntegrationEnabled(ServiceRemotingConstants.IntegrationId))
             {
@@ -92,7 +92,7 @@ namespace Datadog.Trace.ServiceFabric
         /// or <c>IServiceRemotingFailedResponseEventArgs2</c> on failure.</param>
         private static void ServiceRemotingServiceEvents_SendResponse(object? sender, EventArgs? e)
         {
-            if (!_initialized || !Tracer.Instance.Settings.IsIntegrationEnabled(ServiceRemotingConstants.IntegrationId))
+            if (!_initialized || !Tracer.InternalInstance.Settings.IsIntegrationEnabled(ServiceRemotingConstants.IntegrationId))
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -423,7 +423,7 @@ namespace Datadog.Trace
         [return: MaybeNull]
         internal string PrepareTagsHeaderForPropagation()
         {
-            // try to get max length from tracer settings, but do NOT access Tracer.Instance
+            // try to get max length from tracer settings, but do NOT access Tracer.InternalInstance
             var headerMaxLength = TraceContext?.Tracer?.Settings?.OutgoingTagPropagationHeaderMaxLength;
 
             var propagatedTags = PrepareTagsForPropagation();

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -35,6 +35,9 @@ namespace Datadog.Trace
         [PublicApi]
         public ISpanContext? Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
         {
+            // TODO: This API is public but it relies on the internal property SpanContextPropagator.Instance.
+            // Ensure that we follow up and proxy this type appropriately so
+            // the user will receive this type from the automatic assembly.
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextExtractor_Extract);
             var spanContext = SpanContextPropagator.Instance.Extract(carrier, getter);
             if (spanContext is not null

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextExtractor_Extract);
             var spanContext = SpanContextPropagator.Instance.Extract(carrier, getter);
             if (spanContext is not null
-             && Tracer.Instance.TracerManager.DataStreamsManager is { IsEnabled: true } dsm
+             && Tracer.InternalInstance.TracerManager.DataStreamsManager is { IsEnabled: true } dsm
              && getter(carrier, DataStreamsPropagationHeaders.TemporaryEdgeTags).FirstOrDefault() is { Length: > 0 } edgeTagString)
             {
                 var base64PathwayContext = getter(carrier, DataStreamsPropagationHeaders.TemporaryBase64PathwayContext).FirstOrDefault();

--- a/tracer/src/Datadog.Trace/SpanContextInjector.cs
+++ b/tracer/src/Datadog.Trace/SpanContextInjector.cs
@@ -44,6 +44,9 @@ namespace Datadog.Trace
         [PublicApi]
         public void Inject<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext context)
         {
+            // TODO: This API is public but it relies on the internal property SpanContextPropagator.Instance.
+            // Ensure that we follow up and proxy this type appropriately so
+            // the user will receive this type from the automatic assembly.
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_Inject);
 
             if (context is SpanContext spanContext)

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -123,8 +123,7 @@ namespace Datadog.Trace
 
         /// <summary>
         /// Gets or sets the global <see cref="Tracer"/> instance.
-        /// Used by all automatic instrumentation and recommended
-        /// as the entry point for manual instrumentation.
+        /// This is the entry point for manual instrumentation.
         /// </summary>
         [PublicApi]
         public static Tracer Instance
@@ -148,8 +147,8 @@ namespace Datadog.Trace
 
         /// <summary>
         /// Gets or sets the global <see cref="Tracer"/> instance.
-        /// Used by all automatic instrumentation and recommended
-        /// as the entry point for manual instrumentation.
+        /// This is the entry point for automatic instrumentation and must not
+        /// be called by code paths that are exposed to the public API.
         /// </summary>
         internal static Tracer InternalInstance
         {

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -200,7 +200,7 @@ namespace Datadog.Trace
         }
 
         /// <summary>
-        /// Start internal processes that require Tracer.Instance is already set
+        /// Start internal processes that require Tracer.InternalInstance is already set
         /// </summary>
         internal void Start()
         {

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
@@ -1799,7 +1799,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>
@@ -1835,7 +1835,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
         {
-            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.Instance, (IDbCommand)instance));
+            return new CallTargetState(DbScopeFactory.Cache<TTarget>.CreateDbCommandScope(Tracer.InternalInstance, (IDbCommand)instance));
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.TestHelpers/TracerRestorerAttribute.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TracerRestorerAttribute.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.TestHelpers
 
         public override void Before(MethodInfo methodUnderTest)
         {
-            _tracer = Tracer.Instance;
+            _tracer = Tracer.InternalInstance;
             _tracerManager = _tracer.TracerManager;
             _distributedTracer = ClrProfiler.DistributedTracer.Instance;
             base.Before(methodUnderTest);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -21,19 +21,19 @@ namespace Datadog.Trace.Tests.Configuration
         [Fact(Skip = "Disabled until service mapping is re-implemented in dynamic config")]
         public void ApplyServiceMappingToNewTraces()
         {
-            var scope = Tracer.Instance.StartActive("Trace1");
+            var scope = Tracer.InternalInstance.StartActive("Trace1");
 
-            Tracer.Instance.CurrentTraceSettings.GetServiceName(Tracer.Instance, "test")
+            Tracer.InternalInstance.CurrentTraceSettings.GetServiceName(Tracer.InternalInstance, "test")
                .Should().Be($"{Tracer.Instance.DefaultServiceName}-test");
 
             DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig((ConfigurationKeys.ServiceNameMappings, "test:ok")));
 
-            Tracer.Instance.CurrentTraceSettings.GetServiceName(Tracer.Instance, "test")
+            Tracer.InternalInstance.CurrentTraceSettings.GetServiceName(Tracer.InternalInstance, "test")
                .Should().Be($"{Tracer.Instance.DefaultServiceName}-test", "the old configuration should be used inside of the active trace");
 
             scope.Close();
 
-            Tracer.Instance.CurrentTraceSettings.GetServiceName(Tracer.Instance, "test")
+            Tracer.InternalInstance.CurrentTraceSettings.GetServiceName(Tracer.InternalInstance, "test")
                .Should().Be("ok", "the new configuration should be used outside of the active trace");
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/PerTraceSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/PerTraceSettingsTests.cs
@@ -23,9 +23,9 @@ namespace Datadog.Trace.Tests.Configuration
                 [ConfigurationKeys.ServiceNameMappings] = "test:before"
             }));
 
-            var scope = Tracer.Instance.StartActive("Trace1");
+            var scope = Tracer.InternalInstance.StartActive("Trace1");
 
-            Tracer.Instance.CurrentTraceSettings.GetServiceName(Tracer.Instance, "test")
+            Tracer.InternalInstance.CurrentTraceSettings.GetServiceName(Tracer.InternalInstance, "test")
                .Should().Be("before");
 
             Tracer.Configure(TracerSettings.Create(new()
@@ -33,12 +33,12 @@ namespace Datadog.Trace.Tests.Configuration
                 [ConfigurationKeys.ServiceNameMappings] = "test:after"
             }));
 
-            Tracer.Instance.CurrentTraceSettings.GetServiceName(Tracer.Instance, "test")
+            Tracer.InternalInstance.CurrentTraceSettings.GetServiceName(Tracer.InternalInstance, "test")
                .Should().Be("before", "the old configuration should be used inside of the active trace");
 
             scope.Close();
 
-            Tracer.Instance.CurrentTraceSettings.GetServiceName(Tracer.Instance, "test")
+            Tracer.InternalInstance.CurrentTraceSettings.GetServiceName(Tracer.InternalInstance, "test")
                .Should().Be("after", "the new configuration should be used outside of the active trace");
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Tests.Sampling
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, false } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
-            var trace = new[] { Tracer.Instance.StartSpan("1") };
+            var trace = new[] { Tracer.InternalInstance.StartSpan("1") };
             trace[0].Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoReject);
 
             sampler.Sample(new(trace)).Should().BeFalse();

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -27,15 +27,15 @@ namespace Datadog.Trace.Tests
             var tracerTwo = TracerHelper.Create();
 
             TracerRestorerAttribute.SetTracer(tracerOne);
-            Tracer.Instance.Should().Be(tracerOne);
-            Tracer.Instance.TracerManager.Should().Be(tracerOne.TracerManager);
+            Tracer.InternalInstance.Should().Be(tracerOne);
+            Tracer.InternalInstance.TracerManager.Should().Be(tracerOne.TracerManager);
 
             TracerRestorerAttribute.SetTracer(tracerTwo);
-            Tracer.Instance.Should().Be(tracerTwo);
-            Tracer.Instance.TracerManager.Should().Be(tracerTwo.TracerManager);
+            Tracer.InternalInstance.Should().Be(tracerTwo);
+            Tracer.InternalInstance.TracerManager.Should().Be(tracerTwo.TracerManager);
 
             TracerRestorerAttribute.SetTracer(null);
-            Tracer.Instance.Should().BeNull();
+            Tracer.InternalInstance.Should().BeNull();
         }
 
         [Fact]
@@ -45,22 +45,22 @@ namespace Datadog.Trace.Tests
             var tracerTwo = new LockedTracer();
 
             TracerRestorerAttribute.SetTracer(tracerOne);
-            Tracer.Instance.Should().Be(tracerOne);
-            Tracer.Instance.TracerManager.Should().Be(tracerOne.TracerManager);
+            Tracer.InternalInstance.Should().Be(tracerOne);
+            Tracer.InternalInstance.TracerManager.Should().Be(tracerOne.TracerManager);
 
             TracerRestorerAttribute.SetTracer(null);
-            Tracer.Instance.Should().BeNull();
+            Tracer.InternalInstance.Should().BeNull();
 
             // Set the locked tracer
             TracerRestorerAttribute.SetTracer(tracerTwo);
-            Tracer.Instance.Should().Be(tracerTwo);
-            Tracer.Instance.TracerManager.Should().Be(tracerTwo.TracerManager);
+            Tracer.InternalInstance.Should().Be(tracerTwo);
+            Tracer.InternalInstance.TracerManager.Should().Be(tracerTwo.TracerManager);
 
             // We test the locked tracer cannot be replaced.
 #pragma warning disable CS0618 // Setter isn't actually obsolete, just should be internal
-            Assert.Throws<InvalidOperationException>(() => Tracer.Instance = tracerOne);
+            Assert.Throws<InvalidOperationException>(() => Tracer.InternalInstance = tracerOne);
 
-            Assert.Throws<ArgumentNullException>(() => Tracer.Instance = null);
+            Assert.Throws<ArgumentNullException>(() => Tracer.InternalInstance = null);
 
             Assert.Throws<InvalidOperationException>(() => TracerManager.ReplaceGlobalManager(null, TracerManagerFactory.Instance));
             Assert.Throws<InvalidOperationException>(() => TracerManager.ReplaceGlobalManager(null, new CITracerManagerFactory(CIVisibility.Settings, NullDiscoveryService.Instance, false)));
@@ -85,7 +85,7 @@ namespace Datadog.Trace.Tests
                 };
                 Tracer.Configure(oldSettings);
 
-                var span = Tracer.Instance.StartActive("Test span");
+                var span = Tracer.InternalInstance.StartActive("Test span");
 
                 var newSettings = new TracerSettings
                 {

--- a/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
@@ -140,7 +140,7 @@ namespace Benchmarks.Trace
                     };
 
                     // Logs injection emulation
-                    LoggerIntegrationCommon.AddScope(Tracer.Instance, callback, textWriter);
+                    LoggerIntegrationCommon.AddScope(Tracer.InternalInstance, callback, textWriter);
                     scopeProvider.ForEachScope(callback, textWriter);
                 }
             }

--- a/tracer/test/benchmarks/Benchmarks.Trace/TraceProcessorBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/TraceProcessorBenchmark.cs
@@ -21,7 +21,7 @@ namespace Benchmarks.Trace
             _trucantorTraceProcessor = new TruncatorTraceProcessor();
             _obfuscatorTraceProcessor = new ObfuscatorTraceProcessor(true);
             
-            var traceContext = new TraceContext(Tracer.Instance, null);
+            var traceContext = new TraceContext(Tracer.InternalInstance, null);
             var spanContext = new SpanContext(parent: null, traceContext, serviceName: "My Service Name", traceId: (TraceId)100, spanId: 200);
             var span = new Span(spanContext, DateTimeOffset.Now);
             span.ResourceName = "My Resource Name";


### PR DESCRIPTION
## Summary of changes
Moves the logic for the public property `Tracer.Instance` into the internal property `Tracer.InternalInstance` and refactors all internal usages to the internal property

## Reason for change
In order to resolve version-conflict scenarios using automatic instrumentation, we intend to rewrite the bytecode of the public `Tracer.Instance` accessor. As a result, we must clearly identify which code paths are called from the manual API and which code paths are called internally. This refactoring accomplishes that and isolates the wide set of renames to just this PR, so follow-up PR's can focus on the automatic instrumentation and API changes.

Note: This change _does not_ affect any public API's ✅

## Implementation details
- Adds the [PublicApi] attribute to Tracer.Instance, which causes compilation errors for internal uses inside Datadog.Trace
- Adds a new internal Tracer.InternalInstance, which contains the previous Tracer.Instance logic
- Redirect the public Tracer.Instance to get/set Tracer.InternalInstance
- Change all internal usages from Tracer.Instance to Tracer.InternalInstance, except for the following cases:
  - CorrelationIdentifier API's, which are only used for manual logs injection
  - OpenTracingTracerFactory, which is only used from manual instrumentation with OpenTracing

## Test coverage
Existing tests cover this

## Other details
N/A