### PR TITLE
[IAST] Added StringAspects.Concat() micro benchmark

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Iast.cs
+++ b/tracer/src/Datadog.Trace/Iast/Iast.cs
@@ -37,7 +37,7 @@ internal class Iast
     {
     }
 
-    private Iast(IastSettings settings = null)
+    internal Iast(IastSettings settings = null)
     {
         _settings = settings ?? IastSettings.FromDefaultSources();
         if (_settings.Enabled)

--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -71,6 +71,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\..\Datadog.Trace.Security.Unit.Tests\IAST\CustomSettingsForTests.cs" Link="Iast\CustomSettingsForTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="DuckTyping\DuckTypeMethodBenchmark.cs" />
     <None Include="DuckTyping\DuckTypeMethodCallComparisonBenchmark.cs" />
     <None Include="DuckTyping\DuckTypeStructCopyValueTypePropertyBenchmark.cs" />

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -40,8 +40,6 @@ public class StringAspectsBenchmark
     public IEnumerable<List<string>> IastContext(bool enabled)
     {
         yield return InitTaintedContext(5, enabled);
-        yield return InitTaintedContext(10, enabled);
-        yield return InitTaintedContext(20, enabled);
         yield return InitTaintedContext(100, enabled);
     }
 
@@ -86,13 +84,15 @@ public class StringAspectsBenchmark
         return res;
     }
 
