### PR TITLE
[Profiler] Prevent libunwind from crashing when unwinding two signal handlers

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -161,10 +161,15 @@ void LinuxStackFramesCollector::NotifyStackWalkCompleted(std::int32_t resultErro
 // This symbol is defined in the Datadog.Linux.ApiWrapper. It allows us to check if the thread to be profiled
 // contains a frame of a function that might cause a deadlock.
 extern "C" unsigned long long dd_inside_wrapped_functions() __attribute__((weak));
+extern "C" int is_already_running_inside_signal_handler() __attribute__((weak));
 
 std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread(void* ctx)
 {
     if (dd_inside_wrapped_functions != nullptr && dd_inside_wrapped_functions() != 0)
+    {
+        return E_ABORT;
+    }
+    if (is_already_running_inside_signal_handler != nullptr && is_already_running_inside_signal_handler() != 0)
     {
         return E_ABORT;
     }


### PR DESCRIPTION
## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
