### PR TITLE
Fix various GitHub Actions

### DIFF
--- a/.github/workflows/auto_create_rel_env_release_images.yml
+++ b/.github/workflows/auto_create_rel_env_release_images.yml
@@ -33,7 +33,7 @@ jobs:
             ref="refs/heads/hotfix/$version"
           fi
 
-          sha=$(git rev-parse tags/tag_name)
+          sha=$(git rev-parse tags/$tag_name)
 
           echo "using '$ref' ref for '$version' version, with sha '$sha'"
           echo "tag=$tag_name" >> $GITHUB_OUTPUT

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -18,6 +18,18 @@ jobs:
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@v3
 
+      - uses: octokit/request-action@v2.x
+        name: 'Open Code Freeze Milestone'
+        id: milestones
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          route: PATCH /repos/{owner}/{repo}/milestones/115
+          owner: DataDog
+          repo: dd-trace-dotnet
+          state: open
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
       - uses: ./.github/actions/code-freeze
         name: 'Freeze 25 PRs'
         with:

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -418,6 +418,7 @@ partial class Build
                 "shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt",
                 "shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc",
                 "shared/src/msi-installer/WindowsInstaller.wixproj",
+                "tracer/build/artifacts/dd-dotnet.sh",
                 "tracer/build/_build/Build.cs",
                 "tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj",
                 "tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj",


### PR DESCRIPTION
## Summary of changes
- Fix the start code freeze action
- Fix the version bump action
- Fix the rel env release image creation actions

## Reason for change

They were all broken/incomplete

## Implementation details

- The code freeze action wasn't opening the code_freeze milestone like it was supposed to
- The version bump action now expects changes in dd-dotnet.sh
- The rel env release image creation action wasn't expanding a variable correctly

## Test coverage

Nope

## Other details

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
