### PR TITLE
Rename intermediate Linux artifacts for consistency

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -319,10 +319,12 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
+          artifactSuffix: linux-x64
         alpine:
           baseImage: alpine
+          artifactSuffix: linux-musl-x64
     pool:
       name: azure-linux-scale-set
 
@@ -341,15 +343,15 @@ stages:
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
-      artifact: linux-tracer-home-$(baseImage)
+      artifact: linux-tracer-home-$(artifactSuffix)
 
     - publish: $(System.DefaultWorkingDirectory)
       displayName: Upload working directory after the build
-      artifact: build-linux-$(baseImage)-working-directory
+      artifact: build-$(artifactSuffix)-working-directory
 
     - publish: $(symbols)
       displayName: Upload linux tracer symbols
-      artifact: linux-tracer-symbols-$(baseImage)
+      artifact: linux-tracer-symbols-$(artifactSuffix)
 
 - stage: build_linux_profiler
   dependsOn: [merge_commit_id]
@@ -366,10 +368,12 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
+          artifactSuffix: linux-x64
         alpine:
           baseImage: alpine
+          artifactSuffix: linux-musl-x64
     pool:
       name: azure-linux-scale-set
 
@@ -388,15 +392,15 @@ stages:
 
     - publish: $(System.DefaultWorkingDirectory)/profiler/_build
       displayName: Uploading linux profiler output build folder
-      artifact: linux-profiler-binaries-$(baseImage)
+      artifact: linux-profiler-binaries-$(artifactSuffix)
 
     - publish: $(monitoringHome)
       displayName: Uploading linux profiler home artifact
-      artifact: linux-profiler-home-$(baseImage)
+      artifact: linux-profiler-home-$(artifactSuffix)
 
     - publish: $(symbols)
       displayName: Upload linux profiler symbols
-      artifact: linux-profiler-symbols-$(baseImage)
+      artifact: linux-profiler-symbols-$(artifactSuffix)
 
 - stage: package_linux
   dependsOn: [merge_commit_id, build_linux_tracer, build_linux_profiler, build_dd_dotnet_linux]
@@ -413,7 +417,7 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
           artifactSuffix: linux-x64
         alpine:
@@ -431,13 +435,13 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download tracer linux native binary
       inputs:
-        artifact: linux-tracer-home-$(baseImage)
+        artifact: linux-tracer-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
       displayName: Download profiler linux native binary
       inputs:
-        artifact: linux-profiler-home-$(baseImage)
+        artifact: linux-profiler-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
@@ -460,11 +464,11 @@ stages:
 
     - publish: $(artifacts)/linux-x64
       displayName: Upload linux-x64 packages
-      artifact: linux-packages-$(baseImage)
+      artifact: linux-packages-$(artifactSuffix)
 
     - publish: $(monitoringHome)
       displayName: Upload linux-x64 monitoring home
-      artifact: linux-monitoring-home-$(baseImage)
+      artifact: linux-monitoring-home-$(artifactSuffix)
 
 - stage: build_arm64_tracer
   dependsOn: [merge_commit_id]
@@ -750,7 +754,7 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
           artifactSuffix: linux-x64
         alpine:
@@ -840,7 +844,7 @@ stages:
     dependsOn: []
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
         alpine:
           baseImage: alpine
@@ -1034,10 +1038,12 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
+          artifactSuffix: linux-x64
         alpine:
           baseImage: alpine
+          artifactSuffix: linux-musl-x64
     pool:
       name: azure-linux-scale-set
 
@@ -1049,7 +1055,7 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -1074,10 +1080,12 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
+          artifactSuffix: linux-x64
         alpine:
           baseImage: alpine
+          artifactSuffix: linux-musl-x64
     pool:
       name: azure-linux-scale-set
 
@@ -1089,12 +1097,12 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     - task: DownloadPipelineArtifact@2
       displayName: Download linux profiler binaries
       inputs:
