### PR TITLE
Update CI support for release branches

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2260,7 +2260,7 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables.isMainBranch, true),
+        eq(variables.isMainOrReleaseBranch, true),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
       )
     )
@@ -2334,7 +2334,7 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables.isMainBranch, true),
+        eq(variables.isMainOrReleaseBranch, true),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
       )
     )
@@ -4028,7 +4028,7 @@ stages:
     and(succeeded(), 
         eq(variables.isMainRepository, true),
         or(
-          eq(variables.isMainBranch, true),
+          eq(variables.isMainOrReleaseBranch, true),
           eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')))
   dependsOn: [package_linux, generate_variables, build_windows_tracer, merge_commit_id]
   variables:
@@ -6002,7 +6002,7 @@ stages:
     and(
       failed(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(variables['isMainBranch'], true)
+      eq(variables['isMainOrReleaseBranch'], true)
     )
   dependsOn: [trace_pipeline] # so it runs last
   jobs:

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - main
-      - release/1.x
+      - release/**
     types: [closed]
 
 jobs:

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -7,11 +7,13 @@ on:
 jobs:
   bump_version:
     # If this is a 1.x release, do the version bump in the release/1.x branch
-    # If this is a 2.x.0 release, do the version bump on master
-    # If this is a 2.x.x hotfix release, _don't_ do a version bump
+    # If this is a 2.x release, do the version bump in the release/2.x branch
+    # If this is a 3.x.0 release, do the version bump on master
+    # If this is a 3.x.x hotfix release, _don't_ do a version bump
     if: |
       startsWith(github.event.release.tag_name, 'v1.')
-      || (startsWith(github.event.release.tag_name, 'v2.')
+      || startsWith(github.event.release.tag_name, 'v2.')
+      || (startsWith(github.event.release.tag_name, 'v3.')
         && endsWith(github.event.release.tag_name, '.0'))
 
     runs-on: windows-latest
@@ -27,6 +29,9 @@ jobs:
         run: |
           if( "${{ github.event.release.tag_name}}".StartsWith("v1.")) {
             echo "::set-output name=ref::release/1.x"
+          # TODO: Uncomment the following once we cut the release/2.x branch and merge v3
+          # } elseif("${{ github.event.release.tag_name}}".StartsWith("v2.")) {
+            # echo "::set-output name=ref::release/2.x"
           } else {
             echo "::set-output name=ref::master"
           }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,8 @@ deploy_latest_tag_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+    # Don't deploy latest tag if prerelease
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: always
     - when: manual
       allow_failure: true
@@ -140,7 +141,8 @@ deploy_latest_musl_tag_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+      # Don't deploy latest tag if prerelease
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: always
     - when: manual
       allow_failure: true

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1344,7 +1344,8 @@ partial class Build
         var milestoneName = Version switch
         {
             null or { Length: 0 } => throw new Exception("Version was unexpectedly null!"),
-            { } v => $"vNext-v{v[0]}",
+            { } v when v.IndexOf('.') < 0 => throw new Exception("Version didn't contain '.'!"),
+            { } v => $"vNext-v{v.AsSpan(0, v.IndexOf('.'))}",
         };
 
         var milestone = await GetMilestone(gitHubClient, milestoneName);

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1341,7 +1341,12 @@ partial class Build
 
     private async Task<Milestone> GetOrCreateVNextMilestone(GitHubClient gitHubClient)
     {
-        var milestoneName = Version.StartsWith("1.") ? "vNext-v1" : "vNext";
+        var milestoneName = Version switch
+        {
+            null or { Length: 0 } => throw new Exception("Version was unexpectedly null!"),
+            { } v => $"vNext-v{v[0]}",
+        };
+
         var milestone = await GetMilestone(gitHubClient, milestoneName);
         if (milestone is not null)
         {


### PR DESCRIPTION
## Summary of changes

Initial changes to CI to support releasing v2 from `release/2.x` and v3 from `master`

## Reason for change

We're going to be cutting a `release/2.x` branch, and want to make sure our automations work on those branches.

## Implementation details

- Update a bunch of test stages to run on merges to master _or_ `release/**`
- Changed the milestones to always have a version suffix (will require some manual moving of milestones for next release once merged)
- Ensure `auto_add_vnext_milestone_to_pr` runs on all release branches
- Ensure `auto_create_version_bump_pr` does v2 version bumps on `release/2.x`
  - This is disabled for the moment, because we _only_ want to do this _after_ we've cut the `release/2.x` branch and merged `v3-main`. Fixed in:
  - https://github.com/DataDog/dd-trace-dotnet/pull/5356
  - Couldn't find a neater way to do this
- Don't publish lib-injection `:latest` and `:latest-musl` tags for `-prerelease` versions (seems dangerous)

## Test coverage

Yeah... we can't really test all this without doing a release 😬 

## Other details

There are two releated PRs
- https://github.com/DataDog/dd-trace-dotnet/pull/5357 (to be merged into `release/2.x`)
- https://github.com/DataDog/dd-trace-dotnet/pull/5356 (to be merged into `master` when we do v3)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
