### PR TITLE
[Dynamic Instrumentation] Fixed a crash caused by improper handling of module unload

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ModuleUnloadTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ModuleUnloadTest.verified.txt
@@ -1,0 +1,112 @@
+[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "11": {
+              "arguments": {
+                "k": {
+                  "type": "Int32",
+                  "value": "5"
+                },
+                "this": {
+                  "fields": {
+                    "_number": {
+                      "type": "Int32",
+                      "value": "0"
+                    }
+                  },
+                  "type": "ExternalTest",
+                  "value": "ExternalTest"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "UnreferencedExternalClass.cs",
+            "lines": [
+              11
+            ]
+          }
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "InstrumentMe",
+      "name": "Samples.Probes.Unreferenced.External.ExternalTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "12": {
+              "arguments": {
+                "k": {
+                  "type": "Int32",
+                  "value": "5"
+                },
+                "this": {
+                  "fields": {
+                    "_number": {
+                      "type": "Int32",
+                      "value": "1208223660"
+                    }
+                  },
+                  "type": "ExternalTest",
+                  "value": "ExternalTest"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "UnreferencedExternalClass.cs",
+            "lines": [
+              12
+            ]
+          }
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "InstrumentMe",
+      "name": "Samples.Probes.Unreferenced.External.ExternalTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.ModuleUnloadTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.ModuleUnloadTest.verified.txt
@@ -1,0 +1,26 @@
+[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/ModuleUnloadTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/ModuleUnloadTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+#if NET462
+    /// <summary>
+    /// Important: This test has two phases. Upon first execution, it will create a new appdomain, execute some code inside of it and then destroy it & load the assembly `Samples.Probes.Unreferenced.External.dll`
+    /// and upon second execution it will execute code from inside that assembly (namely Samples.Probes.Unreferenced.External.ExternalTest.InstrumentMe).
+    /// Refer to the test `ModuleUnloadInNetFramework462Test` for more information.
+    /// </summary>
+    public class ModuleUnloadTest : IRun
+    {
+        private static AppDomain _newAppDomain;
+
+        public void Run()
+        {
+            const string loadedOnDemandAssemblyName = "Samples.Probes.Unreferenced.External";
+            var unreferencedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(asm => asm.FullName.Contains(loadedOnDemandAssemblyName));
+
+            if (unreferencedAssembly != null)
+            {
+                ExecuteCodeInCurrentAppDomain(unreferencedAssembly);
+            }
+            else
+            {
+                _newAppDomain = AppDomain.CreateDomain("NewAppDomain");
+
+                _newAppDomain.DoCallBack(LoadAndExecuteInNewAppDomain);
+
+                AppDomain.Unload(_newAppDomain);
+
+                var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+                var executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
+                var assemblyPath = Path.Combine(baseDirectory, "Samples.Probes.Unreferenced.External.dll");
+                Assembly.LoadFrom(assemblyPath);
+            }
+
+        }
+
+        public static void ExecuteCodeInCurrentAppDomain(Assembly assembly)
+        {
+            Type externalTestClassType = assembly.GetType("Samples.Probes.Unreferenced.External.ExternalTest");
+            object externalTestClassInstance = Activator.CreateInstance(externalTestClassType);
+            MethodInfo instrumentMeMethod = externalTestClassType.GetMethod("InstrumentMe");
+            instrumentMeMethod.Invoke(externalTestClassInstance, new object[] { 5 });
+        }
+
+        public static void LoadAndExecuteInNewAppDomain()
+        {
+            var baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            var assemblyPath = Path.Combine(baseDirectory, "Samples.Probes.Unreferenced.External.dll");
+            var loadedAssembly = Assembly.Load(File.ReadAllBytes(assemblyPath));
+
+            var externalTestClassType = loadedAssembly.GetType("Samples.Probes.Unreferenced.External.ExternalTest");
+            var externalTestClassInstance = Activator.CreateInstance(externalTestClassType);
+
+            var instrumentMeMethod = externalTestClassType.GetMethod("InstrumentMe");
+            instrumentMeMethod.Invoke(externalTestClassInstance, new object[] { 5 });
+        }
+    }
+
+#endif
+}


### PR DESCRIPTION
## Summary of changes
We experienced a crash of AccessViolation while trying to touch a ModuleID that is no longer in memory.
It was due to improper handling of `ModuleUnloadStarted` callback, where the incoming module was not removed correctly.

## Reason for change
Fix AccessViolation.

## Implementation details
Removing the module properly.

## Test coverage
Added the test`ModuleUnloadInNetFramework462Test`, that creates a new appdomain & destroys it to force several modules to be unloaded, and then it tries to execute Dynamic Instrumentation probe.