### PR TITLE
Maximo/cli tool messaging changes

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckIisCommand.cs
@@ -263,7 +263,7 @@ namespace Datadog.Trace.Tools.Runner
 
             if (foundVariables.Count != 0 || foundPathVariables.Count != 0)
             {
-                Utils.WriteWarning(AppPoolCheckFindings(poolName));
+                AnsiConsole.WriteLine(AppPoolCheckFindings(poolName));
 
                 foreach (var variable in foundVariables)
                 {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/AgentConnectivityCheck.cs
@@ -22,6 +22,9 @@ namespace Datadog.Trace.Tools.Runner.Checks
     {
         public static Task<bool> RunAsync(ProcessInfo process)
         {
+            AnsiConsole.WriteLine(string.Empty);
+            AnsiConsole.WriteLine(DdAgentChecks);
+
             var settings = new ExporterSettings(process.Configuration, NullConfigurationTelemetry.Instance);
 
             var url = settings.AgentUriInternal.ToString();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             if (loaderModule == null)
             {
-                AnsiConsole.WriteLine(LoaderNotLoaded);
+                Utils.WriteWarning(LoaderNotLoaded);
             }
 
             if (nativeTracerModule == null)
@@ -69,7 +69,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                         nativeTracerVersion = null;
                     }
 
-                    AnsiConsole.WriteLine(ProfilerVersion(nativeTracerVersion != null ? $"{nativeTracerVersion}" : "{empty}"));
+                    Utils.WriteSuccess(ProfilerVersion(nativeTracerVersion != null ? $"{nativeTracerVersion}" : "{empty}"));
                 }
             }
 
@@ -83,7 +83,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
             else if (tracerModules.Length == 1)
             {
                 var version = FileVersionInfo.GetVersionInfo(tracerModules[0]);
-                AnsiConsole.WriteLine(TracerVersion(version.FileVersion ?? "{empty}"));
+                Utils.WriteSuccess(TracerVersion(version.FileVersion ?? "{empty}"));
             }
             else if (tracerModules.Length > 1)
             {
@@ -153,6 +153,10 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 Utils.WriteWarning(WrongEnvironmentVariableFormat(corProfilerKey, Utils.Profilerid, corProfiler));
                 ok = false;
             }
+            else if (corProfiler == Utils.Profilerid)
+            {
+                Utils.WriteSuccess(CorrectlySetupEnvironment(corProfilerKey, Utils.Profilerid));
+            }
 
             string corEnableKey = runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_ENABLE_PROFILING" : "COR_ENABLE_PROFILING";
 
@@ -164,6 +168,10 @@ namespace Datadog.Trace.Tools.Runner.Checks
             {
                 Utils.WriteError(WrongEnvironmentVariableFormat(corEnableKey, "1", corEnable));
                 ok = false;
+            }
+            else if (corEnable == "1")
+            {
+                Utils.WriteSuccess(CorrectlySetupEnvironment(corEnableKey, "1"));
             }
 
             process.EnvironmentVariables.TryGetValue(corProfilerPathKey, out var corProfilerPathValue);
@@ -223,7 +231,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 {
                     if (ParseBooleanConfigurationValue(profilingEnabled))
                     {
-                        AnsiConsole.WriteLine(ContinuousProfilerEnabled);
+                        Utils.WriteSuccess(ContinuousProfilerEnabled);
                         isContinuousProfilerEnabled = true;
                     }
                     else
@@ -376,6 +384,10 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 {
                     Utils.WriteError(MissingProfilerEnvironment(key, profilerPath));
                     ok = false;
+                }
+                else
+                {
+                    Utils.WriteSuccess(CorrectlySetupEnvironment(key, profilerPath));
                 }
             }
             else if (requiredOnLinux)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/ProcessBasicCheck.cs
@@ -28,7 +28,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
             var runtime = process.DotnetRuntime;
             Version? nativeTracerVersion = null;
 
-            AnsiConsole.WriteLine(InitialCheckStart);
+            AnsiConsole.WriteLine(string.Empty);
+            AnsiConsole.WriteLine(SetupChecks);
 
             if (runtime == ProcessInfo.Runtime.NetFx)
             {
@@ -207,7 +208,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
             // Running non-blocker checks after confirming setup was done correctly
             if (ok)
             {
-                AnsiConsole.WriteLine(CheckOptionalConfiguration);
+                AnsiConsole.WriteLine(string.Empty);
+                AnsiConsole.WriteLine(ConfigurationChecks);
 
                 AnsiConsole.WriteLine(TraceEnabledCheck);
 
@@ -220,7 +222,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                 }
                 else
                 {
-                    AnsiConsole.WriteLine(TraceEnabledNotSet);
+                    Utils.WriteInfo(TraceEnabledNotSet);
                 }
 
                 bool isContinuousProfilerEnabled;
@@ -236,13 +238,13 @@ namespace Datadog.Trace.Tools.Runner.Checks
                     }
                     else
                     {
-                        AnsiConsole.WriteLine(ContinuousProfilerDisabled);
+                        Utils.WriteInfo(ContinuousProfilerDisabled);
                         isContinuousProfilerEnabled = false;
                     }
                 }
                 else
                 {
-                    AnsiConsole.WriteLine(ContinuousProfilerNotSet);
+                    Utils.WriteInfo(ContinuousProfilerNotSet);
                     isContinuousProfilerEnabled = false;
                 }
 
@@ -328,6 +330,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
                     ok &= CheckClsid(registry, Clsid32Key);
                 }
 
+                // Look for registry keys that could have been set by other profilers
                 // Look for registry keys that could have been set by other profilers
                 var suspiciousNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
@@ -580,13 +583,13 @@ namespace Datadog.Trace.Tools.Runner.Checks
             const string uninstallKey64Bit = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\";
             const string uninstallKey32Bit = @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall";
 
-            if (GetLocalMachineSubKeyVersion(uninstallKey64Bit, datadog64BitProgram, out var tracerVersion))
+            if (GetLocalMachineSubKeyVersion(uninstallKey64Bit, datadog64BitProgram, out var tracerVersion, registryService))
             {
                 Utils.WriteSuccess(TracerProgramFound(datadog64BitProgram));
                 return tracerVersion;
             }
 
