### PR TITLE
[ASM] Enable IAST coverage tests NET8

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text/StringBuilderAspects.cs
@@ -8,12 +8,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Datadog.Trace.Iast.Dataflow;
 using Datadog.Trace.Iast.Propagation;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Telemetry.Metrics;
 
 namespace Datadog.Trace.Iast.Aspects.System.Text;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -51,7 +51,7 @@ public class IastInstrumentationUnitTests : TestHelper
     [InlineData(typeof(StringBuilder), "Replace", null, true)]
     [InlineData(typeof(StringBuilder), "Remove", null, true)]
     [InlineData(typeof(StringBuilder), "CopyTo", null, true)]
-    [InlineData(typeof(StringBuilder), "AppendFormat", null, true)]
+    [InlineData(typeof(StringBuilder), "AppendFormat", new string[] { "System.StringBuilder::AppendFormat(System.IFormatProvider,System.Text.CompositeFormat,System.Object[])" }, true)]
     [InlineData(typeof(string), "Join")]
     [InlineData(typeof(string), "Copy")]
     [InlineData(typeof(string), "ToUpper")]
@@ -88,14 +88,6 @@ public class IastInstrumentationUnitTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public void TestMethodsAspectCover(Type typeToCheck, string methodToCheck, string[] overloadsToExclude = null, bool excludeParameterlessMethods = false)
     {
-#if NET8_0
-        if ((typeToCheck == typeof(StringBuilder) && methodToCheck == "AppendFormat")
-            || (typeToCheck == typeof(string) && methodToCheck == "Format"))
-        {
-            throw new SkipException("FIXME: Failing in .NET 8 only currently due to new overload");
-        }
-
-#endif
         TestMethodOverloads(typeToCheck, methodToCheck, overloadsToExclude?.ToList(), excludeParameterlessMethods);
     }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -65,7 +65,7 @@ public class IastInstrumentationUnitTests : TestHelper
     [InlineData(typeof(string), "Trim")]
     [InlineData(typeof(string), "Substring")]
     [InlineData(typeof(string), "TrimEnd")]
-    [InlineData(typeof(string), "Format")]
+    [InlineData(typeof(string), "Format", new string[] { "System.String Format(System.IFormatProvider, System.Text.CompositeFormat, System.Object[])" })]
     [InlineData(typeof(string), "Split")]
     [InlineData(typeof(string), "Replace", new string[] { "System.String::Replace(System.String,System.String,System.StringComparison)", "System.String::Replace(System.String,System.String,System.Boolean,System.Globalization.CultureInfo)" })]
     [InlineData(typeof(string), "Concat", new string[] { "System.String Concat(System.Object)" })]

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringFormatTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringFormatTests.cs
@@ -355,7 +355,7 @@ public class StringFormatTests : InstrumentationTestsBase
     // System.String Format(System.IFormatProvider, System.Text.CompositeFormat, System.Object[])
 
     [Fact]
-    public void GivenATaintedString_WhenCallingStringBuilderAppendFormatObjectArrayFormatProvider_ResultIsTainted2()
+    public void GivenATaintedString_WhenCallingStringFormatObjectArrayFormatProvider_ResultIsTainted2()
     {
         var composite = CompositeFormat.Parse("myformat{0}{1}");
         AssertUntaintedWithOriginalCallCheck(

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringFormatTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringFormatTests.cs
@@ -350,4 +350,18 @@ public class StringFormatTests : InstrumentationTestsBase
             String.Format(_taintedFormat3Args, new object[] { "ww", "ww", "ww" }),
             () => String.Format(_taintedFormat3Args, new object[] { "ww", "ww", "ww" }));
     }
+
+#if NET8_0
+    // System.String Format(System.IFormatProvider, System.Text.CompositeFormat, System.Object[])
+
+    [Fact]
+    public void GivenATaintedString_WhenCallingStringBuilderAppendFormatObjectArrayFormatProvider_ResultIsTainted2()
+    {
+        var composite = CompositeFormat.Parse("myformat{0}{1}");
+        AssertUntaintedWithOriginalCallCheck(
+            "myformattaintedcustomformatUntaintedStringcustomformat",
+            String.Format(new FormatProviderForTest(), composite, new object[] { _taintedValue, _untaintedString }).ToString(),
+            () => String.Format(new FormatProviderForTest(), composite, new object[] { _taintedValue, _untaintedString }).ToString());
+    }
+#endif
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
@@ -249,8 +249,17 @@ public class StringJoinTests : InstrumentationTestsBase
         AssertTaintedFormatWithOriginalCallCheck(":+-tainted-+:", String.Join(",", new ClassForStringTest(taintedValue)), () => String.Join(",", new ClassForStringTest(taintedValue)));
     }
 
-
 #if !NET462
