### PR TITLE
Inject serverless headers in agentless telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
@@ -23,6 +23,16 @@ namespace Datadog.Trace.Telemetry
         public const string ClientLibraryVersionHeader = "DD-Client-Library-Version";
         public const string ContainerIdHeader = "Datadog-Container-ID";
 
+        public const string CloudProviderHeader = "DD-Cloud-Provider";
+        public const string CloudResourceTypeHeader = "DD-Cloud-Resource-Type";
+        public const string CloudResourceIdentifierHeader = "DD-Cloud-Resource-Identifier";
+
+        public const string GcpServiceVariable = "K_SERVICE";
+        public const string AzureContainerAppVariable = "CONTAINER_APP_NAME";
+        public const string AzureAppServiceVariable1 = "APPSVC_RUN_ZIP";
+        public const string AzureAppServiceVariable2 = "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED";
+        public const string AzureAppServiceIdentifierVariable = "WEBSITE_SITE_NAME";
+
         public static readonly TimeSpan DefaultFlushInterval = TimeSpan.FromMinutes(1);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryHttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryHttpHeaderNames.cs
@@ -23,13 +23,25 @@ namespace Datadog.Trace.Telemetry
         /// <summary>
         /// Gets the default constant headers that should be added to any request to the direct telemetry intake
         /// </summary>
-        internal static KeyValuePair<string, string>[] GetDefaultIntakeHeaders(string apiKey)
-            => new[]
+        internal static KeyValuePair<string, string>[] GetDefaultIntakeHeaders(TelemetrySettings.AgentlessSettings settings)
+        {
+            var headerCount = settings.Cloud is null ? 4 : 7;
+
+            var headers = new KeyValuePair<string, string>[headerCount];
+
+            headers[0] = new(TelemetryConstants.ClientLibraryLanguageHeader, TracerConstants.Language); // optional in v1, required in v2
+            headers[1] = new(TelemetryConstants.ClientLibraryVersionHeader, TracerConstants.AssemblyVersion); // optional in v1, required in v2
+            headers[2] = new(HttpHeaderNames.TracingEnabled, "false"); // don't add automatic instrumentation to requests directed to the agent
+            headers[3] = new(TelemetryConstants.ApiKeyHeader, settings.ApiKey);
+
+            if (settings.Cloud is { } cloud)
             {
-                new KeyValuePair<string, string>(TelemetryConstants.ClientLibraryLanguageHeader, TracerConstants.Language), // optional in v1, required in v2
-                new KeyValuePair<string, string>(TelemetryConstants.ClientLibraryVersionHeader, TracerConstants.AssemblyVersion), // optional in v1, required in v2
-                new KeyValuePair<string, string>(HttpHeaderNames.TracingEnabled, "false"), // don't add automatic instrumentation to requests directed to the agent
-                new KeyValuePair<string, string>(TelemetryConstants.ApiKeyHeader, apiKey),
-            };
+                headers[4] = new(TelemetryConstants.CloudProviderHeader, cloud.Provider);
+                headers[5] = new(TelemetryConstants.CloudResourceTypeHeader, cloud.ResourceType);
+                headers[6] = new(TelemetryConstants.CloudResourceIdentifierHeader, cloud.ResourceIdentifier);
+            }
+
+            return headers;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -132,7 +132,7 @@ namespace Datadog.Trace.Telemetry
 
                 // The uri is already validated in the above code, so this won't fail
                 var finalUri = UriHelpers.Combine(new Uri(agentlessUri, UriKind.Absolute), "/");
-                agentless = new AgentlessSettings(finalUri, apiKey!);
+                agentless = AgentlessSettings.Create(finalUri, apiKey!);
             }
 
             var heartbeatInterval = config
