### PR TITLE
Diagnostic tool improvements

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/IRegistryService.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/IRegistryService.cs
@@ -12,5 +12,9 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
         string[] GetLocalMachineValueNames(string key);
 
         string? GetLocalMachineValue(string key);
+
+        string[] GetLocalMachineKeyNames(string key);
+
+        string? GetLocalMachineKeyNameValue(string key, string subKeyName, string name);
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Datadog.Trace.Tools.dd_dotnet.Checks.Windows;
 using Spectre.Console;
 using static Datadog.Trace.Tools.dd_dotnet.Checks.Resources;
 
@@ -40,27 +41,6 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                 runtime = ProcessInfo.Runtime.NetFx;
             }
 
-            bool isContinuousProfilerEnabled;
-
-            if (process.EnvironmentVariables.TryGetValue("DD_PROFILING_ENABLED", out var profilingEnabled))
-            {
-                if (ParseBooleanConfigurationValue(profilingEnabled))
-                {
-                    AnsiConsole.WriteLine(ContinuousProfilerEnabled);
-                    isContinuousProfilerEnabled = true;
-                }
-                else
-                {
-                    AnsiConsole.WriteLine(ContinuousProfilerDisabled);
-                    isContinuousProfilerEnabled = false;
-                }
-            }
-            else
-            {
-                AnsiConsole.WriteLine(ContinuousProfilerNotSet);
-                isContinuousProfilerEnabled = false;
-            }
-
             var loaderModule = FindLoader(process);
             var nativeTracerModule = FindNativeTracerModule(process, loaderModule != null);
 
@@ -87,11 +67,6 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
                     AnsiConsole.WriteLine(ProfilerVersion(nativeTracerVersion != null ? $"{nativeTracerVersion}" : "{empty}"));
                 }
-            }
-
-            if (isContinuousProfilerEnabled)
-            {
-                ok &= CheckContinousProfiler(process, loaderModule);
             }
 
             var tracerModules = FindTracerModules(process).ToArray();
@@ -147,6 +122,14 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                 ok = false;
             }
 
+            string corProfilerPathKey = runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_PROFILER_PATH" : "COR_PROFILER_PATH";
+            string corProfilerPathKey32 = runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_PROFILER_PATH_32" : "COR_PROFILER_PATH_32";
+            string corProfilerPathKey64 = runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_PROFILER_PATH_64" : "COR_PROFILER_PATH_64";
+
+            ok &= CheckProfilerPath(process, corProfilerPathKey, requiredOnLinux: true);
+            ok &= CheckProfilerPath(process, corProfilerPathKey32, requiredOnLinux: false);
+            ok &= CheckProfilerPath(process, corProfilerPathKey64, requiredOnLinux: false);
+
             string corProfilerKey = runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_PROFILER" : "COR_PROFILER";
 
             process.EnvironmentVariables.TryGetValue(corProfilerKey, out var corProfiler);
@@ -167,34 +150,80 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                 ok = false;
             }
 
