### PR TITLE
[CI Visibility] Capture network exceptions for telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -329,14 +329,23 @@ internal class IntelligentTestRunnerClient
                     Log.Debug("ITR: Getting settings from: {Url}", _settingsUrl.ToString());
                 }
 
-                using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
-                var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
-                if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                string? responseContent;
+                try
                 {
-                    TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsSettingsErrors(errorType);
-                }
+                    using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
+                    responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                    if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                    {
+                        TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsSettingsErrors(errorType);
+                    }
 
-                CheckResponseStatusCode(response, responseContent, finalTry);
+                    CheckResponseStatusCode(response, responseContent, finalTry);
+                }
+                catch
+                {
+                    TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsSettingsErrors(MetricTags.CIVisibilityErrorType.Network);
+                    throw;
+                }
 
                 Log.Debug("ITR: JSON RS = {Json}", responseContent);
                 if (string.IsNullOrEmpty(responseContent))
@@ -414,15 +423,24 @@ internal class IntelligentTestRunnerClient
                     Log.Debug("ITR: Searching skippable tests from: {Url}", _skippableTestsUrl.ToString());
                 }
 
-                using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
-                var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
-                TelemetryFactory.Metrics.RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(Encoding.UTF8.GetByteCount(responseContent ?? string.Empty));
-                if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                string? responseContent;
+                try
                 {
-                    TelemetryFactory.Metrics.RecordCountCIVisibilityITRSkippableTestsRequestErrors(errorType);
-                }
+                    using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
+                    responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                    TelemetryFactory.Metrics.RecordDistributionCIVisibilityITRSkippableTestsResponseBytes(Encoding.UTF8.GetByteCount(responseContent ?? string.Empty));
+                    if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                    {
+                        TelemetryFactory.Metrics.RecordCountCIVisibilityITRSkippableTestsRequestErrors(errorType);
+                    }
 
-                CheckResponseStatusCode(response, responseContent, finalTry);
+                    CheckResponseStatusCode(response, responseContent, finalTry);
+                }
+                catch
+                {
+                    TelemetryFactory.Metrics.RecordCountCIVisibilityITRSkippableTestsRequestErrors(MetricTags.CIVisibilityErrorType.Network);
+                    throw;
+                }
 
                 Log.Debug("ITR: JSON RS = {Json}", responseContent);
                 if (string.IsNullOrEmpty(responseContent))
@@ -526,14 +544,23 @@ internal class IntelligentTestRunnerClient
                     Log.Debug("ITR: Searching commits from: {Url}", _searchCommitsUrl.ToString());
                 }
 
-                using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
-                var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
-                if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                string? responseContent;
+                try
                 {
-                    TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsSearchCommitsErrors(errorType);
-                }
+                    using var response = await request.PostAsync(new ArraySegment<byte>(state), MimeTypes.Json).ConfigureAwait(false);
+                    responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                    if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                    {
+                        TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsSearchCommitsErrors(errorType);
+                    }
 
-                CheckResponseStatusCode(response, responseContent, finalTry);
+                    CheckResponseStatusCode(response, responseContent, finalTry);
+                }
+                catch
+                {
+                    TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsSearchCommitsErrors(MetricTags.CIVisibilityErrorType.Network);
+                    throw;
+                }
 
                 Log.Debug("ITR: JSON RS = {Json}", responseContent);
                 if (string.IsNullOrEmpty(responseContent))
@@ -634,17 +661,26 @@ internal class IntelligentTestRunnerClient
 
                 var multipartRequest = (IMultipartApiRequest)request;
                 using var fileStream = File.Open(packFile, FileMode.Open, FileAccess.Read, FileShare.Read);
-                using var response = await multipartRequest.PostAsync(
-                                                                new MultipartFormItem("pushedSha", MimeTypes.Json, null, new ArraySegment<byte>(jsonPushedShaBytes)),
-                                                                new MultipartFormItem("packfile", "application/octet-stream", null, fileStream))
-                                                           .ConfigureAwait(false);
-                var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
-                if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
-                {
-                    TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsObjectsPackErrors(errorType);
-                }
 
-                CheckResponseStatusCode(response, responseContent, finalTry);
+                try
+                {
+                    using var response = await multipartRequest.PostAsync(
+                                                                    new MultipartFormItem("pushedSha", MimeTypes.Json, null, new ArraySegment<byte>(jsonPushedShaBytes)),
+                                                                    new MultipartFormItem("packfile", "application/octet-stream", null, fileStream))
+                                                               .ConfigureAwait(false);
+                    var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
+                    if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)
+                    {
+                        TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsObjectsPackErrors(errorType);
+                    }
+
+                    CheckResponseStatusCode(response, responseContent, finalTry);
+                }
+                catch
+                {
+                    TelemetryFactory.Metrics.RecordCountCIVisibilityGitRequestsSearchCommitsErrors(MetricTags.CIVisibilityErrorType.Network);
+                    throw;
+                }
 
                 return new FileInfo(packFile).Length;
             }


### PR DESCRIPTION
## Summary of changes

The current implementation of telemetry metrics capture request errors based on the response status code, but doesn't handle a thrown exception. This PR fixes that.

## Reason for change

We are missing this type of errors in the current implementation.

## Implementation details

Wrap the network related function inside a try/catch to set the metric and rethrow.

## Test coverage

A new test suite in the test-environment is on the works for handling this case.
