### PR TITLE
Stop using public properties in built-in record methods

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -602,7 +602,12 @@ namespace Datadog.Trace.Configuration
         public virtual bool Equals(ImmutableTracerSettings? other) => base.Equals(other);
 
         /// <inheritdoc />
-        public override string? ToString() => base.ToString();
+        [PublicApi]
+        public override string? ToString()
+        {
+            TelemetryFactory.Metrics.Record(PublicApiUsage.ImmutableTracerSettings_ToString);
+            return base.ToString();
+        }
 
         internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)
         {

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -8,7 +8,9 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration.Telemetry;
@@ -586,6 +588,21 @@ namespace Datadog.Trace.Configuration
             TelemetryFactory.Metrics.Record(PublicApiUsage.ImmutableTracerSettings_FromDefaultSources);
             return new ImmutableTracerSettings(TracerSettings.FromDefaultSourcesInternal(), true);
         }
+
+        // Overriding the default "record" behaviour here
+        // This type _shouldn't_ be treated as a record generally, we only made it a record
+        // so we could use with {} expressions...
+
+        /// <inheritdoc />
+        // ReSharper disable once BaseObjectGetHashCodeCallInGetHashCode
+        public override int GetHashCode() => base.GetHashCode();
+
+        /// <inheritdoc />
+        // ReSharper disable once BaseObjectEqualsIsObjectEquals
+        public virtual bool Equals(ImmutableTracerSettings? other) => base.Equals(other);
+
+        /// <inheritdoc />
+        public override string? ToString() => base.ToString();
 
         internal bool IsErrorStatusCode(int statusCode, bool serverStatusCode)
         {

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/PublicApiUsage.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/PublicApiUsage.cs
@@ -221,6 +221,7 @@ internal enum PublicApiUsage
     [Description("name:immutabletracersettings_traceenabled_get")] ImmutableTracerSettings_TraceEnabled_Get,
     [Description("name:immutabletracersettings_tracermetricsenabled_get")] ImmutableTracerSettings_TracerMetricsEnabled_Get,
     [Description("name:immutabletracersettings_fromdefaultsources")] ImmutableTracerSettings_FromDefaultSources,
+    [Description("name:immutabletracersettings_tostring")] ImmutableTracerSettings_ToString,
 
     [Description("name:opentracingtracerfactory_createtracer")] OpenTracingTracerFactory_CreateTracer,
     [Description("name:opentracingtracerfactory_wraptracer")] OpenTracingTracerFactory_WrapTracer,

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
@@ -85,5 +85,13 @@ namespace Datadog.Trace.Tests.Configuration
                               .Be(config.GetQueueForTesting().Count)
                               .And.NotBe(0);
         }
+
+        [Fact]
+        public void DoesntInvokeBuiltInToStringMethod()
+        {
+            var settings = new ImmutableTracerSettings(NullConfigurationSource.Instance);
+            var result = settings.ToString();
+            result.Should().Be(typeof(ImmutableTracerSettings).FullName);
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

Override the built-in `record` methods in `ImmutableTracerSettings`

## Reason for change

The built-in implementations automatically access all the public properties, which are marked as `[PublicApi]`, so we're falsely recording telemetry for them, even though they're not technically accessed directly (which is _mostly_ what we care about).

## Implementation details

Override the implementations. This effectively reverts it back to what it was pre- #4235. Also added a metric because why-not 😅 

## Test coverage

Added a unit test. Also manually confirmed that the `with { } ` pattern (which is why we converted to a `record` in the first place _doesn't_ call any of the properties at all, it works on the backing fields directly).

## Other details
The behaviour changed in
- https://github.com/DataDog/dd-trace-dotnet/pull/4235

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
