### PR TITLE
Basic smoke tests for .NET chiseled containers

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4845,13 +4845,6 @@ stages:
           condition: succeededOrFailed()
           continueOnError: true
 
-        - template: steps/run-in-docker.yml
-          parameters:
-            build: true
-            baseImage: alpine
-            command: "CheckSmokeTestsForErrors"
-            apikey: $(DD_LOGGER_DD_API_KEY)
-
 - stage: nuget_installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, merge_commit_id]
@@ -5319,12 +5312,6 @@ stages:
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
           condition: succeededOrFailed()
           continueOnError: true
-
-        - template: steps/run-in-docker.yml
-          parameters:
-            build: true
-            baseImage: debian
-            command: "CheckSmokeTestsForErrors"
 
 - stage: nuget_installer_smoke_tests_arm64
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4761,6 +4761,90 @@ stages:
         command: "CheckSmokeTestsForErrors"
         apikey: $(DD_LOGGER_DD_API_KEY)
 
+- stage: installer_chiseled_smoke_tests
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  dependsOn: [package_linux, generate_variables, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [linux]
+
+    - job: linux
+      timeoutInMinutes: 45 # should take ~5 mins
+      strategy:
+        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_chiseled_smoke_tests_matrix'] ]
+      variables:
+        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+      pool:
+        vmImage: ubuntu-20.04
+      
+      steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+        - task: DownloadPipelineArtifact@2
+          displayName: Download artifacts to smoke test directory
+          inputs:
+            artifact: $(linuxArtifacts)
+            path: $(smokeTestAppDir)/artifacts
+
+        - script: |
+            mkdir -p tracer/build_data/snapshots
+            mkdir -p tracer/build_data/logs
+          displayName: create test data directories
+        
+        # Run the "normal" installer smoke tests
+        - script: |
+            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              chiseled-smoke-tests
+          env:
+            dockerTag: $(dockerTag)
+            DD_LOGGER_DD_API_KEY: $(ddApiKey)
+          displayName: docker-compose build chiseled-smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'chiseled-smoke-tests'
+            snapshotPrefix: "smoke_test"
+        
+        # Run the "dd-dotnet" installer smoke tests
+        - script: |
+            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              --build-arg RUNTIME_ID="$(runtimeId)" \
+              dd-dotnet-chiseled-smoke-tests
+          env:
+            dockerTag: $(dockerTag)
+          displayName: docker-compose build dd-dotnet-chiseled-smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'dd-dotnet-chiseled-smoke-tests'
+            snapshotPrefix: "smoke_test"
+
+        - publish: tracer/build_data
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+          condition: succeededOrFailed()
+          continueOnError: true
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            build: true
+            baseImage: alpine
+            command: "CheckSmokeTestsForErrors"
+            apikey: $(DD_LOGGER_DD_API_KEY)
+
 - stage: nuget_installer_smoke_tests
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, merge_commit_id]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5173,6 +5173,11 @@ stages:
         name: aws-arm64-auto-scaling
 
       steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
         - task: DownloadPipelineArtifact@2
           displayName: Download artifacts to smoke test directory
           inputs:
@@ -5213,6 +5218,96 @@ stages:
           env:
             dockerTag: $(dockerTag)
           displayName: docker-compose build dd-dotnet-smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'dd-dotnet-smoke-tests'
