### PR TITLE
Properly feed the arguments to dd-dotnet

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckCommand.cs
@@ -57,8 +57,6 @@ namespace Datadog.Trace.Tools.Runner
                     $"Unsupported platform/architecture combination: ({other.platform}{(other.musl ? " musl" : string.Empty)}/{other.arch})")
             };
 
-            var commandLine = string.Join(' ', Environment.GetCommandLineArgs().Skip(1));
-
             if (!File.Exists(ddDotnet))
             {
                 Utils.WriteError($"dd-dotnet not found at {ddDotnet}");
@@ -72,7 +70,13 @@ namespace Datadog.Trace.Tools.Runner
                 Process.Start("chmod", $"+x {ddDotnet}")!.WaitForExit();
             }
 
-            var startInfo = new ProcessStartInfo(ddDotnet, commandLine) { UseShellExecute = false };
+            var startInfo = new ProcessStartInfo(ddDotnet) { UseShellExecute = false };
+
+            foreach (var arg in Environment.GetCommandLineArgs().Skip(1))
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+
             startInfo.EnvironmentVariables["DD_INTERNAL_OVERRIDE_COMMAND"] = "dd-trace";
 
             var process = Process.Start(startInfo);

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
@@ -32,7 +32,7 @@ public class CheckCommandTests : RunnerTests
         helper.Drain();
 
         helper.Process.ExitCode.Should().Be(1);
-        helper.StandardOutput.Should().Contain("Could not find IIS application \"hello world\".");
+        helper.StandardOutput.Should().Contain("Could not find IIS application \"hello world/\".");
         helper.ErrorOutput.Should().NotContain("Unrecognized command or argument");
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
@@ -22,4 +22,17 @@ public class CheckCommandTests : RunnerTests
         helper.StandardOutput.Should().Contain("dd-trace check [command] [options]");
         helper.ErrorOutput.Should().Contain("Required command was not provided.");
     }
+
+    [Fact]
+    public void MultipleArguments()
+    {
+        using var helper = StartProcess("check iis \"hello world\"");
+
+        helper.Process.WaitForExit();
+        helper.Drain();
+
+        helper.Process.ExitCode.Should().Be(1);
+        helper.StandardOutput.Should().Contain("Could not find IIS application \"hello world\".");
+        helper.ErrorOutput.Should().NotContain("Unrecognized command or argument");
+    }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
@@ -11,7 +11,7 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests;
 
 public class CheckCommandTests : RunnerTests
 {
-    [Fact]
+    [SkippableFact]
     public void Help()
     {
         using var helper = StartProcess("check");
@@ -24,7 +24,7 @@ public class CheckCommandTests : RunnerTests
         helper.ErrorOutput.Should().Contain("Required command was not provided.");
     }
 
-    [Fact]
+    [SkippableFact]
     public void MultipleArguments()
     {
         // Currently we can only test this one Windows.

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -26,6 +27,9 @@ public class CheckCommandTests : RunnerTests
     [Fact]
     public void MultipleArguments()
     {
+        // Currently we can only test this one Windows.
+        // The only command that accepts a space is "check iis" and it's not available on Linux.
+        SkipOn.Platform(SkipOn.PlatformValue.Linux);
         using var helper = StartProcess("check iis \"hello world\"");
 
         helper.Process.WaitForExit();


### PR DESCRIPTION
## Summary of changes

When calling dd-dotnet from dd-trace with an argument that contains spaces (for instance: `dd-trace check "default web site"`, the quotes were removed which caused dd-dotnet to incorrectly interpret the command.

## Implementation details

Use `ProcessStartInfo.ArgumentList` instead of `ProcessStartInfo.Arguments`.

## Test coverage

Add a test case with an escaped argument.
