### PR TITLE
[TESTS] Segregate samples logs

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*");
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
             using var sample = StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
 
             try
@@ -110,7 +110,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
-            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*");
+            using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
 
             SetEnvironmentVariable("DD_TRACE_SAMPLE_RATE", "0.9");
             using var sample = StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -353,10 +353,10 @@ public class ProbesTests : TestHelper
 
 #endif
 
-    private static LogEntryWatcher CreateLogEntryWatcher()
+    private LogEntryWatcher CreateLogEntryWatcher()
     {
         string processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Probes";
-        return new LogEntryWatcher($"dotnet-tracer-managed-{processName}*");
+        return new LogEntryWatcher($"dotnet-tracer-managed-{processName}*", LogDirectory);
     }
 
     private async Task RunMethodProbeTests(ProbeTestDescription testDescription, bool useStatsD)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
@@ -23,8 +23,6 @@ public class DeduplicationTests : TestHelper
         : base("Deduplication", output)
     {
         SetServiceVersion("1.0.0");
-
-        SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
     }
 
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
@@ -23,6 +23,8 @@ public class DeduplicationTests : TestHelper
         : base("Deduplication", output)
     {
         SetServiceVersion("1.0.0");
+
+        SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
     }
 
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
@@ -45,7 +45,6 @@ public class DeduplicationTests : TestHelper
 
         SetEnvironmentVariable("DD_IAST_ENABLED", "1");
         SetEnvironmentVariable("DD_IAST_DEDUPLICATION_ENABLED", deduplicationEnabled.ToString());
-        SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", Path.Combine(EnvironmentHelper.LogDirectory));
 
         int expectedSpanCount = instrumented ? (deduplicationEnabled ? 1 : 5) : 0;
         var filename = deduplicationEnabled ? "iast.deduplication.deduplicated" : "iast.deduplication.duplicated";

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -27,17 +27,11 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
         Fixture = fixture;
         EnableSecurity = enableSecurity;
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "0.5");
-
-        // the directory would be created anyway, but in certain case a delay can lead to an exception from the LogEntryWatcher
-        Directory.CreateDirectory(LogDirectory);
-        SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
     }
 
     protected AspNetCoreTestFixture Fixture { get; }
 
     protected bool? EnableSecurity { get; }
-
-    protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance), $"{GetType().Name}Logs");
 
     public override void Dispose()
     {

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBaseFramework.cs
@@ -19,11 +19,5 @@ public class RcmBaseFramework : AspNetBase, IClassFixture<AspNetCoreTestFixture>
         : base(sampleName, outputHelper,  shutdownPath, samplesDir, testName)
     {
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "0.5");
-
-        // even if not using the log entry watcher , it's nice to have different logs directories to read artifacts
-        Directory.CreateDirectory(LogDirectory);
-        SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
     }
-
-    protected string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance), $"{GetType().Name}Logs");
 }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -17,9 +17,11 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Iast.Telemetry;
+using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol.Tuf;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -57,9 +59,15 @@ namespace Datadog.Trace.TestHelpers
             Output.WriteLine($"TargetFramework: {EnvironmentHelper.GetTargetFramework()}");
             Output.WriteLine($".NET Core: {EnvironmentHelper.IsCoreClr()}");
             Output.WriteLine($"Native Loader DLL: {EnvironmentHelper.GetNativeLoaderPath()}");
+
+            // the directory would be created anyway, but in certain case a delay can lead to an exception from the LogEntryWatcher
+            Directory.CreateDirectory(LogDirectory);
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
         }
 
         public bool SecurityEnabled { get; private set; }
+
+        protected virtual string LogDirectory => Path.Combine(DatadogLoggingFactory.GetLogDirectory(NullConfigurationTelemetry.Instance), $"{GetType().Name}Logs");
 
         protected EnvironmentHelper EnvironmentHelper { get; }
 


### PR DESCRIPTION
## Summary of changes
Separated each sample app logs on its own folder.

## Reason for change
Until now, all test apps logs where mangled in the same file, making difficult to locate a specific test logs. This change makes analyzing logs (specially in CI) easier

## Implementation details
Moved the `RcmBase` `LogDirectory` property and log redirection to `TestHelper` base. Modified all uses of `LogEntryWatcher` to use the new log file path. Thanks to @anna-git for issuing me the `RcmBase` solution used in Asm tests. 

The resulting logs in the artifacts look like this (a folder per sample app)
![image](https://github.com/DataDog/dd-trace-dotnet/assets/108014683/1e3cf49c-bad3-4025-a8c8-f8880a6da33b)

