### PR TITLE
[Serverless] [Fix PR-4535] EndInvocationAsync should be awaited.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -47,6 +47,8 @@ fault_tolerant_*.h                         @DataDog/debugger-dotnet
 /tracer/src/Datadog.Trace/FaultTolerant/   @DataDog/debugger-dotnet
 
 # Serverless
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-apm
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/    @DataDog/tracing-dotnet  @DataDog/serverless-apm
 /tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/   @DataDog/tracing-dotnet  @DataDog/serverless-apm
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/       @DataDog/tracing-dotnet  @DataDog/serverless-apm
 /tracer/test/test-applications/azure-functions/                    @DataDog/tracing-dotnet  @DataDog/serverless-apm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,8 @@ fault_tolerant_*.h                         @DataDog/debugger-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/   @DataDog/tracing-dotnet  @DataDog/serverless-apm
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/       @DataDog/tracing-dotnet  @DataDog/serverless-apm
 /tracer/test/test-applications/azure-functions/                    @DataDog/tracing-dotnet  @DataDog/serverless-apm
+/tracer/test/test-applications/integrations/Samples.AWS.Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-apm
+/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/        @DataDog/tracing-dotnet  @DataDog/serverless-apm
 docker-compose.serverless.yml                                      @DataDog/tracing-dotnet  @DataDog/serverless-apm
 
 # Shared code we could move to the root folder

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/HandlerWrapperSetHandlerIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/HandlerWrapperSetHandlerIntegration.cs
@@ -99,7 +99,7 @@ public class HandlerWrapperSetHandlerIntegration
         }
 
         /// <inheritdoc/>
-        public Task<TInnerReturn> OnDelegateEndAsync<TInnerReturn>(object sender, TInnerReturn returnValue, Exception exception, object state)
+        public async Task<TInnerReturn> OnDelegateEndAsync<TInnerReturn>(object sender, TInnerReturn returnValue, Exception exception, object state)
         {
             LambdaCommon.Log("DelegateWrapper Running OnDelegateEndAsync");
             try
@@ -108,22 +108,22 @@ public class HandlerWrapperSetHandlerIntegration
                 if (proxyInstance == null)
                 {
                     LambdaCommon.Log("DuckCast.IInvocationResponse got null proxyInstance", debug: false);
-                    LambdaCommon.EndInvocationAsync(string.Empty, exception, ((CallTargetState)state!).Scope, RequestBuilder).ConfigureAwait(false);
+                    await LambdaCommon.EndInvocationAsync(string.Empty, exception, ((CallTargetState)state!).Scope, RequestBuilder).ConfigureAwait(false);
                 }
                 else
                 {
                     var jsonString = ConvertPayloadStream(proxyInstance.OutputStream);
-                    LambdaCommon.EndInvocationAsync(jsonString, exception, ((CallTargetState)state!).Scope, RequestBuilder).ConfigureAwait(false);
+                    await LambdaCommon.EndInvocationAsync(jsonString, exception, ((CallTargetState)state!).Scope, RequestBuilder).ConfigureAwait(false);
                 }
             }
             catch (Exception ex)
             {
                 LambdaCommon.Log("OnDelegateEndAsync could not send payload to the extension", ex, false);
-                LambdaCommon.EndInvocationAsync(string.Empty, ex, ((CallTargetState)state!).Scope, RequestBuilder).ConfigureAwait(false);
+                await LambdaCommon.EndInvocationAsync(string.Empty, ex, ((CallTargetState)state!).Scope, RequestBuilder).ConfigureAwait(false);
             }
 
             LambdaCommon.Log("DelegateWrapper FINISHED Running OnDelegateEndAsync");
-            return Task.FromResult(returnValue);
+            return returnValue;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -29,7 +29,6 @@ internal static class MetricTags
         [Description("component:traceattributes_pinvoke")] TraceAttributesPinvoke,
         [Description("component:managed")] Managed,
         [Description("component:calltarget_defs_pinvoke")] CallTargetDefsPinvoke,
-        [Description("component:serverless")] Serverless,
         [Description("component:calltarget_derived_defs_pinvoke")] CallTargetDerivedDefsPinvoke,
         [Description("component:calltarget_interface_defs_pinvoke")] CallTargetInterfaceDefsPinvoke,
         [Description("component:discovery_service")] DiscoveryService,

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -29,6 +29,7 @@ internal static class MetricTags
         [Description("component:traceattributes_pinvoke")] TraceAttributesPinvoke,
         [Description("component:managed")] Managed,
         [Description("component:calltarget_defs_pinvoke")] CallTargetDefsPinvoke,
+        [Description("component:serverless")] Serverless,
         [Description("component:calltarget_derived_defs_pinvoke")] CallTargetDerivedDefsPinvoke,
         [Description("component:calltarget_interface_defs_pinvoke")] CallTargetInterfaceDefsPinvoke,
         [Description("component:discovery_service")] DiscoveryService,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -237,7 +237,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             // The numbers here may change, but we should have _some_
-            telemetry.GetDistributions(DistributionShared.InitTime.GetName()).Sum(x => x.Points.Count).Should().BeGreaterThan(5);
+            telemetry.GetDistributions(DistributionShared.InitTime.GetName()).Sum(x => x.Points.Count).Should().BeGreaterThan(4);
 
             telemetry.GetMetricDataPoints(Count.TraceChunkEnqueued.GetName()).Sum(x => x.Value).Should().Be(ExpectedTraces);
 


### PR DESCRIPTION
## Summary of changes

Bugfix for PR-4535. The `EndInvocationAsync` calls should be awaited.
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
