### PR TITLE
Build standalone trimmed version for net7.0

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -878,13 +878,8 @@ partial class Build : NukeBuild
                         "alpine",
                         new (string publishFramework, string runtimeTag)[]
                         {
-                            // The standalone .NET tool currently crashes on .NET 8. That's because we currently
-                            // build against .NET Core 3.1, which depends on `libintl`, but that was removed in the 
-                            // .NET 8 alpine packages:
-                            // https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/libintl-package
-                            // The solution is to compile the standalone tool against .NET 5+ to remove that dependency
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"), 
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
+                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"), 
+                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
                             (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
                             (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
                             (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -465,7 +465,6 @@ partial class Build : NukeBuild
                 // .EnableNoDependencies()
                 .SetFramework(TargetFramework.NET7_0)
                 .SetConfiguration(BuildConfiguration)
-                .SetSelfContained(true)
                 .SetNoWarnDotNetCore3()
                 .SetDDEnvironmentVariables("dd-trace-dotnet-runner-tool")
                 .SetProperty("BuildStandalone", "true")

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -463,8 +463,9 @@ partial class Build : NukeBuild
                 // Have to do a restore currently as we're specifying specific runtime
                 // .EnableNoRestore()
                 // .EnableNoDependencies()
-                .SetFramework(TargetFramework.NETCOREAPP3_1)
+                .SetFramework(TargetFramework.NET7_0)
                 .SetConfiguration(BuildConfiguration)
+                .SetSelfContained(true)
                 .SetNoWarnDotNetCore3()
                 .SetDDEnvironmentVariables("dd-trace-dotnet-runner-tool")
                 .SetProperty("BuildStandalone", "true")

--- a/tracer/src/Datadog.Trace.Tools.Runner/Aot/AotProcessor.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Aot/AotProcessor.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -23,6 +24,9 @@ using Spectre.Console;
 
 namespace Datadog.Trace.Tools.Runner.Aot
 {
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("Trimming", "IL2026", Justification = "System.Reflection.Assembly.GetType is only called over the tracer assembly.")]
+#endif
     internal class AotProcessor
     {
         private static readonly NativeCallTargetDefinition[] Definitions;
@@ -36,10 +40,20 @@ namespace Datadog.Trace.Tools.Runner.Aot
 
         private static readonly MethodInfo CallTargetStateGetDefaultMethodInfo;
 
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         private static readonly Type CallTargetReturnVoid;
+#else
+        private static readonly Type CallTargetReturnVoid;
+#endif
         private static readonly MethodInfo CallTargetReturnVoidGetDefaultValueMethodInfo;
 
+#if NET6_0_OR_GREATER
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)]
         private static readonly Type CallTargetReturn;
+#else
+        private static readonly Type CallTargetReturn;
+#endif
         private static readonly MethodInfo CallTargetReturnGetReturnValueMethodInfo;
         private static readonly MethodInfo CallTargetReturnGetDefaultValueMethodInfo;
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -35,6 +35,7 @@
         <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-musl-x64;osx-x64;linux-arm64</RuntimeIdentifiers>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <PublishTrimmed>true</PublishTrimmed>
+        <SelfContained>true</SelfContained>
         <TrimMode>copyused</TrimMode>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -35,10 +35,28 @@
         <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-musl-x64;osx-x64;linux-arm64</RuntimeIdentifiers>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <PublishTrimmed>true</PublishTrimmed>
+        <TrimMode>copyused</TrimMode>
+        <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
+        <ILLinkTreatWarningsAsErrors>false</ILLinkTreatWarningsAsErrors>
         <PublishSingleFile>true</PublishSingleFile>
         <SelfContained>true</SelfContained>
         <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
       </PropertyGroup>
+      <ItemGroup>
+        <TrimmerRootAssembly Include="Datadog.Trace" />
+        <TrimmerRootAssembly Include="dnlib" />
+        <TrimmerRootAssembly Include="ICSharpCode.Decompiler" />
+        <TrimmerRootAssembly Include="Microsoft.TestPlatform.CoreUtilities" />
+        <TrimmerRootAssembly Include="Microsoft.TestPlatform.PlatformAbstractions" />
+        <TrimmerRootAssembly Include="Microsoft.VisualStudio.TestPlatform.ObjectModel" />
+        <TrimmerRootAssembly Include="Microsoft.Web.Administration" />
+        <TrimmerRootAssembly Include="Mono.Cecil" />
+        <TrimmerRootAssembly Include="Mono.Cecil.Pdb" />
+        <TrimmerRootAssembly Include="Spectre.Console" />
+        <TrimmerRootAssembly Include="System.CodeDom" />
+        <TrimmerRootAssembly Include="System.Management" />
+        <TrimmerRootAssembly Include="System.Xml" />
+      </ItemGroup>
       <ItemGroup>
         <Content Include="..\Datadog.Trace.Bundle\home\**\*.*" LinkBase="home">
           <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -147,8 +165,9 @@
     <!-- Required for StrongNamer: https://github.com/dsplaisted/strongnamer/issues/61 -->
     <Message Text="Removing $(DuplicateFileToRemove) from publish output" Importance="high" />
     <ItemGroup>
-      <ResolvedFileToPublish Remove="$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\linked\Spectre.Console.dll" />
-      <ResolvedFileToPublish Remove="$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\linked\ILVerification.dll" />
+      <ResolvedFileToPublish Remove="$(MSBuildThisFileDirectory)$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\SignedAssemblies\Spectre.Console.dll" />
+      <ResolvedFileToPublish Remove="$(MSBuildThisFileDirectory)$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\$(RuntimeIdentifier)\SignedAssemblies\ILVerification.dll" />
     </ItemGroup>
   </Target>
+
 </Project>


### PR DESCRIPTION
## Summary of changes

Update the self-container `dd-trace` too to compile against .NET 7 instead of .NET Core 3.1

## Reason for change

We currently do a standalone-compile with .NET Core 3.1 for the `dd-trace` tool. However, the .NET Core 3.1 runtime depends on `libintl`, which has [been removed from the lastest .NET 8 alpine packages](https://learn.microsoft.com/en-us/dotnet/core/compatibility/containers/8.0/libintl-package), which means we crash on startup there now.

## Implementation details

`libintl` was a dependency on the runtime prior to .NET 5, but [in .NET 5 it was removed](https://github.com/dotnet/runtime/pull/270). If you attempt to load the .NET Core 3.1 runtime in an environment without the package, you'll get an error `Error loading shared library libintl.so.8`.

Given this is a runtime-level issue, the best we can do is use a different runtime. The difficultly is that we were previously targeting .NET Core 3.1 due to issues with trimming. Basically, the `dd-trace` tool is _very_ unfriendly to the trimmer. 

To workaround those issues, this PR updates the linker to use .NET 7, but then copies a bunch of our dependencies directly to the output without trimming. 

> We're using `copyused` for this, [though that is apparently unsupported in .NET 7](https://github.com/dotnet/linker/issues/3039), which implies it may not work as we expect...

## Test coverage

It works in CI... I did a "full" installer run too, and confirm it now works on the previously broken alpine 3.18 image

## Other details
<!-- Fixes #{issue} -->
We _could_ target .NET 5 instead. Maybe that's safer?

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
