### PR TITLE
[ASM]Cleanup null chars

### DIFF
--- a/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/StringExtensions.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Runtime.CompilerServices;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.ExtensionMethods
@@ -128,6 +129,11 @@ namespace Datadog.Trace.ExtensionMethods
 
             normalizedTagName = StringBuilderCache.GetStringAndRelease(sb);
             return true;
+        }
+
+        public static string SanitizeNulls(this string txt)
+        {
+            return txt?.Replace("\0", string.Empty);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Evidence.cs
+++ b/tracer/src/Datadog.Trace/Iast/Evidence.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using Datadog.Trace.ExtensionMethods;
 
 namespace Datadog.Trace.Iast;
 
@@ -18,7 +19,7 @@ internal readonly struct Evidence
 
     public Evidence(string value, Range[]? ranges = null, Range[]? sensitive = null)
     {
-        this._value = value;
+        this._value = value.SanitizeNulls();
         this._ranges = ranges;
         this._sensitive = sensitive;
     }

--- a/tracer/src/Datadog.Trace/Iast/Source.cs
+++ b/tracer/src/Datadog.Trace/Iast/Source.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Text;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Iast;
@@ -27,7 +28,7 @@ internal class Source
     {
         this._origin = origin;
         this.Name = name;
-        this._value = value;
+        this._value = value.SanitizeNulls();
         this._redacted = false;
     }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
@@ -405,4 +405,38 @@ public partial class VulnerabilityBatchTests
             """,
             _vulnerabilitiesScrubber);
     }
+
+    [Fact]
+    public void GivenAnEvidenceWithNullChars_WhenSerializing_JsonHasNoNullchars()
+    {
+        var batch = new VulnerabilityBatch();
+        var source = new Source(2, "name", "val\0ue");
+        var source2 = new Source(3, "name2", "value2");
+        var ranges = new Range[] { new Range(0, 5, source) };
+        var evidence = new Evidence("val\0ue", ranges);
+        var vulnerability = new Vulnerability("sqli", new Location(), evidence);
+        batch.Add(vulnerability);
+
+        var json = batch.ToJson();
+        json.Should().BeJsonEquivalentTo(
+            """
+            {
+              "vulnerabilities": [
+                {
+                  "type": "sqli",
+                  "location": {},
+                  "evidence": {
+                    "valueParts": [
+                      { "value": "value", "source": 0 },
+                    ]
+                  }
+                }
+              ],
+              "sources": [
+                { "origin": "http.request.parameter.name", "name": "name", "value": "value" },
+              ]
+            }
+            """,
+            _vulnerabilitiesScrubber);
+    }
 }


### PR DESCRIPTION
## Summary of changes
Cleaned null chars from sources and evidences

## Reason for change
A bug was being reported in backend

## Implementation details
Added a sanitizing function in the constructor of `Source` and `Evidence`

## Test coverage
Added unit test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
