### PR TITLE
[Profiler] Skip LinuxOnly Tests in VS Test explorer

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -74,6 +74,10 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             return Environment.Is64BitProcess ? "x64" : "x86";
         }
 
+        public static bool IsRunningInCi() =>
+            // This environment variable is set in the CI (Github / AzDo)
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MonitoringHomeDirectory"));
+
         internal static string GetConfiguration()
         {
 #if DEBUG
@@ -247,10 +251,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         {
             return Path.Combine(GetSolutionDirectory(), "profiler", "_build");
         }
-
-        private static bool IsRunningInCi() =>
-            // This environment variable is set in the CI (Github / AzDo)
-            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MonitoringHomeDirectory"));
 
         /// <summary>
         /// Find the solution directory from anywhere in the hierarchy.

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/TestAppFrameworkDiscover.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/TestAppFrameworkDiscover.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Datadog.Profiler.IntegrationTests.Helpers;
 using Xunit.Abstractions;
 using Xunit.Sdk;
@@ -47,6 +48,23 @@ namespace Datadog.Profiler.IntegrationTests.Xunit
                 return results;
             }
 
+            // We only want to filter when running in VS
+            // For CI/Nuke, we use passed the filter passed to dotnet test
+            if (!EnvironmentHelper.IsRunningInCi())
+            {
+                var testStatus = GetSkippableStatus(testMethod);
+                if (testStatus.Skip)
+                {
+                    MessageSink.OnMessage(new DiagnosticMessage("Skipping test. Reason: {0}", testStatus.Reason));
+                    var xx = new SkippableTestCase(
+                        $"Test case skipped. Reason: {testStatus.Reason}",
+                        testMethod,
+                        new object[] { appName, string.Empty, appAssembly });
+                    results.Add(xx);
+                    return results;
+                }
+            }
+
             foreach (var folder in System.IO.Directory.GetDirectories(appFolderPath))
             {
                 var framework = System.IO.Path.GetFileName(folder);
@@ -82,6 +100,77 @@ namespace Datadog.Profiler.IntegrationTests.Xunit
             }
 
             return results;
+        }
+
+        private static TestSkippableStatus GetSkippableStatus(ITestMethod testMethod)
+        {
+            var traits = GetTraits(testMethod);
+            if (traits.Count == 0)
+            {
+                return new TestSkippableStatus(false);
+            }
+
+            var categoryTraits = traits.Where(kv => kv.Key == "Category");
+
+            var (skip, reason) = (Environment.OSVersion.Platform, categoryTraits.Any(kv => kv.Value == "LinuxOnly"), categoryTraits.Any(kv => kv.Value == "WindowsOnly")) switch
+            {
+                (PlatformID.Win32NT, true, _) => (true, $"Test can only be run on Linux"),
+                (PlatformID.Unix, _, true) => (true, $"Test can only be run on Windows"),
+                _ => (false, string.Empty)
+            };
+
+            return new TestSkippableStatus(skip, reason);
+        }
+
+        private static IReadOnlyList<KeyValuePair<string, string>> GetTraits(ITestMethod testMethod)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+
+            var method = testMethod.Method.ToRuntimeMethod();
+            result.AddRange(ExtractTraits(method.CustomAttributes));
+
+            var clazz = testMethod.TestClass.Class.ToRuntimeType();
+            result.AddRange(ExtractTraits(clazz.CustomAttributes));
+
+            return result;
+        }
+
+        private static List<KeyValuePair<string, string>> ExtractTraits(IEnumerable<CustomAttributeData> attributes)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+            var messageSink = new NullMessageSink();
+            foreach (var traitAttributeData in attributes)
+            {
+                var traitAttributeType = traitAttributeData.AttributeType;
+                if (!typeof(ITraitAttribute).GetTypeInfo().IsAssignableFrom(traitAttributeType.GetTypeInfo()))
+                {
+                    continue;
+                }
+
+                var discovererAttributeData = traitAttributeType.GetTypeInfo().CustomAttributes.FirstOrDefault(cad => cad.AttributeType == typeof(TraitDiscovererAttribute));
+                if (discovererAttributeData == null)
+                {
+                    continue;
+                }
+
+                var discoverer = ExtensibilityPointFactory.GetTraitDiscoverer(messageSink, Reflector.Wrap(discovererAttributeData));
+                if (discoverer == null)
+                {
+                    continue;
+                }
+
+                var traits = discoverer.GetTraits(Reflector.Wrap(traitAttributeData));
+                if (traits != null)
+                {
+                    result.AddRange(traits);
+                }
+            }
+
+            return result;
+        }
+
+        private record TestSkippableStatus(bool Skip, string Reason = "")
+        {
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Skip tests with `Category=LinuxOnly` when run in VS Test explorer
## Reason for change

It will be easier to identify failing tests on Windows.

## Implementation details

- Collect Traits Key/Value
- If test has a `Category` with `LinuxOnly` (on Linux `WindowsOnly`), create a `SkippableTestCase` instance.
- Make sure this filtering is not done in CI

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