-        artifact: linux-profiler-binaries-$(baseImage)
+        artifact: linux-profiler-binaries-$(artifactSuffix)
         path: $(System.DefaultWorkingDirectory)/profiler/_build
 
     - template: steps/run-in-docker.yml
@@ -1738,7 +1746,7 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -1752,7 +1760,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux monitoring home
       inputs:
-        artifact: linux-monitoring-home-$(baseImage)
+        artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     - task: DockerCompose@0
@@ -1820,7 +1828,7 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -1834,7 +1842,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux monitoring home
       inputs:
-        artifact: linux-monitoring-home-$(baseImage)
+        artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     - script: |
@@ -1912,6 +1920,7 @@ stages:
       TestAllPackageVersions: false
       IncludeMinorPackageVersions:  false
       baseImage: "centos7"
+      artifactSuffix: "linux-x64"
 
     strategy:
       matrix:
@@ -1932,12 +1941,12 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     - task: DownloadPipelineArtifact@2
       displayName: Download linux monitoring home
       inputs:
-        artifact: linux-monitoring-home-$(baseImage)
+        artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     - template: steps/run-in-docker.yml
@@ -2119,7 +2128,7 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
@@ -2133,7 +2142,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux monitoring home
       inputs:
-        artifact: linux-monitoring-home-$(baseImage)
+        artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     - task: DockerCompose@0
@@ -2260,10 +2269,12 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix:
-        centos7:
+        x64:
           baseImage: centos7
+          artifactSuffix: linux-x64
         alpine:
           baseImage: alpine
+          artifactSuffix: linux-musl-x64
 
     variables:
       IncludeMinorPackageVersions:  $[eq(variables.perform_comprehensive_testing, 'true')]
@@ -2279,12 +2290,12 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     - task: DownloadPipelineArtifact@2
       displayName: Download linux monitoring home
       inputs:
-        artifact: linux-monitoring-home-$(baseImage)
+        artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     # when we build samples separately, we could run this step and the docker-compose one below in //
@@ -2837,7 +2848,7 @@ stages:
 
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(baseImage)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -3044,7 +3055,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux tracer home
       inputs:
-        artifact: linux-tracer-home-centos7
+        artifact: linux-tracer-home-linux-x64
         patterns: |
           **/*.so
           **/loader.conf
@@ -3053,7 +3064,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download alpine tracer home
       inputs:
-        artifact: linux-tracer-home-alpine
+        artifact: linux-tracer-home-linux-musl-x64
         patterns:  |
           **/*.so
           **/loader.conf
@@ -3087,7 +3098,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux profiler home
       inputs:
-        artifact: linux-profiler-home-centos7
+        artifact: linux-profiler-home-linux-x64
         patterns:  |
           **/*.so
           **/loader.conf
@@ -3096,7 +3107,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download alpine profiler home
       inputs:
-        artifact: linux-profiler-home-alpine
+        artifact: linux-profiler-home-linux-musl-x64
         patterns:  |
           **/*.so
           **/loader.conf
@@ -3276,18 +3287,15 @@ stages:
     timeoutInMinutes: 60 #default value
     strategy:
       matrix:
-        centos7:
-          name: centos7
+        x64:
           baseImage: centos7
           artifactSuffix: linux-x64
           poolName: azure-linux-scale-set
         alpine:
-          name: alpine
           baseImage: alpine
           artifactSuffix: linux-musl-x64
           poolName: azure-linux-scale-set
         arm64:
-          name: arm64
           baseImage: debian
           artifactSuffix: linux-arm64
           poolname: aws-arm64-auto-scaling
@@ -3300,14 +3308,15 @@ stages:
       parameters:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
+
     - template: steps/restore-working-directory.yml
       parameters:
-        artifact: build-linux-$(name)-working-directory
+        artifact: build-$(artifactSuffix)-working-directory
 
     - task: DownloadPipelineArtifact@2
       displayName: Download profiler linux native binary
       inputs:
