### PR TITLE
Properly read the installed tracer version in dd-dotnet

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -619,8 +619,14 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
                 if (subKeyDisplayName == datadogProgramName)
                 {
-                    tracerVersion = registryService.GetLocalMachineKeyNameValue(uninstallKey, subKeyName, "VersionMajor") + "." + registryService.GetLocalMachineKeyNameValue(uninstallKey, subKeyName, "VersionMinor");
-                    versionFound = true;
+                    var versionMajor = registryService.GetLocalMachineKeyNameValue(uninstallKey, subKeyName, "VersionMajor");
+                    var versionMinor = registryService.GetLocalMachineKeyNameValue(uninstallKey, subKeyName, "VersionMinor");
+
+                    if (!string.IsNullOrEmpty(versionMajor) && !string.IsNullOrEmpty(versionMinor))
+                    {
+                        tracerVersion = $"{versionMajor}.{versionMinor}";
+                        versionFound = true;
+                    }
                 }
             }
 

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -602,8 +602,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             }
 
             Utils.WriteError(TraceProgramNotFound);
-
-            return tracerVersion;
+            return null;
         }
 
         private static bool GetLocalMachineSubKeyVersion(string uninstallKey, string datadogProgramName, out string? tracerVersion, IRegistryService? registryService = null)

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/RegistryService.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Windows/RegistryService.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows
 
             var registryKey = Registry.LocalMachine.OpenSubKey(key);
 
-            return registryKey?.GetValue(null) as string;
+            return registryKey?.GetValue(null)?.ToString();
         }
 
         public string[] GetLocalMachineKeyNames(string key)
@@ -75,7 +75,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks.Windows
 
             var subKey = registryKey.OpenSubKey(subKeyName);
 
-            return subKey?.GetValue(name) as string;
+            return subKey?.GetValue(name)?.ToString();
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Fix the code that reads the installed version of the tracer from the registry.

## Reason for change

dd-dotnet was failing to read the version, with the message: `The input string '' was not in a correct format.`

## Implementation details

The version keys are stored as DWORD (Int32) in the registry, so the `as string` cast was failing.
Also made the check more robust in case the VersionMinor/VersionMajor sub keys are missing.
