### PR TITLE
Improve `HostMetadata.OsVersion` value

### DIFF
--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -5,9 +5,9 @@
 
 #if !NETFRAMEWORK
 using System;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using Datadog.Trace.Logging;
 
 namespace Datadog.Trace
 {
@@ -57,10 +57,10 @@ namespace Datadog.Trace
                     osPlatform = Trace.OSPlatformName.MacOS;
                 }
 
-                osDescription = RuntimeInformation.OSDescription;
                 osArchitecture = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
                 processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
                 frameworkVersion = GetNetCoreOrNetFrameworkVersion();
+                osDescription = GetOsDescription();
             }
             catch (Exception ex)
             {
@@ -133,6 +133,136 @@ namespace Datadog.Trace
             }
 
             return productVersion;
+        }
+
+        private static string GetOsDescription()
+        {
+            if (RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows))
+            {
+                return RuntimeInformation.OSDescription;
+            }
+
+            // back-ports the .NET 8 implementation of RuntimeInformation.OSDescription
+            // for Linux. This gives us a "friendly" distribution name
+            // https://github.com/dotnet/runtime/blob/9fe22288c3b78dc681dbb02401c4197609cdb544/src/libraries/System.Private.CoreLib/src/System/Runtime/InteropServices/RuntimeInformation.Unix.cs#L34C32-L34C54
+            const string filename = "/etc/os-release";
+
+            if (File.Exists(filename))
+            {
+                string[] lines;
+                try
+                {
+                    lines = File.ReadAllLines(filename);
+                }
+                catch
+                {
+                    return null;
+                }
+
+#if NETCOREAPP
+                // Parse the NAME, PRETTY_NAME, and VERSION fields.
+                // These fields are suitable for presentation to the user.
+                ReadOnlySpan<char> prettyName = default, name = default, version = default;
+                foreach (string line in lines)
+                {
+                    ReadOnlySpan<char> lineSpan = line.AsSpan();
+                    _ = TryGetFieldValue(lineSpan, "PRETTY_NAME=", ref prettyName) ||
+                        TryGetFieldValue(lineSpan, "NAME=", ref name) ||
+                        TryGetFieldValue(lineSpan, "VERSION=", ref version);
+
+                    // Prefer "PRETTY_NAME".
+                    if (!prettyName.IsEmpty)
+                    {
+                        return new string(prettyName);
+                    }
+                }
+
+                // Fall back to "NAME[ VERSION]".
+                if (!name.IsEmpty)
+                {
+                    if (!version.IsEmpty)
+                    {
+                        return string.Concat(name, " ", version);
+                    }
+
+                    return new string(name);
+                }
+#else
+                // Parse the NAME, PRETTY_NAME, and VERSION fields.
+                // These fields are suitable for presentation to the user.
+                string prettyName = default, name = default, version = default;
+                foreach (string line in lines)
+                {
+                    _ = TryGetFieldValue(line, "PRETTY_NAME=", ref prettyName) ||
+                        TryGetFieldValue(line, "NAME=", ref name) ||
+                        TryGetFieldValue(line, "VERSION=", ref version);
+
+                    // Prefer "PRETTY_NAME".
+                    if (!string.IsNullOrEmpty(prettyName))
+                    {
+                        return prettyName;
+                    }
+                }
+
+                // Fall back to "NAME[ VERSION]".
+                if (!string.IsNullOrEmpty(name))
+                {
+                    if (!string.IsNullOrEmpty(version))
+                    {
+                        return string.Concat(name, " ", version);
+                    }
+
+                    return name;
+                }
+#endif
+            }
+
+            // Fallback to the "default" value
+            return RuntimeInformation.OSDescription;
+
+#if NETCOREAPP
+            static bool TryGetFieldValue(ReadOnlySpan<char> line, ReadOnlySpan<char> prefix, ref ReadOnlySpan<char> value)
+            {
+                if (!line.StartsWith(prefix))
+                {
+                    return false;
+                }
+
+                ReadOnlySpan<char> fieldValue = line.Slice(prefix.Length);
+
+                // Remove enclosing quotes.
+                if (fieldValue.Length >= 2 &&
+                    fieldValue[0] is '"' or '\'' &&
+                    fieldValue[0] == fieldValue[^1])
+                {
+                    fieldValue = fieldValue[1..^1];
+                }
+
+                value = fieldValue;
+                return true;
+            }
+#else
+            static bool TryGetFieldValue(string line, string prefix, ref string value)
+            {
+                if (!line.StartsWith(prefix))
+                {
+                    return false;
+                }
+
+                var fieldValue = line.Substring(prefix.Length);
+
+                // Remove enclosing quotes.
+                if (fieldValue.Length >= 2 &&
+                    fieldValue[0] is '"' or '\'' &&
+                    fieldValue[0] == fieldValue[fieldValue.Length - 1])
+                {
+                    fieldValue = fieldValue.Substring(1, fieldValue.Length - 2);
+                }
+
+                value = fieldValue;
+                return true;
+            }
+#endif
         }
     }
 }

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -27,6 +27,7 @@ namespace Datadog.Trace
             var osPlatform = "unknown";
             var osArchitecture = "unknown";
             var processArchitecture = "unknown";
