### PR TITLE
Enabled invariant globalization in `dd-trace` tool

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -14,6 +14,7 @@
     <DebugSymbols>false</DebugSymbols>
     <DebugType>None</DebugType>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <InvariantGlobalization>true</InvariantGlobalization>
 
     <!-- Required for StrongNamer: https://github.com/dsplaisted/strongnamer/issues/61 -->
     <ErrorOnDuplicatePublishOutputFiles>False</ErrorOnDuplicatePublishOutputFiles>


### PR DESCRIPTION
## Summary of changes

Sets `InvariantGlobalization=true`

## Reason for change

We shouldn't depend on ICU packages being installed, so this is an oversight (which causes us to crash if they're not installed)

## Implementation details

Set the flag

## Test coverage

I have tested it in the .NET 8 branch, so "trust me" 😄 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
