### PR TITLE
[ASM] unknown type to encode: log debug instead of warning

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
@@ -443,7 +443,7 @@ namespace Datadog.Trace.AppSec.Waf
                 }
 
                 default:
-                    Log.Warning("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+                    Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
                     ddwafObjectStruct = GetStringObject(string.Empty);
                     break;
             }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
@@ -447,6 +447,7 @@ namespace Datadog.Trace.AppSec.Waf
                     {
                         Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
                     }
+
                     ddwafObjectStruct = GetStringObject(string.Empty);
                     break;
             }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Encoder.cs
@@ -443,7 +443,10 @@ namespace Datadog.Trace.AppSec.Waf
                 }
 
                 default:
-                    Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+                    if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
+                    {
+                        Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+                    }
                     ddwafObjectStruct = GetStringObject(string.Empty);
                     break;
             }


### PR DESCRIPTION
## Summary of changes

Change warning to debug level for asm log, when unexpected type reach the Encoder.cs

## Reason for change

Some unknown types still make it here, we dont want to flood the logs, so make it a debug one for now, before adding a potential metric
Refer to #3553 for same issue 

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