-            ok &= CheckProfilerPath(process, runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_PROFILER_PATH" : "COR_PROFILER_PATH", requiredOnLinux: true);
-            ok &= CheckProfilerPath(process, runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_PROFILER_PATH_32" : "COR_PROFILER_PATH_32", requiredOnLinux: false);
-            ok &= CheckProfilerPath(process, runtime == ProcessInfo.Runtime.NetCore ? "CORECLR_PROFILER_PATH_64" : "COR_PROFILER_PATH_64", requiredOnLinux: false);
+            process.EnvironmentVariables.TryGetValue(corProfilerPathKey, out var corProfilerPathValue);
+            process.EnvironmentVariables.TryGetValue(corProfilerPathKey32, out var corProfilerPathValue32);
+            process.EnvironmentVariables.TryGetValue(corProfilerPathKey64, out var corProfilerPathValue64);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            string?[] valuesToCheck = { corProfilerPathValue, corProfilerPathValue32, corProfilerPathValue64 };
+            var isTracingUsingBundle = TracingWithBundle(valuesToCheck, process.Id);
+
+            if (!ok && isTracingUsingBundle)
             {
-                if (!CheckRegistry(registryService, nativeTracerVersion))
+                AnsiConsole.WriteLine(TracingWithBundleProfilerPath);
+            }
+            else if (!ok)
+            {
+                AnsiConsole.WriteLine(TracingWithInstaller);
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    ok = false;
+                    if (!CheckRegistry(CheckWindowsInstallation(process.Id, registryService), registryService))
+                    {
+                        ok = false;
+                    }
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    CheckLinuxInstallation("/opt/datadog/");
                 }
             }
 
-            if (process.EnvironmentVariables.TryGetValue("DD_TRACE_ENABLED", out var traceEnabledValue))
+            // Running non-blocker checks after confirming setup was done correctly
+            if (ok)
             {
-                if (!ParseBooleanConfigurationValue(traceEnabledValue))
+                if (process.EnvironmentVariables.TryGetValue("DD_TRACE_ENABLED", out var traceEnabledValue))
                 {
-                    Utils.WriteError(TracerNotEnabled(traceEnabledValue));
+                    if (!ParseBooleanConfigurationValue(traceEnabledValue))
+                    {
+                        Utils.WriteError(TracerNotEnabled(traceEnabledValue));
+                    }
+                }
+
+                bool isContinuousProfilerEnabled;
+
+                if (process.EnvironmentVariables.TryGetValue("DD_PROFILING_ENABLED", out var profilingEnabled))
+                {
+                    if (ParseBooleanConfigurationValue(profilingEnabled))
+                    {
+                        AnsiConsole.WriteLine(ContinuousProfilerEnabled);
+                        isContinuousProfilerEnabled = true;
+                    }
+                    else
+                    {
+                        AnsiConsole.WriteLine(ContinuousProfilerDisabled);
+                        isContinuousProfilerEnabled = false;
+                    }
+                }
+                else
+                {
+                    AnsiConsole.WriteLine(ContinuousProfilerNotSet);
+                    isContinuousProfilerEnabled = false;
+                }
+
+                if (isContinuousProfilerEnabled)
+                {
+                    ok &= CheckContinuousProfiler(process, loaderModule);
                 }
             }
 
             return ok;
         }
 
-        internal static bool CheckContinousProfiler(ProcessInfo process, string? loaderModule)
+        internal static bool CheckContinuousProfiler(ProcessInfo process, string? loaderModule)
         {
             bool ok = true;
 
-            var continuousProfilerModule = FindContinousProfilerModule(process);
+            var continuousProfilerModule = FindContinuousProfilerModule(process);
 
             if (continuousProfilerModule == null)
             {
@@ -235,7 +264,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             return ok;
         }
 
-        internal static bool CheckRegistry(IRegistryService? registry = null, Version? tracerVersion = null)
+        internal static bool CheckRegistry(string? tracerProgramVersion, IRegistryService? registry = null)
         {
             registry ??= new Windows.RegistryService();
 
@@ -244,9 +273,22 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                 bool ok = true;
 
                 // Check that the profiler is properly registered
-                if (tracerVersion == null || tracerVersion < new Version("2.14.0.0"))
+                if (tracerProgramVersion is null)
                 {
                     ok &= CheckClsid(registry, ClsidKey);
+                    ok &= CheckClsid(registry, Clsid32Key);
+                }
+                else if (RuntimeInformation.OSArchitecture is Architecture.X64)
+                {
+                    ok &= CheckClsid(registry, ClsidKey);
+
+                    if (new Version(tracerProgramVersion) < new Version("2.14.0.0"))
+                    {
+                        ok &= CheckClsid(registry, Clsid32Key);
+                    }
+                }
+                else if (RuntimeInformation.OSArchitecture is Architecture.X86)
+                {
                     ok &= CheckClsid(registry, Clsid32Key);
                 }
 
@@ -290,7 +332,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             }
         }
 
-        private static bool CheckProfilerPath(ProcessInfo process, string key, bool requiredOnLinux)
+        internal static bool CheckProfilerPath(ProcessInfo process, string key, bool requiredOnLinux)
         {
             bool ok = true;
 
@@ -345,7 +387,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             return true;
         }
 