+
+    [Fact]
+    public void GivenATaintedStringInList_WhenCallingJoinWithChar_ResultIsTainted10()
+    {
+        var objectList = new List<object> { TaintedObject, UntaintedObject, OtherTaintedObject };
+        AssertUntaintedWithOriginalCallCheck(
+            () => string.Join(' ', objectList),
+            () => string.Join(' ', objectList));
+    }
+
     [Fact]
     public void GivenATaintedStringInNestedMethodObject_WhenCallingJoinWithChar_ResultIsTainted6()
     {
@@ -515,14 +524,5 @@ public class StringJoinTests : InstrumentationTestsBase
         AssertTaintedFormatWithOriginalCallCheck("UntaintedString|:+-TaintedString-+:",
             string.Join<ClassForStringTest>("|", list),
             () => string.Join<ClassForStringTest>("|", list));
-    }
-
-    [Fact]
-    public void GivenATaintedStringInList_WhenCallingJoinWithChar_ResultIsTainted10()
-    {
-        var objectList = new List<object> { TaintedObject, UntaintedObject, OtherTaintedObject };
-        AssertUntaintedWithOriginalCallCheck(
-            () => string.Join(' ', objectList),
-            () => string.Join(' ', objectList));
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
@@ -516,4 +516,13 @@ public class StringJoinTests : InstrumentationTestsBase
             string.Join<ClassForStringTest>("|", list),
             () => string.Join<ClassForStringTest>("|", list));
     }
+
+    [Fact]
+    public void GivenATaintedStringInList_WhenCallingJoinWithChar_ResultIsTainted10()
+    {
+        var objectList = new List<object> { TaintedObject, UntaintedObject, OtherTaintedObject };
+        AssertUntaintedWithOriginalCallCheck(
+            () => string.Join(' ', objectList),
+            () => string.Join(' ', objectList));
+    }
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/String/StringJoinTests.cs
@@ -255,8 +255,9 @@ public class StringJoinTests : InstrumentationTestsBase
     public void GivenATaintedStringInList_WhenCallingJoinWithChar_ResultIsTainted10()
     {
         var objectList = new List<object> { TaintedObject, UntaintedObject, OtherTaintedObject };
-        AssertUntaintedWithOriginalCallCheck(
-            () => string.Join(' ', objectList),
+        AssertTaintedFormatWithOriginalCallCheck(
+            ":+-TaintedObject-+: UntaintedObject :+-OtherTaintedObject-+:",
+            string.Join(' ', objectList),
             () => string.Join(' ', objectList));
     }
 

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/StringBuilder/StringBuilderAppendFormatTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/StringBuilder/StringBuilderAppendFormatTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text;
 using Xunit;
 
@@ -181,4 +182,19 @@ public class StringBuilderAppendFormatTests : InstrumentationTestsBase
             new StringBuilder(string.Empty).AppendFormat(new FormatProviderForTest(), "myformat{0}{1}", new object[] { _taintedValue, _notTaintedValue }).ToString(), 
             () => new StringBuilder(string.Empty).AppendFormat(new FormatProviderForTest(), "myformat{0}{1}", new object[] { _taintedValue, _notTaintedValue }).ToString());
     }
+
+    
+#if NET8_0
+    // System.StringBuilder::AppendFormat(System.IFormatProvider,System.Text.CompositeFormat,System.Object[])
+     
+    [Fact]
+    public void GivenATaintedString_WhenCallingStringBuilderAppendFormatObjectArrayFormatProvider_ResultIsTainted2()
+    {
+        var composite = CompositeFormat.Parse("myformat{0}{1}");
+        AssertUntaintedWithOriginalCallCheck(
+            "myformattaintedcustomformatnotTaintedcustomformat",
+            new StringBuilder(string.Empty).AppendFormat(new FormatProviderForTest(), composite, new object[] { _taintedValue, _notTaintedValue }).ToString(),
+            () => new StringBuilder(string.Empty).AppendFormat(new FormatProviderForTest(), composite, new object[] { _taintedValue, _notTaintedValue }).ToString());
+    }
+#endif
 }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Properties/launchSettings.json
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Properties/launchSettings.json
@@ -26,7 +26,7 @@
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DD_APPSEC_ENABLED": null,
+        "DD_APPSEC_ENABLED": "true",
         "DD_APPSEC_BLOCKING_ENABLED": "true",
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)\\shared\\bin\\monitoring-home\\",
         "CORECLR_ENABLE_PROFILING": "1",


### PR DESCRIPTION
## Summary of changes

The coverage tests in .net8 were failing because of some new methods added to .Net8 : System.StringBuilder::AppendFormat(System.IFormatProvider,System.Text.CompositeFormat,System.Object[])
System.String Format(System.IFormatProvider, System.Text.CompositeFormat, System.Object[])

A new aspect could have been added to our aspects, but, since our tracer is compiled in .Net6, those methods could not be called directly, which means that we would need to use reflection, which we don't currently do for any method and can be expensive. Because of that, it was decided not to taint these overloads for now.

A new string join test was also added to test a case that was not covered.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