-        artifact: linux-profiler-home-$(name)
+        artifact: linux-profiler-home-$(artifactSuffix)
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
@@ -3399,7 +3408,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux-packages
       inputs:
-        artifact: linux-packages-centos7
+        artifact: linux-packages-linux-x64
         patterns: '**/*amd64.deb'
         path: s3_upload
 
@@ -3503,13 +3512,13 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download linux Alpine packages
           inputs:
-            artifact: linux-packages-alpine
+            artifact: linux-packages-linux-musl-x64
             path: $(Build.ArtifactStagingDirectory)
 
         - task: DownloadPipelineArtifact@2
-          displayName: Download linux CentOS7 packages
+          displayName: Download linux x64 packages
           inputs:
-            artifact: linux-packages-centos7
+            artifact: linux-packages-linux-x64
             path: $(Build.ArtifactStagingDirectory)
 
         - task: DownloadPipelineArtifact@2
@@ -3522,13 +3531,13 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download linux profiler Alpine symbols
           inputs:
-            artifact: linux-profiler-symbols-alpine
+            artifact: linux-profiler-symbols-linux-musl-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
 
         - task: DownloadPipelineArtifact@2
-          displayName: Download linux profiler CentOS7 symbols
+          displayName: Download linux profiler x64 symbols
           inputs:
-            artifact: linux-profiler-symbols-centos7
+            artifact: linux-profiler-symbols-linux-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
 
         - task: DownloadPipelineArtifact@2
@@ -3540,13 +3549,13 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download linux tracer Alpine symbols
           inputs:
-            artifact: linux-tracer-symbols-alpine
+            artifact: linux-tracer-symbols-linux-musl-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
 
         - task: DownloadPipelineArtifact@2
-          displayName: Download linux tracer CentOS7 symbols
+          displayName: Download linux tracer x64 symbols
           inputs:
-            artifact: linux-tracer-symbols-centos7
+            artifact: linux-tracer-symbols-linux-x64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
 
         - task: DownloadPipelineArtifact@2
@@ -3760,7 +3769,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:
-        artifact: linux-monitoring-home-centos7
+        artifact: linux-monitoring-home-linux-x64
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
 
     - script: |
@@ -3910,7 +3919,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:
-        artifact: linux-monitoring-home-centos7
+        artifact: linux-monitoring-home-linux-x64
         path: $(System.DefaultWorkingDirectory)/monitoring-home-linux
 
     - script: |
@@ -4012,7 +4021,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:
-        artifact: linux-monitoring-home-centos7
+        artifact: linux-monitoring-home-linux-x64
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
 
     - script: |
@@ -4349,7 +4358,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download profiler linux native binary
       inputs:
-        artifact: linux-profiler-home-centos7
+        artifact: linux-profiler-home-linux-x64
         path: $(monitoringHome)
       retryCountOnTaskFailure: 5
 
@@ -4499,7 +4508,7 @@ stages:
       - task: DownloadPipelineArtifact@2
         displayName: Download linux-packages
         inputs:
-          artifact: linux-packages-centos7
+          artifact: linux-packages-linux-x64
           patterns: '**/*tar.gz'
           path: $(Build.ArtifactStagingDirectory)
 
@@ -4888,7 +4897,7 @@ stages:
       dockerTag: debian_net6
       runtimeImage: "mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim"
       installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb"
-      linuxArtifacts: "linux-packages-centos7"
+      linuxArtifacts: "linux-packages-linux-x64"
     pool:
       vmImage: ubuntu-20.04
 
@@ -5796,6 +5805,7 @@ stages:
       vmImage: ubuntu-20.04
 
     steps:
