### PR TITLE
Include Datadog.Trace in our root-descriptors file

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2100,6 +2100,9 @@ partial class Build
                 datadogTraceTypes.AddRange(GetTypeReferences(DatadogTraceDirectory / "bin" / BuildConfiguration / tfm / Projects.DatadogTrace + ".dll"));
             }
 
+            // add Datadog projects to the root descriptors file
+            datadogTraceTypes.Add(new(Projects.DatadogTrace, null));
+
             var types = loaderTypes
                        .Concat(datadogTraceTypes)
                        .Distinct()

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -8,6 +8,7 @@
    <assembly fullname="Azure.Messaging.ServiceBus" />
    <assembly fullname="Confluent.Kafka" />
    <assembly fullname="Couchbase.NetClient" />
+   <assembly fullname="Datadog.Trace" />
    <assembly fullname="Elasticsearch.Net" />
    <assembly fullname="GraphQL" />
    <assembly fullname="GraphQL.SystemReactive" />

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -11,6 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsTrimmable>false</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary of changes

- Include Datadog.Trace in our root-descriptors file
- Mark Datadog.Trace itself as non-trimmable

## Reason for change

Trimming Datadog.Trace itself is likely to make things go 💥. Would only manifest if the customer was using manual instrumentation

## Implementation details

Add Datadog.Trace to our trimming library

## Test coverage

No 🤔 We could/should probably update the trimmer test. I'd like to do that in a separate PR though after my .NET 8 behemoth is rebased if possible

## Other details
<!-- Fixes #{issue} -->

Random thought - should we add the trimming package as a dependency of Datadog.Trace? 🤔 There's no harm for customers that _aren't_ using trimming, and for customers that are using manual instrumentation, it's one less change needed to their app 🤔 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