+            var osDescription = "unknown";
 
             try
             {
@@ -56,6 +57,7 @@ namespace Datadog.Trace
                     osPlatform = Trace.OSPlatformName.MacOS;
                 }
 
+                osDescription = RuntimeInformation.OSDescription;
                 osArchitecture = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
                 processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
                 frameworkVersion = GetNetCoreOrNetFrameworkVersion();
@@ -70,7 +72,8 @@ namespace Datadog.Trace
                 productVersion: frameworkVersion,
                 osPlatform: osPlatform,
                 osArchitecture: osArchitecture,
-                processArchitecture: processArchitecture);
+                processArchitecture: processArchitecture,
+                osDescription: osDescription);
         }
 
         public bool IsCoreClr()

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetCore.cs
@@ -60,7 +60,11 @@ namespace Datadog.Trace
                 osArchitecture = RuntimeInformation.OSArchitecture.ToString().ToLowerInvariant();
                 processArchitecture = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
                 frameworkVersion = GetNetCoreOrNetFrameworkVersion();
+#if NET8_0_OR_GREATER
+                osDescription = RuntimeInformation.OSDescription;
+#else
                 osDescription = GetOsDescription();
+#endif
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.NetFramework.cs
@@ -25,9 +25,11 @@ namespace Datadog.Trace
             var osArchitecture = "unknown";
             var processArchitecture = "unknown";
             var frameworkVersion = "unknown";
+            var osDescription = "unknown";
 
             try
             {
+                osDescription = Environment.OSVersion.VersionString;
                 osArchitecture = Environment.Is64BitOperatingSystem ? "x64" : "x86";
                 processArchitecture = Environment.Is64BitProcess ? "x64" : "x86";
                 frameworkVersion = GetNetFrameworkVersion();
@@ -42,7 +44,8 @@ namespace Datadog.Trace
                 productVersion: frameworkVersion,
                 osPlatform: "Windows",
                 osArchitecture: osArchitecture,
-                processArchitecture: processArchitecture);
+                processArchitecture: processArchitecture,
+                osDescription: osDescription);
         }
 
         public bool IsCoreClr()

--- a/tracer/src/Datadog.Trace/FrameworkDescription.cs
+++ b/tracer/src/Datadog.Trace/FrameworkDescription.cs
@@ -40,12 +40,14 @@ namespace Datadog.Trace
             string productVersion,
             string osPlatform,
             string osArchitecture,
-            string processArchitecture)
+            string processArchitecture,
+            string osDescription)
         {
             Name = name;
             ProductVersion = productVersion;
             OSPlatform = osPlatform;
             OSArchitecture = osArchitecture;
+            OSDescription = osDescription;
             ProcessArchitecture = processArchitecture;
         }
 
@@ -58,6 +60,8 @@ namespace Datadog.Trace
         public string OSArchitecture { get; }
 
         public string ProcessArchitecture { get; }
+
+        public string OSDescription { get; }
 
         public static bool IsNet5()
         {

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ApplicationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ApplicationTelemetryCollector.cs
@@ -40,12 +40,16 @@ internal class ApplicationTelemetryCollector
         }
 
         var host = HostMetadata.Instance;
