### PR TITLE
Disable profiling integration tests on non-profiler PRs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5837,8 +5837,6 @@ stages:
     - integration_tests_arm64
     - integration_tests_arm64_debugger
     - static_analysis_checks_tracer
-    - profiler_integration_tests_linux
-    - profiler_integration_tests_windows
     - exploration_tests_windows
     - exploration_tests_linux
     - benchmarks

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2197,7 +2197,15 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
 - stage: profiler_integration_tests_windows
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      or(
+        eq(variables.isMainBranch, true),
+        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
+      )
+    )
   dependsOn: [package_windows, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -2263,7 +2271,15 @@ stages:
       condition: succeededOrFailed()
 
 - stage: profiler_integration_tests_linux
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      or(
+        eq(variables.isMainBranch, true),
+        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
+      )
+    )
   dependsOn: [package_linux, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -32,7 +32,15 @@ partial class Build : NukeBuild
 
             void GenerateConditionVariables()
             {
-                GenerateConditionVariableBasedOnGitChange("isAppSecChanged", new[] { "tracer/src/Datadog.Trace/Iast", "tracer/src/Datadog.Tracer.Native/iast", "tracer/src/Datadog.Trace/AppSec" }, new string[] { });
+                GenerateConditionVariableBasedOnGitChange("isAppSecChanged",
+                new[] {
+                    "tracer/src/Datadog.Trace/Iast",
+                    "tracer/src/Datadog.Tracer.Native/iast",
+                    "tracer/src/Datadog.Trace/AppSec",
+                    "tracer/test/Datadog.Trace.Security.IntegrationTests",
+                    "tracer/test/Datadog.Trace.Security.Unit.Tests",
+                    "tracer/test/test-applications/security",
+                }, new string[] { });
                 GenerateConditionVariableBasedOnGitChange("isTracerChanged", new[] { "tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation", "tracer/src/Datadog.Tracer.Native" }, new string[] {  });
                 GenerateConditionVariableBasedOnGitChange("isDebuggerChanged", new[]
                 {
@@ -40,9 +48,16 @@ partial class Build : NukeBuild
                     "tracer/src/Datadog.Tracer.Native",
                     "tracer/test/Datadog.Trace.Debugger.IntegrationTests",
                     "tracer/test/test-applications/debugger",
-                    "tracer/build/_build/Build.Steps.Debugger.cs"
+                    "tracer/build/_build/Build.Steps.Debugger.cs",
                 }, new string[] { });
-                GenerateConditionVariableBasedOnGitChange("isProfilerChanged", new[] { "profiler/src", "profiler/test" }, new string[] { });
+                GenerateConditionVariableBasedOnGitChange("isProfilerChanged", new[]
+                {
+                    "profiler/",
+                    "shared/",
+                    "build/",
+                    "tracer/build/_build/Build.Shared.Steps.cs",
+                    "tracer/build/_build/Build.Profiler.Steps.cs",
+                }, new string[] { });
 
                 void GenerateConditionVariableBasedOnGitChange(string variableName, string[] filters, string[] exclusionFilters)
                 {
@@ -70,7 +85,7 @@ partial class Build : NukeBuild
                         var changedFiles = GetGitChangedFiles(baseBranch);
 
                         // Choose changedFiles that meet any of the filters => Choose changedFiles that DON'T meet any of the exclusion filters
-                        isChanged = changedFiles.Any(s => filters.Any(filter => s.Contains(filter, StringComparison.OrdinalIgnoreCase)) && !exclusionFilters.Any(filter => s.Contains(filter, StringComparison.OrdinalIgnoreCase)));
+                        isChanged = changedFiles.Any(s => filters.Any(filter => s.StartsWith(filter, StringComparison.OrdinalIgnoreCase)) && !exclusionFilters.Any(filter => s.Contains(filter, StringComparison.OrdinalIgnoreCase)));
                     }
 
                     Logger.Information($"{variableName} - {isChanged}");


### PR DESCRIPTION
## Summary of changes

Disable profiler integration tests unless running a profiler PR (or master)

## Reason for change

Some profiler tests are flaky and impact tracer-only PRs

## Implementation details

Add condition to the stages

## Test coverage

- [x] Tested that a profiler change _does_ trigger them to run
- [x] Tested that a non-profiler change _doesn't_ trigger them to run

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
