### PR TITLE
[Profiler] Fix unit tests flackyness on Alpine

### DIFF
--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -212,6 +212,10 @@ public:
 
     void ValidateCallstack(const std::vector<uintptr_t>& ips)
     {
+        // Disable this check on Alpine due to flackyness
+        // Libunwind randomly fails with unw_backtrace2 (from a signal handler)
+        // but unw_backtrace
+#ifndef DD_ALPINE
         const auto& expectedCallstack = _workerThread->GetExpectedCallStack();
 
         const auto expectedNbFrames = expectedCallstack.size();
@@ -222,6 +226,7 @@ public:
 
         EXPECT_EQ(ips[collectedNbFrames - 1], (uintptr_t)expectedCallstack[expectedNbFrames - 1]);
         EXPECT_EQ(ips[collectedNbFrames - 2], (uintptr_t)expectedCallstack[expectedNbFrames - 2]);
+#endif
     }
 
     static ProfilerSignalManager* GetSignalManager()
@@ -422,12 +427,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerSignalHandlerIsRestoredIfA
 
     buffer->CopyInstructionPointers(ips);
 
-    // Disable this check on Alpine due to flackyness
-    // Libunwind randomly fails with unw_backtrace2 (from a signal handler)
-    // but unw_backtrace
-#ifndef DD_ALPINE
     ValidateCallstack(ips);
-#endif
 
     // now the custmer handler must not work
     EXPECT_FALSE(WasCallbackCalled());


### PR DESCRIPTION
## Summary of changes

## Reason for change

Really 🤣 
Ok the previous change did not take into account the fact that other unit tests were calling this function and time to time it was failing on alpine.

## Implementation details

Enable the check only when it's not alpine.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
