### PR TITLE
Update source generator to record the "instrumented assemblies"

### DIFF
--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -482,6 +482,42 @@ namespace Datadog.Trace.ClrProfiler
             };
         }
 
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("AerospikeClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("amqmdnetstd,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Couchbase.NetClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Elasticsearch.Net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL.SystemReactive,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("HotChocolate.Execution,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("log4net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MongoDB.Driver.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySql.Data,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySqlConnector,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("netstandard,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("NLog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Npgsql,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("nunit.framework,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry.Api,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.DataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.ManagedDataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("RabbitMQ.Client,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Serilog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("ServiceStack.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis.StrongName,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("System,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.desktop,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.dotnet,", StringComparison.Ordinal);
+
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
             return integrationTypeName switch

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -505,6 +505,45 @@ namespace Datadog.Trace.ClrProfiler
             };
         }
 
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("AerospikeClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Amazon.Lambda.RuntimeSupport,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("amqmdnetstd,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Couchbase.NetClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Elasticsearch.Net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL.SystemReactive,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.AspNetCore.Server,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.Net.Client,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("HotChocolate.Execution,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("log4net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MongoDB.Driver.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySql.Data,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySqlConnector,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("netstandard,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("NLog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Npgsql,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("nunit.framework,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry.Api,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.DataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.ManagedDataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("RabbitMQ.Client,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Serilog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("ServiceStack.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis.StrongName,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("System,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.desktop,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.dotnet,", StringComparison.Ordinal);
+
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
             return integrationTypeName switch

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -502,6 +502,44 @@ namespace Datadog.Trace.ClrProfiler
             };
         }
 
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("AerospikeClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("amqmdnetstd,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Couchbase.NetClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Elasticsearch.Net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL.SystemReactive,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.AspNetCore.Server,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.Net.Client,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("HotChocolate.Execution,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("log4net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MongoDB.Driver.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySql.Data,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySqlConnector,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("netstandard,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("NLog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Npgsql,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("nunit.framework,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry.Api,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.DataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.ManagedDataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("RabbitMQ.Client,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Serilog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("ServiceStack.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis.StrongName,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("System,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.desktop,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.dotnet,", StringComparison.Ordinal);
+
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
             return integrationTypeName switch

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/InstrumentationDefinitionsGenerator/InstrumentationDefinitions.g.cs
@@ -502,6 +502,44 @@ namespace Datadog.Trace.ClrProfiler
             };
         }
 
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("AerospikeClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("amqmdnetstd,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Couchbase.NetClient,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Elasticsearch.Net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("GraphQL.SystemReactive,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.AspNetCore.Server,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Grpc.Net.Client,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("HotChocolate.Execution,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("log4net,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MongoDB.Driver.Core,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySql.Data,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("MySqlConnector,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("netstandard,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("NLog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Npgsql,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("nunit.framework,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("OpenTelemetry.Api,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.DataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Oracle.ManagedDataAccess,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("RabbitMQ.Client,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("Serilog,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("ServiceStack.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("StackExchange.Redis.StrongName,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("System,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.desktop,", StringComparison.Ordinal)
+            || assemblyName.StartsWith("xunit.execution.dotnet,", StringComparison.Ordinal);
+
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
             return integrationTypeName switch

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
@@ -61,18 +61,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "Confluent.Kafka", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -81,6 +72,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka.Producer`2"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Produce"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Void", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Action`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]"), 4, 1, 4, 0, 1, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaProduceSyncIntegration"), 0, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -164,18 +163,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "Confluent.Kafka", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -185,6 +175,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka.Producer`2"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("ProduceAsync"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Threading.Tasks.Task`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Threading.CancellationToken"), 4, 1, 4, 0, 1, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaProduceAsyncIntegration"), 0, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -269,18 +267,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "Confluent.Kafka", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -290,6 +279,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka.Producer`2"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("ProduceAsync"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Threading.Tasks.Task`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Threading.CancellationToken"), 4, 1, 4, 0, 1, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaProduceAsyncIntegration"), 0, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -375,18 +372,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "Confluent.Kafka", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -396,6 +384,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka.Producer`2"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("ProduceAsync"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Threading.Tasks.Task`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Threading.CancellationToken"), 4, 1, 4, 0, 1, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaProduceAsyncIntegration"), 1, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -481,18 +477,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "Confluent.Kafka", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -502,6 +489,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka.Producer`2"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("ProduceAsync"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Threading.Tasks.Task`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Threading.CancellationToken"), 4, 1, 4, 0, 1, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.KafkaProduceAsyncIntegration"), 2, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -586,18 +581,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "Confluent.Kafka", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -609,6 +595,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Confluent.Kafka.Producer`2"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("ProduceAsync"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Threading.Tasks.Task`1[Confluent.Kafka.DeliveryReport`2[!0,!1]]", "Confluent.Kafka.TopicPartition", "Confluent.Kafka.Message`2[!0,!1]", "System.Threading.CancellationToken"), 4, 1, 4, 0, 1, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.Kafka.FakeMongoDbIntegration"), 0, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("Confluent.Kafka,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -685,18 +679,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "MySql.Data", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -706,6 +691,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("MySql.Data"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("MySql.Data.MySqlClient.MySqlCommand"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("ExecuteReader"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("MySql.Data.MySqlClient.MySqlDataReader"), 1, 6, 7, 0, 6, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteReaderIntegration"), 0, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("MySql.Data,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -802,18 +795,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(1, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { "MySql.Data", };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -826,6 +810,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("MySql.Data"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("MySql.Data.MySqlClient.MySqlCommand"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("ExecuteReader"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("MySql.Data.MySqlClient.MySqlDataReader"), 1, 6, 7, 0, 6, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.CommandExecuteReaderIntegration"), 0, 1),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => assemblyName.StartsWith("MySql.Data,", StringComparison.Ordinal);
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -923,18 +915,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(0, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -944,6 +927,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Microsoft.AspNetCore.Mvc.Core"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Microsoft.AspNetCore.Mvc.ModelBinding.DefaultModelBindingContext"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("set_Result"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Void", "Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingResult"), 2, 2, 0, 0, 6, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AspNetCore.DefaultModelBindingContext_SetResult_Integration"), 1, 2),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => false;
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {
@@ -1032,18 +1023,9 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
-        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
-            InstrumentedAssemblies =
-#if NETCOREAPP
-                new HashSet<string>(0, StringComparer.Ordinal)
-#else
-                new HashSet<string>(StringComparer.Ordinal)
-#endif
-                { };
-
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -1053,6 +1035,14 @@ namespace Datadog.Trace.ClrProfiler
                 new (NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Microsoft.AspNetCore.Mvc.Core"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Microsoft.AspNetCore.Mvc.ModelBinding.DefaultModelBindingContext"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("set_Result"), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray("System.Void", "Microsoft.AspNetCore.Mvc.ModelBinding.ModelBindingResult"), 2, 2, 0, 0, 6, 65535, 65535, NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String(assemblyFullName), NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16String("Datadog.Trace.ClrProfiler.AspNetCore.DefaultModelBindingContext_SetResult_Integration"), 1, 3),
             };
         }
+
+        /// <summary>
+        /// Checks if the provided <see cref="System.Reflection.Assembly.FullName"/> assembly
+        /// is one we instrument. Assumes you have already checked for "well-known" prefixes
+        /// like "System" and "Microsoft".
+        /// </summary>
+        internal static bool IsInstrumentedAssembly(string assemblyName)
+            => false;
 
         internal static Datadog.Trace.Configuration.IntegrationId? GetIntegrationId(string? integrationTypeName, System.Type targetType)
         {

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
@@ -61,9 +61,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "Confluent.Kafka", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -155,9 +164,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "Confluent.Kafka", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -251,9 +269,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "Confluent.Kafka", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -348,9 +375,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "Confluent.Kafka", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -445,9 +481,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "Confluent.Kafka", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -541,9 +586,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "Confluent.Kafka", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -631,9 +685,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "MySql.Data", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -739,9 +802,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(1, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { "MySql.Data", };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -851,9 +923,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(0, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {
@@ -951,9 +1032,18 @@ namespace Datadog.Trace.ClrProfiler
     internal static partial class InstrumentationDefinitions
     {
         internal static NativeCallTargetDefinition2[] Instrumentations;
+        internal static HashSet<string> InstrumentedAssemblies;
 
         static InstrumentationDefinitions()
         {
+            InstrumentedAssemblies =
+#if NETCOREAPP
+                new HashSet<string>(0, StringComparer.Ordinal)
+#else
+                new HashSet<string>(StringComparer.Ordinal)
+#endif
+                { };
+
             // CallTarget types
             Instrumentations = new NativeCallTargetDefinition2[]
             {


### PR DESCRIPTION
## Summary of changes

Generate a (filtered) list of assemblies that we instrument

## Reason for change

As part of sending redacted error logs to telemetry, we want to redact stack frames that we don't know about. It's safe to keep frames of libraries we directly instrument.

## Implementation details

In the instrumentation definitions generator, grab the assemblies, filter the duplicates, exclude some "common" prefixes (which we exclude as a matter of course) and ~~put the rest in a hashset~~ Turns out a hashset is slow, so went with a simpler approach!

> Note that I originally wasn't going to do this in the source generator, but the way we store the assembly names as an `IntPtr` for native invoking means that this is just easier in the end

## Test coverage

Covered by unit-tests snapshots

## Other details

Part 1 of a stack of PRs 
- https://github.com/DataDog/dd-trace-dotnet/pull/4832 (this PR)
- https://github.com/DataDog/dd-trace-dotnet/pull/4833
- https://github.com/DataDog/dd-trace-dotnet/pull/4834
- https://github.com/DataDog/dd-trace-dotnet/pull/4835

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
