### PR TITLE
Fix flaky DSM test

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -51,7 +51,9 @@ public class DataStreamsMonitoringTransportTests
     {
         using var agent = Create((TracesTransportType)transport);
 
-        var bucketDurationMs = 100; // 100 ms
+        // We don't want to trigger a flush based on the timer, only based on the disposal of the writer
+        // That ensures we only get a single payload
+        var bucketDurationMs = (int)TimeSpan.FromMinutes(60).TotalMilliseconds;
         var tracerSettings = new TracerSettings { Exporter = GetExporterSettings(agent) };
         var api = new DataStreamsApi(
             DataStreamsTransportStrategy.GetAgentIntakeFactory(tracerSettings.Build().Exporter));


### PR DESCRIPTION
## Summary of changes

Fixes a flaky DSM unit test

## Reason for change

Saw it flake recently, we got two payloads when we only expected one. That's because there's a timer running in the background every 100ms, and the test obviously ran a bit slower than usual

## Implementation details

Bump the interval up to be arbitrarily large for the test. We flush on dispose anyway

## Test coverage

N/A

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
