### PR TITLE
[Profiler] Change Garbage Collector frame layout

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.cpp
@@ -64,9 +64,13 @@ std::vector<std::shared_ptr<IThreadInfo>> const& GCThreadsCpuProvider::GetThread
     return _gcThreads;
 }
 
-FrameInfoView GCThreadsCpuProvider::GetFrameInfo()
+std::vector<FrameInfoView> GCThreadsCpuProvider::GetFrames()
 {
-    return {"CLR", "|lm: |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:", "", 0};
+    return
+    {
+        {"", "|lm:[native] GC |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:", "", 0},
+        {"", "|lm:[native] CLR |ns: |ct: |cg: |fn:.NET |fg: |sg:", "", 0}
+    };
 }
 
 void GCThreadsCpuProvider::OnCpuDuration(std::uint64_t cpuTime)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GCThreadsCpuProvider.h
@@ -24,7 +24,7 @@ protected:
 private:
     bool IsGcThread(std::shared_ptr<IThreadInfo> const& thread);
     std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() override;
-    FrameInfoView GetFrameInfo() override;
+    std::vector<FrameInfoView> GetFrames() override;
 
     std::vector<std::shared_ptr<IThreadInfo>> _gcThreads;
     std::uint8_t _number_of_attempts = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -49,7 +49,10 @@ std::list<std::shared_ptr<Sample>> NativeThreadsCpuProviderBase::GetSamples()
     // The resulting callstack of the transformation is empty
     // Add a fake "GC" frame to the sample
     // TODO add strings as static field ? (from framestore ?)
-    sample->AddFrame(GetFrameInfo());
+    for (auto frame : GetFrames())
+    {
+        sample->AddFrame(frame);
+    }
 
     samples.push_back(sample);
     return samples;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
@@ -22,7 +22,7 @@ protected:
 private:
     std::list<std::shared_ptr<Sample>> GetSamples() override;
 
-    virtual FrameInfoView GetFrameInfo() = 0;
+    virtual std::vector<FrameInfoView> GetFrames() = 0;
     virtual std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() = 0;
 
     CpuTimeProvider* _cpuTimeProvider;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
@@ -15,7 +15,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
     public class GarbageCollectorCpuTimeTest
     {
         private const string ScenarioGenerics = "--scenario 12";
-        private const string GcFrame = "|lm: |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:";
+        private const string GcFrame = "|lm:[native] GC |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:";
 
         private readonly ITestOutputHelper _output;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
@@ -15,7 +15,10 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
     public class GarbageCollectorCpuTimeTest
     {
         private const string ScenarioGenerics = "--scenario 12";
-        private const string GcFrame = "|lm:[native] GC |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:";
+        private static readonly StackFrame GcFrame = new("|lm:[native] GC |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:");
+        private static readonly StackFrame ClrFrame = new("|lm:[native] CLR |ns: |ct: |cg: |fn:.NET |fg: |sg:");
+
+        private readonly StackTrace gcStack = new(GcFrame, ClrFrame);
 
         private readonly ITestOutputHelper _output;
 
@@ -41,11 +44,9 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
             runner.Run(agent);
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
-            var gcStackTrace = new StackTrace(new StackFrame(GcFrame));
-
             SamplesHelper.GetSamples(runner.Environment.PprofDir).Should()
                 // match the GC stacktrace and check that the waltime value is 0 and the cpu value is not 0
-                .Contain(sample => sample.StackTrace.Equals(gcStackTrace) && sample.Values[0] == 0 && sample.Values[1] != 0);
+                .Contain(sample => sample.StackTrace.Equals(gcStack) && sample.Values[0] == 0 && sample.Values[1] != 0);
         }
 
         [TestAppFact("Samples.Computer01", new[] { "net6.0", "net7.0" })]
@@ -66,8 +67,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
             runner.Run(agent);
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
-            var gcStackTrace = new StackTrace(new StackFrame(GcFrame));
-            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStackTrace));
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStack));
         }
 
         [TestAppFact("Samples.Computer01", new[] { "net6.0", "net7.0" })]
@@ -86,8 +86,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
             runner.Run(agent);
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
-            var gcStackTrace = new StackTrace(new StackFrame(GcFrame));
-            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStackTrace));
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStack));
         }
 
         [TestAppFact("Samples.Computer01", new[] { "net6.0", "net7.0" })]
@@ -106,8 +105,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
             runner.Run(agent);
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
-            var gcStackTrace = new StackTrace(new StackFrame(GcFrame));
-            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStackTrace));
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStack));
         }
 
         [TestAppFact("Samples.Computer01", new[] { "net6.0", "net7.0" })]
@@ -126,8 +124,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
             runner.Run(agent);
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
-            var gcStackTrace = new StackTrace(new StackFrame(GcFrame));
-            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStackTrace));
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStack));
         }
 
         [TestAppFact("Samples.Computer01", new[] { "netcoreapp3.1" })]
@@ -146,8 +143,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
             runner.Run(agent);
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
-            var gcStackTrace = new StackTrace(new StackFrame(GcFrame));
-            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStackTrace));
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStack));
         }
 
         [TestAppFact("Samples.Computer01", new[] { "net45" })]
@@ -166,8 +162,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
             runner.Run(agent);
             Assert.True(agent.NbCallsOnProfilingEndpoint > 0);
 
-            var gcStackTrace = new StackTrace(new StackFrame(GcFrame));
-            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStackTrace));
+            SamplesHelper.GetSamples(runner.Environment.PprofDir).Should().NotContain(sample => sample.StackTrace.Equals(gcStack));
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Change garbage collector frame layout.

## Reason for change

As of today, we display only the GC threads cpu usage. But if we want to display other parts of the .NET runtime CPU consumption, it would be nice to have them under a root `.NET` frame.
Another thing, the change here allows the backend to different User code from non-User code.
This will also allow to represent profiler threads CPU consumption later (not under the same root for sure :) ).

## Implementation details
- Add `[native] ` prefix to identify
- Add `.NET` root frame

## Test coverage
Update the existing tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
