### PR TITLE
Update python packages and use the new image in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ build:
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts) { remove-item -recurse -force artifacts }
-    - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e ENABLE_MULTIPROCESSOR_COMPILATION=false -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e NUGET_CERT_REVOCATION_MODE=offline datadog/dd-trace-dotnet-docker-build:net8
+    - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e ENABLE_MULTIPROCESSOR_COMPILATION=false -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e NUGET_CERT_REVOCATION_MODE=offline datadog/dd-trace-dotnet-docker-build:pythonfix
     - mkdir artifacts
     - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts
     - remove-item -recurse -force build-out\${CI_JOB_ID}

--- a/tracer/build/_build/docker/gitlab/constraints.txt
+++ b/tracer/build/_build/docker/gitlab/constraints.txt
@@ -1,0 +1,32 @@
+﻿# Taken from on https://github.com/DataDog/datadog-agent-buildimages/blob/a916f5e0836ec4a24f6b65b7c449e5126d26b913/requirements/constraints.txt
+
+awscli==1.29.45
+black==22.10.0
+boto3==1.28.45
+codeowners==0.6.0
+datadog-api-client==2.16.0
+docker-squash==1.1.0
+docker==5.0.3; python_version < '3.7'
+docker==6.1.3; python_version >= '3.7'
+dulwich==0.21.6
+flake8-bugbear==22.10.27
+flake8-comprehensions==3.10.1
+flake8-unused-arguments==0.0.12
+flake8-use-fstring==1.4
+flake8==5.0.4
+invoke==2.2.0
+isort==5.10.1
+jira==3.5.2
+packaging==21.3
+reno==3.5.0
+requests==2.31.0
+toml==0.10.2
+# urllib3 major version 2, released on May 4th 2023, breaks botocore used
+# by awscli (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)
+#############################################################
+# NOTE
+# The version of urllib3 has been bumped compared to the datadog-agent-buildimage
+#############################################################
+urllib3==1.26.18
+vulture==2.6
+wheel==0.40.0

--- a/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
+++ b/tracer/build/_build/docker/gitlab/gitlab.windows.dockerfile
@@ -48,13 +48,11 @@ ENV PYTHON_VERSION "3.8.2"
 COPY install_python3.ps1 .
 RUN powershell -Command .\install_python3.ps1 -Version $ENV:PYTHON_VERSION
 
-COPY requirements.txt .
-COPY install_python_packages.ps1 .
+COPY requirements.txt constraints.txt install_python_packages.ps1 ./
 RUN powershell -Command .\install_python_packages.ps1
 
 # Install JAVA
-COPY helpers.ps1 .
-COPY install_java.ps1 .
+COPY helpers.ps1 install_java.ps1 ./
 RUN powershell -Command .\install_java.ps1
 
 # Install 

--- a/tracer/build/_build/docker/gitlab/requirements.txt
+++ b/tracer/build/_build/docker/gitlab/requirements.txt
@@ -1,19 +1,16 @@
-# python development requirements for the Datadog Agent
-invoke==1.7.3
-reno==3.5.0
-docker==6.0.1; python_version >= '3.7'
-docker==5.0.3; python_version < '3.7'
-docker-squash==1.0.9
-dulwich==0.20.45
-requests==2.27.1
-PyYAML==5.4.1
-toml==0.10.2
-packaging==21.3
-# more recent boto3 has a bug which generates an import exception.
-# pin until this can be resolved.
-boto3==1.22.4
-botocore==1.25.4 ## for awscli
-awscli==1.23.4
-# urllib3 major version 2, released on May 4th 2023, breaks botocore used
-# by awscli (removed DEFAULT_CIPHERS list from urllib3.util.ssl_)
-urllib3==1.26.15
+# Based on from https://github.com/DataDog/datadog-agent-buildimages/blob/a916f5e0836ec4a24f6b65b7c449e5126d26b913/requirements.txt
+
+-c constraints.txt
+
+awscli
+boto3
+codeowners
+docker
+docker-squash
+dulwich
+invoke
+packaging
+reno
+requests
+toml
+urllib3


### PR DESCRIPTION
## Summary of changes

Update the python packages to match the agent build images https://github.com/DataDog/datadog-agent-buildimages

## Reason for change

Some packages were out of date and we got update suggestions

## Implementation details

Copy-paste mostly

## Test coverage

Ran a manual build in GitLab, and all looks good

## Other details
<!-- Fixes #{issue} -->
I bumped the `urllib3` version by a patch release compared to the agent versions

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
