### PR TITLE
Re-enable runnign the throughput tests on all PRs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3682,12 +3682,7 @@ stages:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
 - stage: throughput
-  condition: >
-    and(succeeded(), 
-        eq(variables.isMainRepository, true),
-        or(
-          eq(variables.isMainBranch, true),
-          eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')))
+  condition: and(succeeded(), eq(variables.isMainRepository, true))
   dependsOn: [package_linux, package_arm64, build_windows_tracer, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -3937,12 +3932,7 @@ stages:
       continueOnError: true
 
 - stage: throughput_appsec
-  condition: >
-    and(succeeded(), 
-        eq(variables.isMainRepository, true),
-        or(
-          eq(variables.isMainBranch, true),
-          eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')))
+  condition: and(succeeded(), eq(variables.isMainRepository, true))
   dependsOn: [package_linux, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]


### PR DESCRIPTION
## Summary of changes

Re-enabled running the tracer and ASM throughput tests on all PRs

## Reason for change

- The `IsTracerChanged` check misses some genuine cases where the tracer has changed
- There was a bug causing the check to always fail (`generate_variables` was missing from `dependsOn`)
- We should consider adding `IsAsmChanged` 

## Implementation details

Partially revert #4670

## Test coverage

Meh

## Other details
<!-- Fixes #{issue} -->

We should improve the `IsTracerChanged` check!

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
