### PR TITLE
[CI Visibility] Fix code coverage reporter

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Coverage/CoverageEventHandler.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/CoverageEventHandler.cs
@@ -22,7 +22,7 @@ internal abstract class CoverageEventHandler
 
     protected CoverageEventHandler()
     {
-        _asyncContext = new(obj => CoverageReporter.FireContextContainerChangeAction(obj.CurrentValue));
+        _asyncContext = new();
         _globalContainer = new CoverageContextContainer();
     }
 

--- a/tracer/src/Datadog.Trace/Ci/Coverage/CoverageReporter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Coverage/CoverageReporter.cs
@@ -18,7 +18,6 @@ namespace Datadog.Trace.Ci.Coverage;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class CoverageReporter
 {
-    private static readonly List<Action<CoverageContextContainer?>> CoverageContextContainerChangeActions = new();
     private static CoverageEventHandler _handler = new DefaultWithGlobalCoverageEventHandler();
 
     /// <summary>
@@ -36,23 +35,4 @@ public static class CoverageReporter
     internal static CoverageContextContainer? Container => _handler.Container;
 
     internal static CoverageContextContainer GlobalContainer => _handler.GlobalContainer;
-
-    internal static void AddContextContainerChangeAction(Action<CoverageContextContainer?> action)
-    {
-        lock (CoverageContextContainerChangeActions)
-        {
-            CoverageContextContainerChangeActions.Add(action);
-        }
-    }
-
-    internal static void FireContextContainerChangeAction(CoverageContextContainer? ctx)
-    {
-        lock (CoverageContextContainerChangeActions)
-        {
-            foreach (var action in CoverageContextContainerChangeActions)
-            {
-                action?.Invoke(ctx);
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Summary of changes

This PR fixes an odd behaviour detected using Telemetry metrics where some non skipped tests were getting empty code coverage.

The issue was caused by the caching mechanism over `_currentModuleValue` in the async context container. The problem was mitigated by removing that caching mechanism and accessing directly the `CoverageReporter.Container` async local.

## Implementation details

Removed the caching mechanism over the AsyncLocal, and we just access the async local directly when needed.

## Test coverage

The `test-environment` now asserts over the Telemetry metrics payload, the tests will now include an assertion over the `CodeCoverage.IsEmpty` metric.

This work will be done after merging this PR

