### PR TITLE
[Profiler] Workaround to avoid unwinding SIGSEGV signal handler

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -42,6 +42,7 @@ namespace Samples.Computer01
         private LineNumber _lineNumber;
         private NullThreadNameBugCheck _nullThreadNameBugCheck;
         private MethodsSignature _methodsSignature;
+        private SigSegvHandlerExecution _sigsegvHandler;
 
 #if NET5_0_OR_GREATER
         private OpenLdapCrash _openldapCrash;
@@ -160,9 +161,18 @@ namespace Samples.Computer01
                     StartSocketTimeout();
                     break;
 #endif
+                case Scenario.ForceSigSegvHandler:
+                    StartForceSigSegvHandler();
+                    break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(scenario), $"Unsupported scenario #{_scenario}");
             }
+        }
+
+        private void StartForceSigSegvHandler()
+        {
+            _sigsegvHandler = new SigSegvHandlerExecution();
+            _sigsegvHandler.Start();
         }
 
         public void StopService()
@@ -274,7 +284,15 @@ namespace Samples.Computer01
                     _socketTest.Stop();
                     break;
 #endif
+                case Scenario.ForceSigSegvHandler:
+                    StopForceSigSegvHandler();
+                    break;
             }
+        }
+
+        private void StopForceSigSegvHandler()
+        {
+            _sigsegvHandler.Stop();
         }
 
         public void Run(Scenario scenario, int iterations, int nbThreads, int parameter)
@@ -393,6 +411,9 @@ namespace Samples.Computer01
                         RunSocketTimeout();
                         break;
 #endif
+                    case Scenario.ForceSigSegvHandler:
+                        RunForceSigSegvHandler();
+                        break;
                     default:
                         throw new ArgumentOutOfRangeException(nameof(scenario), $"Unsupported scenario #{_scenario}");
                 }
@@ -401,6 +422,12 @@ namespace Samples.Computer01
             }
 
             Console.WriteLine($"End of {iterations} iterations of {scenario.ToString()} in {sw.Elapsed}");
+        }
+
+        private void RunForceSigSegvHandler()
+        {
+            var test = new SigSegvHandlerExecution();
+            test.Run();
         }
 
         public void RunAsService(TimeSpan timeout, Scenario scenario, int parameter)

--- a/profiler/src/Demos/Samples.Computer01/Program.cs
+++ b/profiler/src/Demos/Samples.Computer01/Program.cs
@@ -35,7 +35,8 @@ namespace Samples.Computer01
         NullThreadNameBug,
         MethodSignature,
         OpenLdapCrash,
-        SocketTimeout
+        SocketTimeout,
+        ForceSigSegvHandler,
     }
 
     public class Program

--- a/profiler/src/Demos/Samples.Computer01/SigSegvHandlerExecution.cs
+++ b/profiler/src/Demos/Samples.Computer01/SigSegvHandlerExecution.cs
@@ -1,0 +1,43 @@
+// <copyright file="SigSegvHandlerExecution.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Samples.Computer01
+{
+    internal class SigSegvHandlerExecution : ScenarioBase
+    {
+        private interface IFluff
+        {
+            void Plop();
+        }
+
+        public override void OnProcess()
+        {
+            try
+            {
+                GetFluff().Plop();
+            }
+            catch
+            {
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Fluffinator GetFluff()
+        {
+            return null;
+        }
+
+        private class Fluffinator
+        {
+            public virtual void Plop()
+            {
+                Console.WriteLine("plop");
+            }
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/UnwinderCrash.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/UnwinderCrash.cs
@@ -1,0 +1,31 @@
+// <copyright file="UnwinderCrash.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.SmokeTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.LinuxOnly
+{
+    [Trait("Category", "LinuxOnly")]
+    public class UnwinderCrash
+    {
+        private const string Scenario = "--scenario 23";
+        private readonly ITestOutputHelper _output;
+
+        public UnwinderCrash(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void CheckThatProfilerDoesNotCrashWhileUnwinding2SignalFrames(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, Scenario, _output);
+            runner.RunAndCheck();
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
Prevent customer app crashing while unwinding SIGSEGV signal handler.

## Reason for change

We got crash report where the profiler, more specifically libunwind, crashed while unwinding a SIGSEGV handler (from libcoreclr). This situation is weird and we do not fully understand what's happening. The [issue was reported upstream](https://github.com/libunwind/libunwind/issues/648) .
Until we have a better understanding or fix, we need a workaround.

## Implementation details

When the profiler is executing a signal handler, the signal (for that handler) is blocked. This can be checked in `uc_sigmask` field from the `ucontext` passed as parameter.
If `SIGSEGV` is part of that set, we can assume that the thread was previously executing a SIGSEGV handler. And we can safely bail.

Note:
In general, this field displays signals that are blocked for the thread, but it's less likely that someone would block SIGSEGV signal for threads. 
## Test coverage
* Added a new smoke test
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