@@ -189,10 +189,18 @@ namespace Datadog.Trace.Telemetry
 
         public class AgentlessSettings
         {
-            public AgentlessSettings(Uri agentlessUri, string apiKey)
+            /// <summary>
+            /// Initializes a new instance of the <see cref="AgentlessSettings"/> class.
+            /// For testing only, prefer using <see cref="Create"/> instead
+            /// </summary>
+            public AgentlessSettings(
+                Uri agentlessUri,
+                string apiKey,
+                CloudSettings? cloudSettings)
             {
                 AgentlessUri = agentlessUri;
                 ApiKey = apiKey;
+                Cloud = cloudSettings;
             }
 
             /// <summary>
@@ -204,6 +212,49 @@ namespace Datadog.Trace.Telemetry
             /// Gets the api key to use when sending requests to the agentless telemetry intake
             /// </summary>
             public string ApiKey { get; }
+
+            public CloudSettings? Cloud { get; }
+
+            public static AgentlessSettings Create(Uri agentlessUri, string apiKey)
+            {
+                CloudSettings? cloud = null;
+                if (EnvironmentHelpers.GetEnvironmentVariable(TelemetryConstants.GcpServiceVariable) is { Length: >0 } gcp)
+                {
+                    cloud = new("GCP", "GCPCloudRun", gcp);
+                }
+                else if (EnvironmentHelpers.GetEnvironmentVariable(TelemetryConstants.AzureContainerAppVariable) is { Length: >0 } aca)
+                {
+                    cloud = new("Azure", "AzureContainerApp", aca);
+                }
+                else if (!string.IsNullOrEmpty(EnvironmentHelpers.GetEnvironmentVariable(TelemetryConstants.AzureAppServiceVariable1))
+                    || !string.IsNullOrEmpty(EnvironmentHelpers.GetEnvironmentVariable(TelemetryConstants.AzureAppServiceVariable2)))
+                {
+                    cloud = new("Azure", "AzureAppService", EnvironmentHelpers.GetEnvironmentVariable(TelemetryConstants.AzureAppServiceIdentifierVariable));
+                }
+
+                // TODO: Handle AWS Lambda. We don't currently have a good way to get the ARN as the identifier so skip for now
+
+                return new AgentlessSettings(agentlessUri, apiKey, cloud);
+            }
+
+            public class CloudSettings
+            {
+                public CloudSettings(
+                    string provider,
+                    string resourceType,
+                    string resourceIdentifier)
+                {
+                    Provider = provider;
+                    ResourceType = resourceType;
+                    ResourceIdentifier = resourceIdentifier;
+                }
+
+                public string Provider { get; }
+
+                public string ResourceType { get; }
+
+                public string ResourceIdentifier { get; }
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportFactory.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Telemetry.Transports
 
         private static ITelemetryTransport GetAgentlessFactory(TelemetrySettings.AgentlessSettings agentlessSettings, bool debugEnabled)
             => new AgentlessTelemetryTransport(
-                TelemetryTransportStrategy.GetDirectIntakeFactory(agentlessSettings.AgentlessUri, agentlessSettings.ApiKey),
+                TelemetryTransportStrategy.GetDirectIntakeFactory(agentlessSettings),
                 debugEnabled: debugEnabled);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/TelemetryTransportStrategy.cs
@@ -18,14 +18,14 @@ internal static class TelemetryTransportStrategy
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TelemetryTransportStrategy));
     private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
 
