### PR TITLE
[All] Add build-id to Linux binaries

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(${API_WRAPPER_SHARED_LIB_NAME} SHARED
 target_link_libraries(${API_WRAPPER_SHARED_LIB_NAME}
     -pthread
     -ldl
+    -Wl,--build-id
 )
 
 set_target_properties(${API_WRAPPER_SHARED_LIB_NAME} PROPERTIES PREFIX "")

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -121,6 +121,7 @@ target_link_libraries(${PROFILER_STATIC_LIB_NAME}
     -lstdc++fs
     -pthread
     -ldl
+    -Wl,--build-id
 )
 
 add_dependencies(${PROFILER_STATIC_LIB_NAME} libdatadog-lib libunwind-lib coreclr spdlog-headers PPDB)

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -178,6 +178,7 @@ elseif(ISLINUX)
         ${CMAKE_DL_LIBS}
         coreclr
         spdlog-headers
+        -Wl,--build-id
     )
 endif()
 

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -205,7 +205,6 @@ if (ISMACOS)
         spdlog-headers
         ${CMAKE_DL_LIBS}
         ${GENERATED_OBJ_FILES}
-        -Wl,--build-id
     )
 elseif(ISLINUX)
     target_link_libraries("Datadog.Tracer.Native.static"

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -205,6 +205,7 @@ if (ISMACOS)
         spdlog-headers
         ${CMAKE_DL_LIBS}
         ${GENERATED_OBJ_FILES}
+        -Wl,--build-id
     )
 elseif(ISLINUX)
     target_link_libraries("Datadog.Tracer.Native.static"
@@ -216,6 +217,7 @@ elseif(ISLINUX)
         ${CMAKE_DL_LIBS}
         -static-libgcc
         -static-libstdc++
+        -Wl,--build-id
     )
 endif()
 


### PR DESCRIPTION
## Summary of changes

Add `build-id` to Linux binaries.

## Reason for change

When investigating a coredump, it will be nice to have the `build-id` of the artifact to check if we have the right version.
This will also avoid warning message from `dotnet tool`
![image](https://github.com/DataDog/dd-trace-dotnet/assets/17292193/443f1ffe-ce63-49c4-868e-a632ae26bf6f)


## Implementation details

Add `-W,--build-id` to the target link.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
