### PR TITLE
Fix installer smoke tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4713,6 +4713,7 @@ stages:
         mkdir -p tracer/build_data/logs
       displayName: create test data directories
 
+    # Run the "normal" installer smoke tests
     - script: |
         docker-compose -p ddtrace_$(Build.BuildNumber) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
@@ -4731,6 +4732,23 @@ stages:
         target: 'smoke-tests'
         snapshotPrefix: "smoke_test"
 
+    # Run the "dd-dotnet" installer smoke tests
+    - script: |
+        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+          --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg INSTALL_CMD="$(installCmd)" \
+          dd-dotnet-smoke-tests
+      env:
+        dockerTag: $(dockerTag)
+      displayName: docker-compose build smoke-tests
+      retryCountOnTaskFailure: 3
+
+    - template: steps/run-snapshot-test.yml
+      parameters:
+        target: 'dd-dotnet-smoke-tests'
+        snapshotPrefix: "smoke_test"
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
@@ -4806,7 +4824,7 @@ stages:
 
     - script: |
         docker-compose -p ddtrace_$(Build.BuildNumber) build \
-          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
@@ -4965,72 +4983,6 @@ stages:
         baseImage: alpine
         command: "CheckSmokeTestsForErrors"
 
-- stage: dd_dotnet_installer_smoke_tests_linux
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [package_linux, generate_variables, merge_commit_id]
-  variables:
-    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
-    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-  jobs:
-    - template: steps/update-github-status-jobs.yml
-      parameters:
-        jobs: [linux]
-
-    - job: linux
-      timeoutInMinutes: 45 # should take ~5 mins
-      strategy:
-        # This uses the same matrix as installer_smoke_tests
-        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_smoke_tests_matrix'] ]
-      variables:
-        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
-      pool:
-        vmImage: ubuntu-20.04
-      
-      steps:
-        - template: steps/clone-repo.yml
-          parameters:
-            targetShaId: $(targetShaId)
-            targetBranch: $(targetBranch)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download artifacts to smoke test directory
-          inputs:
-            artifact: $(linuxArtifacts)
-            path: $(smokeTestAppDir)/artifacts
-
-        - script: |
-            mkdir -p tracer/build_data/snapshots
-            mkdir -p tracer/build_data/logs
-          displayName: create test data directories
-
-        - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
-              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
-              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
-              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
-              --build-arg INSTALL_CMD="$(installCmd)" \
-              dd-dotnet-smoke-tests
-          env:
-            dockerTag: $(dockerTag)
-          displayName: docker-compose build smoke-tests
-          retryCountOnTaskFailure: 3
-
-        - template: steps/run-snapshot-test.yml
-          parameters:
-            target: 'dd-dotnet-smoke-tests'
-            snapshotPrefix: "smoke_test"
-
-        - publish: tracer/build_data
-          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
-          condition: succeededOrFailed()
-          continueOnError: true
-
-        - template: steps/run-in-docker.yml
-          parameters:
-            build: true
-            baseImage: alpine
-            command: "CheckSmokeTestsForErrors"
-
 - stage: dotnet_tool_self_instrument_smoke_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
@@ -5141,6 +5093,7 @@ stages:
             mkdir -p tracer/build_data/logs
           displayName: create test data directories
 
+        # Run the "normal" installer smoke tests 
         - script: |
             docker-compose -p ddtrace_$(Build.BuildNumber) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
@@ -5156,6 +5109,24 @@ stages:
         - template: steps/run-snapshot-test.yml
           parameters:
             target: 'smoke-tests'
+            snapshotPrefix: "smoke_test"
+
+        # Run the "dd-dotnet" installer smoke tests
+        - script: |
+            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              --build-arg INSTALL_CMD="$(installCmd)" \
+              dd-dotnet-smoke-tests
+          env:
+            dockerTag: $(dockerTag)
+          displayName: docker-compose build smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'dd-dotnet-smoke-tests'
             snapshotPrefix: "smoke_test"
 
         - publish: tracer/build_data
@@ -5231,7 +5202,7 @@ stages:
 
     - script: |
         docker-compose -p ddtrace_$(Build.BuildNumber) build \
