### PR TITLE
[Profiler] Add Profiler_Version as exported symbol to allow version check in dumps

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -63,8 +63,17 @@ IClrLifetime* CorProfilerCallback::GetClrLifetime() const
     return _pClrLifetime.get();
 }
 
-// Initialization
+// This can be used to detect profiler version in a memory dump
+// in WinDbg:  dt Datadog_Profiler_Native!Profiler_Version
+// in gdb: p Profiler_Version
+#ifndef _WIN32
+extern "C" __attribute__((visibility("default"))) const char* Profiler_Version = PROFILER_VERSION;
+#else
+extern "C" __declspec(dllexport) const char* Profiler_Version = PROFILER_VERSION;
+#endif
 
+
+// Initialization
 CorProfilerCallback* CorProfilerCallback::_this = nullptr;
 
 CorProfilerCallback::CorProfilerCallback()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -55,6 +55,7 @@ namespace shared {
 class Loader;
 }
 
+
 class CorProfilerCallback : public ICorProfilerCallback10
 {
 private:


### PR DESCRIPTION
## Summary of changes
Add Profiler_Version as an exported symbol with the version of the profiler

## Reason for change
Allow version check in memory dumpa

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