+            snapshotPrefix: "smoke_test"
+
+        - publish: tracer/build_data
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+          condition: succeededOrFailed()
+          continueOnError: true
+
+        - template: steps/run-in-docker.yml
+          parameters:
+            build: true
+            baseImage: debian
+            command: "CheckSmokeTestsForErrors"
+
+- stage: installer_chiseled_smoke_tests_arm64
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [package_arm64, generate_variables, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [linux]
+
+    - job: linux
+      timeoutInMinutes: 45 # should take ~15 mins
+      strategy:
+        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_chiseled_smoke_tests_arm64_matrix'] ]
+      variables:
+        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+      pool:
+        name: aws-arm64-auto-scaling
+
+      steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download artifacts to smoke test directory
+          inputs:
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'latestFromBranch'
+            branchName: 'refs/heads/master'
+            artifact: $(linuxArtifacts)
+            path: $(smokeTestAppDir)/artifacts
+
+        - script: |
+            mkdir -p tracer/build_data/snapshots
+            mkdir -p tracer/build_data/logs
+          displayName: create test data directories
+
+        # Run the "normal" installer smoke tests 
+        - script: |
+            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              chiseled-smoke-tests
+          env:
+            dockerTag: $(dockerTag)
+            DD_LOGGER_DD_API_KEY: $(ddApiKey)
+          displayName: docker-compose build chiseled-smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'chiseled-smoke-tests'
+            snapshotPrefix: "smoke_test"
+        
+        # Run the "dd-dotnet" installer smoke tests
+        - script: |
+            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              --build-arg RUNTIME_ID="$(runtimeId)" \
+              dd-dotnet-chiseled-smoke-tests
+          env:
+            dockerTag: $(dockerTag)
+            dockerTarget: $(runtimeId)
+          displayName: docker-compose build dd-dotnet-chiseled-smoke-tests
           retryCountOnTaskFailure: 3
 
         - template: steps/run-snapshot-test.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5295,7 +5295,7 @@ stages:
 
         - template: steps/run-snapshot-test.yml
           parameters:
-            target: 'dd-dotnet-smoke-tests'
+            target: 'dd-dotnet-chiseled-smoke-tests'
             snapshotPrefix: "smoke_test"
 
         - publish: tracer/build_data

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5296,16 +5296,16 @@ stages:
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
               --build-arg RUNTIME_ID="$(runtimeId)" \
-              dd-dotnet-chiseled-smoke-tests
+              dd-dotnet-chiseled-arm64-smoke-tests
           env:
             dockerTag: $(dockerTag)
             dockerTarget: $(runtimeId)
-          displayName: docker-compose build dd-dotnet-chiseled-smoke-tests
+          displayName: docker-compose build dd-dotnet-chiseled-arm64-smoke-tests
           retryCountOnTaskFailure: 3
 
         - template: steps/run-snapshot-test.yml
           parameters:
-            target: 'dd-dotnet-chiseled-smoke-tests'
+            target: 'dd-dotnet-chiseled-arm64-smoke-tests'
             snapshotPrefix: "smoke_test"
 
         - publish: tracer/build_data

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4786,9 +4786,15 @@ stages:
           parameters:
             targetShaId: $(targetShaId)
             targetBranch: $(targetBranch)
+
         - task: DownloadPipelineArtifact@2
           displayName: Download artifacts to smoke test directory
           inputs:
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'latestFromBranch'
+            branchName: 'refs/heads/master'
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4790,11 +4790,6 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download artifacts to smoke test directory
           inputs:
-            buildType: 'specific'
-            project: 'dd-trace-dotnet'
-            definition: 54
-            buildVersionToDownload: 'latestFromBranch'
-            branchName: 'refs/heads/master'
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
 
@@ -5258,11 +5253,6 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download artifacts to smoke test directory
           inputs:
-            buildType: 'specific'
-            project: 'dd-trace-dotnet'
-            definition: 54
-            buildVersionToDownload: 'latestFromBranch'
-            branchName: 'refs/heads/master'
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4831,6 +4831,7 @@ stages:
               dd-dotnet-chiseled-smoke-tests
           env:
             dockerTag: $(dockerTag)
+            dockerTarget: $(runtimeId)
           displayName: docker-compose build dd-dotnet-chiseled-smoke-tests
           retryCountOnTaskFailure: 3
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4790,6 +4790,11 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download artifacts to smoke test directory
           inputs:
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'latestFromBranch'
+            branchName: 'refs/heads/master'
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
 
@@ -5253,6 +5258,11 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download artifacts to smoke test directory
           inputs:
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'latestFromBranch'
+            branchName: 'refs/heads/master'
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1013,7 +1013,7 @@ services:
     build:
       context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
       dockerfile: build/_build/docker/smoke.chiseled.dockerfile
-      target: dd-dotnet-final-${RUNTIME_ID:-linux-x64}
+      target: dd-dotnet-final-linux-x64
         # args:
         # Note that the following build arguments must be provided
         # - DOTNETSDK_VERSION=
@@ -1021,6 +1021,27 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - RUNTIME_ID=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dd-dotnet-chiseled-tester
+    volumes:
+      - ./:/project
+      - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    environment:
+      - dockerTag=${dockerTag:-unset}
+      - DD_TRACE_AGENT_URL=http://test-agent:8126
+    depends_on:
+      - test-agent
+
+  dd-dotnet-chiseled-arm64-smoke-tests:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.chiseled.dockerfile
+      target: dd-dotnet-final-linux-arm64
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - RUNTIME_ID=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-dd-dotnet-arm64-chiseled-tester
     volumes:
       - ./:/project
       - ./tracer/build_data/logs:/var/log/datadog/dotnet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1013,7 +1013,7 @@ services:
     build:
       context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
       dockerfile: build/_build/docker/smoke.chiseled.dockerfile
-      target: dd-dotnet-final
+      target: dd-dotnet-final-${RUNTIME_ID:-linux-x64}
         # args:
         # Note that the following build arguments must be provided
         # - DOTNETSDK_VERSION=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -993,7 +993,7 @@ services:
     build:
       context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
       dockerfile: build/_build/docker/smoke.chiseled.dockerfile
-      target: final
+      target: installer-final
         # args:
         # Note that the following build arguments must be provided
         # - DOTNETSDK_VERSION=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.4'
 services:
   # ARM64 dependencies
   localstack_arm64:
@@ -980,6 +980,47 @@ services:
         # - PUBLISH_FRAMEWORK=
         # - INSTALL_CMD=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dd-dotnet-tester
+    volumes:
+      - ./:/project
+      - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    environment:
+      - dockerTag=${dockerTag:-unset}
+      - DD_TRACE_AGENT_URL=http://test-agent:8126
+    depends_on:
+      - test-agent
+
+  chiseled-smoke-tests:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.chiseled.dockerfile
+      target: final
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-chiseled-tester
+    volumes:
+      - ./:/project
+      - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    environment:
+      - dockerTag=${dockerTag:-unset}
+      - DD_TRACE_AGENT_URL=http://test-agent:8126
+    depends_on:
+      - test-agent
+
+  dd-dotnet-chiseled-smoke-tests:
+    build:
+      context: ./tracer/ # have to use this as the context, as Dockercompose requires dockerfile to be inside context dir
+      dockerfile: build/_build/docker/smoke.chiseled.dockerfile
+      target: dd-dotnet-final
+        # args:
+        # Note that the following build arguments must be provided
+        # - DOTNETSDK_VERSION=
+        # - RUNTIME_IMAGE=
+        # - PUBLISH_FRAMEWORK=
+        # - RUNTIME_ID=
+    image: dd-trace-dotnet/${dockerTag:-not-set}-dd-dotnet-chiseled-tester
     volumes:
       - ./:/project
       - ./tracer/build_data/logs:/var/log/datadog/dotnet

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -376,6 +376,7 @@ partial class Build : NukeBuild
                 GenerateLinuxInstallerSmokeTestsMatrix();
                 GenerateLinuxSmokeTestsArm64Matrix();
                 GenerateLinuxChiseledInstallerSmokeTestsMatrix();
+                GenerateLinuxChiseledInstallerArm64SmokeTestsMatrix();
 
                 // nuget smoke tests
                 GenerateLinuxNuGetSmokeTestsMatrix();
@@ -406,8 +407,6 @@ partial class Build : NukeBuild
                         {
                             (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers
                             (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
                             (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
@@ -557,8 +556,8 @@ partial class Build : NukeBuild
                         "debian",
                         new (string publishFramework, string runtimeTag)[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers
+                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
+                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
                         },
                         installer: null,
                         installCmd: null,
@@ -582,8 +581,6 @@ partial class Build : NukeBuild
                         new (string publishFramework, string runtimeTag)[]
                         {
                             (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers
                             (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
                             (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
@@ -620,8 +617,6 @@ partial class Build : NukeBuild
                         new (string publishFramework, string runtimeTag)[]
                         {
                             (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers
                             (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
                             (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
@@ -636,6 +631,30 @@ partial class Build : NukeBuild
                     Logger.Information($"Installer smoke tests matrix");
                     Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetOutputVariable("installer_smoke_tests_arm64_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateLinuxChiseledInstallerArm64SmokeTestsMatrix()
+                {
+                    var matrix = new Dictionary<string, object>();
+
+                    AddToLinuxSmokeTestsMatrix(
+                        matrix,
+                        "debian",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
+                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
+                        },
+                        installer: null,
+                        installCmd: null,
+                        linuxArtifacts: "linux-packages-linux-arm64",
+                        runtimeId: "linux-arm64",
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
+                    Logger.Information($"Installer chiseled smoke tests arm64 matrix");
+                    Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetOutputVariable("installer_chiseled_smoke_tests_arm64_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
 
                 void AddToLinuxSmokeTestsMatrix(

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -732,8 +732,8 @@ partial class Build : NukeBuild
                         new (string publishFramework, string runtimeTag)[]
                         {
                             (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
-                            // (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            // (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
+                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
+                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
                             (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
                             (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
                             (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -375,6 +375,7 @@ partial class Build : NukeBuild
                 // installer smoke tests
                 GenerateLinuxInstallerSmokeTestsMatrix();
                 GenerateLinuxSmokeTestsArm64Matrix();
+                GenerateLinuxChiseledInstallerSmokeTestsMatrix();
 
                 // nuget smoke tests
                 GenerateLinuxNuGetSmokeTestsMatrix();
@@ -545,6 +546,30 @@ partial class Build : NukeBuild
                     Logger.Information($"Installer smoke tests matrix");
                     Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetOutputVariable("installer_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateLinuxChiseledInstallerSmokeTestsMatrix()
+                {
+                    var matrix = new Dictionary<string, object>();
+
+                    AddToLinuxSmokeTestsMatrix(
+                        matrix,
+                        "debian",
+                        new (string publishFramework, string runtimeTag)[]
+                        {
+                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers
+                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers
+                        },
+                        installer: null,
+                        installCmd: null,
+                        linuxArtifacts: "linux-packages-linux-x64",
+                        runtimeId: "linux-x64",
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
+                    Logger.Information($"Installer chiseled smoke tests matrix");
+                    Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetOutputVariable("installer_chiseled_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
 
                 void GenerateLinuxSmokeTestsArm64Matrix()

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -11,8 +11,8 @@ COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 ARG PUBLISH_FRAMEWORK
 RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
-# Creating a placeolder file we can copy in the publish stage to create the logs folder
-RUN touch /src/artifacts/.placeholder.txt
+# Creating a placeholder file we can copy in the publish stage to create the logs folder
+RUN mkdir -p /install && touch /install/.placeholder
 
 FROM $RUNTIME_IMAGE AS publish
 
@@ -20,10 +20,10 @@ WORKDIR /app
 
 # Add and extract the installer files to the expected location
 # from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
-ADD --from=builder /src/artifacts/datadog-dotnet-apm*.tar.gz /opt/datadog
+ADD /src/artifacts/datadog-dotnet-apm*.tar.gz /opt/datadog
 
 # Copy the placeholder file to create the logs directory
-COPY --from=builder /src/artifacts/.placeholder.txt /var/log/datadog/dotnet/.placeholder.txt
+COPY --from=builder /install/.placeholder /var/log/datadog/dotnet/.placeholder
 
 # Set a random env var we should ignore
 ENV SUPER_SECRET_CANARY=MySuperSecretCanary

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -18,13 +18,6 @@ FROM $RUNTIME_IMAGE AS publish
 
 WORKDIR /src
 
-# Add and extract the installer files to the expected location
-# from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
-ADD ./test/test-applications/regression/AspNetCoreSmokeTest/artifacts/datadog-dotnet-apm-2.41.0.tar.gz /opt/datadog
-
-# Copy the placeholder file to create the logs directory
-COPY --from=builder /install/.placeholder /var/log/datadog/dotnet/.placeholder
-
 # Set a random env var we should ignore
 ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 
@@ -33,13 +26,20 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 ENV ASPNETCORE_URLS=http://localhost:5000
 
+# Add and extract the installer files to the expected location
+# from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+ADD ./test/test-applications/regression/AspNetCoreSmokeTest/artifacts/datadog-dotnet-apm-2.41.0.tar.gz /opt/datadog
+
+# Use the non-root user
+USER $APP_UID
+
+# Copy the placeholder file to create the logs directory
+COPY --from=builder /install/.placeholder /var/log/datadog/dotnet/.placeholder
+
 WORKDIR /app
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.
-
-# Use the non-root user
-USER $APP_UID
 
 # The final image, with "manual" configuration
 FROM publish as final

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -34,7 +34,8 @@ USER root
 
 # Copy the placeholder file to create the logs directory
 # THIS DOESN'T WORK, but SOMETHING like it hopefully will... so leaving as inspiration 
-COPY --chown=64198 --chmod=777 --from=builder /install /var/log/datadog/dotnet
+#COPY --chown=64198 --chmod=777 --from=builder /install /var/log/datadog/dotnet
+COPY --from=builder /install/.placeholder /var/log/datadog/dotnet/.placeholder
 
 # Use the non-root user
 USER $APP_UID

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -30,11 +30,14 @@ ENV ASPNETCORE_URLS=http://localhost:5000
 # from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
 ADD ./test/test-applications/regression/AspNetCoreSmokeTest/artifacts/datadog-dotnet-apm-2.41.0.tar.gz /opt/datadog
 
-# Use the non-root user
-USER $APP_UID
+USER root
 
 # Copy the placeholder file to create the logs directory
-COPY --from=builder /install/.placeholder /var/log/datadog/dotnet/.placeholder
+# THIS DOESN'T WORK, but SOMETHING like it hopefully will... so leaving as inspiration 
+COPY --chown=64198 --chmod=777 --from=builder /install /var/log/datadog/dotnet
+
+# Use the non-root user
+USER $APP_UID
 
 WORKDIR /app
 

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -1,0 +1,60 @@
+﻿ARG DOTNETSDK_VERSION
+ARG RUNTIME_IMAGE
+
+# Build the ASP.NET Core app using the latest SDK
+FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
+
+# Build the smoke test app
+WORKDIR /src
+COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
+
+ARG PUBLISH_FRAMEWORK
+RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+
+# Creating a placeolder file we can copy in the publish stage to create the logs folder
+RUN touch /src/artifacts/.placeholder.txt
+
+FROM $RUNTIME_IMAGE AS publish
+
+WORKDIR /app
+
+# Add and extract the installer files to the expected location
+# from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
+ADD --from=builder /src/artifacts/datadog-dotnet-apm*.tar.gz /opt/datadog
+
+# Copy the placeholder file to create the logs directory
+COPY --from=builder /src/artifacts/.placeholder.txt /var/log/datadog/dotnet/.placeholder.txt
+
+# Set a random env var we should ignore
+ENV SUPER_SECRET_CANARY=MySuperSecretCanary
+
+# see https://github.com/DataDog/dd-trace-dotnet/pull/3579
+ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
+
+ENV ASPNETCORE_URLS=http://localhost:5000
+
+# Copy the app across
+COPY --from=builder /src/publish /app/.
+
+# The final image, with "manual" configuration
+FROM publish as final
+
+# Set the required env vars
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/opt/datadog
+ENV LD_PRELOAD=/opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so
+ENV DD_PROFILING_ENABLED=1
+ENV DD_APPSEC_ENABLED=1
+ENV DD_TRACE_DEBUG=1
+
+ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]
+
+# The final image, with "dd-dotnet" configuration
+# Note that we _can't_ use dd-dotnet-sh in this case
+# Because there _is_ no shell in the chiseled containers
+FROM publish as dd-dotnet-final
+ARG RUNTIME_ID
+
+ENTRYPOINT ["/opt/datadog/$RUNTIME_ID/dd-dotnet", "run", "--set-env", "DD_PROFILING_ENABLED=1","--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--", "dotnet", "/app/AspNetCoreSmokeTest.dll"]

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -28,7 +28,7 @@ ENV ASPNETCORE_URLS=http://localhost:5000
 
 # Add and extract the installer files to the expected location
 # from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
-ADD ./test/test-applications/regression/AspNetCoreSmokeTest/artifacts/datadog-dotnet-apm-2.41.0.tar.gz /opt/datadog
+ADD ./test/test-applications/regression/AspNetCoreSmokeTest/artifacts/datadog-dotnet-apm-*.tar.gz /opt/datadog
 
 USER root
 

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -16,11 +16,11 @@ RUN mkdir -p /install && touch /install/.placeholder
 
 FROM $RUNTIME_IMAGE AS publish
 
-WORKDIR /app
+WORKDIR /src
 
 # Add and extract the installer files to the expected location
 # from tracer/test/test-applications/regression/AspNetCoreSmokeTest/artifacts
-ADD /src/artifacts/datadog-dotnet-apm*.tar.gz /opt/datadog
+ADD ./test/test-applications/regression/AspNetCoreSmokeTest/artifacts/datadog-dotnet-apm-2.41.0.tar.gz /opt/datadog
 
 # Copy the placeholder file to create the logs directory
 COPY --from=builder /install/.placeholder /var/log/datadog/dotnet/.placeholder
@@ -32,6 +32,8 @@ ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 ENV ASPNETCORE_URLS=http://localhost:5000
+
+WORKDIR /app
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.
@@ -56,5 +58,6 @@ ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]
 # Because there _is_ no shell in the chiseled containers
 FROM publish as dd-dotnet-final
 ARG RUNTIME_ID
+ENV RUNTIME_ID=$RUNTIME_ID
 
 ENTRYPOINT ["/opt/datadog/$RUNTIME_ID/dd-dotnet", "run", "--set-env", "DD_PROFILING_ENABLED=1","--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--", "dotnet", "/app/AspNetCoreSmokeTest.dll"]


### PR DESCRIPTION
## Summary of changes

Adds basic smoke tests on .NET 8 chiseled containers

## Reason for change

In .NET 8, Microsoft GA'd their support for chiseled containers ([I wrote about them recently](https://andrewlock.net/exploring-the-dotnet-8-preview-updates-to-docker-images-in-dotnet-8/#support-for-chiseled-containers)). We want to make sure that we can run correctly on chiseled containers

## Implementation details

Add additional stages for chiseled containers. Unfortunately, our existing dockerfile build process wouldn't work with them (because you can't `RUN` anything), so it was easiest to create separate tests. This PR adds

- Installer (tar.gz only, because that's all you can use!) tests for `linux-x64` and `linux-arm64`
- `dd-dotnet` tests (via the tar.gz) for `linux-x64` and `linux-arm64`

_Theoretically_, we should also test:

- The NuGet bundle. This is functionally identical to the installer tests, so not worth the hassle right now IMO
- The `dd-trace` global tool. It isn't practical use the global tool in production chiseled images, so I don't think this one matters (and don't know how I would do it)
- The `dd-trace` standalone tool. This one is interesting. When I try to test it in a .NET 8 chiseled container I get:

```
Failure processing application bundle.
Couldn't open host binary for reading contents
```

I think this is the "self-extracting" part of the "self-contained single-file" app failing, so this seems like a fundamental limitation. 

## Test coverage

Ran a test using binaries from master and it works

## Other details
<!-- Fixes #{issue} -->
I know... everyone was thinking it... more stages in the pipeline that's _definitely_ what we need

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
