### PR TITLE
[ASM] Remove debug mode for unit tests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
@@ -30,8 +30,6 @@ namespace Datadog.Trace.Security.Unit.Tests
         [Fact]
         public void RulesUpdate()
         {
-            GlobalSettings.SetDebugEnabled(true);
-
             var initResult = Waf.Create(WafLibraryInvoker!, string.Empty, string.Empty);
             using var waf = initResult.Waf;
             waf.Should().NotBeNull();


### PR DESCRIPTION
## Summary of changes

Accidentally added debug mode for unit tests so remove it

## Reason for change

 can potentially cause waf timeouts during tests

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