+    - checkout: none
     - bash: |
         sha=$(echo $(OriginalCommitId) | head -c 7)
         curl -X POST \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -502,7 +502,7 @@ stages:
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
-      artifact: linux-tracer-home-arm64
+      artifact: linux-tracer-home-linux-arm64
 
     - publish: $(System.DefaultWorkingDirectory)
       displayName: Upload working directory after the build
@@ -510,7 +510,7 @@ stages:
 
     - publish: $(symbols)
       displayName: Upload linux tracer symbols
-      artifact: linux-tracer-symbols-arm64
+      artifact: linux-tracer-symbols-linux-arm64
 
 - stage: build_arm64_profiler
   dependsOn: [merge_commit_id]
@@ -544,15 +544,15 @@ stages:
 
     - publish: $(System.DefaultWorkingDirectory)/profiler/_build
       displayName: Uploading linux profiler output build folder
-      artifact: linux-profiler-binaries-arm64
+      artifact: linux-profiler-binaries-linux-arm64
 
     - publish: $(monitoringHome)
       displayName: Uploading linux profiler home artifact
-      artifact: linux-profiler-home-arm64
+      artifact: linux-profiler-home-linux-arm64
 
     - publish: $(symbols)
       displayName: Upload linux profiler symbols
-      artifact: linux-profiler-symbols-arm64
+      artifact: linux-profiler-symbols-linux-arm64
 
 - stage: package_arm64
   dependsOn: [merge_commit_id, build_arm64_tracer, build_arm64_profiler, build_dd_dotnet_linux_arm64]
@@ -579,13 +579,13 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download tracer arm64 native binary
       inputs:
-        artifact: linux-tracer-home-arm64
+        artifact: linux-tracer-home-linux-arm64
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
       displayName: Download profiler arm64 native binary
       inputs:
-        artifact: linux-profiler-home-arm64
+        artifact: linux-profiler-home-linux-arm64
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
@@ -608,11 +608,11 @@ stages:
 
     - publish: $(artifacts)/linux-arm64
       displayName: Upload arm64 packages
-      artifact: linux-packages-arm64
+      artifact: linux-packages-linux-arm64
 
     - publish: $(monitoringHome)
       displayName: Upload arm64 monitoring home
-      artifact: linux-monitoring-home-arm64
+      artifact: linux-monitoring-home-linux-arm64
 
 - stage: build_macos
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -2508,7 +2508,7 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download arm64 monitoring home
           inputs:
-            artifact: linux-monitoring-home-arm64
+            artifact: linux-monitoring-home-linux-arm64
             path: $(monitoringHome)
 
         - task: DockerCompose@0
@@ -2586,7 +2586,7 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download arm64 monitoring home
           inputs:
-            artifact: linux-monitoring-home-arm64
+            artifact: linux-monitoring-home-linux-arm64
             path: $(monitoringHome)
 
         - script: |
@@ -2699,7 +2699,7 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download arm64 monitoring home
           inputs:
-            artifact: linux-monitoring-home-arm64
+            artifact: linux-monitoring-home-linux-arm64
             path: $(monitoringHome)
 
         - task: DockerCompose@0
@@ -3073,7 +3073,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 tracer home
       inputs:
-        artifact: linux-tracer-home-arm64
+        artifact: linux-tracer-home-linux-arm64
         patterns:  |
           **/*.so
           **/loader.conf
@@ -3116,7 +3116,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 profiler home
       inputs:
-        artifact: linux-profiler-home-arm64
+        artifact: linux-profiler-home-linux-arm64
         patterns:  |
           **/*.so
           **/loader.conf
@@ -3524,7 +3524,7 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download linux Arm64 packages
           inputs:
-            artifact: linux-packages-arm64
+            artifact: linux-packages-linux-arm64
             path: $(Build.ArtifactStagingDirectory)
 
         # Linux symbols
@@ -3543,7 +3543,7 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download linux profiler Arm64 symbols
           inputs:
