### PR TITLE
Fix bug when duck typing types with very long names

### DIFF
--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/LongTypeNameTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/LongTypeNameTests.cs
@@ -1,0 +1,150 @@
+﻿// <copyright file="LongTypeNameTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using FluentAssertions;
+using Xunit;
+
+#pragma warning disable SA1201 // Elements must appear in the correct order
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1403 // file may only contain one namespace
+
+namespace Datadog.Trace.DuckTyping.Tests
+{
+    public class LongTypeNameTests
+    {
+        public const string ExpectedValue = "It works!";
+
+        [Fact]
+        public void CanDuckTypeLongNamedTypes()
+        {
+            // We saw this in an escalation
+            // Type name was too long. The fully qualified type name must be less than 1,024 characters
+            // Note that this limitation doesn't include the length of any parent classes for nested types
+            // or the length of the assembly name
+            const int maxTypeNameSize = 1024;
+
+            var originalTestCase = new Grpc.AspNetCore.Server.Internal.CallHandlers.UnaryServerCallHandler<
+                                       SomeNamespace.ThatIsPrettyLong.Ish.Services.ProductSecretValuesServiceImpl<
+                                           SomeNamespace.ThatIsPrettyLong.Ish.Data.Infrastructure.Database.Connection.DatabaseConnectionHandle,
+                                           SomeNamespace.ThatIsPrettyLong.Ish.Data.Infrastructure.Database.Transaction.DatabaseTransactionHandle>,
+                                        SomeNamespace.ThatIsPrettyLong.Ish.Services.SomeBigProductThing.GetSuperSecretWossnameToHandleThisNewRequest,
+                                        SomeNamespace.ThatIsPrettyLong.Ish.Services.SomeBigProductThing.ThisTestWossnameResponse>();
+
+            var longGeneric = new MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                    MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                        MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                            MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                    MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                        MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                            MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                                MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                                    MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                                        MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                                            MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                                                MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<
+                                                                    MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<string>>>>>>>>>>>>>>>();
+
+            // We can't create a type which has a "raw" name longer than 1024 (doesn't compile)
+            // But this will mean will still need to do some truncation when creating the type
+            var javaStyle = new CreatingSomeNestingToMakeThingsEvenWorse.MyTargetTypeThatHasAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName();
+
+            longGeneric.GetType().FullName!.Length.Should().BeGreaterThan(maxTypeNameSize);
+            originalTestCase.GetType().FullName!.Length.Should().BeGreaterThan(maxTypeNameSize);
+
+            // original test case
+            var interfaceProxy = originalTestCase.DuckCast<ILongNamedTypeProxy>();
+            interfaceProxy.Value.Should().Be(ExpectedValue);
+
+            var structProxy = longGeneric.DuckCast<LongNamedTypeProxy>();
+            structProxy.Value.Should().Be(ExpectedValue);
+
+            // long generic
+            interfaceProxy = longGeneric.DuckCast<ILongNamedTypeProxy>();
+            interfaceProxy.Value.Should().Be(ExpectedValue);
+
+            structProxy = longGeneric.DuckCast<LongNamedTypeProxy>();
+            structProxy.Value.Should().Be(ExpectedValue);
+
+            // javaStyle
+            interfaceProxy = javaStyle.DuckCast<ILongNamedTypeProxy>();
+            interfaceProxy.Value.Should().Be(ExpectedValue);
+
+            structProxy = javaStyle.DuckCast<LongNamedTypeProxy>();
+            structProxy.Value.Should().Be(ExpectedValue);
+        }
+
+        public class MyTargetTypeThatHasAReallyReallyReallyLongNameAndIsGenericToMakeItWorse<T>
+        {
+            public string Value => ExpectedValue;
+        }
+
+        public class CreatingSomeNestingToMakeThingsEvenWorse
+        {
+            public class MyTargetTypeThatHasAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongName
+            {
+                public string Value => ExpectedValue;
+            }
+        }
+
+        public interface ILongNamedTypeProxy
+        {
+            public string Value { get; }
+        }
+
+        [DuckCopy]
+        public struct LongNamedTypeProxy
+        {
+            public string Value;
+        }
+    }
+}
+
+namespace Grpc.AspNetCore.Server.Internal.CallHandlers
+{
+    public class UnaryServerCallHandler<T1, T2, T3>
+    {
+        public string Value => Datadog.Trace.DuckTyping.Tests.LongTypeNameTests.ExpectedValue;
+    }
+}
+
+namespace SomeNamespace.ThatIsPrettyLong.Ish
+{
+    namespace Services
+    {
+        public class ProductSecretValuesServiceImpl<T1, T2>
+        {
+        }
+
+        namespace SomeBigProductThing
+        {
+            public class GetSuperSecretWossnameToHandleThisNewRequest
+            {
+            }
+
+            public class ThisTestWossnameResponse
+            {
+            }
+        }
+    }
+
+    namespace Data.Infrastructure.Database
+    {
+        public class Connection
+        {
+            public class DatabaseConnectionHandle
+            {
+            }
+        }
+
+        public class Transaction
+        {
+            public class DatabaseTransactionHandle
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Handles the case where the type we're proxying has a very long type name

## Reason for change

We had a recent support case in which we were proxying a type that had a very long type name. When we tried to duck type it, we were getting an exception `System.ArgumentException: Type name was too long. The fully qualified type name must be less than 1,024 characters. (Parameter 'fullname')`

```
2023-10-03 13:38:15.439 +02:00 [ERR] Exception occurred when calling the CallTarget integration continuation. Datadog.Trace.DuckTyping.DuckTypeException: Error creating duck type using proxy: 'Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspNetCoreServer.ServerCallHandlerBaseStruct'
 ---> System.ArgumentException: Type name was too long. The fully qualified type name must be less than 1,024 characters. (Parameter 'fullname')
   at System.Reflection.Emit.TypeBuilder..ctor(String fullname, TypeAttributes attr, Type parent, Type[] interfaces, ModuleBuilder module, PackingSize iPackingSize, Int32 iTypeSize, TypeBuilder enclosingType)
   at System.Reflection.Emit.ModuleBuilder.DefineType(String name, TypeAttributes attr, Type parent, Type[] interfaces)
   at Datadog.Trace.DuckTyping.DuckType.CreateTypeAndModuleBuilder(Type typeToDeriveFrom, Type typeToDelegateTo, TypeBuilder& proxyTypeBuilder, FieldInfo& instanceField) in c:\mnt\tracer\src\Datadog.Trace\DuckTyping\DuckType.cs:line 380
   at Datadog.Trace.DuckTyping.DuckType.CreateProxyType(Type proxyDefinitionType, Type targetType, Boolean dryRun) in c:\mnt\tracer\src\Datadog.Trace\DuckTyping\DuckType.cs:line 192
   --- End of inner exception stack trace ---
   at Datadog.Trace.DuckTyping.DuckTypeException.Throw(String message, Exception innerException) in c:\mnt\tracer\src\Datadog.Trace\DuckTyping\DuckTypeExceptions.cs:line 45
   at Datadog.Trace.DuckTyping.DuckType.CreateProxyType(Type proxyDefinitionType, Type targetType, Boolean dryRun) in c:\mnt\tracer\src\Datadog.Trace\DuckTyping\DuckType.cs:line 237
--- End of stack trace from previous location ---
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspNetCoreServer.GrpcDotNetServerCommon.CreateServerSpan[T](Tracer tracer, T instance, HttpRequest requestMessage) in c:\mnt\tracer\src\Datadog.Trace\ClrProfiler\AutoInstrumentation\Grpc\GrpcDotNet\GrpcAspNetCoreServer\GrpcDotNetServerCommon.cs:line 32
   at ServerCallHandlerBaseHandleCallAsyncIntegration.OnMethodBegin(Object, HttpContext&)
   at Grpc.AspNetCore.Server.Internal.CallHandlers.ServerCallHandlerBase`3.HandleCallAsync(HttpContext httpContext)
```

## Implementation details

Pretty crude truncation of the type name to make sure we don't exceed the 2023 maximum size. 

Theoretically, we were trying to make the proxy type names have "valid" names. That's because the benchmark dotnet project uses the proxy type directly in c# code and compiles against it, so it has to be a valid type.

With this truncation, the type is no longer guaranteed to be a valid C# type name, but that was _already_ the case for generics anyway (because they use the AQN for type arguments) so we don't really care.

## Test coverage

Added explicit regression tests for long name scenarios in the duck type unit tests project. All the existing tests cover "short name" scenarios, we the change should be pretty safe.

## Other details

We might want refactor and simplify the name generation here in general, as we mostly use the proxy names for better stacktraces etc. For example, we also use the target type name in the generated assembly name, which could make for very big type names in some cases.

I didn't want to do any of that cleanup in this PR, instead just focusing on creating a fix.


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
