### PR TITLE
[Profiler] Fix Preprocessor variable

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -41,12 +41,12 @@ std::pair<bool, FrameInfoView> FrameStore::GetFrame(uintptr_t instructionPointer
     // We may end up in a situation where the module containing that symbol was just unloaded.
     // For linux, we do not have solution yet.
     HRESULT hr;
-#ifdef WINDOWS
+#ifdef _WINDOWS
     __try
     {
 #endif
         hr = _pCorProfilerInfo->GetFunctionFromIP((LPCBYTE)instructionPointer, &functionId);
-#ifdef WINDOWS
+#ifdef _WINDOWS
     }
     __except (EXCEPTION_EXECUTE_HANDLER)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <unordered_map>
 #include <string>
 #include <vector>
@@ -41,6 +42,8 @@ public :
 
 
 private:
+    std::optional<std::pair<HRESULT, FunctionID>> GetFunctionFromIP(uintptr_t instructionPointer);
+
     bool GetFunctionInfo(
         FunctionID functionId,
         mdToken& mdTokenFunc,


### PR DESCRIPTION
## Summary of changes

Replace `WINDOWS` by `_WINDOWS`.

## Reason for change

On Windows, ASP.NET application can load and unload module. The issue is that we get instruction pointer that can belong to unloaded modules. 
In this case, `GetFunctionFromIP` crashes. A fix was made to catch the `Access Violation` exception and continue the execution.
Since structured exception does exist on Linux we had to protect it by using `#ifdef ..` .... but we used the wrong one `WINDOWS` instead of `_WINDOWS`.


## Implementation details

replace `WINDOWS` by `_WINDOWS`

## Test coverage

Our current tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