+        var osDescription = frameworkDescription.OSArchitecture == "x86"
+                                ? $"{frameworkDescription.OSDescription} (32bit)"
+                                : frameworkDescription.OSDescription;
+
         _hostData = new HostTelemetryData(
             hostname: host.Hostname ?? string.Empty, // this is required, but we don't have it
             os: frameworkDescription.OSPlatform,
             architecture: frameworkDescription.ProcessArchitecture)
         {
-            OsVersion = Environment.OSVersion.ToString(),
+            OsVersion = osDescription,
             KernelName = host.KernelName,
             KernelRelease = host.KernelRelease,
             KernelVersion = host.KernelVersion

--- a/tracer/test/Datadog.Trace.Tests/FrameworkDescriptionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FrameworkDescriptionTests.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="FrameworkDescriptionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.InteropServices;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+using static Datadog.Trace.TestHelpers.SkipOn.PlatformValue;
+
+namespace Datadog.Trace.Tests;
+
+public class FrameworkDescriptionTests
+{
+#if NETFRAMEWORK
+    [SkippableFact]
+    public void Windows_GivesExpectedValues()
+    {
+        // We don't support Mono
+        SkipOn.Platform(MacOs);
+        SkipOn.Platform(Linux);
+
+        var description = FrameworkDescription.Create();
+        description.OSPlatform.Should().Be("Windows");
+        description.OSArchitecture.Should().Be("x64"); // We only test on 64 bit OS atm
+        description.OSDescription.Should().StartWith("Microsoft Windows NT 10.0."); // Windows 10/11
+    }
+#else
+    [SkippableFact]
+    public void Windows_GivesExpectedValues()
+    {
+        SkipOn.Platform(MacOs);
+        SkipOn.Platform(Linux);
+
+        var description = FrameworkDescription.Create();
+        description.OSPlatform.Should().Be("Windows");
+        description.OSArchitecture.Should().Be("x64"); // We only test on 64 bit OS atm
+        description.OSDescription.Should().StartWith("Microsoft Windows 10.0."); // Windows 10/11, note that this is _slightly_ different to the .NET FX version annoyingly
+    }
+
+    [SkippableFact]
+    public void Linux_GivesExpectedValues()
+    {
+        SkipOn.Platform(Windows);
+        SkipOn.Platform(MacOs);
+
+        var expectedOs = EnvironmentHelper.IsAlpine()
+                             ? "Alpine Linux v3.14"
+                             : "Debian GNU/Linux 10 (buster)";
+
+        var description = FrameworkDescription.Create();
+        var arch = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+
+        description.OSPlatform.Should().Be("Linux");
+        description.OSArchitecture.Should().Be(arch);
+        description.OSDescription.Should().StartWith(expectedOs);
+    }
+#endif
+}


### PR DESCRIPTION
## Summary of changes

Record the `RuntimeInformation.OSDescription` value instead of the `Environment.OSVersion` value

## Reason for change

`Environment.OSVersion` gives relatively opaque values on Linux:

```
Unix 13.4.1
Unix 14.0.2
```

whereas `RuntimeInformation.OSDescription` gives more useful values*:

```
Alpine Linux v3.14
Debian GNU/Linux 10 (buster)
```

> *Unfortunately, I discovered that it _only_ gives these values on .NET 8. Luckily it's a pretty simple implementation, so backported it to earlier versions too. Once we drop .NET Standard we can simplify this implementation even further.


## Implementation details

- Added `OSDescription` to `FrameworkDescription`
- Added a backport of [the .NET 8 immplentation of `Interop.OsReleaseFile.GetPrettyName()`](https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/Interop/Linux/os-release/Interop.OSReleaseFile.cs#L17)
- On Windows, there's basically no change in the value we send, but on Linux we get better results
- Also appended ` (32-bit)` to the string if we're running on x86 (only supported on Windows) so we can track OS architecture

## Test coverage

Added a small test for the `FrameworkDescription` updates, but otherwise this is simple enough

## Other details
<!-- Fixes #{issue} -->

We don't support mono or Windows/.NET FX on arm etc but we may need to revisit `FrameworkDescription` to account for those at some point...

Also there's a _slight_ difference in the OS description between .NET Core and .NET Framework
- `Microsoft Windows NT 10.0.x.x` <- .NET Framework
- `Microsoft Windows 10.0.x.x` <- .NET Core

I was inclined to not worry about that, but we could try to clean it up in the source if people think it's worth it. It's not entirely simple unfortunately...



<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
