### PR TITLE
Increase timeout for query string obfuscator unit tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
@@ -19,7 +19,8 @@ namespace Datadog.Trace.Tests.Util.Http;
 [Collection(nameof(QueryStringObfuscatorTests))]
 public class QueryStringObfuscatorTests
 {
-    private const double Timeout = 500;
+    // seems on macos, netcore<=3.0 it can timeout
+    private const double Timeout = 3000;
 
     public static IEnumerable<object[]> GetData()
     {

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Tests.Util.Http;
 public class QueryStringObfuscatorTests
 {
     // seems on macos, netcore<=3.0 it can timeout
-    private const double Timeout = 3000;
+    private const double Timeout = 20000;
 
     public static IEnumerable<object[]> GetData()
     {


### PR DESCRIPTION
## Summary of changes

On mac os <= net core3.0 , regex execution seems to timeout

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
