### PR TITLE
Merge `throughput_appsec` into `throughput` stage

### DIFF
--- a/.azure-pipelines/steps/update-github-status-jobs.yml
+++ b/.azure-pipelines/steps/update-github-status-jobs.yml
@@ -3,6 +3,10 @@ parameters:
     type: object
     default: {}
 
+  - name: allowSkipped
+    type: boolean
+    default: false
+
 jobs:
   - job: set_pending
     timeoutInMinutes: 60 #default value
@@ -24,7 +28,14 @@ jobs:
     - set_pending
     - ${{ each job in parameters.jobs }}:
       - ${{ job }}
-    condition: succeeded()
+    condition: >
+      or(
+        succeeded(),
+        and(
+          eq('${{ parameters.allowSkipped }}', true),
+          not(failed())
+        )
+      )
     steps:
     - checkout: none
     - template: update-github-status.yml
@@ -41,7 +52,14 @@ jobs:
       - set_pending
       - ${{ each job in parameters.jobs }}:
           - ${{ job }}
-    condition: not(succeeded())
+    condition: >
+      not(or(
+        succeeded(),
+        and(
+          eq('${{ parameters.allowSkipped }}', true),
+          not(failed())
+        )
+      ))
     steps:
     - checkout: none
     - template: update-github-status.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3922,7 +3922,7 @@ stages:
       or(
       eq(variables.isMainBranch, true),
       eq(variables.force_appsec_throughput_run, 'true'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True')))
+      eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'], 'True')))
 
     steps:
       - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3917,12 +3917,18 @@ stages:
     timeoutInMinutes: 60
     pool: Throughput-AppSec
     condition: >
-      and(succeeded(), 
-      eq(variables.isMainRepository, true),
       or(
-      eq(variables.isMainBranch, true),
-      eq(variables.force_appsec_throughput_run, 'true'),
-      eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'], 'True')))
+        eq(variables.isMainBranch, true),
+        eq(variables.force_appsec_throughput_run, 'true'),
+        eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'], 'True'),
+        eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables.generate_variables_step.isAppSecChanged'], 'True'),
+        eq(stageDependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True'),
+        eq(stageDependencies.generate_variables.outputs['generate_variables_step.isAppSecChanged'], 'True'),
+        eq(dependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'], 'True'),
+        eq(dependencies.generate_variables.generate_variables_job.outputs['generate_variables.generate_variables_step.isAppSecChanged'], 'True'),
+        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True'),
+        eq(dependencies.generate_variables.outputs['generate_variables_step.isAppSecChanged'], 'True')
+      )
 
     steps:
       - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3764,7 +3764,7 @@ stages:
 
 - stage: throughput
   condition: and(succeeded(), eq(variables.isMainRepository, true))
-  dependsOn: [package_linux, package_arm64, build_windows_tracer, merge_commit_id]
+  dependsOn: [package_linux, package_arm64, build_windows_tracer, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3768,6 +3768,7 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
     # By default all throughput tests happen on release or master branches only, or when running a benchmarks only build. Overridable by setting 'run_extended_throughput_tests' to true
     runExtendedThroughputTests: $[or(eq(variables.isMainOrReleaseBranch, 'true'), not(eq(variables['isBenchmarksOnlyBuild'], 'False')), eq(variables.run_extended_throughput_tests, 'true'))]
     CrankDir: $(System.DefaultWorkingDirectory)/tracer/build/crank
@@ -3920,14 +3921,7 @@ stages:
       or(
         eq(variables.isMainBranch, true),
         eq(variables.force_appsec_throughput_run, 'true'),
-        eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'], 'True'),
-        eq(stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables.generate_variables_step.isAppSecChanged'], 'True'),
-        eq(stageDependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True'),
-        eq(stageDependencies.generate_variables.outputs['generate_variables_step.isAppSecChanged'], 'True'),
-        eq(dependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'], 'True'),
-        eq(dependencies.generate_variables.generate_variables_job.outputs['generate_variables.generate_variables_step.isAppSecChanged'], 'True'),
-        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True'),
-        eq(dependencies.generate_variables.outputs['generate_variables_step.isAppSecChanged'], 'True')
+        eq(variables.isAppSecChanged, 'True')
       )
 
     steps:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3771,15 +3771,15 @@ stages:
     # By default all throughput tests happen on release or master branches only, or when running a benchmarks only build. Overridable by setting 'run_extended_throughput_tests' to true
     runExtendedThroughputTests: $[or(eq(variables.isMainOrReleaseBranch, 'true'), not(eq(variables['isBenchmarksOnlyBuild'], 'False')), eq(variables.run_extended_throughput_tests, 'true'))]
     CrankDir: $(System.DefaultWorkingDirectory)/tracer/build/crank
-  pool: Throughput
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [Linux64, Windows64, LinuxArm64]
+      jobs: [Linux64, Windows64, LinuxArm64, AsmLinux64]
   #### Throughput Linux 64, windows 64, linux arm 64
 
   - job: Linux64
     timeoutInMinutes: 60
+    pool: Throughput
 
     steps:
     - template: steps/clone-repo.yml
@@ -3824,6 +3824,7 @@ stages:
 
   - job: Windows64
     timeoutInMinutes: 60
+    pool: Throughput
 
     steps:
     - template: steps/clone-repo.yml
@@ -3868,6 +3869,7 @@ stages:
 
   - job: LinuxArm64
     timeoutInMinutes: 60
+    pool: Throughput
 
     steps:
     - template: steps/clone-repo.yml
@@ -3908,6 +3910,55 @@ stages:
       # bother trying to upload these in case of failure, which means we can retry the
       # stages without issue
       artifact: crank_linux_arm64_1
+    
+    #### Throughput-AppSec Linux 64
+
+  - job: AsmLinux64
+    timeoutInMinutes: 60
+    pool: Throughput-AppSec
+    condition: >
+      and(succeeded(), 
+      eq(variables.isMainRepository, true),
+      or(
+      eq(variables.isMainBranch, true),
+      eq(variables.force_appsec_throughput_run, 'true'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True')))
+
+    steps:
+      - template: steps/clone-repo.yml
+        parameters:
+          targetShaId: $(targetShaId)
+          targetBranch: $(targetBranch)
+      - task: DownloadPipelineArtifact@2
+        displayName: Download linux native binary
+        inputs:
+          artifact: linux-monitoring-home-linux-x64
+          path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
+
+      - script: |
+          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
+          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
+          test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
+          mkdir -p $(CrankDir)/results/logs
+          cd $(CrankDir)
+          chmod +x ./run-appsec.sh
+          ./run-appsec.sh "linux"
+        displayName: Crank
+        env:
+          DD_SERVICE: dd-trace-dotnet
+          DD_ENV: CI
+
+      - script: |
+          cp $(CrankDir)/*.json $(CrankDir)/results
+        displayName: Copy the results to results dir
+
+      - publish: "$(CrankDir)/results"
+        displayName: Publish results
+        # We don't include the JobAttempt in this case, because we rely on a specific name
+        # and an error in the throughput tests probably means no usable data, so dont
+        # bother trying to upload these in case of failure, which means we can retry the
+        # stages without issue
+        artifact: crank_linux_x64_asm_1
 
 - stage: throughput_profiler
   condition: >
@@ -4011,65 +4062,6 @@ stages:
       artifact: crank_profiler_windows64_$(System.JobAttempt)
       condition: succeededOrFailed()
       continueOnError: true
-
-- stage: throughput_appsec
-  condition: >
-    and(succeeded(), 
-        eq(variables.isMainRepository, true),
-        or(
-          eq(variables.isMainBranch, true),
-          eq(variables.force_appsec_throughput_run, 'true'),
-          eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True')))
-  dependsOn: [package_linux, generate_variables, merge_commit_id]
-  variables:
-    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
-    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-    CrankDir: $(System.DefaultWorkingDirectory)/tracer/build/crank
-  pool: Throughput-AppSec
-  jobs:
-  - template: steps/update-github-status-jobs.yml
-    parameters:
-      jobs: [Linux64]
-  #### Throughput-AppSec Linux 64
-
-  - job: Linux64
-    timeoutInMinutes: 60
-
-    steps:
-    - template: steps/clone-repo.yml
-      parameters:
-        targetShaId: $(targetShaId)
-        targetBranch: $(targetBranch)
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux native binary
-      inputs:
-        artifact: linux-monitoring-home-linux-x64
-        path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
-
-    - script: |
-        test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
-        test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
-        test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-        mkdir -p $(CrankDir)/results/logs
-        cd $(CrankDir)
-        chmod +x ./run-appsec.sh
-        ./run-appsec.sh "linux"
-      displayName: Crank
-      env:
-        DD_SERVICE: dd-trace-dotnet
-        DD_ENV: CI
-
-    - script: |
-        cp $(CrankDir)/*.json $(CrankDir)/results
-      displayName: Copy the results to results dir
-
-    - publish: "$(CrankDir)/results"
-      displayName: Publish results
-      # We don't include the JobAttempt in this case, because we rely on a specific name
-      # and an error in the throughput tests probably means no usable data, so dont
-      # bother trying to upload these in case of failure, which means we can retry the
-      # stages without issue
-      artifact: crank_linux_x64_asm_1
 
 - stage: coverage
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), eq(variables['runCodeCoverage'], 'True'))
@@ -5748,7 +5740,7 @@ stages:
 
 - stage: compare_throughput
   condition: and(succeeded(), eq(variables.isMainRepository, true))
-  dependsOn: [throughput, throughput_appsec, merge_commit_id]
+  dependsOn: [throughput, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -5834,7 +5826,6 @@ stages:
     - exploration_tests_linux
     - benchmarks
     - throughput
-    - throughput_appsec
     - tool_artifacts_tests_windows
     - tool_artifacts_tests_linux
     - upload_to_s3

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3776,6 +3776,7 @@ stages:
   - template: steps/update-github-status-jobs.yml
     parameters:
       jobs: [Linux64, Windows64, LinuxArm64, AsmLinux64]
+      allowSkipped: true
   #### Throughput Linux 64, windows 64, linux arm 64
 
   - job: Linux64


### PR DESCRIPTION
## Summary of changes

Does what it says on the tin.

## Reason for change

In AzureDevops all the dependencies of a stage need to run before the stage runs. Unfortunately, that falls apart if you want to _conditionally_ run a stage (as we do with `throughput_appsec`). That requires a bunch of gymnastics to make things work

## Implementation details

Move the AppSec job into the Throughput stage. We are still using separate jobs, so there's no impact on the tracer throughput tests - they're still independent. But as the `throughput` stage always runs, we don't have to do anything weird to make sure `compare_throughput` runs.

The only "regression" is that the `throughput` stage depends on:

```
package_linux, package_arm64, build_windows_tracer, merge_commit_id
```

whereas `throughput_appsec` previously did not depend on the windows or arm64 builds

```
package_linux, merge_commit_id
```

This probably isn't a big issue for ASM, but it's the only thing that could impact  the change

## Test coverage

- [x] Made a no-op change to an ASM file to try to make sure that the stage runs as expected
- [x] Removed the change, to make sure the stage _doesn't_ run, but we still get comparisons

## Other details
Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/4739

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
