### PR TITLE
[Profiler] Fix named pipe permissions on IPC server

### DIFF
--- a/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.vcxproj
+++ b/profiler/src/Tools/ETW/dd-prof-etw/dd-prof-etw-client/dd-prof-etw-client.vcxproj
@@ -76,6 +76,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -90,6 +91,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -104,6 +106,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,6 +121,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/profiler/src/Tools/ETW/dd-prof-etw/shared/IpcServer.cpp
+++ b/profiler/src/Tools/ETW/dd-prof-etw/shared/IpcServer.cpp
@@ -150,8 +150,19 @@ void CALLBACK IpcServer::StartCallback(PTP_CALLBACK_INSTANCE instance, PVOID con
         }
 
         std::wstring ddagentUser, ddagentDomain;
-        GetStringRegKey(hKey, L"installedUser", ddagentUser, L"");
-        GetStringRegKey(hKey, L"installedDomain", ddagentDomain, L"");
+        if (GetStringRegKey(hKey, L"installedUser", ddagentUser, L"") != ERROR_SUCCESS)
+        {
+            pThis->ShowLastError("Failed to retrieve installedUser...");
+            pThis->_pHandler->OnStartError();
+            return;
+        }
+
+        if (GetStringRegKey(hKey, L"installedDomain", ddagentDomain, L"") != ERROR_SUCCESS)
+        {
+            pThis->ShowLastError("Failed to retrieve installedDomain...");
+            pThis->_pHandler->OnStartError();
+            return;
+        }
 
         DWORD cbSid = 0;
         DWORD cchRefDomain = 0;

--- a/profiler/src/Tools/ETW/dd-prof-etw/shared/IpcServer.cpp
+++ b/profiler/src/Tools/ETW/dd-prof-etw/shared/IpcServer.cpp
@@ -152,6 +152,7 @@ void CALLBACK IpcServer::StartCallback(PTP_CALLBACK_INSTANCE instance, PVOID con
         std::wstring ddagentUser, ddagentDomain;
         if (GetStringRegKey(hKey, L"installedUser", ddagentUser, L"") != ERROR_SUCCESS)
         {
+            RegCloseKey(hKey);
             pThis->ShowLastError("Failed to retrieve installedUser...");
             pThis->_pHandler->OnStartError();
             return;
@@ -159,10 +160,12 @@ void CALLBACK IpcServer::StartCallback(PTP_CALLBACK_INSTANCE instance, PVOID con
 
         if (GetStringRegKey(hKey, L"installedDomain", ddagentDomain, L"") != ERROR_SUCCESS)
         {
+            RegCloseKey(hKey);
             pThis->ShowLastError("Failed to retrieve installedDomain...");
             pThis->_pHandler->OnStartError();
             return;
         }
+        RegCloseKey(hKey);
 
         DWORD cbSid = 0;
         DWORD cchRefDomain = 0;


### PR DESCRIPTION
## Summary of changes
This PR changes the permissions on the POC IPC server from https://github.com/DataDog/dd-trace-dotnet/pull/4649.

## Reason for change
The `ddagentuser` is not part of the `Users` group, and thus an explicit permission is required to allow it to access the named pipe created by the POC.

## Implementation details
This simply retrieves the user the Datadog Agent service runs as from the registry. A more sophisticated (but potentially limited by access permissions) would be to query the service configuration directly.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