-            artifact: linux-profiler-symbols-arm64
+            artifact: linux-profiler-symbols-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
 
         - task: DownloadPipelineArtifact@2
@@ -3561,7 +3561,7 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download linux tracer Arm64 symbols
           inputs:
-            artifact: linux-tracer-symbols-arm64
+            artifact: linux-tracer-symbols-linux-arm64
             path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
 
         - task: DownloadPipelineArtifact@2
@@ -3856,7 +3856,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 native binary
       inputs:
-        artifact: linux-monitoring-home-arm64
+        artifact: linux-monitoring-home-linux-arm64
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux-arm64
 
     - script: |

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -542,7 +542,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb",
                         installCmd: "dpkg -i ./datadog-dotnet-apm_*_arm64.deb",
-                        linuxArtifacts: "linux-packages-arm64",
+                        linuxArtifacts: "linux-packages-linux-arm64",
                         runtimeId: "linux-arm64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
                     );
@@ -558,7 +558,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*-1.aarch64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.aarch64.rpm",
-                        linuxArtifacts: "linux-packages-arm64",
+                        linuxArtifacts: "linux-packages-linux-arm64",
                         runtimeId: "linux-arm64",
                         dockerName: "andrewlock/dotnet-fedora-arm64"
                     );
@@ -575,7 +575,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb", // we advise customers to install the .deb in this case
                         installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*.arm64.tar.gz",
-                        linuxArtifacts: "linux-packages-arm64",
+                        linuxArtifacts: "linux-packages-linux-arm64",
                         runtimeId: "linux-arm64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
                     );

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -217,16 +217,21 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsLinuxMatrix()
             {
-                var baseImages = new[] { "centos7", "alpine" };
+                var baseImages = new []
+                {
+                    (baseImage: "centos7", artifactSuffix: "linux-x64"), 
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"), 
+                };
+
                 var targetFrameworks = TestingFrameworks.Except(new[] { TargetFramework.NET461, TargetFramework.NET462, TargetFramework.NETSTANDARD2_0 });
 
 
                 var matrix = new Dictionary<string, object>();
                 foreach (var framework in targetFrameworks)
                 {
-                    foreach (var baseImage in baseImages)
+                    foreach (var (baseImage, artifactSuffix) in baseImages)
                     {
-                        matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage });
+                        matrix.Add($"{baseImage}_{framework}", new { publishTargetFramework = framework, baseImage = baseImage, artifactSuffix = artifactSuffix });
                     }
                 }
 
@@ -237,13 +242,17 @@ partial class Build : NukeBuild
             void GenerateIntegrationTestsDebuggerLinuxMatrix()
             {
                 var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462 });
-                var baseImages = new[] { "centos7", "alpine" };
+                var baseImages = new []
+                {
+                    (baseImage: "centos7", artifactSuffix: "linux-x64"), 
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"), 
+                };
                 var optimizations = new[] { "true", "false" };
 
                 var matrix = new Dictionary<string, object>();
                 foreach (var framework in targetFrameworks)
                 {
-                    foreach (var baseImage in baseImages)
+                    foreach (var (baseImage, artifactSuffix) in baseImages)
                     {
                         foreach (var optimize in optimizations)
                         {
@@ -253,6 +262,7 @@ partial class Build : NukeBuild
                                            publishTargetFramework = framework,
                                            baseImage = baseImage,
                                            optimize = optimize,
+                                           artifactSuffix = artifactSuffix,
                                        });
                         }
                     }
@@ -312,11 +322,15 @@ partial class Build : NukeBuild
                 var testDescriptions = ExplorationTestDescription.GetAllExplorationTestDescriptions();
                 var targetFrameworks = TargetFramework.GetFrameworks(except: new[] { TargetFramework.NET461, TargetFramework.NET462, TargetFramework.NETSTANDARD2_0, });
 
