### PR TITLE
[ASM] Add IAST header tainting integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             foreach (var header in headersValues)
             {
-                _httpClient.DefaultRequestHeaders[header.Key] = header.Value;
+                _httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
             }
         }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -80,7 +80,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             foreach (var header in headersValues)
             {
-                _httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+                _httpClient.DefaultRequestHeaders[header.Key] = header.Value;
             }
         }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -64,7 +64,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             // Keep-alive is causing some weird failures on aspnetcore 2.1
             _httpClient.DefaultRequestHeaders.ConnectionClose = true;
 #endif
-
             _jsonSerializerSettingsOrderProperty = new JsonSerializerSettings { ContractResolver = new OrderedContractResolver() };
             EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_WAF_TIMEOUT", 10_000_000.ToString());
         }
@@ -75,6 +74,14 @@ namespace Datadog.Trace.Security.IntegrationTests
         {
             base.Dispose();
             _httpClient?.Dispose();
+        }
+
+        public void AddHeaders(Dictionary<string, string> headersValues)
+        {
+            foreach (var header in headersValues)
+            {
+                _httpClient.DefaultRequestHeaders.Add(header.Key, header.Value);
+            }
         }
 
         public void AddCookies(Dictionary<string, string> cookiesValues)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -341,7 +341,7 @@ public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
         if (RedactionEnabled is true) { filename += ".RedactionEnabled"; }
         var url = "/Iast/ExecuteCommandFromHeader";
         IncludeAllHttpSpans = true;
-        AddHeaders(new () { { "file", "file.txt" }, { "argumentLine", "arg1" } });
+        AddHeaders(new() { { "file", "file.txt" }, { "argumentLine", "arg1" } });
         await TryStartApp();
         var agent = Fixture.Agent;
         var spans = await SendRequestsAsync(agent, new string[] { url });

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -341,7 +341,7 @@ public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
         if (RedactionEnabled is true) { filename += ".RedactionEnabled"; }
         var url = "/Iast/ExecuteCommandFromHeader";
         IncludeAllHttpSpans = true;
-        AddHeaders(new Dictionary<string, string>() { { "file", "file.txt" }, { "argumentLine", "arg1" } });
+        AddHeaders(new () { { "file", "file.txt" }, { "argumentLine", "arg1" } });
         await TryStartApp();
         var agent = Fixture.Agent;
         var spans = await SendRequestsAsync(agent, new string[] { url });

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -335,6 +335,27 @@ public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
 
     [SkippableFact]
     [Trait("RunOnWindows", "True")]
