### PR TITLE
[Tracing] Fix WebRequest bug with existing distributed tracing headers

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HeadersInjectedCache.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HeadersInjectedCache.cs
@@ -1,0 +1,31 @@
+// <copyright file="HeadersInjectedCache.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Net;
+using System.Runtime.CompilerServices;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest;
+
+internal static class HeadersInjectedCache
+{
+    private static readonly object InjectedValue = new();
+    private static readonly ConditionalWeakTable<WebHeaderCollection, object> Cache = new();
+
+    public static void SetInjectedHeaders(WebHeaderCollection headers)
+    {
+#if NETCOREAPP3_1_OR_GREATER
+        Cache.AddOrUpdate(headers, InjectedValue);
+#else
+        Cache.GetValue(headers, _ => InjectedValue);
+#endif
+    }
+
+    public static bool TryGetInjectedHeaders(WebHeaderCollection headers)
+    {
+        return Cache.TryGetValue(headers, out _);
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetRequestStream_Integration.cs
@@ -72,7 +72,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
                         // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
                         // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
+                        // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
+                        // added by us, not the application
                         SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_BeginGetResponse_Integration.cs
@@ -65,7 +65,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         // Add distributed tracing headers to the HTTP request.
                         // We don't want to set an active scope now, because it's possible that EndGetResponse will never be called.
                         // Instead, we generate a spancontext and inject it in the headers. EndGetResponse will fetch them and create an active scope with the right id.
+                        // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
+                        // added by us, not the application
                         SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                     }
                 }
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_EndGetResponse_Integration.cs
@@ -65,7 +65,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                 }
 
                 // Check if any headers were injected by a previous call
-                var existingSpanContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
+                // Since it is possible for users to manually propagate headers (which we should
+                // overwrite), check our cache which will be populated with header objects
+                // that we have injected context into
+                SpanContext existingSpanContext = null;
+                if (HeadersInjectedCache.TryGetInjectedHeaders(request.Headers))
+                {
+                    existingSpanContext = SpanContextPropagator.Instance.Extract(request.Headers.Wrap());
+                }
 
                 // If this operation creates the trace, then we need to re-apply the sampling priority
                 bool setSamplingPriority = existingSpanContext?.SamplingPriority != null && Tracer.Instance.ActiveScope == null;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/WebRequest/HttpWebRequest_GetRequestStream_Integration.cs
@@ -67,7 +67,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Http.WebRequest
                         // The expected sequence of calls is GetRequestStream -> GetResponse. Headers can't be modified after calling GetRequestStream.
                         // At the same time, we don't want to set an active scope now, because it's possible that GetResponse will never be called.
                         // Instead, we generate a spancontext and inject it in the headers. GetResponse will fetch them and create an active scope with the right id.
+                        // Additionally, add the request headers to a cache to indicate that distributed tracing headers were
+                        // added by us, not the application
                         SpanContextPropagator.Instance.Inject(span.Context, request.Headers.Wrap());
+                        HeadersInjectedCache.SetInjectedHeaders(request.Headers);
                     }
                 }
             }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("SupportsInstrumentationVerification", "True")]
         public void RenamesService()
         {
-            var expectedSpanCount = 82;
+            var expectedSpanCount = 87;
 
             SetInstrumentationVerification();
             const string expectedOperationName = "http.request";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("SupportsInstrumentationVerification", "True")]
         public void RenamesService()
         {
-            var expectedSpanCount = 82;
+            var expectedSpanCount = 87;
 
             SetInstrumentationVerification();
             const string expectedOperationName = "http.request";


### PR DESCRIPTION
## Summary of changes
When we pre-emptively add distributed tracing headers in `WebRequest.BeginGetRequestStream`, `WebRequest.BeginGetResponse`, and `WebRequest.GetRequestStream`, add the headers to a cache to signal to the later integrations that we had last updated the headers and we are responsible for the distributed tracing headers in the WebRequest object.

When we check for the pre-emptively added distributed tracing headers in `WebRequest.EndGetResponse`, `WebRequest.GetResponse` and `WebRequest.GetResponseAsync`, first check a cache to know whether we added distributed tracing headers to the WebRequest object. If present, then continue to use the injected trace context. Otherwise, we create a new context.

## Reason for change
In our `GetResponse` integrations, we check the WebRequest headers to see if we had to pre-emptively add distributed tracing headers before the headers became locked, and if they are present then we use that context for the newly created WebRequest span.

The problem with this, as seen in a user issue, is that some applications may proxy incoming headers to the outbound HTTP requests. Before this change, our handling would cause our integrations for `WebRequest.EndGetResponse`, `WebRequest.GetResponse`, and `WebRequest.GetResponseAsync` to re-use the trace context in the headers for the WebRequest span, which results in the server span and the outgoing HTTP span having the same trace-id and span-id. After the fix, we only re-use the trace context when we know that we had last updated the headers.

## Implementation details
For our cache, we use (surprise!) a ConditionalWeakTable to keep track of request headers that we injected a trace context into. We use this data structure because it will remove stale entries when the keys are no longer referenced. In the `GetResponse` integrations we only use the trace context from the request headers if our automatic instrumentation had injected the headers.

## Test coverage
Update the WebRequest test application to manually add distributed tracing headers, and rewrite the integration tests to collect all spans from the application and assert that there are no duplicate trace-id/span-id combinations. Before the product change, we would see duplicates from the `GetResponse` and `GetResponseAsync` calls.

## Other details
N/A