### PR TITLE
Fix compilation errors in CodeQL job

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DogstatsdService.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DogstatsdService.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <string>
+#include <cstdint>
 
 #include "IMetricsSender.h"
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <tuple>
 #include <vector>
+#include <cstdint>
 
 #include "TagsHelper.h"
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IDebugInfoStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IDebugInfoStore.h
@@ -9,6 +9,7 @@
 // end
 
 #include <string_view>
+#include <cstdint>
 
 struct SymbolDebugInfo
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IFrameStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IFrameStore.h
@@ -6,6 +6,7 @@
 #include "corprof.h"
 
 #include <string>
+#include <cstdint>
 
 struct FrameInfoView
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IMetricsSender.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IMetricsSender.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <cstdint>
 
 class IMetricsSender
 {

--- a/shared/src/native-src/miniutf.hpp
+++ b/shared/src/native-src/miniutf.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "stdint.h"
+#include <cstdint>
 #include <string>
 
 namespace miniutf {

--- a/shared/src/native-src/miniutf.hpp
+++ b/shared/src/native-src/miniutf.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "stdint.h"
 #include <string>
 
 namespace miniutf {


### PR DESCRIPTION
## Summary of changes

Sprinkle our code with some `#include <cstdint>`

## Reason for change

The ubuntu-latest github action images have been updated, and now include gcc 13. It causes a bunch of compilation errors because some headers are not implicitly included anymore.