-            if (GetLocalMachineSubKeyVersion(uninstallKey32Bit, datadog32BitProgram, out tracerVersion))
+            if (GetLocalMachineSubKeyVersion(uninstallKey32Bit, datadog32BitProgram, out tracerVersion, registryService))
             {
                 Utils.WriteSuccess(TracerProgramFound(datadog32BitProgram));
                 var processBitness = ProcessEnvironmentWindows.GetProcessBitness(Process.GetProcessById(processId));

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -17,21 +17,21 @@ namespace Datadog.Trace.Tools.Runner.Checks
     {
         public const string NetFrameworkRuntime = "Target process is running with .NET Framework";
         public const string NetCoreRuntime = "Target process is running with .NET Core";
-        public const string RuntimeDetectionFailed = "Failed to detect target process runtime, assuming .NET Framework";
-        public const string BothRuntimesDetected = "The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
-        public const string LoaderNotLoaded = "The native loader library is not loaded into the process";
+        public const string RuntimeDetectionFailed = "- Failed to detect target process runtime, assuming .NET Framework";
+        public const string BothRuntimesDetected = "- The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
+        public const string LoaderNotLoaded = "- The native loader library is not loaded into the process";
         public const string NativeTracerNotLoaded = "The native tracer library is not loaded into the process";
-        public const string TracerNotLoaded = "Tracer is not loaded into the process";
-        public const string AgentDetectionFailed = "Could not detect the agent version. It may be running with a version older than 7.27.0.";
-        public const string IisProcess = "The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
-        public const string MissingGac = "The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
-        public const string NoWorkerProcess = "No worker process found, to perform additional checks make sure the application is active";
-        public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
-        public const string IisNoIssue = "No issue found with the IIS site.";
-        public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflict: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#create-the-iis-site:~:text=CLR%20version%20to-,No%20Managed%20Code,-%3A";
-        public const string OutOfProcess = "Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
-        public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
-        public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
+        public const string TracerNotLoaded = "- Tracer is not loaded into the process";
+        public const string AgentDetectionFailed = "- Could not detect the agent version. It may be running with a version older than 7.27.0.";
+        public const string IisProcess = "- The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
+        public const string MissingGac = "- The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
+        public const string NoWorkerProcess = "- No worker process found, to perform additional checks make sure the application is active";
+        public const string GetProcessError = "- Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
+        public const string IisNoIssue = "- No issue found with the IIS site.";
+        public const string IisMixedRuntimes = "- The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflict: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#create-the-iis-site:~:text=CLR%20version%20to-,No%20Managed%20Code,-%3A";
+        public const string OutOfProcess = "- Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
+        public const string AspNetCoreProcessNotFound = "- Could not find the ASP.NET Core applicative process.";
+        public const string VersionConflict = "- Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
 
         public const string TracingWithBundleProfilerPath = "Datadog.Trace.Bundle Nuget related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
         public const string TracingWithInstaller = "Installer/MSI related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
@@ -50,61 +50,59 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string ContinuousProfilerNotLoaded = "The continuous profiler library is not loaded into the process.";
         public const string ContinuousProfilerWithoutLoader = "The continuous profiler needs the Datadog.Trace.ClrProfiler.Native module and the loader.conf file to work. Try reinstalling the tracer in version 2.14+.";
 
-        public const string LdPreloadNotSet = "The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
+        public const string LdPreloadNotSet = "- The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
 
-        public static string TracerNotEnabled(string value) => $"The value for DD_TRACE_ENABLED is set to {value}, to enable automatic tracing set it to true.";
+        public static string TracerNotEnabled(string value) => $"- The value for DD_TRACE_ENABLED is set to {value}, to enable automatic tracing set it to true.";
 
-        public static string ApiWrapperNotFound(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
+        public static string ApiWrapperNotFound(string path) => $"- The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
 
-        public static string WrongLdPreload(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but it should point to Datadog.Linux.ApiWrapper.x64.so instead. Check the Datadog .NET Profiler documentation to set it properly.";
+        public static string WrongLdPreload(string path) => $"- The environment variable LD_PRELOAD is set to '{path}' but it should point to Datadog.Linux.ApiWrapper.x64.so instead. Check the Datadog .NET Profiler documentation to set it properly.";
 
-        public static string ProfilerVersion(string version) => $"The native library version {version} is loaded into the process.";
+        public static string ProfilerVersion(string version) => $"- The native library version {version} is loaded into the process.";
 
-        public static string TracerVersion(string version) => $"The tracer version {version} is loaded into the process.";
+        public static string TracerVersion(string version) => $"- The tracer version {version} is loaded into the process.";
 
-        public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set.";
+        public static string EnvironmentVariableNotSet(string environmentVariable) => $"- The environment variable {environmentVariable} is not set";
 
-        public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist.";
+        public static string TracerHomeNotFoundFormat(string tracerHome) => $"- DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 
-        public static string TracerHomeFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' and the directory was found correctly.";
+        public static string WrongEnvironmentVariableFormat(string key, string expectedValue, string? actualValue) => $"- The environment variable {key} should be set to '{expectedValue}' (current value: {EscapeOrNotSet(actualValue)})";
 
-        public static string WrongEnvironmentVariableFormat(string key, string expectedValue, string? actualValue) => $"The environment variable {key} should be set to '{expectedValue}' (current value: {EscapeOrNotSet(actualValue)})";
+        public static string DetectedAgentUrlFormat(string url) => $"- Detected agent url: {url}. Note: this url may be incorrect if you configured the application through a configuration file.";
 
-        public static string DetectedAgentUrlFormat(string url) => $"Detected agent url: {url}. Note: this url may be incorrect if you configured the application through a configuration file.";
+        public static string WrongStatusCodeFormat(HttpStatusCode statusCode) => $"- Agent replied with wrong status code: {statusCode}";
 
-        public static string WrongStatusCodeFormat(HttpStatusCode statusCode) => $"Agent replied with wrong status code: {statusCode}";
+        public static string DetectedAgentVersionFormat(string version) => $"- Detected agent version {version}";
 
-        public static string DetectedAgentVersionFormat(string version) => $"Detected agent version {version}";
+        public static string ErrorDetectingAgent(string url, string error) => $"- Error connecting to Agent at {url}: {error}";
 
-        public static string ErrorDetectingAgent(string url, string error) => $"Error connecting to Agent at {url}: {error}";
+        public static string ConnectToEndpointFormat(string endpoint, string transport) => $"- Connecting to Agent at endpoint {endpoint} using {transport}";
 
-        public static string ConnectToEndpointFormat(string endpoint, string transport) => $"Connecting to Agent at endpoint {endpoint} using {transport}";
+        public static string ErrorCheckingRegistry(string error) => $"- Error trying to read the registry: {error}";
 
-        public static string ErrorCheckingRegistry(string error) => $"Error trying to read the registry: {error}";
+        public static string SuspiciousRegistryKey(string parentKey, string key) => $@"- The registry key HKEY_LOCAL_MACHINE\{parentKey}\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
 
-        public static string SuspiciousRegistryKey(string parentKey, string key) => $@"The registry key HKEY_LOCAL_MACHINE\{parentKey}\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
+        public static string MissingRegistryKey(string key) => $@"- The registry key {key} is missing. If using the MSI, make sure the installation was completed correctly try to repair/reinstall it.";
 
-        public static string MissingRegistryKey(string key) => $@"The registry key {key} is missing. If using the MSI, make sure the installation was completed correctly try to repair/reinstall it.";
+        public static string MissingProfilerRegistry(string key, string path) => $@"- The registry key {key} was set to path '{path}' but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
 
-        public static string MissingProfilerRegistry(string key, string path) => $@"The registry key {key} was set to path '{path}' but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
+        public static string MissingProfilerEnvironment(string key, string path) => $@"- The environment variable {key} is set to {path} but the file is missing or you don't have sufficient permission.";
 
-        public static string MissingProfilerEnvironment(string key, string path) => $@"The environment variable {key} is set to {path} but the file is missing or you don't have sufficient permission.";
-
-        public static string GacVersionFormat(string version) => $"Found Datadog.Trace version {version} in the GAC";
+        public static string GacVersionFormat(string version) => $"- Found Datadog.Trace version {version} in the GAC";
 
         public static string FetchingApplication(string site, string application) => $"Fetching IIS application \"{site}{application}\".";
 
         public static string InspectingWorkerProcess(int pid) => $"Inspecting worker process {pid}";
 
-        public static string ErrorExtractingConfiguration(string error) => $"Could not extract configuration from site: {error}";
+        public static string ErrorExtractingConfiguration(string error) => $"- Could not extract configuration from site: {error}";
 
-        public static string AspNetCoreProcessFound(int pid) => $"Found ASP.NET Core applicative process: {pid}";
+        public static string AspNetCoreProcessFound(int pid) => $"- Found ASP.NET Core applicative process: {pid}";
 
-        public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
+        public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"- The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
 
-        public static string IisApplicationNotProvided() => "IIS application name not provided. ";
+        public static string IisApplicationNotProvided() => "- IIS application name not provided. ";
 
-        public static string CouldNotFindIisApplication(string site, string application) => $"Could not find IIS application \"{site}{application}\". ";
+        public static string CouldNotFindIisApplication(string site, string application) => $"- Could not find IIS application \"{site}{application}\". ";
 
         public static string ListAllIisApplications(IEnumerable<string> availableApplications)
         {
@@ -150,20 +148,16 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         private static string EscapeOrNotSet(string? str) => str == null ? "not set" : $"'{str}'";
 
-        public static string TracerProgramFound(string tracerProgramName) => $"{tracerProgramName} found in the installed programs.";
+        public static string TracerProgramFound(string tracerProgramName) => $"- {tracerProgramName} found in the installed programs.";
 
-        public static string WrongTracerArchitecture(string tracerArchitecture) => $"Found {tracerArchitecture} installed but the current process is 64 Bit, make sure to install the 64-bit tracer instead.";
+        public static string WrongTracerArchitecture(string tracerArchitecture) => $"- Found {tracerArchitecture} installed but the current process is 64 Bit, make sure to install the 64-bit tracer instead.";
 
-        public static string AppPoolCheckFindings(string appPool) => $"Initial run check did not pass, found the incorrect configuration on the {appPool} AppPool:";
+        public static string AppPoolCheckFindings(string appPool) => $"- Check did not pass, fix the configuration on the {appPool} AppPool:";
 
-        public static string WrongLinuxFolder(string expected, string found) => $"Unable to find expected {expected} folder, found {found} instead, make sure to use the correct installer.";
+        public static string WrongLinuxFolder(string expected, string found) => $"- Unable to find expected {expected} folder, found {found} instead, make sure to use the correct installer.";
 
-        public static string UnsupportedLinuxArchitecture(string osArchitecture) => $"The Linux architecture: {osArchitecture} is not supported by the tracer, check: https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures ";
+        public static string UnsupportedLinuxArchitecture(string osArchitecture) => $"- The Linux architecture: {osArchitecture} is not supported by the tracer, check: https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures ";
 
-        public static string ErrorCheckingLinuxDirectory(string error) => $"Error trying to check the Linux installer directory: {error}";
-
-        public static string EnvVarCheck(string number, string envVar) => $"{number}. Checking {envVar} and related configuration value:";
-
-        public static string CorrectLinuxDirectoryFound(string path) => $"Found the expected path {path} based on the current OS Architecture.";
+        public static string ErrorCheckingLinuxDirectory(string error) => $"- Error trying to check the Linux installer directory: {error}";
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -17,21 +17,24 @@ namespace Datadog.Trace.Tools.Runner.Checks
     {
         public const string NetFrameworkRuntime = "Target process is running with .NET Framework";
         public const string NetCoreRuntime = "Target process is running with .NET Core";
-        public const string RuntimeDetectionFailed = "- Failed to detect target process runtime, assuming .NET Framework";
-        public const string BothRuntimesDetected = "- The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
-        public const string LoaderNotLoaded = "- The native loader library is not loaded into the process";
-        public const string NativeTracerNotLoaded = "- The native tracer library is not loaded into the process";
-        public const string TracerNotLoaded = "- Tracer is not loaded into the process";
-        public const string AgentDetectionFailed = "- Could not detect the agent version. It may be running with a version older than 7.27.0.";
-        public const string IisProcess = "- The target process is an IIS process. The detection of the configuration might be incomplete, please use dd-trace check iis <site name> instead.";
-        public const string MissingGac = "- The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
-        public const string NoWorkerProcess = "- No worker process found, to perform additional checks make sure the application is active";
-        public const string GetProcessError = "- Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
-        public const string IisNoIssue = "- No issue found with the IIS site.";
-        public const string IisMixedRuntimes = "- The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflict: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#create-the-iis-site:~:text=CLR%20version%20to-,No%20Managed%20Code,-%3A";
-        public const string OutOfProcess = "- Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
-        public const string AspNetCoreProcessNotFound = "- Could not find the ASP.NET Core applicative process.";
-        public const string VersionConflict = "- Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
+        public const string RuntimeDetectionFailed = "Failed to detect target process runtime, assuming .NET Framework";
+        public const string BothRuntimesDetected = "The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
+        public const string LoaderNotLoaded = "The native loader library is not loaded into the process";
+        public const string NativeTracerNotLoaded = "The native tracer library is not loaded into the process";
+        public const string TracerNotLoaded = "Tracer is not loaded into the process";
+        public const string AgentDetectionFailed = "Could not detect the agent version. It may be running with a version older than 7.27.0.";
+        public const string IisProcess = "The target process is an IIS process. The detection of the configuration might be incomplete, please use dd-trace check iis <site name> instead.";
+        public const string MissingGac = "The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
+        public const string NoWorkerProcess = "No worker process found, to perform additional checks make sure the application is active";
+        public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
+        public const string IisNoIssue = "No issue found with the IIS site.";
+        public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflict: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#create-the-iis-site:~:text=CLR%20version%20to-,No%20Managed%20Code,-%3A";
+        public const string OutOfProcess = "Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
+        public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
+        public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
+        public const string TracingWithBundleProfilerPath = "Check failing with Datadog.Trace.Bundle Nuget, related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
+        public const string TracingWithInstaller = "Check failing with Installer/MSI, related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
+        public const string TraceProgramNotFound = "Unable to find Datadog .NET Tracer program, make sure the tracer has been properly installed with the MSI.";
 
         public const string TracingWithBundleProfilerPath = "Datadog.Trace.Bundle Nuget related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
         public const string TracingWithInstaller = "Installer/MSI related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
@@ -50,61 +53,59 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string ContinuousProfilerNotLoaded = "The continuous profiler library is not loaded into the process.";
         public const string ContinuousProfilerWithoutLoader = "The continuous profiler needs the Datadog.Trace.ClrProfiler.Native module and the loader.conf file to work. Try reinstalling the tracer in version 2.14+.";
 
-        public const string LdPreloadNotSet = "- The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
+        public static string TracerNotEnabled(string value) => $"Tracing is explicitly disabled through DD_TRACE_ENABLED with a value of {value}, to enable automatic tracing set it to true.";
 
-        public static string TracerNotEnabled(string value) => $"- The value for DD_TRACE_ENABLED is set to {value}, to enable automatic tracing set it to true.";
+        public static string ApiWrapperNotFound(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
 
-        public static string ApiWrapperNotFound(string path) => $"- The environment variable LD_PRELOAD is set to '{path}' but the file could not be found. Check the Datadog .NET Profiler documentation to set it properly.";
+        public static string WrongLdPreload(string path) => $"The environment variable LD_PRELOAD is set to '{path}' but it should point to Datadog.Linux.ApiWrapper.x64.so instead. Check the Datadog .NET Profiler documentation to set it properly.";
 
-        public static string WrongLdPreload(string path) => $"- The environment variable LD_PRELOAD is set to '{path}' but it should point to Datadog.Linux.ApiWrapper.x64.so instead. Check the Datadog .NET Profiler documentation to set it properly.";
+        public static string ProfilerVersion(string version) => $"The native library version {version} is loaded into the process.";
 
-        public static string ProfilerVersion(string version) => $"- The native library version {version} is loaded into the process.";
+        public static string TracerVersion(string version) => $"The tracer version {version} is loaded into the process.";
 
-        public static string TracerVersion(string version) => $"- The tracer version {version} is loaded into the process.";
+        public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set";
 
-        public static string EnvironmentVariableNotSet(string environmentVariable) => $"- The environment variable {environmentVariable} is not set";
+        public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
 
-        public static string TracerHomeNotFoundFormat(string tracerHome) => $"- DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
+        public static string WrongEnvironmentVariableFormat(string key, string expectedValue, string? actualValue) => $"The environment variable {key} should be set to '{expectedValue}' (current value: {EscapeOrNotSet(actualValue)})";
 
-        public static string WrongEnvironmentVariableFormat(string key, string expectedValue, string? actualValue) => $"- The environment variable {key} should be set to '{expectedValue}' (current value: {EscapeOrNotSet(actualValue)})";
+        public static string DetectedAgentUrlFormat(string url) => $"Detected agent url: {url}. Note: this url may be incorrect if you configured the application through a configuration file.";
 
-        public static string DetectedAgentUrlFormat(string url) => $"- Detected agent url: {url}. Note: this url may be incorrect if you configured the application through a configuration file.";
+        public static string WrongStatusCodeFormat(HttpStatusCode statusCode) => $"Agent replied with wrong status code: {statusCode}";
 
-        public static string WrongStatusCodeFormat(HttpStatusCode statusCode) => $"- Agent replied with wrong status code: {statusCode}";
+        public static string DetectedAgentVersionFormat(string version) => $"Detected agent version {version}";
 
-        public static string DetectedAgentVersionFormat(string version) => $"- Detected agent version {version}";
+        public static string ErrorDetectingAgent(string url, string error) => $"Error connecting to Agent at {url}: {error}";
 
-        public static string ErrorDetectingAgent(string url, string error) => $"- Error connecting to Agent at {url}: {error}";
+        public static string ConnectToEndpointFormat(string endpoint, string transport) => $"Connecting to Agent at endpoint {endpoint} using {transport}";
 
-        public static string ConnectToEndpointFormat(string endpoint, string transport) => $"- Connecting to Agent at endpoint {endpoint} using {transport}";
+        public static string ErrorCheckingRegistry(string error) => $"Error trying to read the registry: {error}";
 
-        public static string ErrorCheckingRegistry(string error) => $"- Error trying to read the registry: {error}";
+        public static string SuspiciousRegistryKey(string parentKey, string key) => $@"The registry key HKEY_LOCAL_MACHINE\{parentKey}\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
 
-        public static string SuspiciousRegistryKey(string parentKey, string key) => $@"- The registry key HKEY_LOCAL_MACHINE\{parentKey}\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
+        public static string MissingRegistryKey(string key) => $@"The registry key {key} is missing. If using the MSI, make sure the installation was completed correctly try to repair/reinstall it.";
 
-        public static string MissingRegistryKey(string key) => $@"- The registry key {key} is missing. If using the MSI, make sure the installation was completed correctly try to repair/reinstall it.";
+        public static string MissingProfilerRegistry(string key, string path) => $@"The registry key {key} was set to path '{path}' but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
 
-        public static string MissingProfilerRegistry(string key, string path) => $@"- The registry key {key} was set to path '{path}' but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
+        public static string MissingProfilerEnvironment(string key, string path) => $@"The environment variable {key} is set to {path} but the file is missing or you don't have sufficient permission.";
 
-        public static string MissingProfilerEnvironment(string key, string path) => $@"- The environment variable {key} is set to {path} but the file is missing or you don't have sufficient permission.";
+        public static string CorrectlySetupEnvironment(string key, string value) => $@"The environment variable {key} is set to the correct value of {value}.";
 
-        public static string CorrectlySetupEnvironment(string key, string value) => $@"- The environment variable {key} is set to the correct value of {path}.";
-
-        public static string GacVersionFormat(string version) => $"- Found Datadog.Trace version {version} in the GAC";
+        public static string GacVersionFormat(string version) => $"Found Datadog.Trace version {version} in the GAC";
 
         public static string FetchingApplication(string site, string application) => $"Fetching IIS application \"{site}{application}\".";
 
         public static string InspectingWorkerProcess(int pid) => $"Inspecting worker process {pid}";
 
-        public static string ErrorExtractingConfiguration(string error) => $"- Could not extract configuration from site: {error}";
+        public static string ErrorExtractingConfiguration(string error) => $"Could not extract configuration from site: {error}";
 
-        public static string AspNetCoreProcessFound(int pid) => $"- Found ASP.NET Core applicative process: {pid}";
+        public static string AspNetCoreProcessFound(int pid) => $"Found ASP.NET Core applicative process: {pid}";
 
-        public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"- The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
+        public static string WrongProfilerRegistry(string registryKey, string actualProfiler) => $"The registry key {registryKey} was set to '{actualProfiler}' but it should point to 'Datadog.Trace.ClrProfiler.Native.dll'. Please check that all external profilers have been uninstalled properly and try reinstalling the tracer.";
 
-        public static string IisApplicationNotProvided() => "- IIS application name not provided. ";
+        public static string IisApplicationNotProvided() => "IIS application name not provided. ";
 
-        public static string CouldNotFindIisApplication(string site, string application) => $"- Could not find IIS application \"{site}{application}\". ";
+        public static string CouldNotFindIisApplication(string site, string application) => $"Could not find IIS application \"{site}{application}\". ";
 
         public static string ListAllIisApplications(IEnumerable<string> availableApplications)
         {
@@ -114,7 +115,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
             foreach (var app in availableApplications)
             {
-                sb.AppendLine($" - {app}");
+                sb.AppendLine($" {app}");
             }
 
             sb.AppendLine();
@@ -134,7 +135,7 @@ namespace Datadog.Trace.Tools.Runner.Checks
             // The ordering is not required but makes the output consistent for tests
             foreach (var version in versions.OrderBy(v => v))
             {
-                sb.AppendLine($"- {version}");
+                sb.AppendLine($"{version}");
             }
 
             return sb.ToString();
@@ -145,20 +146,20 @@ namespace Datadog.Trace.Tools.Runner.Checks
             var expectedProfiler = RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
                 ? "Datadog.Trace.ClrProfiler.Native.dll" : "Datadog.Trace.ClrProfiler.Native.so";
 
-            return $"- The environment variable {environmentVariable} was set to '{actualProfiler}' but it should point to '{expectedProfiler}'";
+            return $"The environment variable {environmentVariable} was set to '{actualProfiler}' but it should point to '{expectedProfiler}'";
         }
 
         private static string EscapeOrNotSet(string? str) => str == null ? "not set" : $"'{str}'";
 
-        public static string TracerProgramFound(string tracerProgramName) => $"- {tracerProgramName} found in the installed programs.";
+        public static string TracerProgramFound(string tracerProgramName) => $"{tracerProgramName} found in the installed programs.";
 
-        public static string WrongTracerArchitecture(string tracerArchitecture) => $"- Found {tracerArchitecture} installed but the current process is 64 Bit, make sure to install the 64-bit tracer instead.";
+        public static string WrongTracerArchitecture(string tracerArchitecture) => $"Found {tracerArchitecture} installed but the current process is 64 Bit, make sure to install the 64-bit tracer instead.";
 
         public static string AppPoolCheckFindings(string appPool) => $"Initial run check did not pass, found the incorrect configuration on the {appPool} AppPool:";
 
-        public static string WrongLinuxFolder(string expected, string found) => $"- Unable to find expected {expected} folder, found {found} instead, make sure to use the correct installer.";
+        public static string WrongLinuxFolder(string expected, string found) => $"Unable to find expected {expected} folder, found {found} instead, make sure to use the correct installer.";
 
-        public static string UnsupportedLinuxArchitecture(string osArchitecture) => $"- The Linux architecture: {osArchitecture} is not supported by the tracer, check: https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures ";
+        public static string UnsupportedLinuxArchitecture(string osArchitecture) => $"The Linux architecture: {osArchitecture} is not supported by the tracer, check: https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures ";
 
         public static string ErrorCheckingLinuxDirectory(string error) => $"Error trying to check the Linux installer directory: {error}";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -35,14 +35,15 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string TracingWithBundleProfilerPath = "Check failing with Datadog.Trace.Bundle Nuget, related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
         public const string TracingWithInstaller = "Check failing with Installer/MSI, related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
         public const string TraceProgramNotFound = "Unable to find Datadog .NET Tracer program, make sure the tracer has been properly installed with the MSI.";
-        public const string InitialCheckStart = "Starting .NET Tracer Check:";
         public const string ModuleCheck = "1. Checking Modules Needed so the Tracer Loads:";
         public const string TracerCheck = "6. Checking if process tracing configuration matches Installer or Bundler:";
-        public const string CheckOptionalConfiguration = "Setup checks passed, checking configuration for main related products:";
-        public const string TraceEnabledCheck = "*Checking if tracing is disabled using DD_TRACE_ENABLED.";
-        public const string TraceEnabledNotSet = "- DD_TRACE_ENABLED is not set, note that the default value is true.";
+        public const string TraceEnabledCheck = "1. Checking if tracing is disabled using DD_TRACE_ENABLED.";
+        public const string TraceEnabledNotSet = "DD_TRACE_ENABLED is not set, the default value is true.";
+        public const string SetupChecks = "---- STARTING TRACER SETUP CHECKS -----";
+        public const string ConfigurationChecks = "---- CONFIGURATION CHECKS -----";
+        public const string DdAgentChecks = "---- DATADOG AGENT CHECKS -----";
 
-        public const string ContinuousProfilerCheck = "*Checking if profiling is enabled using DD_PROFILING_ENABLED.";
+        public const string ContinuousProfilerCheck = "2. Checking if profiling is enabled using DD_PROFILING_ENABLED.";
         public const string ContinuousProfilerEnabled = "DD_PROFILING_ENABLED is set.";
         public const string ContinuousProfilerDisabled = "The continuous profiler is explicitly disabled through DD_PROFILING_ENABLED.";
         public const string ContinuousProfilerNotSet = "DD_PROFILING_ENABLED is not set, the continuous profiler is disabled.";

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -42,22 +42,14 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string TraceEnabledCheck = "*Checking if tracing is disabled using DD_TRACE_ENABLED.";
         public const string TraceEnabledNotSet = "- DD_TRACE_ENABLED is not set, note that the default value is true.";
 
-        public const string TracingWithBundleProfilerPath = "Datadog.Trace.Bundle Nuget related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
-        public const string TracingWithInstaller = "Installer/MSI related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
-        public const string TraceProgramNotFound = "Unable to find Datadog .NET Tracer program, make sure the tracer has been properly installed with the MSI.";
-        public const string InitialCheckStart = "Starting .NET Tracer Check:";
-        public const string ModuleCheck = "1. Checking Modules Needed so the Tracer Loads:";
-        public const string TracerCheck = "6. Checking if process tracing configuration matches Installer or Bundler:";
-        public const string CheckOptionalConfiguration = "Setup checks passed, checking configuration for main related products:";
-        public const string TraceEnabledCheck = "*Checking if tracing is disabled using DD_TRACE_ENABLED.";
-        public const string TraceEnabledNotSet = "DD_TRACE_ENABLED is not set, note that the default value is true.";
-
         public const string ContinuousProfilerCheck = "*Checking if profiling is enabled using DD_PROFILING_ENABLED.";
         public const string ContinuousProfilerEnabled = "DD_PROFILING_ENABLED is set.";
         public const string ContinuousProfilerDisabled = "The continuous profiler is explicitly disabled through DD_PROFILING_ENABLED.";
         public const string ContinuousProfilerNotSet = "DD_PROFILING_ENABLED is not set, the continuous profiler is disabled.";
         public const string ContinuousProfilerNotLoaded = "The continuous profiler library is not loaded into the process.";
         public const string ContinuousProfilerWithoutLoader = "The continuous profiler needs the Datadog.Trace.ClrProfiler.Native module and the loader.conf file to work. Try reinstalling the tracer in version 2.14+.";
+
+        public const string LdPreloadNotSet = "The environment variable LD_PRELOAD is not set. Check the Datadog .NET Profiler documentation to set it properly.";
 
         public static string TracerNotEnabled(string value) => $"Tracing is explicitly disabled through DD_TRACE_ENABLED with a value of {value}, to enable automatic tracing set it to true.";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -36,7 +36,14 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string TracingWithBundleProfilerPath = "Datadog.Trace.Bundle Nuget related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
         public const string TracingWithInstaller = "Installer/MSI related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
         public const string TraceProgramNotFound = "Unable to find Datadog .NET Tracer program, make sure the tracer has been properly installed with the MSI.";
+        public const string InitialCheckStart = "Starting .NET Tracer Check:";
+        public const string ModuleCheck = "1. Checking Modules Needed so the Tracer Loads:";
+        public const string TracerCheck = "6. Checking if process tracing configuration matches Installer or Bundler:";
+        public const string CheckOptionalConfiguration = "Setup checks passed, checking configuration for main related products:";
+        public const string TraceEnabledCheck = "*Checking if tracing is disabled using DD_TRACE_ENABLED.";
+        public const string TraceEnabledNotSet = "DD_TRACE_ENABLED is not set, note that the default value is true.";
 
+        public const string ContinuousProfilerCheck = "*Checking if profiling is enabled using DD_PROFILING_ENABLED.";
         public const string ContinuousProfilerEnabled = "DD_PROFILING_ENABLED is set.";
         public const string ContinuousProfilerDisabled = "The continuous profiler is explicitly disabled through DD_PROFILING_ENABLED.";
         public const string ContinuousProfilerNotSet = "DD_PROFILING_ENABLED is not set, the continuous profiler is disabled.";
@@ -55,9 +62,11 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string TracerVersion(string version) => $"The tracer version {version} is loaded into the process.";
 
-        public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set";
+        public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set.";
 
-        public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
+        public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist.";
+
+        public static string TracerHomeFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' and the directory was found correctly.";
 
         public static string WrongEnvironmentVariableFormat(string key, string expectedValue, string? actualValue) => $"The environment variable {key} should be set to '{expectedValue}' (current value: {EscapeOrNotSet(actualValue)})";
 
@@ -145,12 +154,16 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string WrongTracerArchitecture(string tracerArchitecture) => $"Found {tracerArchitecture} installed but the current process is 64 Bit, make sure to install the 64-bit tracer instead.";
 
-        public static string AppPoolCheckFindings(string appPool) => $"Check did not pass, fix the configuration on the {appPool} AppPool:";
+        public static string AppPoolCheckFindings(string appPool) => $"Initial run check did not pass, found the incorrect configuration on the {appPool} AppPool:";
 
         public static string WrongLinuxFolder(string expected, string found) => $"Unable to find expected {expected} folder, found {found} instead, make sure to use the correct installer.";
 
         public static string UnsupportedLinuxArchitecture(string osArchitecture) => $"The Linux architecture: {osArchitecture} is not supported by the tracer, check: https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures ";
 
         public static string ErrorCheckingLinuxDirectory(string error) => $"Error trying to check the Linux installer directory: {error}";
+
+        public static string EnvVarCheck(string number, string envVar) => $"{number}. Checking {envVar} and related configuration value:";
+
+        public static string CorrectLinuxDirectoryFound(string path) => $"Found the expected path {path} based on the current OS Architecture.";
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -35,6 +35,12 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string TracingWithBundleProfilerPath = "Check failing with Datadog.Trace.Bundle Nuget, related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
         public const string TracingWithInstaller = "Check failing with Installer/MSI, related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
         public const string TraceProgramNotFound = "Unable to find Datadog .NET Tracer program, make sure the tracer has been properly installed with the MSI.";
+        public const string InitialCheckStart = "Starting .NET Tracer Check:";
+        public const string ModuleCheck = "1. Checking Modules Needed so the Tracer Loads:";
+        public const string TracerCheck = "6. Checking if process tracing configuration matches Installer or Bundler:";
+        public const string CheckOptionalConfiguration = "Setup checks passed, checking configuration for main related products:";
+        public const string TraceEnabledCheck = "*Checking if tracing is disabled using DD_TRACE_ENABLED.";
+        public const string TraceEnabledNotSet = "- DD_TRACE_ENABLED is not set, note that the default value is true.";
 
         public const string TracingWithBundleProfilerPath = "Datadog.Trace.Bundle Nuget related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
         public const string TracingWithInstaller = "Installer/MSI related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
@@ -63,9 +69,11 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string TracerVersion(string version) => $"The tracer version {version} is loaded into the process.";
 
-        public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set";
+        public static string EnvironmentVariableNotSet(string environmentVariable) => $"The environment variable {environmentVariable} is not set.";
 
-        public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist";
+        public static string TracerHomeNotFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' but the directory does not exist.";
+
+        public static string TracerHomeFoundFormat(string tracerHome) => $"DD_DOTNET_TRACER_HOME is set to '{tracerHome}' and the directory was found correctly.";
 
         public static string WrongEnvironmentVariableFormat(string key, string expectedValue, string? actualValue) => $"The environment variable {key} should be set to '{expectedValue}' (current value: {EscapeOrNotSet(actualValue)})";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -20,10 +20,10 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public const string RuntimeDetectionFailed = "- Failed to detect target process runtime, assuming .NET Framework";
         public const string BothRuntimesDetected = "- The target process is running .NET Framework and .NET Core simultaneously. Checks will be performed assuming a .NET Framework runtime.";
         public const string LoaderNotLoaded = "- The native loader library is not loaded into the process";
-        public const string NativeTracerNotLoaded = "The native tracer library is not loaded into the process";
+        public const string NativeTracerNotLoaded = "- The native tracer library is not loaded into the process";
         public const string TracerNotLoaded = "- Tracer is not loaded into the process";
         public const string AgentDetectionFailed = "- Could not detect the agent version. It may be running with a version older than 7.27.0.";
-        public const string IisProcess = "- The target process is an IIS process. The detection of the configuration might be incomplete, it's recommended to use dd-trace check iis <site name> instead.";
+        public const string IisProcess = "- The target process is an IIS process. The detection of the configuration might be incomplete, please use dd-trace check iis <site name> instead.";
         public const string MissingGac = "- The Datadog.Trace assembly could not be found in the GAC. Make sure the tracer has been properly installed with the MSI.";
         public const string NoWorkerProcess = "- No worker process found, to perform additional checks make sure the application is active";
         public const string GetProcessError = "- Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
@@ -87,6 +87,8 @@ namespace Datadog.Trace.Tools.Runner.Checks
         public static string MissingProfilerRegistry(string key, string path) => $@"- The registry key {key} was set to path '{path}' but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
 
         public static string MissingProfilerEnvironment(string key, string path) => $@"- The environment variable {key} is set to {path} but the file is missing or you don't have sufficient permission.";
+
+        public static string CorrectlySetupEnvironment(string key, string value) => $@"- The environment variable {key} is set to the correct value of {path}.";
 
         public static string GacVersionFormat(string version) => $"- Found Datadog.Trace version {version} in the GAC";
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Checks/Resources.cs
@@ -152,12 +152,16 @@ namespace Datadog.Trace.Tools.Runner.Checks
 
         public static string WrongTracerArchitecture(string tracerArchitecture) => $"- Found {tracerArchitecture} installed but the current process is 64 Bit, make sure to install the 64-bit tracer instead.";
 
-        public static string AppPoolCheckFindings(string appPool) => $"- Check did not pass, fix the configuration on the {appPool} AppPool:";
+        public static string AppPoolCheckFindings(string appPool) => $"Initial run check did not pass, found the incorrect configuration on the {appPool} AppPool:";
 
         public static string WrongLinuxFolder(string expected, string found) => $"- Unable to find expected {expected} folder, found {found} instead, make sure to use the correct installer.";
 
         public static string UnsupportedLinuxArchitecture(string osArchitecture) => $"- The Linux architecture: {osArchitecture} is not supported by the tracer, check: https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures ";
 
-        public static string ErrorCheckingLinuxDirectory(string error) => $"- Error trying to check the Linux installer directory: {error}";
+        public static string ErrorCheckingLinuxDirectory(string error) => $"Error trying to check the Linux installer directory: {error}";
+
+        public static string EnvVarCheck(string number, string envVar) => $"{number}. Checking {envVar} and related configuration value:";
+
+        public static string CorrectLinuxDirectoryFound(string path) => $"Found the expected path {path} based on the current OS Architecture.";
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -353,17 +353,17 @@ namespace Datadog.Trace.Tools.Runner
 
         internal static void WriteError(string message)
         {
-            AnsiConsole.MarkupLine($"[red3 on black]{message.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[red] [[FAILURE]]: {message.EscapeMarkup()}[/]");
         }
 
         internal static void WriteWarning(string message)
         {
-            AnsiConsole.MarkupLine($"[yellow on black]{message.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[yellow] [[WARNING]]: {message.EscapeMarkup()}[/]");
         }
 
         internal static void WriteSuccess(string message)
         {
-            AnsiConsole.MarkupLine($"[lime on black]{message.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[lime] [[SUCCESS]]: {message.EscapeMarkup()}[/]");
         }
 
         internal static bool IsAlpine()

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -366,6 +366,11 @@ namespace Datadog.Trace.Tools.Runner
             AnsiConsole.MarkupLine($"[lime] [[SUCCESS]]: {message.EscapeMarkup()}[/]");
         }
 
+        internal static void WriteInfo(string message)
+        {
+            AnsiConsole.MarkupLine($"[aqua] [[INFO]]: {message.EscapeMarkup()}[/]");
+        }
+
         internal static bool IsAlpine()
         {
             try

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -353,17 +353,17 @@ namespace Datadog.Trace.Tools.Runner
 
         internal static void WriteError(string message)
         {
-            AnsiConsole.MarkupLine($"[red]{message.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[red3 on black]{message.EscapeMarkup()}[/]");
         }
 
         internal static void WriteWarning(string message)
         {
-            AnsiConsole.MarkupLine($"[yellow]{message.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[yellow on black]{message.EscapeMarkup()}[/]");
         }
 
         internal static void WriteSuccess(string message)
         {
-            AnsiConsole.MarkupLine($"[green]{message.EscapeMarkup()}[/]");
+            AnsiConsole.MarkupLine($"[lime on black]{message.EscapeMarkup()}[/]");
         }
 
         internal static bool IsAlpine()

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -193,15 +193,17 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 console.Output.Should().Contain(ProfilerVersion(TracerConstants.AssemblyVersion));
             }
 
-            console.Output.Should().NotContainAny(
+            console.Output.Should().NotContain(
                 NativeTracerNotLoaded,
                 TracerNotLoaded,
-                "DD_DOTNET_TRACER_HOME",
-                CorProfilerKey,
-                CorEnableKey,
-                CorProfilerPathKey,
-                CorProfilerPath32Key,
-                CorProfilerPath64Key);
+                TracerHomeNotFoundFormat("DD_DOTNET_TRACER_HOME"));
+
+            console.Output.Should().Contain(
+                CorrectlySetupEnvironment(CorProfilerKey, Environment.GetEnvironmentVariable(CorProfilerKey)),
+                CorrectlySetupEnvironment(CorEnableKey, Environment.GetEnvironmentVariable(CorEnableKey)),
+                CorrectlySetupEnvironment(CorProfilerPathKey, Environment.GetEnvironmentVariable(CorProfilerPathKey)),
+                CorrectlySetupEnvironment(CorProfilerPath32Key, Environment.GetEnvironmentVariable(CorProfilerPath32Key)),
+                CorrectlySetupEnvironment(CorProfilerPath64Key, Environment.GetEnvironmentVariable(CorProfilerPath64Key)));
         }
 
         [SkippableFact]
@@ -240,7 +242,12 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
             console.Output.Should().ContainAll(
                 TracerVersion(TracerConstants.AssemblyVersion),
-                ContinuousProfilerEnabled);
+                ContinuousProfilerEnabled,
+                CorrectlySetupEnvironment(CorProfilerKey, Environment.GetEnvironmentVariable(CorProfilerKey)),
+                CorrectlySetupEnvironment(CorEnableKey, Environment.GetEnvironmentVariable(CorEnableKey)),
+                CorrectlySetupEnvironment(CorProfilerPathKey, Environment.GetEnvironmentVariable(CorProfilerPathKey)),
+                CorrectlySetupEnvironment(CorProfilerPath32Key, Environment.GetEnvironmentVariable(CorProfilerPath32Key)),
+                CorrectlySetupEnvironment(CorProfilerPath64Key, Environment.GetEnvironmentVariable(CorProfilerPath64Key)));
 
             console.Output.Should().NotContainAny(
                 NativeTracerNotLoaded,
@@ -248,12 +255,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 ContinuousProfilerNotSet,
                 ContinuousProfilerNotLoaded,
                 "LD_PRELOAD",
-                "DD_DOTNET_TRACER_HOME",
-                CorProfilerKey,
-                CorEnableKey,
-                CorProfilerPathKey,
-                CorProfilerPath32Key,
-                CorProfilerPath64Key);
+                TracerHomeNotFoundFormat("DD_DOTNET_TRACER_HOME"));
         }
 
         [SkippableFact]
@@ -464,7 +466,11 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 using var console = ConsoleHelper.Redirect();
 
                 ProcessBasicCheck.CheckLinuxInstallation(tempDirectory);
-                console.Output.Should().BeEmpty();
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    console.Output.Should().Contain(CorrectLinuxDirectoryFound(tempDirectory));
+                }
             }
             finally
             {

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -199,11 +199,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
                 TracerHomeNotFoundFormat("DD_DOTNET_TRACER_HOME"));
 
             console.Output.Should().Contain(
-                CorrectlySetupEnvironment(CorProfilerKey, Environment.GetEnvironmentVariable(CorProfilerKey)),
-                CorrectlySetupEnvironment(CorEnableKey, Environment.GetEnvironmentVariable(CorEnableKey)),
-                CorrectlySetupEnvironment(CorProfilerPathKey, Environment.GetEnvironmentVariable(CorProfilerPathKey)),
-                CorrectlySetupEnvironment(CorProfilerPath32Key, Environment.GetEnvironmentVariable(CorProfilerPath32Key)),
-                CorrectlySetupEnvironment(CorProfilerPath64Key, Environment.GetEnvironmentVariable(CorProfilerPath64Key)));
+                CorrectlySetupEnvironment(CorProfilerKey, Utils.Profilerid),
+                CorrectlySetupEnvironment(CorEnableKey, "1"),
+                CorrectlySetupEnvironment(CorProfilerPathKey, ProfilerPath));
         }
 
         [SkippableFact]
