### PR TITLE
Remove the check command on OSX

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckCommand.cs
@@ -23,9 +23,19 @@ namespace Datadog.Trace.Tools.Runner
         {
             _applicationContext = applicationContext;
 
-            AddArgument(Command);
-
-            this.SetHandler(Execute);
+            if (applicationContext.Platform == Platform.MacOS)
+            {
+                this.SetHandler(context =>
+                {
+                    Utils.WriteError("The check command is not supported on MacOS.");
+                    context.ExitCode = 1;
+                });
+            }
+            else
+            {
+                AddArgument(Command);
+                this.SetHandler(Execute);
+            }
         }
 
         public Argument<string[]> Command { get; } = new("command", CommandLineHelpers.ParseArrayArgument, isDefault: true);

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -102,7 +102,10 @@ namespace Datadog.Trace.Tools.Runner
             ciCommand.AddCommand(new RunCiCommand(applicationContext));
             ciCommand.AddCommand(new CrankCommand());
 
-            builder.Command.AddCommand(new CheckCommand(applicationContext));
+            if (platform != Platform.MacOS)
+            {
+                builder.Command.AddCommand(new CheckCommand(applicationContext));
+            }
 
             builder.Command.AddCommand(new RunCommand(applicationContext));
             builder.Command.AddCommand(new AotCommand { IsHidden = true });

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Help;
-using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Builder;
 using System.CommandLine.Help;
+using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.IO;
 using System.Linq;
@@ -102,10 +103,7 @@ namespace Datadog.Trace.Tools.Runner
             ciCommand.AddCommand(new RunCiCommand(applicationContext));
             ciCommand.AddCommand(new CrankCommand());
 
-            if (platform != Platform.MacOS)
-            {
-                builder.Command.AddCommand(new CheckCommand(applicationContext));
-            }
+            builder.Command.AddCommand(new CheckCommand(applicationContext));
 
             builder.Command.AddCommand(new RunCommand(applicationContext));
             builder.Command.AddCommand(new AotCommand { IsHidden = true });


### PR DESCRIPTION
## Summary of changes

Remove the `dd-trace check` command on OSX.

## Reason for change

dd-dotnet is currently not available on OSX, so the command would return an error.