+    const int Iterations = 1000;
+
     [Benchmark]
     [ArgumentsSource(nameof(IastDisabledContext))]
     public void StringConcatBenchmark(List<string> parameters)
     {
         var list = new List<string>(parameters.Count);
         var arr = parameters.ToArray();
-        for (int x = 0; x < 100; x++)
+        for (int x = 0; x < Iterations; x++)
         {
             var txt = string.Concat(arr);
             list.Add(string.Concat(x.ToString(), "Select * from users where name in (", txt, ")"));
@@ -106,7 +106,7 @@ public class StringAspectsBenchmark
     {
         var list = new List<string>(parameters.Count);
         var arr = parameters.ToArray();
-        for (int x = 0; x < 100; x++)
+        for (int x = 0; x < Iterations; x++)
         {
             var txt = StringAspects.Concat(arr);
             list.Add(StringAspects.Concat(x.ToString(), "Select * from users where name in (", txt, ")"));

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -55,10 +55,11 @@ public class StringAspectsBenchmark
         if (initTainted)
         {
             var settings = new CustomSettingsForTests(new Dictionary<string, object>()
-        {
-            { ConfigurationKeys.Iast.RequestSampling, 100 },
-            { ConfigurationKeys.Iast.Enabled, true }
-        });
+            {
+                { ConfigurationKeys.Iast.RequestSampling, 100 },
+                { ConfigurationKeys.Iast.Enabled, true },
+                { ConfigurationKeys.Iast.IsIastDeduplicationEnabled, false },
+            });
             var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
             Datadog.Trace.Iast.Iast.Instance = new Datadog.Trace.Iast.Iast(iastSettings);
 
@@ -104,6 +105,7 @@ public class StringAspectsBenchmark
     [IterationCleanup]
     public void Cleanup()
     {
+        Tracer.Instance?.ActiveScope?.Close();
         Datadog.Trace.Iast.Iast.Instance = null;
     }
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -5,13 +5,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
-using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Waf;
-using Datadog.Trace.AppSec.Waf.NativeBindings;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Iast;
+using Datadog.Trace.Iast.Settings;
+using Datadog.Trace.Security.Unit.Tests.Iast;
+
 
 namespace Benchmarks.Trace.Iast;
 
@@ -25,12 +26,20 @@ public class StringAspectsBenchmark
     {
     }
 
-    public IEnumerable<int> TaintedDictionary()
+    public IEnumerable<int> IastEnabledContext()
     {
-        yield return MakeTaintedDictionary(10);
-        yield return MakeTaintedDictionary(20);
-        yield return MakeTaintedDictionary(100);
+        yield return InitTaintedContext(10);
+        //yield return InitTaintedContext(20);
+        //yield return InitTaintedContext(100);
     }
+
+    public IEnumerable<int> IastDisabledContext()
+    {
+        yield return 10;
+        //yield return InitTaintedContext(20);
+        //yield return InitTaintedContext(100);
+    }
+
 
     /// <summary>
     /// Generates dummy arguments for the waf
@@ -38,34 +47,57 @@ public class StringAspectsBenchmark
     /// <param name="nestingDepth">Encoder.cs respects WafConstants.cs limits to process arguments with a max depth of 20 so above depth 20, there shouldn't be much difference of performances.</param>
     /// <param name="withAttack">an attack present in arguments can slow down waf's run</param>
     /// <returns></returns>
-    private static int MakeTaintedDictionary(int size)
+    private static int InitTaintedContext(int size)
     {
+        System.Diagnostics.Debugger.Break();
+
+        var settings = new CustomSettingsForTests(new Dictionary<string, object>()
+        {
+            { ConfigurationKeys.Iast.RequestSampling, 100 },
+            { ConfigurationKeys.Iast.Enabled, true }
+        });
+        var iastSettings = new IastSettings(settings, NullConfigurationTelemetry.Instance);
+        Datadog.Trace.Iast.Iast.Instance = new Datadog.Trace.Iast.Iast(iastSettings);
+
+        var tracer = Tracer.Instance;
+        System.Diagnostics.Debug.Assert(tracer != null, "Tracer is NULL");
+        var iast = Datadog.Trace.Iast.Iast.Instance;
+        System.Diagnostics.Debug.Assert(iast != null, "IastInstance is NULL");
+        var context = IastModule.GetIastContext();
+        System.Diagnostics.Debug.Assert(context != null, "IastContext is NULL");
+        var taintedObjects = context.GetTaintedObjects();
+        System.Diagnostics.Debug.Assert(taintedObjects != null, "TaintedObjects is NULL");
+
+        taintedObjects.TaintInputString("param1", new Source(1, "kk", "kk"));
+
         return size;
     }
 
     [Benchmark]
-    [ArgumentsSource(nameof(MakeTaintedDictionary))]
+    [ArgumentsSource(nameof(IastDisabledContext))]
     public void RunStringBenchmark(int size)
-    { 
-    
+    {
+        var parameters = new string[] { "param1", "param2", "param3" };
+        for (int x = 0; x < 1000; x++)
+        {
+            var txt = "Select * from users where name in (" + string.Join(", ", parameters) + ")";
+        }
     }
 
     [Benchmark]
-    [ArgumentsSource(nameof(MakeTaintedDictionary))]
+    [ArgumentsSource(nameof(IastEnabledContext))]
     public void RunStringAspectBenchmark(int size) 
     {
-    
+        var parameters = new string[] { "param1", "param2", "param3" };
+        for (int x = 0; x < 1000; x++)
+        {
+            var txt = "Select * from users where name in (" + string.Join(", ", parameters) + ")";
+        }
     }
 
-    private void RunStringBenchmark(NestedMap args)
+    [IterationCleanup]
+    public void Cleanup()
     {
-        var context = Waf.CreateContext();
-        context!.Run(args.Map, TimeoutMicroSeconds);
-        context.Dispose();
-    }
-
-    public record NestedMap(Dictionary<string, object> Map, int NestingDepth, bool IsAttack = false)
-    {
-        public override string ToString() => IsAttack ? $"NestedMap ({NestingDepth}, attack)" : $"NestedMap ({NestingDepth})";
+        Datadog.Trace.Iast.Iast.Instance = null;
     }
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -88,22 +88,30 @@ public class StringAspectsBenchmark
 
     [Benchmark]
     [ArgumentsSource(nameof(IastDisabledContext))]
-    public void RunStringBenchmark(List<string> parameters)
+    public void StringConcatBenchmark(List<string> parameters)
     {
-        for (int x = 0; x < 1000; x++)
+        var list = new List<string>(parameters.Count);
+        var arr = parameters.ToArray();
+        for (int x = 0; x < 100; x++)
         {
-            var txt = string.Concat("Select * from users where name in (", string.Join(", ", parameters), ")");
+            var txt = string.Concat(arr);
+            list.Add(string.Concat(x.ToString(), "Select * from users where name in (", txt, ")"));
         }
+        System.Diagnostics.Trace.WriteLine($"{list.Count} elements computed");
     }
 
     [Benchmark]
     [ArgumentsSource(nameof(IastEnabledContext))]
-    public void RunStringAspectBenchmark(List<string> parameters)
+    public void StringConcatAspectBenchmark(List<string> parameters)
     {
-        for (int x = 0; x < 1000; x++)
+        var list = new List<string>(parameters.Count);
+        var arr = parameters.ToArray();
+        for (int x = 0; x < 100; x++)
         {
-            var txt = StringAspects.Concat("Select * from users where name in (", StringAspects.Join(", ", parameters), ")");
+            var txt = StringAspects.Concat(arr);
+            list.Add(StringAspects.Concat(x.ToString(), "Select * from users where name in (", txt, ")"));
         }
+        System.Diagnostics.Trace.WriteLine($"{list.Count} elements computed");
     }
 
     [IterationCleanup]

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -29,18 +29,21 @@ public class StringAspectsBenchmark
 
     public IEnumerable<List<string>> IastEnabledContext()
     {
-        yield return InitTaintedContext(10);
-        yield return InitTaintedContext(20);
-        yield return InitTaintedContext(100);
+        return IastContext(true);
     }
 
     public IEnumerable<List<string>> IastDisabledContext()
     {
-        yield return InitTaintedContext(10, false);
-        yield return InitTaintedContext(20, false);
-        yield return InitTaintedContext(100, false);
+        return IastContext(false);
     }
 
+    public IEnumerable<List<string>> IastContext(bool enabled)
+    {
+        yield return InitTaintedContext(5, enabled);
+        yield return InitTaintedContext(10, enabled);
+        yield return InitTaintedContext(20, enabled);
+        yield return InitTaintedContext(100, enabled);
+    }
 
     /// <summary>
     /// Generates dummy arguments for the waf
@@ -71,11 +74,12 @@ public class StringAspectsBenchmark
             var context = traceContext?.IastRequestContext;
             taintedObjects = context.GetTaintedObjects();
         }
+
         List<string> res = new List<string>();
         for (int x = 0; x < size; x++)
         {
             var p = $"param{x}";
-            taintedObjects?.TaintInputString(p, new Source(1, "kk", "kk"));
+            taintedObjects?.TaintInputString(p, new Source((byte)x, $"source{x}", p));
             res.Add(p);
         }
 
@@ -88,7 +92,7 @@ public class StringAspectsBenchmark
     {
         for (int x = 0; x < 1000; x++)
         {
-            var txt = "Select * from users where name in (" + string.Join(", ", parameters) + ")";
+            var txt = string.Concat("Select * from users where name in (", string.Join(", ", parameters), ")");
         }
     }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -43,12 +43,6 @@ public class StringAspectsBenchmark
         yield return InitTaintedContext(100, enabled);
     }
 
-    /// <summary>
-    /// Generates dummy arguments for the waf
-    /// </summary>
-    /// <param name="nestingDepth">Encoder.cs respects WafConstants.cs limits to process arguments with a max depth of 20 so above depth 20, there shouldn't be much difference of performances.</param>
-    /// <param name="withAttack">an attack present in arguments can slow down waf's run</param>
-    /// <returns></returns>
     private static List<string> InitTaintedContext(int size, bool initTainted = true)
     {
         TaintedObjects taintedObjects = null;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -1,4 +1,4 @@
-// <copyright file="StringInstrumentationBenchmark.cs" company="Datadog">
+// <copyright file="StringAspectsBenchmark.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -1,0 +1,71 @@
+// <copyright file="StringInstrumentationBenchmark.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Datadog.Trace;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.AppSec.Waf.NativeBindings;
+
+namespace Benchmarks.Trace.Iast;
+
+[MemoryDiagnoser]
+[BenchmarkAgent7]
+public class StringAspectsBenchmark
+{
+    private const int TimeoutMicroSeconds = 1_000_000;
+
+    static StringAspectsBenchmark()
+    {
+    }
+
+    public IEnumerable<int> TaintedDictionary()
+    {
+        yield return MakeTaintedDictionary(10);
+        yield return MakeTaintedDictionary(20);
+        yield return MakeTaintedDictionary(100);
+    }
+
+    /// <summary>
+    /// Generates dummy arguments for the waf
+    /// </summary>
+    /// <param name="nestingDepth">Encoder.cs respects WafConstants.cs limits to process arguments with a max depth of 20 so above depth 20, there shouldn't be much difference of performances.</param>
+    /// <param name="withAttack">an attack present in arguments can slow down waf's run</param>
+    /// <returns></returns>
+    private static int MakeTaintedDictionary(int size)
+    {
+        return size;
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(MakeTaintedDictionary))]
+    public void RunStringBenchmark(int size)
+    { 
+    
+    }
+
+    [Benchmark]
+    [ArgumentsSource(nameof(MakeTaintedDictionary))]
+    public void RunStringAspectBenchmark(int size) 
+    {
+    
+    }
+
+    private void RunStringBenchmark(NestedMap args)
+    {
+        var context = Waf.CreateContext();
+        context!.Run(args.Map, TimeoutMicroSeconds);
+        context.Dispose();
+    }
+
+    public record NestedMap(Dictionary<string, object> Map, int NestingDepth, bool IsAttack = false)
+    {
+        public override string ToString() => IsAttack ? $"NestedMap ({NestingDepth}, attack)" : $"NestedMap ({NestingDepth})";
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -39,8 +39,7 @@ public class StringAspectsBenchmark
 
     public IEnumerable<List<string>> IastContext(bool enabled)
     {
-        yield return InitTaintedContext(5, enabled);
-        yield return InitTaintedContext(100, enabled);
+        yield return InitTaintedContext(10, enabled);
     }
 
     private static List<string> InitTaintedContext(int size, bool initTainted = true)
@@ -78,7 +77,7 @@ public class StringAspectsBenchmark
         return res;
     }
 
-    const int Iterations = 1000;
+    const int Iterations = 100;
 
     [Benchmark]
     [ArgumentsSource(nameof(IastDisabledContext))]


### PR DESCRIPTION
## Summary of changes
Added StringAspects.Concat micro benchmark

## Reason for change
We need a way to measure discrete IAST operation overhead

## Implementation details
Implemented two BnechmarDotNet benchmarks, a vanilla one and the other one using the Aspects version

