### PR TITLE
Fix flaky DSM transport test

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -85,7 +85,14 @@ public class DataStreamsMonitoringTransportTests
              .OnlyContain(
                   headers => headers.AllKeys.Contains("Content-Encoding")
                           && headers["Content-Encoding"] == "gzip");
-        result.Should().OnlyContain(payload => payload.Stats.Count(s => s.Backlogs != null) == 1);
+
+        // should only have a single backlog across all payloads, but we don't know which payload it will be in
+        result
+           .SelectMany(x => x.Stats)
+           .Where(x => x.Backlogs is not null)
+           .Should()
+           .ContainSingle()
+           .And.ContainSingle();
     }
 
     private StatsPoint CreateStatsPoint(long timestamp = 0)

--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsMonitoringTransportTests.cs
@@ -92,7 +92,8 @@ public class DataStreamsMonitoringTransportTests
            .Where(x => x.Backlogs is not null)
            .Should()
            .ContainSingle()
-           .And.ContainSingle();
+           .Which.Backlogs.Should()
+           .ContainSingle();
     }
 
     private StatsPoint CreateStatsPoint(long timestamp = 0)


### PR DESCRIPTION
## Summary of changes

Try and _actually_ fix the DSM flake

## Reason for change

It's _horribly_ flaky

## Implementation details

The following is an example payload that currently causes the test to fail:

<details><summary>Failing payload</summary>
<code language="json"><pre>
[
    {
      "Env": "env",
      "Service": "service",
      "PrimaryTag": null,
      "TracerVersion": "2.42.0.0",
      "Lang": "dotnet",
      "Stats": [
        {
          "Start": 1699354800000000000,
          "Duration": 3600000000000,
          "Stats": null,
          "Backlogs": [
            {
              "Tags": [
                "type:produce"
              ],
              "Value": 100
            }
          ]
        }
      ]
    },
    {
      "Env": "env",
      "Service": "service",
      "PrimaryTag": null,
      "TracerVersion": "2.42.0.0",
      "Lang": "dotnet",
      "Stats": [
        {
          "Start": 1699354800000000000,
          "Duration": 3600000000000,
          "Stats": [
            {
              "EdgeTags": [
                "direction:out",
                "type:kafka"
              ],
              "Hash": 425502778,
              "ParentHash": 1133180426,
              "PathwayLatency": "ChIJAAAAAABA8D8RAAAAAADqlEASDRIIAAAAAAAA8D8YxBYaAA==",
              "EdgeLatency": "ChIJAAAAAABA8D8RAAAAAADqlEASDRIIAAAAAAAA8D8YzhUaAA==",
              "PayloadSize": "ChIJAAAAAABA8D8RAAAAAADqlEASDRIIAAAAAAAA8D8Y8hsaAA==",
              "TimestampType": "current"
            }
          ],
          "Backlogs": null
        },
        {
          "Start": 1699354800000000000,
          "Duration": 3600000000000,
          "Stats": [
            {
              "EdgeTags": [
                "direction:out",
                "type:kafka"
              ],
              "Hash": 425502778,
              "ParentHash": 1133180426,
              "PathwayLatency": "ChIJAAAAAABA8D8RAAAAAADqlEASDRIIAAAAAAAA8D8YxBYaAA==",
              "EdgeLatency": "ChIJAAAAAABA8D8RAAAAAADqlEASDRIIAAAAAAAA8D8YzhUaAA==",
              "PayloadSize": "ChIJAAAAAABA8D8RAAAAAADqlEASDRIIAAAAAAAA8D8Y8hsaAA==",
              "TimestampType": "origin"
            }
          ],
          "Backlogs": null
        }
      ]
    }
  ]
</pre></code></details>

The key point is that there are potentially _multiple_ payloads, and all that we're trying to check is that there is a _single_ `Backlog` entry across _all_ payloads.

## Test coverage

Tested with the above payload locally to confirm the fix, then did two dedicated runs in CI to check it doesn't happen again

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
