### PR TITLE
Add missing metric in agent writer

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -410,6 +410,7 @@ namespace Datadog.Trace.Agent
                 if (shouldSendTrace)
                 {
                     TelemetryFactory.Metrics.RecordCountTraceChunkEnqueued(MetricTags.TraceChunkEnqueueReason.P0Keep);
+                    TelemetryFactory.Metrics.RecordCountSpanEnqueuedForSerialization(MetricTags.SpanEnqueueReason.P0Keep, spans.Count);
                 }
                 else
                 {


### PR DESCRIPTION
## Summary of changes

Add missing metric

## Reason for change

We weren't recording the number of spans when stats computation was enabled + the aggregator determined we should keep the trace.

## Implementation details

Add missing metric call

## Test coverage

meh

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
