### PR TITLE
Avoid loader injection on <CrtImplementationDetails>

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1512,6 +1512,17 @@ HRESULT STDMETHODCALLTYPE CorProfiler::JITCompilationStarted(FunctionID function
                 
             pType = pType->parent_type;
         }
+
+        // *********************************************************************
+        // Checking if the caller is inside of the <CrtImplementationDetails> type
+        // *********************************************************************
+
+        if (caller.type.name.find(WStr("<CrtImplementationDetails>")) != shared::WSTRING::npos)
+        {
+            Logger::Debug("JITCompilationStarted: Startup hook skipped from ", caller.type.name, ".", caller.name, "()");
+            return S_OK;
+        }
+
         // *********************************************************************
 
         bool domain_neutral_assembly = runtime_information_.is_desktop() && corlib_module_loaded &&


### PR DESCRIPTION
## Summary of changes

This PR is a continuation of #4274 by skipping the managed loader injection on the `<CrtImplementationDetails>` type and nested types

## Reason for change

Same customer returned with another issue regarding on the managed loader injection on the `<CrtImplementationDetails>` type.


## Tests

Manual testing with the following application in `.NET Framework`:

```csharp
using System.Data;

var newDomain = AppDomain.CreateDomain("Child");
newDomain.CreateInstance(typeof(DataTable).Assembly.FullName, typeof(DataTable).FullName);
```

The native logs indicates that the `<CrtImplementationDetails>` type is skipped:
```log
...
10/25/23 01:56:46.295 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>..cctor()
10/25/23 01:56:46.296 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.{ctor}()
10/25/23 01:56:46.296 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.gcroot<System::String ^>.{ctor}()
10/25/23 01:56:46.296 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.Initialize()
10/25/23 01:56:46.296 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.___CxxCallUnwindDtor()
10/25/23 01:56:46.296 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.Cleanup()
10/25/23 01:56:46.297 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.gcroot<System::String ^>.=()
10/25/23 01:56:46.297 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport._Initialize()
10/25/23 01:56:46.297 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.InitializeVtables()
10/25/23 01:56:46.297 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>._initterm_m()
10/25/23 01:56:46.297 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.DefaultDomain.NeedsInitialization()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.DefaultDomain.HasPerProcess()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.DefaultDomain.HasNative()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.InitializePerAppDomain()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>._initatexit_app_domain()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.AtExitLock.AddRef()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.AtExitLock._lock_Get()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.AtExitLock._handle()
10/25/23 01:56:46.298 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.AtExitLock._lock_Set()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.ThisModule.ResolveMethod<void const * __clrcall(void)>()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.ThisModule.Handle()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.?A0x6a95255b.??__E?Initialized@CurrentDomain@<CrtImplementationDetails>@@$$Q2HA@@YMXXZ()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.?A0x6a95255b.??__E?Uninitialized@CurrentDomain@<CrtImplementationDetails>@@$$Q2HA@@YMXXZ()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.?A0x6a95255b.??__E?IsDefaultDomain@CurrentDomain@<CrtImplementationDetails>@@$$Q2_NA@@YMXXZ()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.?A0x6a95255b.??__E?InitializedNative@CurrentDomain@<CrtImplementationDetails>@@$$Q2W4Progress@2@A@@YMXXZ()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.?A0x6a95255b.??__E?InitializedPerProcess@CurrentDomain@<CrtImplementationDetails>@@$$Q2W4Progress@2@A@@YMXXZ()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.?A0x6a95255b.??__E?InitializedPerAppDomain@CurrentDomain@<CrtImplementationDetails>@@$$Q2W4Progress@2@A@@YMXXZ()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.InitializeUninitializer()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.RegisterModuleUninitializer()
10/25/23 01:56:46.299 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <CrtImplementationDetails>.ModuleUninitializer..cctor()
10/25/23 01:56:46.300 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <CrtImplementationDetails>.ModuleUninitializer..ctor()
10/25/23 01:56:46.300 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.DomainUnload()
10/25/23 01:56:46.300 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.<CrtImplementationDetails>.LanguageSupport.{dtor}()
10/25/23 01:56:46.300 PM [55196|12524] [debug] JITCompilationStarted: Startup hook skipped from <Module>.gcroot<System::String ^>.{dtor}()
10/25/23 01:56:46.300 PM [55196|12524] [info] JITCompilationStarted: Startup hook registered in function_id=152099464 token=100666456 name=System.Data.DataTable..ctor(), assembly_name=System.Data app_domain_id=125681440 domain_neutral=0
...
```

Also tested with a mixed-mode C++/CLR application. This test demonstrates the customer's issue, in which the SSL/TLS configuration gets messed up with our injection point. Confirmed the fix here resolves the issue. 

> Note, haven't included the app here, because not trying to test this app regularly in CI etc as it requires additional workloads. This is a niche enough issue, with a small enough parameter space, that I don't think it's worth the time or effort to go further. The following instructions describe how to recreate the app I tested with.

1. Follow the instructions [here](https://learn.microsoft.com/en-us/cpp/dotnet/walkthrough-compiling-a-cpp-program-that-targets-the-clr-in-visual-studio?view=msvc-170) to create a new C++/CLR console project called _MixedModeClrConsoleApp_. Note that you'll need the **Desktop development with C++** workload in the VS installer and check the optional **C++/CLI Support** component (I used **latest**)
2. After creating a new project, open _MixedModeClrConsoleApp.cpp_ and replace the contents with the following:
```cpp
#include "pch.h"
#include <iostream>

using namespace System;
namespace OtherClasses
{
    public ref class Widget
    {
    public:
        [System::Runtime::CompilerServices::MethodImplAttribute(System::Runtime::CompilerServices::MethodImplOptions::NoInlining)]
        void DontInlineMe()
        {
            // Broken: Ssl3, Tls
            // Fixed: Tls, Tls11, Tls12, Tls13
            System::Console::WriteLine(System::Net::ServicePointManager::SecurityProtocol.ToString());
        }
    };
}

namespace WhatIsThisStuff
{
    int main(array<System::String ^> ^args)
    {
        System::Text::StringBuilder^ builder = gcnew System::Text::StringBuilder;
        builder->AppendLine("Calling some managed classes.");
        System::Console::WriteLine(builder->ToString());

        OtherClasses::Widget^ widget = gcnew OtherClasses::Widget;
        widget->DontInlineMe();
        return 0;
    }
}
```
3. Right-click the Project name > **Properties**. Under **Linker** > **Advanced** > **Entry Point** set the value `main`:
![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/34eaaa59-4fd3-46ac-aa9f-d5320adcb660)

4. Build and run the app.