-        private static bool IsExpectedProfilerFile(string fullPath)
+        internal static bool IsExpectedProfilerFile(string fullPath)
         {
             var fileName = Path.GetFileName(fullPath);
 
@@ -394,7 +436,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             return null;
         }
 
-        private static string? FindContinousProfilerModule(ProcessInfo process)
+        private static string? FindContinuousProfilerModule(ProcessInfo process)
         {
             foreach (var module in process.Modules)
             {
@@ -458,6 +500,132 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                 or "Y"
                 or "y"
                 or "1";
+        }
+
+        private static bool TracingWithBundle(string?[] profilerPathValues, int processId)
+        {
+            Process process = Process.GetProcessById(processId);
+
+            // Get the file path of the main module (the .exe file)
+            string? filePath = process.MainModule?.FileName;
+            string? directoryPath = Path.GetDirectoryName(filePath);
+
+            string[] expectedEndingsForBundleSetup =
+            {
+                "/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so",
+                "/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
+                "/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so",
+                "\\datadog\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+                "\\datadog\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll"
+            };
+
+            foreach (var bundleSetupEnding in expectedEndingsForBundleSetup)
+            {
+                foreach (var profilerPath in profilerPathValues)
+                {
+                    if (profilerPath is not null && profilerPath.Equals(directoryPath + bundleSetupEnding, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static string? CheckWindowsInstallation(int processId, IRegistryService? registryService = null)
+        {
+            const string datadog64BitProgram = "Datadog .NET Tracer 64-bit";
+            const string datadog32BitProgram = "Datadog .NET Tracer 32-bit";
+            const string uninstallKey64Bit = @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\";
+            const string uninstallKey32Bit = @"SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall";
+
+            if (GetLocalMachineSubKeyVersion(uninstallKey64Bit, datadog64BitProgram, out var tracerVersion))
+            {
+                Utils.WriteSuccess(TracerProgramFound(datadog64BitProgram));
+                return tracerVersion;
+            }
+
+            if (GetLocalMachineSubKeyVersion(uninstallKey32Bit, datadog32BitProgram, out tracerVersion))
+            {
+                Utils.WriteSuccess(TracerProgramFound(datadog32BitProgram));
+                var processBitness = ProcessEnvironmentWindows.GetProcessBitness(Process.GetProcessById(processId));
+
+                if (processBitness is 64)
+                {
+                    Utils.WriteError(WrongTracerArchitecture(datadog32BitProgram));
+                }
+
+                return tracerVersion;
+            }
+
+            Utils.WriteError(TraceProgramNotFound);
+
+            return tracerVersion;
+        }
+
+        private static bool GetLocalMachineSubKeyVersion(string uninstallKey, string datadogProgramName, out string? tracerVersion, IRegistryService? registryService = null)
+        {
+            registryService ??= new Windows.RegistryService();
+
+            tracerVersion = null;
+            var versionFound = false;
+
+            foreach (var subKeyName in registryService.GetLocalMachineKeyNames(uninstallKey))
+            {
+                var subKeyDisplayName = registryService.GetLocalMachineKeyNameValue(uninstallKey, subKeyName, "DisplayName");
+
+                if (subKeyDisplayName == datadogProgramName)
+                {
+                    tracerVersion = registryService.GetLocalMachineKeyNameValue(uninstallKey, subKeyName, "VersionMajor") + "." + registryService.GetLocalMachineKeyNameValue(uninstallKey, subKeyName, "VersionMinor");
+                    versionFound = true;
+                }
+            }
+
+            return versionFound;
+        }
+
+        internal static void CheckLinuxInstallation(string installDirectory)
+        {
+            string archFolder;
+            var osArchitecture = RuntimeInformation.OSArchitecture;
+
+            if (osArchitecture == Architecture.X64)
+            {
+                archFolder = Utils.IsAlpine() ? "linux-musl-x64" : "linux-x64";
+            }
+            else if (osArchitecture == Architecture.Arm64)
+            {
+                archFolder = "linux-arm64";
+            }
+            else
+            {
+                Utils.WriteError(UnsupportedLinuxArchitecture(osArchitecture.ToString()));
+                return;
+            }
+
+            try
+            {
+                if (!Directory.Exists(Path.Join(installDirectory, archFolder)))
+                {
+                    string[] directories = Directory.GetDirectories(installDirectory);
+
+                    // Iterate through directories and filter based on the starting string
+                    foreach (string directory in directories)
+                    {
+                        DirectoryInfo dirInfo = new DirectoryInfo(directory);
+                        if (dirInfo.Name.StartsWith("linux-", StringComparison.OrdinalIgnoreCase))
+                        {
+                            Utils.WriteError(WrongLinuxFolder(archFolder, dirInfo.Name));
+                            return;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Utils.WriteError(ErrorCheckingLinuxDirectory(ex.Message));
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Resources.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -27,11 +26,15 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
         public const string NoWorkerProcess = "No worker process found, to perform additional checks make sure the application is active";
         public const string GetProcessError = "Could not fetch information about target process. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
         public const string IisNoIssue = "No issue found with the IIS site.";
-        public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflicts.";
+        public const string IisMixedRuntimes = "The application pool is configured to host both .NET Framework and .NET Core runtimes. When hosting .NET Core, it's recommended to set '.NET CLR Version' to 'No managed code' to prevent conflict: https://learn.microsoft.com/en-us/aspnet/core/host-and-deploy/iis/?view=aspnetcore-3.1#create-the-iis-site:~:text=CLR%20version%20to-,No%20Managed%20Code,-%3A";
         public const string OutOfProcess = "Detected ASP.NET Core hosted out of proces. Trying to find the application process.";
         public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
         public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
         public const string IisExpressWorkerProcess = "Cannot detect the worker process when using IIS Express. Use the --workerProcess option to manually provide it.";
+
+        public const string TracingWithBundleProfilerPath = "Datadog.Trace.Bundle Nuget related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
+        public const string TracingWithInstaller = "Installer/MSI related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";
+        public const string TraceProgramNotFound = "Unable to find Datadog .NET Tracer program, make sure the tracer has been properly installed with the MSI.";
 
         public const string ContinuousProfilerEnabled = "DD_PROFILING_ENABLED is set.";
         public const string ContinuousProfilerDisabled = "The continuous profiler is explicitly disabled through DD_PROFILING_ENABLED.";
@@ -71,7 +74,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
         public static string SuspiciousRegistryKey(string parentKey, string key) => $@"The registry key HKEY_LOCAL_MACHINE\{parentKey}\{key} is defined and could prevent the tracer from working properly. Please check that all external profilers have been uninstalled properly.";
 
-        public static string MissingRegistryKey(string key) => $@"The registry key {key} is missing. Make sure the tracer has been properly installed with the MSI.";
+        public static string MissingRegistryKey(string key) => $@"The registry key {key} is missing. If using the MSI, make sure the installation was completed correctly try to repair/reinstall it.";
 
         public static string MissingProfilerRegistry(string key, string path) => $@"The registry key {key} was set to path '{path}' but the file is missing or you don't have sufficient permission. Try reinstalling the tracer with the MSI and check the permissions.";
 
@@ -134,8 +137,20 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             var expectedProfiler = RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
                 ? "Datadog.Trace.ClrProfiler.Native.dll" : "Datadog.Trace.ClrProfiler.Native.so";
 
-            return $"The environment variable {environmentVariable} was set to '{actualProfiler}' but it should point to '{expectedProfiler}'";
+            return $"- The environment variable {environmentVariable} was set to '{actualProfiler}' but it should point to '{expectedProfiler}'";
         }
+
+        public static string TracerProgramFound(string tracerProgramName) => $"{tracerProgramName} found in the installed programs.";
+
+        public static string WrongTracerArchitecture(string tracerArchitecture) => $"Found {tracerArchitecture} installed but the current process is 64 Bit, make sure to install the 64-bit tracer instead.";
+
+        public static string AppPoolCheckFindings(string appPool) => $"Check did not pass, fix the configuration on the {appPool} AppPool:";
+
+        public static string WrongLinuxFolder(string expected, string found) => $"Unable to find expected {expected} folder, found {found} instead, make sure to use the correct installer.";
+
+        public static string UnsupportedLinuxArchitecture(string osArchitecture) => $"The Linux architecture: {osArchitecture} is not supported by the tracer, check: https://docs.datadoghq.com/tracing/trace_collection/compatibility/dotnet-core/#supported-processor-architectures ";
+
+        public static string ErrorCheckingLinuxDirectory(string error) => $"Error trying to check the Linux installer directory: {error}";
 
         private static string EscapeOrNotSet(string? str) => str == null ? "not set" : $"'{str}'";
     }

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/ApplicationPool.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/ApplicationPool.cs
@@ -1,0 +1,71 @@
+// <copyright file="ApplicationPool.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows.IIS
+{
+    internal class ApplicationPool : IDisposable
+    {
+        private readonly IAppHostElement _applicationPool;
+
+        public ApplicationPool(IAppHostElement element)
+        {
+            _applicationPool = element;
+        }
+
+        public void Dispose()
+        {
+            _applicationPool.Dispose();
+            // Don't dispose the IAppHostAdminManager because we don't own it
+        }
+
+        public int GetWorkerProcess()
+        {
+            using var workerProcesses = _applicationPool.GetElementByName("workerProcesses");
+            var workerProcessesCollection = workerProcesses.Collection();
+
+            if (workerProcessesCollection.Count() > 0)
+            {
+                using var workerProcess = workerProcessesCollection.GetItem(0);
+
+                if (int.TryParse(workerProcess.GetStringProperty("processId"), out var pid))
+                {
+                    return pid;
+                }
+            }
+
+            return default;
+        }
+
+        public string GetName()
+        {
+            return _applicationPool.GetStringProperty("name");
+        }
+
+        public string GetManagedRuntimeVersion()
+        {
+            return _applicationPool.GetStringProperty("managedRuntimeVersion");
+        }
+
+        public IReadOnlyDictionary<string, string> GetEnvironmentVariables()
+        {
+            var result = new Dictionary<string, string>();
+
+            using var environmentVariables = _applicationPool.GetElementByName("environmentVariables");
+            using var collection = environmentVariables.Collection();
+            var count = collection.Count();
+
+            for (int i = 0; i < count; i++)
+            {
+                using var item = collection.GetItem(i);
+                result.Add(item.GetStringProperty("name"), item.GetStringProperty("value"));
+            }
+
+            return result;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/IisManager.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/IisManager.cs
@@ -131,6 +131,26 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows.IIS
             return result;
         }
 
+        public IReadOnlyDictionary<string, string> GetDefaultEnvironmentVariables()
+        {
+            var result = new Dictionary<string, string>();
+
+            using var applicationPoolsSection = _appHostAdminManager.GetAdminSection("system.applicationHost/applicationPools", "MACHINE/WEBROOT/APPHOST");
+            using var applicationPoolDefaults = applicationPoolsSection.GetElementByName("applicationPoolDefaults");
+            using var environmentVariables = applicationPoolDefaults.GetElementByName("environmentVariables");
+
+            using var collection = environmentVariables.Collection();
+            var count = collection.Count();
+
+            for (int i = 0; i < count; i++)
+            {
+                using var item = collection.GetItem(i);
+                result.Add(item.GetStringProperty("name"), item.GetStringProperty("value"));
+            }
+
+            return result;
+        }
+
         private unsafe class PathMapper : IAppHostPathMapper
         {
             private static readonly Guid Guid = Guid.Parse("e7927575-5cc3-403b-822e-328a6b904bee");

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/ProcessEnvironmentWindows.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/ProcessEnvironmentWindows.cs
@@ -38,6 +38,11 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows
             return _ReadVariablesCore(process);
         }
 
+        public static int GetProcessBitness(Process process)
+        {
+            return _GetProcessBitness(process.Handle);
+        }
+
         private static Dictionary<string, string> _ReadVariablesCore(Process process)
         {
             int retryCount = 5;

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/RegistryService.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/RegistryService.cs
@@ -41,5 +41,41 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows
 
             return registryKey?.GetValue(null) as string;
         }
+
+        public string[] GetLocalMachineKeyNames(string key)
+        {
+            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                return Array.Empty<string>();
+            }
+
+            var registryKey = Registry.LocalMachine.OpenSubKey(key);
+
+            if (registryKey == null)
+            {
+                return Array.Empty<string>();
+            }
+
+            return registryKey.GetSubKeyNames();
+        }
+
+        public string? GetLocalMachineKeyNameValue(string key, string subKeyName, string name)
+        {
+            if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                return string.Empty;
+            }
+
+            var registryKey = Registry.LocalMachine.OpenSubKey(key);
+
+            if (registryKey == null)
+            {
+                return string.Empty;
+            }
+
+            var subKey = registryKey.OpenSubKey(subKeyName);
+
+            return subKey?.GetValue(name) as string;
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
@@ -144,7 +144,7 @@ public class IisCheckTests : ToolTestHelper
 
         EnvironmentHelper.SetAutomaticInstrumentation(false);
 
-        using var iisFixture = await StartIis(IisAppType.AspNetCoreInProcess);
+        using var iisFixture = await StartIis(GetAppType());
 
         var (standardOutput, errorOutput, exitCode) = await RunTool($"check iis sample {IisExpressOptions(iisFixture)}");
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
@@ -136,6 +136,25 @@ public class IisCheckTests : ToolTestHelper
         exitCode.Should().Be(1);
     }
 
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task IncorrectlyConfiguredAppPool()
+    {
+        EnsureWindowsAndX64();
+
+        EnvironmentHelper.SetAutomaticInstrumentation(false);
+
+        using var iisFixture = await StartIis(IisAppType.AspNetCoreInProcess);
+
+        var (standardOutput, errorOutput, exitCode) = await RunTool($"check iis sample {IisExpressOptions(iisFixture)}");
+
+        exitCode.Should().Be(1);
+        standardOutput.Should().Contain(Resources.AppPoolCheckFindings("applicationPoolDefaults"));
+        standardOutput.Should().Contain(Resources.WrongEnvironmentVariableFormat("COR_ENABLE_PROFILING", "1", "0"));
+        standardOutput.Should().Contain(Resources.WrongEnvironmentVariableFormat("CORECLR_ENABLE_PROFILING", "1", "0"));
+        errorOutput.Should().BeEmpty();
+    }
+
     private static IisAppType GetAppType()
     {
 #if NETFRAMEWORK

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ProcessBasicChecksTests.cs
@@ -131,8 +131,6 @@ namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks
                 LoaderNotLoaded,
                 NativeTracerNotLoaded,
                 TracerNotLoaded,
-                ContinuousProfilerEnabled,
-                ContinuousProfilerNotLoaded,
                 TracerHomeNotFoundFormat("TheDirectoryDoesNotExist"),
                 WrongEnvironmentVariableFormat(CorProfilerKey, Profilerid, Guid.Empty.ToString("B")),
                 WrongEnvironmentVariableFormat(CorEnableKey, "1", "0"),
@@ -142,6 +140,10 @@ namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests.Checks
                 WrongProfilerEnvironment(CorProfilerPath32Key, "dummyPath"),
                 MissingProfilerEnvironment(CorProfilerPath64Key, "dummyPath"),
                 WrongProfilerEnvironment(CorProfilerPath64Key, "dummyPath"));
+
+            // Because TracingWithInstaller has a long URL, it gets split in the Spectre.Console output
+            // Removing the spaces to make the assertion work, until we figure out a better way
+            standardOutput.Replace(" ", string.Empty).Should().Contain(TracingWithInstaller.Replace(" ", string.Empty));
 
             errorOutput.Should().BeEmpty();
             exitCode.Should().Be(1);

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/applicationHost.config
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/applicationHost.config
@@ -140,6 +140,10 @@
       <add name="UnmanagedClassicAppPool" managedRuntimeVersion="" managedPipelineMode="Classic" autoStart="true" />
       <applicationPoolDefaults managedRuntimeVersion="v4.0">
         <processModel loadUserProfile="true" setProfileEnvironment="false" />
+        <environmentVariables>
+          <add name="COR_ENABLE_PROFILING" value="0" />
+          <add name="CORECLR_ENABLE_PROFILING" value="0" />
+        </environmentVariables>
       </applicationPoolDefaults>
     </applicationPools>
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
@@ -203,6 +203,28 @@ public class IisCheckTests : TestHelper
         console.Output.Should().Contain(Resources.CouldNotFindIisApplication("sample", "/dummy"));
     }
 
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task IncorrectlyConfiguredAppPool()
+    {
+        EnsureWindowsAndX64();
+
+        EnvironmentHelper.SetAutomaticInstrumentation(false);
+
+        using var iisFixture = await StartIis(IisAppType.AspNetCoreInProcess);
+        using var console = ConsoleHelper.Redirect();
+        var result = await CheckIisCommand.ExecuteAsync(
+                         "sample",
+                         iisFixture.IisExpress.ConfigFile,
+                         iisFixture.IisExpress.Process.Id,
+                         MockRegistryService());
+
+        result.Should().Be(1);
+        console.Output.Should().Contain(Resources.AppPoolCheckFindings("applicationPoolDefaults"));
+        console.Output.Should().Contain(Resources.WrongEnvironmentVariableFormat("COR_ENABLE_PROFILING", "1", "0"));
+        console.Output.Should().Contain(Resources.WrongEnvironmentVariableFormat("CORECLR_ENABLE_PROFILING", "1", "0"));
+    }
+
     private static void EnsureWindowsAndX64()
     {
         if (!RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -379,6 +379,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     public void ProfilerNotRegistered()
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
         var registryService = MockRegistryService(Array.Empty<string>(), null);
 
         using var console = ConsoleHelper.Redirect();
@@ -395,6 +396,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     public void ProfilerNotFoundRegistry()
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
         var registryService = MockRegistryService(Array.Empty<string>(), "dummyPath/" + Path.GetFileName(ProfilerPath));
 
         using var console = ConsoleHelper.Redirect();
@@ -412,6 +414,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     public void WrongProfilerRegistry()
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+        SkipOn.PlatformAndArchitecture(SkipOn.PlatformValue.Linux, SkipOn.ArchitectureValue.ARM64);
         var registryService = MockRegistryService(Array.Empty<string>(), "wrongProfiler.dll");
 
         using var console = ConsoleHelper.Redirect();

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -141,8 +141,6 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
             LoaderNotLoaded,
             NativeTracerNotLoaded,
             TracerNotLoaded,
-            ContinuousProfilerEnabled,
-            ContinuousProfilerNotLoaded,
             TracerHomeNotFoundFormat("TheDirectoryDoesNotExist"),
             WrongEnvironmentVariableFormat(CorProfilerKey, Utils.Profilerid, Guid.Empty.ToString("B")),
             WrongEnvironmentVariableFormat(CorEnableKey, "1", "0"),
@@ -151,7 +149,9 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
             MissingProfilerEnvironment(CorProfilerPath32Key, "dummyPath"),
             WrongProfilerEnvironment(CorProfilerPath32Key, "dummyPath"),
             MissingProfilerEnvironment(CorProfilerPath64Key, "dummyPath"),
-            WrongProfilerEnvironment(CorProfilerPath64Key, "dummyPath"));
+            WrongProfilerEnvironment(CorProfilerPath64Key, "dummyPath"),
+            WrongProfilerEnvironment(CorProfilerPath64Key, "dummyPath"),
+            TracingWithInstaller);
     }
 
     [SkippableFact]
@@ -345,7 +345,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
 
         using var console = ConsoleHelper.Redirect();
 
-        var result = ProcessBasicCheck.CheckRegistry(registryService);
+        var result = ProcessBasicCheck.CheckRegistry("2.14", registryService);
 
         result.Should().BeTrue();
 
@@ -365,7 +365,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
 
         using var console = ConsoleHelper.Redirect();
 
-        var result = ProcessBasicCheck.CheckRegistry(registryService);
+        var result = ProcessBasicCheck.CheckRegistry("2.14", registryService);
 
         result.Should().BeFalse();
 
@@ -383,7 +383,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
 
         using var console = ConsoleHelper.Redirect();
 
-        var result = ProcessBasicCheck.CheckRegistry(registryService);
+        var result = ProcessBasicCheck.CheckRegistry("2.14", registryService);
 
         result.Should().BeFalse();
 
@@ -399,7 +399,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
 
         using var console = ConsoleHelper.Redirect();
 
-        var result = ProcessBasicCheck.CheckRegistry(registryService);
+        var result = ProcessBasicCheck.CheckRegistry("2.14", registryService);
 
         result.Should().BeFalse();
 
@@ -416,12 +416,50 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
 
         using var console = ConsoleHelper.Redirect();
 
-        var result = ProcessBasicCheck.CheckRegistry(registryService);
+        var result = ProcessBasicCheck.CheckRegistry("2.14", registryService);
 
         result.Should().BeFalse();
 
         console.Output.Should().NotContain(MissingRegistryKey(ClsidKey));
         console.Output.Should().Contain(Resources.WrongProfilerRegistry(ClsidKey, "wrongProfiler.dll"));
+    }
+
+    [SkippableFact]
+    public void LinuxInstallationDirectory()
+    {
+        SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
+        string tempDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDirectory);
+
+        try
+        {
+            var (extension, archPath) = (EnvironmentTools.GetOS(), EnvironmentTools.GetPlatform(), EnvironmentTools.GetTestTargetPlatform(), Utils.IsAlpine()) switch
+            {
+                ("win", _, "X64", _) => ("dll", "win-x64"),
+                ("win", _, "X86", _) => ("dll", "win-x86"),
+                ("linux", "Arm64", _, _) => ("so", "linux-arm64"),
+                ("linux", "X64", _, false) => ("so", "linux-x64"),
+                ("linux", "X64", _, true) => ("so", "linux-musl-x64"),
+                ("osx", _, _, _) => ("dylib", "osx"),
+                var unsupportedTarget => throw new PlatformNotSupportedException(unsupportedTarget.ToString())
+            };
+
+            var dir = Path.Join(tempDirectory, archPath);
+            var path = Path.Join(dir, $"Datadog.Trace.ClrProfiler.Native.{extension}");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(path, string.Empty);
+
+            using var console = ConsoleHelper.Redirect();
+
+            ProcessBasicCheck.CheckLinuxInstallation(tempDirectory);
+            console.Output.Should().BeEmpty();
+        }
+        finally
+        {
+            // cleanup
+            Directory.Delete(tempDirectory, recursive: true);
+        }
     }
 
     private static IRegistryService MockRegistryService(string[] frameworkKeyValues, string? profilerKeyValue, bool wow64 = false)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/applicationHost.config
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/applicationHost.config
@@ -140,6 +140,10 @@
       <add name="UnmanagedClassicAppPool" managedRuntimeVersion="" managedPipelineMode="Classic" autoStart="true" />
       <applicationPoolDefaults managedRuntimeVersion="v4.0">
         <processModel loadUserProfile="true" setProfileEnvironment="false" />
+        <environmentVariables>
+          <add name="COR_ENABLE_PROFILING" value="0" />
+          <add name="CORECLR_ENABLE_PROFILING" value="0" />
+        </environmentVariables>
       </applicationPoolDefaults>
     </applicationPools>
 


### PR DESCRIPTION
## Summary of changes

Port changes from https://github.com/DataDog/dd-trace-dotnet/pull/4605 into dd-dotnet.

## Reason for change

This is needed before delegating the diagnostic part of dd-trace to dd-dotnet.

## Implementation details

Mostly copy/pasting, there is some specific code on the IIS part for the application pools, since dd-dotnet doesn't use the Microsoft.Web.Administration library.

## Test coverage

Same as the original PR. I haven't ported the registry service tests because dd-dotnet doesn't have a unit test project yet. I'll add them when removing the diagnostic part from dd-trace.