-                var baseImages = new[] { "centos7", "alpine" };
+                var baseImages = new []
+                {
+                    (baseImage: "centos7", artifactSuffix: "linux-x64"), 
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-x64"), 
+                };
 
                 var matrix = new Dictionary<string, object>();
 
-                foreach (var baseImage in baseImages)
+                foreach (var (baseImage, artifactSuffix) in baseImages)
                 {
                     foreach (var explorationTestUseCase in useCases)
                     {
@@ -328,7 +342,7 @@ partial class Build : NukeBuild
                                 {
                                     matrix.Add(
                                         $"{baseImage}_{targetFramework}_{explorationTestUseCase}_{testDescription.Name}",
-                                        new { baseImage = baseImage, publishTargetFramework = targetFramework, explorationTestUseCase = explorationTestUseCase, explorationTestName = testDescription.Name });
+                                        new { baseImage = baseImage, publishTargetFramework = targetFramework, explorationTestUseCase = explorationTestUseCase, explorationTestName = testDescription.Name, artifactSuffix = artifactSuffix });
                                 }
                             }
                         }
@@ -386,7 +400,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*_amd64.deb",
                         installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb",
-                        linuxArtifacts: "linux-packages-centos7",
+                        linuxArtifacts: "linux-packages-linux-x64",
                         runtimeId: "linux-x64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
                     );
@@ -409,7 +423,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
-                        linuxArtifacts: "linux-packages-centos7",
+                        linuxArtifacts: "linux-packages-linux-x64",
                         runtimeId: "linux-x64",
                         dockerName: "andrewlock/dotnet-fedora"
                     );
@@ -430,7 +444,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*-musl.tar.gz",
                         installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*-musl.tar.gz",
-                        linuxArtifacts: "linux-packages-alpine",
+                        linuxArtifacts: "linux-packages-linux-musl-x64",
                         runtimeId: "linux-musl-x64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
                     );
@@ -448,7 +462,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
-                        linuxArtifacts: "linux-packages-centos7",
+                        linuxArtifacts: "linux-packages-linux-x64",
                         runtimeId: "linux-x64",
                         dockerName: "andrewlock/dotnet-centos"
                     );
@@ -465,7 +479,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
-                        linuxArtifacts: "linux-packages-centos7",
+                        linuxArtifacts: "linux-packages-linux-x64",
                         runtimeId: "linux-x64",
                         dockerName: "andrewlock/dotnet-rhel"
                     );
@@ -483,7 +497,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
-                        linuxArtifacts: "linux-packages-centos7",
+                        linuxArtifacts: "linux-packages-linux-x64",
                         runtimeId: "linux-x64",
                         dockerName: "andrewlock/dotnet-centos-stream"
                     );
@@ -501,7 +515,7 @@ partial class Build : NukeBuild
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
-                        linuxArtifacts: "linux-packages-centos7",
+                        linuxArtifacts: "linux-packages-linux-x64",
                         runtimeId: "linux-x64",
                         dockerName: "andrewlock/dotnet-opensuse"
                     );


### PR DESCRIPTION
## Summary of changes

Rename the intermediate linux artifacts in the pipeline to use the suffixes `linux-x64` and `linux-musl-arm64`

## Reason for change

Currently we're using a mixture of `-centos7` and `-alpine` (as well as  `linux-x64` and `linux-musl-arm64`), but that's going to get even more confusing with .NET 8 when we start using debian for some of it...

## Implementation details

Anywhere we are using `-centos7` or `-alpine` as a suffix for an artifact, use `-linux-x64` or `linux-musl-x64` instead. Also use x64 in the job names (but that's not important). This results in occasional cases where we have `linux` in the artifact names twice, but it's not worth the hassle to resolve that right now IMO. I also normalised the `-arm64` suffixes for consistency to `-linux-arm64`

## Test coverage

If the pipeline runs, we're probably good, but I'll also run a separate "thorough" test too

## Other details
Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/4690
- Required for .NET 8 branch (WIP)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