@@ -243,11 +241,9 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
             console.Output.Should().ContainAll(
                 TracerVersion(TracerConstants.AssemblyVersion),
                 ContinuousProfilerEnabled,
-                CorrectlySetupEnvironment(CorProfilerKey, Environment.GetEnvironmentVariable(CorProfilerKey)),
-                CorrectlySetupEnvironment(CorEnableKey, Environment.GetEnvironmentVariable(CorEnableKey)),
-                CorrectlySetupEnvironment(CorProfilerPathKey, Environment.GetEnvironmentVariable(CorProfilerPathKey)),
-                CorrectlySetupEnvironment(CorProfilerPath32Key, Environment.GetEnvironmentVariable(CorProfilerPath32Key)),
-                CorrectlySetupEnvironment(CorProfilerPath64Key, Environment.GetEnvironmentVariable(CorProfilerPath64Key)));
+                CorrectlySetupEnvironment(CorProfilerKey, Utils.Profilerid),
+                CorrectlySetupEnvironment(CorEnableKey, "1"),
+                CorrectlySetupEnvironment(CorProfilerPathKey, ProfilerPath));
 
             console.Output.Should().NotContainAny(
                 NativeTracerNotLoaded,
@@ -469,7 +465,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests.Checks
 
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    console.Output.Should().Contain(CorrectLinuxDirectoryFound(tempDirectory));
+                    console.Output.Should().Contain(CorrectLinuxDirectoryFound(dir));
                 }
             }
             finally


### PR DESCRIPTION
## Summary of changes
Follow up to previous Diagnostic Tool changes PR, adding more details to the output message of the tool and confirmation if check is ran successfully. 

## Reason for change
So the message giving is clearer and hopefully more easily actionable by the user of the tool.

## Test coverage
Tested locally, find below some of the outcomes (see comments below for updated screenshots)

1. **Tracer uninstalled:**
![image](https://github.com/DataDog/dd-trace-dotnet/assets/28125428/bd90faf5-e2cf-43c4-bf31-fde60e2dc881)

2. **.NET Core on IIS with Managed Code:**
![image](https://github.com/DataDog/dd-trace-dotnet/assets/28125428/41127c2c-e43d-4f7b-bab4-7b7713d962f7)

3. **.NET Core on IIS without Managed Code:**
![image](https://github.com/DataDog/dd-trace-dotnet/assets/28125428/6bb19363-ba03-40ca-a517-3afacaf7377a)