-          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
@@ -5320,67 +5291,6 @@ stages:
         baseImage: debian
         command: "CheckSmokeTestsForErrors"
 
-- stage: dd_dotnet_installer_smoke_tests_arm64
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
-  dependsOn: [package_arm64, generate_variables, merge_commit_id]
-  variables:
-    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
-    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-  jobs:
-    - template: steps/update-github-status-jobs.yml
-      parameters:
-        jobs: [linux]
-
-    - job: linux
-      timeoutInMinutes: 45 # should take ~15 mins
-      strategy:
-        # This uses the same matrix as installer_smoke_tests_arm64
-        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_smoke_tests_arm64_matrix'] ]
-      variables:
-        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
-      pool:
-        name: aws-arm64-auto-scaling
-
-      steps:
-        - task: DownloadPipelineArtifact@2
-          displayName: Download artifacts to smoke test directory
-          inputs:
-            artifact: $(linuxArtifacts)
-            path: $(smokeTestAppDir)/artifacts
-
-        - script: |
-            mkdir -p tracer/build_data/snapshots
-            mkdir -p tracer/build_data/logs
-          displayName: create test data directories
-
-        - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
-              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
-              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
-              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
-              --build-arg INSTALL_CMD="$(installCmd)" \
-              dd-dotnet-smoke-tests
-          env:
-            dockerTag: $(dockerTag)
-          displayName: docker-compose build smoke-tests
-          retryCountOnTaskFailure: 3
-
-        - template: steps/run-snapshot-test.yml
-          parameters:
-            target: 'dd-dotnet-smoke-tests'
-            snapshotPrefix: "smoke_test"
-
-        - publish: tracer/build_data
-          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
-          condition: succeededOrFailed()
-          continueOnError: true
-
-        - template: steps/run-in-docker.yml
-          parameters:
-            build: true
-            baseImage: debian
-            command: "CheckSmokeTestsForErrors"
-
 - stage: nuget_installer_smoke_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, merge_commit_id]
@@ -5445,7 +5355,7 @@ stages:
 
     - bash: |
         docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
-          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersion) \
+          --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
           --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
@@ -5952,8 +5862,6 @@ stages:
     - dotnet_tool_self_instrument_smoke_tests_linux
     - dotnet_tool_smoke_tests_arm64
     - dotnet_tool_smoke_tests_windows
-    - dd_dotnet_installer_smoke_tests_linux
-    - dd_dotnet_installer_smoke_tests_arm64
     - dd_dotnet_msi_installer_smoke_tests
     - dd_dotnet_installer_failure_tests_linux
     - dd_dotnet_installer_failure_tests_linux_arm64

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4742,7 +4742,7 @@ stages:
           dd-dotnet-smoke-tests
       env:
         dockerTag: $(dockerTag)
-      displayName: docker-compose build smoke-tests
+      displayName: docker-compose build dd-dotnet-smoke-tests
       retryCountOnTaskFailure: 3
 
     - template: steps/run-snapshot-test.yml
@@ -5121,7 +5121,7 @@ stages:
               dd-dotnet-smoke-tests
           env:
             dockerTag: $(dockerTag)
-          displayName: docker-compose build smoke-tests
+          displayName: docker-compose build dd-dotnet-smoke-tests
           retryCountOnTaskFailure: 3
 
         - template: steps/run-snapshot-test.yml

--- a/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
@@ -2,7 +2,7 @@
 ARG RUNTIME_IMAGE
 
 # Build the ASP.NET Core app using the latest SDK
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-bullseye-slim as builder
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 
 # Build the smoke test app
 WORKDIR /src

--- a/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
@@ -2,7 +2,7 @@
 ARG RUNTIME_IMAGE
 
 # Build the ASP.NET Core app using the latest SDK
-FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION-windowsservercore-ltsc2022 as builder
 
 # Without this, the container doesn't have permission to add the new package 
 USER ContainerAdministrator


### PR DESCRIPTION
## Summary of changes

Fix the dd-dotnet installer smoke tests

## Reason for change

Merge resolution errors meant that the .NET 8 build fails on master (installer tests).

## Implementation details

- Pass the correct variables to the smoke tests
- Combine some stages for CI efficiency reasons

## Test coverage

- [ ] Doing a force run of all the installer smoke tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
