### PR TITLE
Add error message when IIS is not found

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Resources.cs
@@ -30,6 +30,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
         public const string AspNetCoreProcessNotFound = "Could not find the ASP.NET Core applicative process.";
         public const string VersionConflict = "Tracer version 1.x can't be loaded simultaneously with other versions and will produce orphaned traces. Make sure to synchronize the Datadog.Trace NuGet version with the installed automatic instrumentation package version.";
         public const string IisExpressWorkerProcess = "Cannot detect the worker process when using IIS Express. Use the --workerProcess option to manually provide it.";
+        public const string IisNotFound = "Could not find IIS. Make sure IIS is properly installed and enable, and run the tool from an elevated prompt.";
 
         public const string TracingWithBundleProfilerPath = "Check failing with Datadog.Trace.Bundle Nuget, related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-core/?tab=nuget#install-the-tracer";
         public const string TracingWithInstallerWindowsNetFramework = "Installer/MSI related documentation: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/dotnet-framework?tab=windows#install-the-tracer";

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/IisManager.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/IIS/IisManager.cs
@@ -36,7 +36,15 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows.IIS
 
             if (result != 0)
             {
-                Utils.WriteError(Resources.IisManagerInitializationError(Marshal.GetPInvokeErrorMessage(result)));
+                if (result == -2147221164)
+                {
+                    Utils.WriteError(Resources.IisNotFound);
+                }
+                else
+                {
+                    Utils.WriteError(Resources.IisManagerInitializationError(Marshal.GetPInvokeErrorMessage(result)));
+                }
+
                 return null;
             }
 


### PR DESCRIPTION
## Summary of changes

Display a specific message when IIS is not installed.

## Reason for change

It looks like _some people_ are trying to run the tool without installing IIS.

## Implementation details

Asked _some people_ to give me the error code then pasted it in the code.

## Test coverage

That's difficult to test, short of asking _some people_ to run it on their machine.