-    public static IApiRequestFactory GetDirectIntakeFactory(Uri baseEndpoint, string apiKey)
+    public static IApiRequestFactory GetDirectIntakeFactory(TelemetrySettings.AgentlessSettings settings)
     {
 #if NETCOREAPP
         Log.Information("Using {FactoryType} for telemetry transport direct to intake.", nameof(HttpClientRequestFactory));
-        return new HttpClientRequestFactory(baseEndpoint, TelemetryHttpHeaderNames.GetDefaultIntakeHeaders(apiKey), timeout: Timeout);
+        return new HttpClientRequestFactory(settings.AgentlessUri, TelemetryHttpHeaderNames.GetDefaultIntakeHeaders(settings), timeout: Timeout);
 #else
         Log.Information("Using {FactoryType} for telemetry transport direct to intake.", nameof(ApiWebRequestFactory));
-        return new ApiWebRequestFactory(baseEndpoint, TelemetryHttpHeaderNames.GetDefaultIntakeHeaders(apiKey), timeout: Timeout);
+        return new ApiWebRequestFactory(settings.AgentlessUri, TelemetryHttpHeaderNames.GetDefaultIntakeHeaders(settings), timeout: Timeout);
 #endif
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsAgentlessSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetrySettingsAgentlessSettingsTests.cs
@@ -1,0 +1,92 @@
+﻿// <copyright file="TelemetrySettingsAgentlessSettingsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Telemetry;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Telemetry;
+
+[Collection(nameof(EnvironmentVariablesTestCollection))]
+public class TelemetrySettingsAgentlessSettingsTests : IDisposable
+{
+    private const string ApiKey = "some-key";
+    private static readonly Uri Uri = new("http://localhost:8080");
+    private static readonly string[] CloudVariables = { "K_SERVICE", "CONTAINER_APP_NAME", "APPSVC_RUN_ZIP", "WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED", "WEBSITE_SITE_NAME" };
+    private readonly Dictionary<string, string> _originalVariables = new();
+
+    public TelemetrySettingsAgentlessSettingsTests()
+    {
+        foreach (var variable in CloudVariables)
+        {
+            _originalVariables[variable] = Environment.GetEnvironmentVariable(variable);
+            // clear variable
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var variable in _originalVariables)
+        {
+            Environment.SetEnvironmentVariable(variable.Key, variable.Value);
+        }
+    }
+
+    [Fact]
+    public void CloudDetection_WhenNoCloudVariables()
+    {
+        var settings = TelemetrySettings.AgentlessSettings.Create(Uri, ApiKey);
+
+        settings.Cloud.Should().BeNull();
+    }
+
+    [Fact]
+    public void CloudDetection_WhenGcp()
+    {
+        var id = "some-identifier";
+        Environment.SetEnvironmentVariable("K_SERVICE", id);
+
+        var settings = TelemetrySettings.AgentlessSettings.Create(Uri, ApiKey);
+
+        var cloud = settings.Cloud.Should().NotBeNull();
+        settings.Cloud.Provider.Should().Be("GCP");
+        settings.Cloud.ResourceType.Should().Be("GCPCloudRun");
+        settings.Cloud.ResourceIdentifier.Should().Be(id);
+    }
+
+    [Fact]
+    public void CloudDetection_WhenAzureContainerApps()
+    {
+        var id = "some-identifier";
+        Environment.SetEnvironmentVariable("CONTAINER_APP_NAME", id);
+
+        var settings = TelemetrySettings.AgentlessSettings.Create(Uri, ApiKey);
+
+        var cloud = settings.Cloud.Should().NotBeNull();
+        settings.Cloud.Provider.Should().Be("Azure");
+        settings.Cloud.ResourceType.Should().Be("AzureContainerApp");
+        settings.Cloud.ResourceIdentifier.Should().Be(id);
+    }
+
+    [Theory]
+    [InlineData("APPSVC_RUN_ZIP")]
+    [InlineData("WEBSITE_APPSERVICEAPPLOGS_TRACE_ENABLED")]
+    public void CloudDetection_WhenAzureAppService(string variable)
+    {
+        var id = "some-identifier";
+        Environment.SetEnvironmentVariable("WEBSITE_SITE_NAME", id);
+        Environment.SetEnvironmentVariable(variable, "anything");
+
+        var settings = TelemetrySettings.AgentlessSettings.Create(Uri, ApiKey);
+
+        var cloud = settings.Cloud.Should().NotBeNull();
+        settings.Cloud.Provider.Should().Be("Azure");
+        settings.Cloud.ResourceType.Should().Be("AzureAppService");
+        settings.Cloud.ResourceIdentifier.Should().Be(id);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/TelemetryTransportFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/TelemetryTransportFactoryTests.cs
@@ -24,7 +24,7 @@ public class TelemetryTransportFactoryTests
         var telemetrySettings = new TelemetrySettings(
             telemetryEnabled: true,
             configurationError: null,
-            agentlessSettings: agentlessEnabled ? new TelemetrySettings.AgentlessSettings(new Uri("http://localhost"), "SOME_API_KEY") : null,
+            agentlessSettings: agentlessEnabled ? new TelemetrySettings.AgentlessSettings(new Uri("http://localhost"), "SOME_API_KEY", null) : null,
             agentProxyEnabled: agentProxyEnabled,
             heartbeatInterval: TimeSpan.FromSeconds(1),
             dependencyCollectionEnabled: true,


### PR DESCRIPTION
## Summary of changes

Add the serverless header identifiers to agentless telemetry requests

## Reason for change

Telemetry analytics have asked these to be added

## Implementation details

Detects GCP and Azure currently. I haven't implemented Aws as we don't have a good way of getting the ARN yet

## Test coverage

Added unit tests for detecting the environment and for checking they're added to the outgoing requests correctly

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