+    public async Task TestIastHeaderTaintingRequest()
+    {
+        var filename = IastEnabled ? "Iast.HeaderTainting.AspNetCore5.IastEnabled" : "Iast.HeaderTainting.AspNetCore5.IastDisabled";
+        if (RedactionEnabled is true) { filename += ".RedactionEnabled"; }
+        var url = "/Iast/ExecuteCommandFromHeader";
+        IncludeAllHttpSpans = true;
+        AddHeaders(new Dictionary<string, string>() { { "file", "file.txt" }, { "argumentLine", "arg1" } });
+        await TryStartApp();
+        var agent = Fixture.Agent;
+        var spans = await SendRequestsAsync(agent, new string[] { url });
+        var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddIastScrubbing();
+        await VerifyHelper.VerifySpans(spansFiltered, settings)
+                            .UseFileName(filename)
+                            .DisableRequireUniquePrefix();
+    }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
     public async Task TestIastCookieTaintingRequest()
     {
         var filename = IastEnabled ? "Iast.CookieTainting.AspNetCore5.IastEnabled" : "Iast.CookieTainting.AspNetCore5.IastDisabled";

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -116,6 +116,7 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         SetEnvironmentVariable("DD_IAST_REQUEST_SAMPLING", "100");
         SetEnvironmentVariable("DD_IAST_MAX_CONCURRENT_REQUESTS", "100");
         SetEnvironmentVariable("DD_IAST_VULNERABILITIES_PER_REQUEST", "100");
+        SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
         DisableObfuscationQueryString();
         SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 
@@ -176,6 +177,25 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         var settings = VerifyHelper.GetSpanVerifierSettings(test, sanitisedUrl, body);
         var spans = await SendRequestsAsync(_iisFixture.Agent, new string[] { url });
         var filename = _enableIast ? "Iast.PathTraversal.AspNetMvc5.IastEnabled" : "Iast.PathTraversal.AspNetMvc5.IastDisabled";
+        var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
+        settings.AddIastScrubbing();
+        await VerifyHelper.VerifySpans(spansFiltered, settings)
+                          .UseFileName(filename)
+                          .DisableRequireUniquePrefix();
+    }
+
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    [Trait("LoadFromGAC", "True")]
+    [SkippableTheory]
+    [InlineData(AddressesConstants.RequestQuery, "/Iast/ExecuteCommandFromHeader", null)]
+    public async Task TestIastHeaderTaintingRequest(string test, string url, string body)
+    {
+        var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
+        var settings = VerifyHelper.GetSpanVerifierSettings(test, sanitisedUrl, body);
+        AddHeaders(new Dictionary<string, string>() { { "file", "file.txt" }, { "argumentLine", "arg1" } });
+        var spans = await SendRequestsAsync(_iisFixture.Agent, new string[] { url });
+        var filename = _enableIast ? "Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled" : "Iast.ExecuteCommandFromHeader.AspNetMvc5.IastDisabled";
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
         settings.AddIastScrubbing();
         await VerifyHelper.VerifySpans(spansFiltered, settings)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -116,7 +116,6 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         SetEnvironmentVariable("DD_IAST_REQUEST_SAMPLING", "100");
         SetEnvironmentVariable("DD_IAST_MAX_CONCURRENT_REQUESTS", "100");
         SetEnvironmentVariable("DD_IAST_VULNERABILITIES_PER_REQUEST", "100");
-        SetEnvironmentVariable("DD_TRACE_DEBUG", "1");
         DisableObfuscationQueryString();
         SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 

--- a/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastDisabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastDisabled.verified.txt
@@ -1,0 +1,52 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: {controller}/{action}/{id},
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommandFromHeader,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: sample,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet.action: executecommandfromheader,
+      aspnet.controller: iast,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommandFromHeader,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
@@ -1,0 +1,89 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: sample,
+    Type: web,
+    Tags: {
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: {controller}/{action}/{id},
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommandFromHeader,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "COMMAND_INJECTION",
+      
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "file.txt",
+            "source": 0
+          },
+          {
+            "value": " "
+          },
+          {
+            "value": "arg1",
+            "source": 1
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.header",
+      "name": "file",
+      "value": "file.txt"
+    },
+    {
+      "origin": "http.request.header",
+      "name": "argumentLine",
+      "value": "arg1"
+    }
+  ]
+},
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet-mvc.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: sample,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet.action: executecommandfromheader,
+      aspnet.controller: iast,
+      aspnet.route: {controller}/{action}/{id},
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommandFromHeader,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastDisabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastDisabled.verified.txt
@@ -1,0 +1,55 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.ExecuteCommandFromHeader (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/executecommandfromheader,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/executecommandfromheader,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommandFromHeader,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: executecommandfromheader,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/executecommandfromheader,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -1,0 +1,94 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.ExecuteCommandFromHeader (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/executecommandfromheader,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/executecommandfromheader,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommandFromHeader,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "COMMAND_INJECTION",
+      
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "file.txt",
+            "source": 0
+          },
+          {
+            "value": " "
+          },
+          {
+            "redacted": true,
+            "pattern": "abcd",
+            "source": 1
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.header",
+      "name": "file",
+      "value": "file.txt"
+    },
+    {
+      "origin": "http.request.header",
+      "name": "argumentLine",
+      "redacted": true,
+      "pattern": "abcd"
+    }
+  ]
+},
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: executecommandfromheader,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/executecommandfromheader,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
@@ -1,0 +1,92 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.ExecuteCommandFromHeader (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/executecommandfromheader,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/executecommandfromheader,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/ExecuteCommandFromHeader,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "COMMAND_INJECTION",
+      
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "file.txt",
+            "source": 0
+          },
+          {
+            "value": " "
+          },
+          {
+            "value": "arg1",
+            "source": 1
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.header",
+      "name": "file",
+      "value": "file.txt"
+    },
+    {
+      "origin": "http.request.header",
+      "name": "argumentLine",
+      "value": "arg1"
+    }
+  ]
+},
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/executecommandfromheader,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: executecommandfromheader,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/executecommandfromheader,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  }
+]

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -237,6 +237,13 @@ namespace Samples.Security.AspNetCore5.Controllers
             return Content($"No query was provided");
         }
 
+        [HttpGet("ExecuteCommandFromHeader")]
+        [Route("ExecuteCommandFromHeader")]
+        public IActionResult ExecuteCommandFromHeader()
+        {
+            return ExecuteCommandInternal(Request.Headers["file"], Request.Headers["argumentLine"]);
+        }
+
         [HttpGet("ExecuteCommandFromCookie")]
         [Route("ExecuteCommandFromCookie")]
         public IActionResult ExecuteCommandFromCookie()

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/IastController.cs
@@ -196,6 +196,12 @@ namespace Samples.Security.AspNetCore5.Controllers
             return ExecuteCommandInternal(Request.Cookies["file"].Value, argumentValue);
         }
 
+        [Route("ExecuteCommandFromHeader")]
+        public ActionResult ExecuteCommandFromHeader()
+        {
+            return ExecuteCommandInternal(Request.Headers["file"], Request.Headers["argumentLine"]);
+        }
+
         [Route("GetDirectoryContent")]
         public ActionResult GetDirectoryContent(string directory)
         {


### PR DESCRIPTION
## Summary of changes

We already support the tainting of headers in IAST. We had some unit tests but we did not have integrations tests. This PR adds those tests.

## Reason for change

To increase the quality of our testing.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
