### PR TITLE
Handle potential `NullReferenceException` in DSM

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IMessage.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/IMessage.cs
@@ -3,12 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.DuckTyping;
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
 {
     /// <summary>
     /// Message interface for duck-typing
     /// </summary>
-    internal interface IMessage
+    internal interface IMessage : IDuckType
     {
         /// <summary>
         /// Gets the key of the message

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -328,7 +328,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             TMessage message)
             where TMessage : IMessage
         {
-            if (!_headersInjectionEnabled || ((IDuckType)message).Instance is null)
+            if (!_headersInjectionEnabled || message.Instance is null)
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaHelper.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Text;
 using Datadog.Trace.DataStreamsMonitoring;
@@ -24,14 +26,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
         private static bool _headersInjectionEnabled = true;
         private static string[] defaultProduceEdgeTags = new[] { "direction:out", "type:kafka" };
 
-        internal static Scope CreateProducerScope(
+        internal static Scope? CreateProducerScope(
             Tracer tracer,
             object producer,
             ITopicPartition topicPartition,
             bool isTombstone,
             bool finishOnClose)
         {
-            Scope scope = null;
+            Scope? scope = null;
 
             try
             {
@@ -125,7 +127,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             return size;
         }
 
-        internal static Scope CreateConsumerScope(
+        internal static Scope? CreateConsumerScope(
             Tracer tracer,
             DataStreamsManager dataStreamsManager,
             object consumer,
@@ -134,7 +136,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             Offset? offset,
             IMessage message)
         {
-            Scope scope = null;
+            Scope? scope = null;
 
             try
             {
@@ -153,7 +155,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                     return null;
                 }
 
-                SpanContext propagatedContext = null;
+                SpanContext? propagatedContext = null;
                 PathwayContext? pathwayContext = null;
 
                 // Try to extract propagated context from headers
@@ -269,7 +271,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                             dataStreamsManager,
                             CheckpointKind.Consume,
                             edgeTags,
-                            GetMessageSize(message),
+                            message is null ? 0 : GetMessageSize(message),
                             tags.MessageQueueTimeMs == null ? 0 : (long)tags.MessageQueueTimeMs);
                     }
                 }
@@ -302,7 +304,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
                 }
 
                 // TODO: record end-to-end time?
-                activeScope.Dispose();
+                activeScope!.Dispose();
             }
             catch (Exception ex)
             {
@@ -326,7 +328,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka
             TMessage message)
             where TMessage : IMessage
         {
-            if (!_headersInjectionEnabled)
+            if (!_headersInjectionEnabled || ((IDuckType)message).Instance is null)
             {
                 return;
             }


### PR DESCRIPTION
## Summary of changes

Add nullable annotations and fix the warnings

## Reason for change

A recent escalation noted an incidental `NullReferenceException` in the logs:

```
[ERR] Error creating or populating scope. System.NullReferenceException: Object reference not set to an instance of an object.
at Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaHelper.GetMessageSize[T](T message)
at Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaHelper.CreateConsumerScope(Tracer tracer, DataStreamsManager dataStreamsManager, Object consumer, String topic, Nullable`1 partition, Nullable`1 offset, IMessage message)
```

The `GetMessageSize()` method is quite careful about null-checking, so my best guess is that the `message` object passed in itself is `null` (which the nullable annotations also suggested).

I think this is partly due to the difference in how duck typing works for duck-typing in instrumentations (where the duck-type object will _never_ be `null`, as it's implemented as a `struct`, even if using interfaces) and when using duck-chaining (where the duck-type object _can_ be `null` if you're using interfaces)

## Implementation details

Add `#nullable enable`, add some null checks

## Test coverage

Not easy, just checking there's no regressions

## Other details

<!-- Fixes #{issue} -->
Maybe we should make it a habit of marking duck-chained interface properties as nullable reference types? 🤔 I think that would help avoid this ambiguity?

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
