### PR TITLE
Record TFM value in telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -389,6 +389,7 @@ namespace Datadog.Trace.Configuration
             // we "enrich" with these values which aren't _strictly_ configuration, but which we want to track as we tracked them in v1
             telemetry.Record(ConfigTelemetryData.NativeTracerVersion, Instrumentation.GetNativeTracerVersion(), recordValue: true, ConfigurationOrigins.Default);
             telemetry.Record(ConfigTelemetryData.FullTrustAppDomain, value: AppDomain.CurrentDomain.IsFullyTrusted, ConfigurationOrigins.Default);
+            telemetry.Record(ConfigTelemetryData.ManagedTracerTfm, value: ConfigTelemetryData.ManagedTracerTfmValue, recordValue: true, ConfigurationOrigins.Default);
 
             if (AzureAppServiceMetadata is not null)
             {

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -15,6 +15,7 @@ namespace Datadog.Trace.Telemetry
         public const string AgentTraceTransport = "agent_transport";
         public const string Debug = "debug";
         public const string NativeTracerVersion = "native_tracer_version";
+        public const string ManagedTracerTfm = "managed_tracer_framework";
         public const string AnalyticsEnabled = "analytics_enabled";
         public const string SampleRate = "sample_rate";
         public const string SamplingRules = "sampling_rules";
@@ -46,5 +47,18 @@ namespace Datadog.Trace.Telemetry
 
         public const string ProfilerLoaded = "profiler_loaded";
         public const string CodeHotspotsEnabled = "code_hotspots_enabled";
+
+        // We intentionally are using specific values here, not OR_GREATER_THAN
+#if NET6_0
+        public const string ManagedTracerTfmValue = "net6.0";
+#elif NETCOREAPP3_1
+        public const string ManagedTracerTfmValue = "netcoreapp3.1";
+#elif NETSTANDARD2_0
+        public const string ManagedTracerTfmValue = "netstandard2.0";
+#elif NETFRAMEWORK
+        public const string ManagedTracerTfmValue = "net461";
+#else
+#error Unexpected TFM
+#endif
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -29,6 +29,7 @@
   "security_enabled": "appsec_enabled",
   "stats_computation_enabled": "trace_stats_computation_enabled",
   "native_tracer_version": "native_tracer_version",
+  "managed_tracer_framework": "managed_tracer_framework",
   "wcf_obfuscation_enabled": "trace_wcf_obfuscation_enabled",
   "data.streams.enabled": "data_streams_enabled",
   "dynamic.instrumentation.enabled": "dynamic_instrumentation_enabled",


### PR DESCRIPTION
## Summary of changes

Records the TFM of the managed library in telemetry

## Reason for change

We want to track usages of the netstandard version of the library, particularly in "incorrect" scenarios

## Implementation details

Conditionally compile the telemetry constant into the dll and submit that with telemetry

## Test coverage

Added a test to confirm we're using the correct values.

## Other details
Will also need to update the normalization list in the backend

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
