### PR TITLE
Add redacted-error-log telemetry collector and sinks

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -686,6 +686,11 @@ namespace Datadog.Trace.Configuration
             /// <see cref="TelemetrySettings.DebugEnabled"/>
             /// </summary>
             public const string DebugEnabled = "DD_INTERNAL_TELEMETRY_DEBUG_ENABLED";
+
+            /// <summary>
+            /// Configuration key for whether to enable redacted error log collection.
+            /// </summary>
+            public const string TelemetryLogsEnabled = "DD_TELEMETRY_LOG_COLLECTION_ENABLED";
         }
 
         internal static class TagPropagation

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
@@ -10,10 +10,12 @@ internal readonly struct DatadogLoggingConfiguration
 {
     public readonly int RateLimit;
     public readonly FileLoggingConfiguration? File;
+    public readonly RedactedErrorLoggingConfiguration? ErrorLogging;
 
-    public DatadogLoggingConfiguration(int rateLimit, FileLoggingConfiguration? file)
+    public DatadogLoggingConfiguration(int rateLimit, FileLoggingConfiguration? file, RedactedErrorLoggingConfiguration? errorLogging)
     {
         RateLimit = rateLimit;
         File = file;
+        ErrorLogging = errorLogging;
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/RedactedErrorLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/RedactedErrorLoggingConfiguration.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="RedactedErrorLoggingConfiguration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.Telemetry.Collectors;
+
+namespace Datadog.Trace.Logging.Internal.Configuration;
+
+internal class RedactedErrorLoggingConfiguration
+{
+    public RedactedErrorLoggingConfiguration(RedactedErrorLogCollector collector)
+    {
+        Collector = collector;
+    }
+
+    public RedactedErrorLogCollector Collector { get; }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -7,13 +7,15 @@
 
 using System;
 using System.IO;
-using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Logging.Internal;
 using Datadog.Trace.Logging.Internal.Configuration;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;
+using Datadog.Trace.Vendors.Serilog.Core;
 
 namespace Datadog.Trace.Logging;
 
@@ -36,12 +38,14 @@ internal static class DatadogLoggingFactory
             fileConfig = GetFileLoggingConfiguration(source, telemetry);
         }
 
+        var redactedErrorLogsConfig = GetRedactedErrorTelemetryConfiguration(source, telemetry);
+
         var rateLimit = new ConfigurationBuilder(source, telemetry)
                        .WithKeys(ConfigurationKeys.LogRateLimit)
                        .AsInt32(DefaultRateLimit, x => x >= 0)
                        .Value;
 
-        return new DatadogLoggingConfiguration(rateLimit, fileConfig);
+        return new DatadogLoggingConfiguration(rateLimit, fileConfig, redactedErrorLogsConfig);
 
         static bool Contains(string?[]? array, string toMatch)
         {
@@ -71,7 +75,7 @@ internal static class DatadogLoggingFactory
         in DatadogLoggingConfiguration config,
         DomainMetadata domainMetadata)
     {
-        if (!config.File.HasValue)
+        if (config is { File: null, ErrorLogging: null })
         {
             // no enabled sinks
             return null;
@@ -81,6 +85,16 @@ internal static class DatadogLoggingFactory
             new LoggerConfiguration()
                .Enrich.FromLogContext()
                .MinimumLevel.ControlledBy(DatadogLogging.LoggingLevelSwitch);
+
+        if (config.ErrorLogging is { } telemetry)
+        {
+            // Write error logs to the redacted log sink
+            loggerConfiguration
+               .WriteTo.Logger(
+                    lc => lc
+                         .MinimumLevel.Error()
+                         .WriteTo.Sink(new RedactedErrorLogSink(telemetry.Collector)));
+        }
 
         if (config.File is { } fileConfig)
         {
@@ -233,5 +247,14 @@ internal static class DatadogLoggingFactory
                                   .Value;
 
         return new FileLoggingConfiguration(maxLogFileSize, logDirectory, logFileRetentionDays);
+    }
+
+    private static RedactedErrorLoggingConfiguration? GetRedactedErrorTelemetryConfiguration(IConfigurationSource source, IConfigurationTelemetry telemetry)
+    {
+        var config = new ConfigurationBuilder(source, telemetry);
+
+        return config.WithKeys(ConfigurationKeys.Telemetry.TelemetryLogsEnabled).AsBool(true)
+                   ? new RedactedErrorLoggingConfiguration(TelemetryFactory.RedactedErrorLogs) // use the global collector
+                   : null;
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -253,8 +253,17 @@ internal static class DatadogLoggingFactory
     {
         var config = new ConfigurationBuilder(source, telemetry);
 
-        return config.WithKeys(ConfigurationKeys.Telemetry.TelemetryLogsEnabled).AsBool(true)
-                   ? new RedactedErrorLoggingConfiguration(TelemetryFactory.RedactedErrorLogs) // use the global collector
-                   : null;
+        // We only check for the top-level key here, telemetry may be _indirectly_ disabled (because other keys are etc)
+        // in which case the collector will be disabled later, but this is a preferable option.
+        var telemetryEnabled = config.WithKeys(ConfigurationKeys.Telemetry.Enabled).AsBool(true);
+        if (telemetryEnabled)
+        {
+            return config.WithKeys(ConfigurationKeys.Telemetry.TelemetryLogsEnabled).AsBool(true)
+                       ? new RedactedErrorLoggingConfiguration(TelemetryFactory.RedactedErrorLogs) // use the global collector
+                       : null;
+        }
+
+        // If telemetry is disabled
+        return null;
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/RedactedErrorLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/RedactedErrorLogSink.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="RedactedErrorLogSink.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Collectors;
+using Datadog.Trace.Telemetry.DTOs;
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+
+namespace Datadog.Trace.Logging.Internal;
+
+internal class RedactedErrorLogSink : ILogEventSink
+{
+    private readonly RedactedErrorLogCollector _collector;
+
+    public RedactedErrorLogSink(RedactedErrorLogCollector collector)
+    {
+        _collector = collector;
+    }
+
+    // logs are immediately queued to channel
+    public void Emit(LogEvent? logEvent)
+    {
+        if (logEvent is null)
+        {
+            return;
+        }
+
+        var message = logEvent.Exception is { } ex
+                          ? $"{logEvent.MessageTemplate.Render(logEvent.Properties)}. Ex: {ex.Message}"
+                          : logEvent.MessageTemplate.Render(logEvent.Properties);
+
+        var logLevel = ToLogLevel(logEvent.Level);
+        var telemetryLog = new LogMessageData(message, logLevel, logEvent.Timestamp) { StackTrace = logEvent.Exception?.StackTrace };
+
+        _collector.EnqueueLog(telemetryLog);
+    }
+
+    private static TelemetryLogLevel ToLogLevel(LogEventLevel logEventLevel)
+        => logEventLevel switch
+        {
+            LogEventLevel.Fatal => TelemetryLogLevel.ERROR,
+            LogEventLevel.Error => TelemetryLogLevel.ERROR,
+            LogEventLevel.Warning => TelemetryLogLevel.WARN,
+            _ => TelemetryLogLevel.DEBUG,
+        };
+}

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
@@ -68,9 +68,9 @@ internal class RedactedErrorLogCollector
     {
         _queue.TryEnqueue(log);
 
-        if (_queue.Count > QueueSizeTrigger && _tcs is { Task.IsCompleted: false } tcs)
+        if (_queue.Count > QueueSizeTrigger)
         {
-            tcs.TrySetResult(true);
+            _tcs.TrySetResult(true);
         }
     }
 

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="RedactedErrorLogCollector.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Telemetry.DTOs;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Telemetry.Collectors;
+
+internal class RedactedErrorLogCollector
+{
+    private const TaskCreationOptions TaskOptions = TaskCreationOptions.RunContinuationsAsynchronously;
+
+    internal const int MaximumQueueSize = 10_000;
+    // Real maximum size is 5MB, but we do _very_ conservative estimates on size, so this should be fine
+    internal const int MaximumBatchSizeBytes = 4_800_000;
+    // Rough size of queued messages that should force trigger a flush
+    internal const int QueueSizeTrigger = 100;
+    private readonly BoundedConcurrentQueue<LogMessageData> _queue = new(MaximumQueueSize);
+    private TaskCompletionSource<bool> _tcs = new(TaskOptions);
+
+    public List<List<LogMessageData>>? GetLogs()
+    {
+        // This method should only be called in a single-threaded loop
+        List<List<LogMessageData>>? batches = null;
+        var batchSize = 0;
+        List<LogMessageData>? logs = null;
+        while (_queue.TryDequeue(out var log))
+        {
+            var logSize = log.GetApproximateSerializationSize();
+            if (batchSize + logSize < MaximumBatchSizeBytes)
+            {
+                batchSize += log.GetApproximateSerializationSize();
+                logs ??= new();
+                logs.Add(log);
+            }
+            else if (logSize < MaximumBatchSizeBytes)
+            {
+                // ignore oversized log message (shouldn't happen in practice)
+                // Exceeded max batch size. As we reject over-size logs,
+                // we know we will always have some logs here
+                batches ??= new();
+                batches.Add(logs!);
+
+                // Start a new batch with the left-over log
+                batchSize = logSize;
+                logs = new() { log };
+            }
+        }
+
+        // add final partial batch
+        if (logs is { Count: > 0 })
+        {
+            batches ??= new();
+            batches.Add(logs);
+        }
+
+        return batches;
+    }
+
+    public void EnqueueLog(LogMessageData log)
+    {
+        _queue.TryEnqueue(log);
+
+        if (_queue.Count > QueueSizeTrigger && _tcs is { Task.IsCompleted: false } tcs)
+        {
+            tcs.TrySetResult(true);
+        }
+    }
+
+    /// <summary>
+    /// Returns a task that completes when the queue reaches the trigger size.
+    /// If the queue has already reached the required size, triggers an immediate flush
+    /// </summary>
+    public Task WaitForLogsAsync()
+    {
+        // we're already above the trigger
+        if (_queue.Count > QueueSizeTrigger)
+        {
+            return Task.CompletedTask;
+        }
+
+        var tcs = _tcs.Task.IsCompleted
+                      ? Interlocked.Exchange(ref _tcs, new TaskCompletionSource<bool>(TaskOptions))
+                      : _tcs;
+
+        // small chance that we missed an update, so check again to be on the safe side
+        if (_queue.Count > QueueSizeTrigger)
+        {
+            tcs.TrySetResult(true);
+        }
+
+        return tcs.Task;
+    }
+}

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
@@ -6,12 +6,23 @@
 #nullable enable
 
 using System;
+using System.Text;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Converters;
 
 namespace Datadog.Trace.Telemetry.DTOs;
 
 internal class LogMessageData
 {
+    private const int FixedSerializationCharacterCount =
+        7 /*message*/ +
+        5 /*level*/ +
+        5 /*level value*/ +
+        4 /*tags*/ +
+        11 /*stack_trace*/ +
+        11 /* tracer_time */ +
+        10 /* tracer_time value */ +
+        15 /* json ,"{}  etc*/;
+
     public LogMessageData(string message, TelemetryLogLevel level, DateTimeOffset timestamp)
     {
         Message = message;
@@ -32,4 +43,7 @@ internal class LogMessageData
     /// Gets or sets unix timestamp (in seconds) for the log
     /// </summary>
     public long TracerTime { get; set; }
+
+    public int GetApproximateSerializationSize()
+        => Encoding.UTF8.GetMaxByteCount(FixedSerializationCharacterCount + Message.Length + (StackTrace?.Length ?? 0) + (Tags?.Length ?? 0));
 }

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="LogMessageData.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Converters;
+
+namespace Datadog.Trace.Telemetry.DTOs;
+
+internal class LogMessageData
+{
+    public LogMessageData(string message, TelemetryLogLevel level, DateTimeOffset timestamp)
+    {
+        Message = message;
+        Level = level;
+        TracerTime = timestamp.ToUnixTimeSeconds();
+    }
+
+    public string Message { get; set; }
+
+    [Vendors.Newtonsoft.Json.JsonConverter(typeof(StringEnumConverter))]
+    public TelemetryLogLevel Level { get; set; }
+
+    public string? Tags { get; set; }
+
+    public string? StackTrace { get; set; }
+
+    /// <summary>
+    /// Gets or sets unix timestamp (in seconds) for the log
+    /// </summary>
+    public long TracerTime { get; set; }
+}

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/LogsPayload.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/LogsPayload.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="LogsPayload.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+
+#nullable enable
+
+namespace Datadog.Trace.Telemetry.DTOs;
+
+internal class LogsPayload : IPayload
+{
+    public LogsPayload(List<LogMessageData> logs)
+    {
+        Logs = logs;
+    }
+
+    public string? Tags { get; set; }
+
+    public List<LogMessageData> Logs { get; set; }
+}

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/TelemetryLogLevel.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/TelemetryLogLevel.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="TelemetryLogLevel.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Telemetry;
+
+internal enum TelemetryLogLevel
+{
+    ERROR,
+    WARN,
+    DEBUG
+}

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -31,6 +31,7 @@ internal class TelemetryController : ITelemetryController
     private readonly IntegrationTelemetryCollector _integrations = new();
     private readonly ProductsTelemetryCollector _products = new();
     private readonly IMetricsTelemetryCollector _metrics;
+    private readonly RedactedErrorLogCollector _redactedErrorLogs;
     private readonly TaskCompletionSource<bool> _processExit = new();
     private readonly Task _flushTask;
     private readonly Scheduler _scheduler;
@@ -43,6 +44,7 @@ internal class TelemetryController : ITelemetryController
         IConfigurationTelemetry configuration,
         IDependencyTelemetryCollector dependencies,
         IMetricsTelemetryCollector metrics,
+        RedactedErrorLogCollector redactedErrorLogs,
         TelemetryTransportManager transportManager,
         TimeSpan flushInterval)
     {
@@ -50,7 +52,8 @@ internal class TelemetryController : ITelemetryController
         _dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _transportManager = transportManager ?? throw new ArgumentNullException(nameof(transportManager));
-        _scheduler = new(flushInterval, _processExit);
+        _redactedErrorLogs = redactedErrorLogs ?? throw new ArgumentNullException(nameof(redactedErrorLogs));
+        _scheduler = new(flushInterval, _redactedErrorLogs.WaitForLogsAsync, _processExit);
 
         try
         {
@@ -194,7 +197,7 @@ internal class TelemetryController : ITelemetryController
 
             if (_isStarted && _sendTelemetry && _scheduler.ShouldFlushTelemetry)
             {
-                await PushTelemetry(sendAppClosing: isFinalPush).ConfigureAwait(false);
+                await PushTelemetry(includeLogs: _scheduler.ShouldFlushRedactedErrorLogs, sendAppClosing: isFinalPush).ConfigureAwait(false);
             }
 
             if (isFinalPush)
@@ -208,7 +211,7 @@ internal class TelemetryController : ITelemetryController
         }
     }
 
-    private async Task PushTelemetry(bool sendAppClosing)
+    private async Task PushTelemetry(bool includeLogs, bool sendAppClosing)
     {
         try
         {
@@ -230,6 +233,16 @@ internal class TelemetryController : ITelemetryController
             {
                 Log.Debug("Telemetry not initialized, skipping");
                 return;
+            }
+
+            if (includeLogs && _redactedErrorLogs.GetLogs() is { } batches)
+            {
+                foreach (var batch in batches)
+                {
+                    var logPayload = _dataBuilder.BuildLogsTelemetryData(application, host, batch, _namingVersion);
+                    Log.Debug("Pushing diagnostic logs");
+                    await _transportManager.TryPushTelemetry(logPayload).ConfigureAwait(false);
+                }
             }
 
             // use values from previous failed attempt if necessary
@@ -282,36 +295,40 @@ internal class TelemetryController : ITelemetryController
         private const int DelayTaskIndex = 0;
         private const int ProcessTaskIndex = 1;
         private const int InitializationTaskIndex = 2;
+        private const int LogQueueSizeTaskIndex = 3;
 
         private readonly TaskCompletionSource<bool> _tracerInitialized = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private readonly TaskCompletionSource<bool> _processExitSource;
         private readonly Task[] _tasks;
+        private readonly Func<Task> _logQueueTaskGenerator;
         private readonly IClock _clock;
         private readonly IDelayFactory _delayFactory;
         private TimeSpan _flushInterval;
         private DateTime _lastFlush;
         private bool _initializationFlushExecuted = false;
 
-        public Scheduler(TimeSpan flushInterval, TaskCompletionSource<bool> processExitSource)
-        : this(flushInterval, processExitSource, new Clock(), new DelayFactory())
+        public Scheduler(TimeSpan flushInterval, Func<Task> logQueueTaskGenerator, TaskCompletionSource<bool> processExitSource)
+            : this(flushInterval, logQueueTaskGenerator, processExitSource, new Clock(), new DelayFactory())
         {
         }
 
         // For testing only
-        public Scheduler(TimeSpan flushInterval, TaskCompletionSource<bool> processExitSource, IClock clock, IDelayFactory delayFactory)
+        public Scheduler(TimeSpan flushInterval, Func<Task> logQueueTaskGenerator, TaskCompletionSource<bool> processExitSource, IClock clock, IDelayFactory delayFactory)
         {
             _clock = clock;
             _delayFactory = delayFactory;
             _processExitSource = processExitSource;
             _flushInterval = flushInterval;
+            _logQueueTaskGenerator = logQueueTaskGenerator;
             ShouldFlushTelemetry = false; // wait for initialization before flushing metrics
             _lastFlush = _clock.UtcNow;
 
             // Using a task array instead of overloads to avoid allocating the array every loop
-            _tasks = new Task[3];
+            _tasks = new Task[4];
             _tasks[DelayTaskIndex] = Task.CompletedTask; // Replaced on first iteration of WaitForNextInterval(), but ensures there's no nulls around
             _tasks[ProcessTaskIndex] = processExitSource.Task;
             _tasks[InitializationTaskIndex] = _tracerInitialized.Task;
+            _tasks[LogQueueSizeTaskIndex] = _logQueueTaskGenerator();
         }
 
         public interface IDelayFactory
@@ -320,6 +337,8 @@ internal class TelemetryController : ITelemetryController
         }
 
         public bool ShouldFlushTelemetry { get; private set; }
+
+        public bool ShouldFlushRedactedErrorLogs { get; private set; }
 
         public void SetFlushInterval(TimeSpan flushInterval)
         {
@@ -343,7 +362,7 @@ internal class TelemetryController : ITelemetryController
                                  ? nextFlush - _clock.UtcNow
                                  : null;
 
-            Task? completedTask = null;
+            var logFlushTask = _logQueueTaskGenerator();
             if (waitPeriod.HasValue && waitPeriod.Value <= TimeSpan.Zero)
             {
                 Log.Debug(
@@ -353,30 +372,45 @@ internal class TelemetryController : ITelemetryController
             {
                 // if we don't have a wait period, it's because we're waiting for initialization
                 _tasks[DelayTaskIndex] = _delayFactory.Delay(waitPeriod ?? Timeout.InfiniteTimeSpan);
-                completedTask = await Task.WhenAny(_tasks).ConfigureAwait(false);
+                _tasks[LogQueueSizeTaskIndex] = logFlushTask;
+                await Task.WhenAny(_tasks).ConfigureAwait(false);
             }
 
             if (_processExitSource.Task.IsCompleted)
             {
                 // end of the line, flush everything, don't bother recalculating;
                 ShouldFlushTelemetry = true;
+                ShouldFlushRedactedErrorLogs = true;
                 return;
             }
 
+            // Reset variables
+            ShouldFlushTelemetry = false;
+            ShouldFlushRedactedErrorLogs = false;
             var now = _clock.UtcNow;
 
             // Should we flush telemetry?
-            if (completedTask == _tracerInitialized.Task)
+            if (!_initializationFlushExecuted && _tracerInitialized.Task.IsCompleted)
             {
                 _initializationFlushExecuted = true;
                 // We've just been started, so should always flush telemetry
                 ShouldFlushTelemetry = true;
+                // Including logs as we typically log a lot at startup
+                ShouldFlushRedactedErrorLogs = true;
                 // replace the tracerInitializedTask with a task that never completes
                 _tasks[InitializationTaskIndex] = Task.Delay(Timeout.Infinite);
             }
-            else
+
+            if (_initializationFlushExecuted && logFlushTask.IsCompleted)
             {
-                ShouldFlushTelemetry = _initializationFlushExecuted && (nextFlush <= now);
+                // should flush logs if we've reached the threshold
+                ShouldFlushRedactedErrorLogs = true;
+            }
+
+            if (_initializationFlushExecuted && (nextFlush <= now))
+            {
+                ShouldFlushTelemetry = true;
+                ShouldFlushRedactedErrorLogs = true;
             }
 
             if (ShouldFlushTelemetry)

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilder.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilder.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry.DTOs;
 
 namespace Datadog.Trace.Telemetry;
 
@@ -135,6 +136,9 @@ internal class TelemetryDataBuilder
 
         return GetRequest(application, host, new MessageBatchPayload(data), namingSchemeVersion);
     }
+
+    public TelemetryData BuildLogsTelemetryData(ApplicationTelemetryData application, HostTelemetryData host, List<LogMessageData> logs, string? namingSchemeVersion)
+                => GetRequest(application, host, TelemetryRequestTypes.RedactedErrorLogs, new LogsPayload(logs), namingSchemeVersion);
 
     public TelemetryData BuildHeartbeatData(ApplicationTelemetryData application, HostTelemetryData host, string? namingSchemeVersion)
         => GetRequest(application, host, TelemetryRequestTypes.AppHeartbeat, payload: null, namingSchemeVersion);

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.Telemetry
     internal class TelemetryFactory
     {
         // need to start collecting these immediately
+        private static readonly Lazy<RedactedErrorLogCollector> _logs = new();
         private static IMetricsTelemetryCollector _metrics = new MetricsTelemetryCollector();
         private static IConfigurationTelemetry _configuration = new ConfigurationTelemetry();
         private readonly object _sync = new();
@@ -45,7 +46,7 @@ namespace Datadog.Trace.Telemetry
         /// <summary>
         /// Gets the static log collector used to record redacted error logs
         /// </summary>
-        internal static RedactedErrorLogCollector RedactedErrorLogs { get; } = new();
+        internal static RedactedErrorLogCollector RedactedErrorLogs => _logs.Value;
 
         internal static IMetricsTelemetryCollector SetMetricsForTesting(IMetricsTelemetryCollector telemetry)
             => Interlocked.Exchange(ref _metrics, telemetry);
@@ -168,7 +169,7 @@ namespace Datadog.Trace.Telemetry
                         Config,
                         _dependencies!,
                         Metrics,
-                        RedactedErrorLogs,
+                        _logs.IsValueCreated ? _logs.Value : null, // if we haven't created it by now, we don't need it
                         transportManager,
                         settings.HeartbeatInterval);
                 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Telemetry
             // Deliberately not a static field, because otherwise creates a circular dependency during startup
             var log = DatadogLogging.GetLoggerFor<TelemetryFactory>();
 
-            // we assume telemetry can't switch between enabled/disabled
+            // we assume telemetry can't switch between enabled/disabled because it can only be set via static config
             if (!settings.TelemetryEnabled)
             {
                 log.Debug("Telemetry collection disabled");
@@ -124,6 +124,11 @@ namespace Datadog.Trace.Telemetry
         {
             DisableMetricsCollector();
             DisableConfigCollector();
+            if (_logs.IsValueCreated)
+            {
+                // Logs were enabled, even though telemetry isn't
+                _logs.Value.DisableCollector();
+            }
         }
 
         private static void DisableMetricsCollector()

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -42,6 +42,11 @@ namespace Datadog.Trace.Telemetry
         /// </summary>
         internal static IConfigurationTelemetry Config => Volatile.Read(ref _configuration);
 
+        /// <summary>
+        /// Gets the static log collector used to record redacted error logs
+        /// </summary>
+        internal static RedactedErrorLogCollector RedactedErrorLogs { get; } = new();
+
         internal static IMetricsTelemetryCollector SetMetricsForTesting(IMetricsTelemetryCollector telemetry)
             => Interlocked.Exchange(ref _metrics, telemetry);
 
@@ -163,6 +168,7 @@ namespace Datadog.Trace.Telemetry
                         Config,
                         _dependencies!,
                         Metrics,
+                        RedactedErrorLogs,
                         transportManager,
                         settings.HeartbeatInterval);
                 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryRequestTypes.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryRequestTypes.cs
@@ -15,6 +15,8 @@ namespace Datadog.Trace.Telemetry
         public const string AppHeartbeat = "app-heartbeat";
         public const string AppClosing = "app-closing";
         public const string AppExtendedHeartbeat = "app-extended-heartbeat";
+        // This payload type for redacted error logs
+        public const string RedactedErrorLogs = "logs";
 
         public const string GenerateMetrics = "generate-metrics";
         public const string Distributions = "distributions";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -6,10 +6,12 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.DTOs;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -71,6 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             AssertService(telemetry, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(telemetry, enableDependencies);
+            AssertNoRedactedErrorLogs(telemetry);
             agent.Telemetry.Should().BeEmpty();
         }
 
@@ -102,6 +105,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             AssertService(agent, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(agent, enableDependencies);
+            AssertNoRedactedErrorLogs(agent);
         }
 
         [SkippableFact]
@@ -128,6 +132,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Shouldn't have any, but wait for 5s
             agent.WaitForLatestTelemetry(x => true);
             agent.Telemetry.Should().BeEmpty();
+            AssertNoRedactedErrorLogs(agent);
         }
 
         [SkippableTheory]
@@ -179,6 +184,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
                 AssertService(agent, "Samples.Telemetry", ServiceVersion);
                 AssertDependencies(agent, enableDependencies);
+                AssertNoRedactedErrorLogs(agent);
             }
         }
 
@@ -208,6 +214,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             AssertService(agent, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(agent, enableDependencies);
+            AssertNoRedactedErrorLogs(agent);
         }
 #endif
 
@@ -280,6 +287,56 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             telemetry.GetMetricDataPoints(Count.TraceApiErrors.GetName()).Should().BeEmpty();
         }
 
+        [SkippableFact]
+        [Trait("Category", "EndToEnd")]
+        [Trait("RunOnWindows", "True")]
+        public async Task Telemetry_SendsRedactedErrorLogs()
+        {
+            // we don't want to record the logs for this test, otherwise they'll cause the CheckLogsForErrors
+            // stage to fail in CI. So instead, we write the logs to a temp directory which we won't check
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, Path.GetTempPath());
+
+            using var agent = MockTracerAgent.Create(Output, useTelemetry: true);
+            Output.WriteLine($"Assigned port {agent.Port} for the agentPort.");
+
+            using var telemetry = new MockTelemetryAgent();
+            Output.WriteLine($"Assigned port {telemetry.Port} for the telemetry port.");
+
+            EnableAgentlessTelemetry(telemetry.Port, enableDependencies: true);
+            SetEnvironmentVariable(ConfigurationKeys.Telemetry.TelemetryLogsEnabled, "1");
+            // Create invalid sampling rules (invalid JSON) to trigger parsing error
+            SetEnvironmentVariable(ConfigurationKeys.CustomSamplingRules, "[{\"sample_rate\":0.1");
+
+            int httpPort = TcpPortProvider.GetOpenPort();
+            Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
+            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            {
+                ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
+
+                var spans = agent.WaitForSpans(ExpectedSpans);
+                await AssertExpectedSpans(spans);
+            }
+
+            WaitForAllTelemetry(telemetry);
+            telemetry.Telemetry
+                     .Where(x => x.IsRequestType(TelemetryRequestTypes.RedactedErrorLogs))
+                     .Should()
+                     .NotBeEmpty();
+
+            var allLogs = telemetry.Telemetry
+                                   .OrderBy(x => x.SeqId)
+                                   .Select(x => x.TryGetPayload<LogsPayload>(TelemetryRequestTypes.RedactedErrorLogs))
+                                   .Where(x => x is not null)
+                                   .SelectMany(x => x.Logs)
+                                   .ToList();
+
+            // a debug log created in Instrumentation.cs
+            allLogs.Should()
+                   .ContainSingle()
+                   .Which.Message.Should()
+                   .StartWith("Unable to parse custom sampling rules");
+        }
+
         private static void AssertService(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)
         {
             mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppStarted));
@@ -337,6 +394,27 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                               .UseFileName("TelemetryTests");
         }
 
+        private static void WaitForAllTelemetry(MockTracerAgent mockAgent)
+            => mockAgent.WaitForLatestTelemetry(x => ((TelemetryData)x).IsRequestType(TelemetryRequestTypes.AppClosing));
+
+        private static void WaitForAllTelemetry(MockTelemetryAgent telemetry)
+            => telemetry.WaitForLatestTelemetry(x => x.IsRequestType(TelemetryRequestTypes.AppClosing));
+
+        private static void AssertNoRedactedErrorLogs(MockTracerAgent mockAgent)
+        {
+            WaitForAllTelemetry(mockAgent);
+            AssertNoRedactedErrorLogs(mockAgent.Telemetry.Cast<TelemetryData>());
+        }
+
+        private static void AssertNoRedactedErrorLogs(MockTelemetryAgent telemetry)
+        {
+            WaitForAllTelemetry(telemetry);
+            AssertNoRedactedErrorLogs(telemetry.Telemetry);
+        }
+
+        private static void AssertNoRedactedErrorLogs(IEnumerable<TelemetryData> allData)
+            => allData.Where(x => x.IsRequestType(TelemetryRequestTypes.RedactedErrorLogs)).Should().BeEmpty();
+
         private void EnableAgentlessTelemetry(int standaloneAgentPort, bool? enableDependencies)
         {
             SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true");
@@ -346,6 +424,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // API key is required for agentless
             SetEnvironmentVariable("DD_API_KEY", "INVALID_KEY_FOR_TESTS");
             EnableDependencies(enableDependencies);
+            // Disable by default
+            SetEnvironmentVariable(ConfigurationKeys.Telemetry.TelemetryLogsEnabled, "0");
         }
 
         private void EnableAgentProxyTelemetry(bool? enableDependencies)
@@ -353,6 +433,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_ENABLED", "true");
             SetEnvironmentVariable("DD_INSTRUMENTATION_TELEMETRY_AGENTLESS_ENABLED", "false");
             EnableDependencies(enableDependencies);
+            // Disable by default for tests
+            SetEnvironmentVariable(ConfigurationKeys.Telemetry.TelemetryLogsEnabled, "0");
         }
 
         private void EnableDependencies(bool? enableDependencies)

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
@@ -14,6 +14,7 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.DTOs;
 using Datadog.Trace.Telemetry.Transports;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
@@ -224,6 +225,7 @@ namespace Datadog.Trace.TestHelpers
                     { TelemetryRequestTypes.AppProductChanged, CreateSerializer<AppProductChangePayload>() },
                     { TelemetryRequestTypes.GenerateMetrics, CreateSerializer<GenerateMetricsPayload>() },
                     { TelemetryRequestTypes.Distributions, CreateSerializer<DistributionsPayload>() },
+                    { TelemetryRequestTypes.RedactedErrorLogs, CreateSerializer<LogsPayload>() },
                     { TelemetryRequestTypes.AppExtendedHeartbeat, CreateSerializer<AppExtendedHeartbeatPayload>() },
                     { TelemetryRequestTypes.AppClosing, CreateNullPayloadSerializer() },
                     { TelemetryRequestTypes.AppHeartbeat, CreateNullPayloadSerializer() },

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/RedactedErrorLogCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/RedactedErrorLogCollectorTests.cs
@@ -1,0 +1,171 @@
+﻿// <copyright file="RedactedErrorLogCollectorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Collectors;
+using Datadog.Trace.Telemetry.DTOs;
+using FluentAssertions;
+using Xunit;
+using JsonConvert = Datadog.Trace.Vendors.Newtonsoft.Json.JsonConvert;
+
+namespace Datadog.Trace.Tests.Telemetry.Collectors;
+
+public class RedactedErrorLogCollectorTests
+{
+    [Fact]
+    public void DoesNotQueueMoreThanMaximumQueueSize()
+    {
+        var collector = new RedactedErrorLogCollector();
+        var messagesToSend = RedactedErrorLogCollector.MaximumQueueSize * 2;
+        while (messagesToSend > 0)
+        {
+            collector.EnqueueLog(new("Something", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
+            messagesToSend--;
+        }
+
+        var logs = collector.GetLogs();
+        logs.Should().NotBeNull();
+        logs.Sum(x => x.Count).Should().Be(RedactedErrorLogCollector.MaximumQueueSize);
+    }
+
+    [Fact]
+    public void CompletesTaskWhenQueueSizeTriggerIsReached()
+    {
+        var collector = new RedactedErrorLogCollector();
+        var threshold = RedactedErrorLogCollector.QueueSizeTrigger;
+        var task = collector.WaitForLogsAsync();
+        var messages = 0;
+        while (messages < threshold)
+        {
+            collector.EnqueueLog(new("Something", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
+            messages++;
+            task.IsCompleted.Should().BeFalse();
+        }
+
+        // sending one more message should complete the task
+        // and should remain completed subsequently
+        messages = 0;
+        while (messages < 100)
+        {
+            collector.EnqueueLog(new("Something", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
+            messages++;
+            task.IsCompleted.Should().BeTrue();
+        }
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1_000)]
+    [InlineData(10_000)]
+    public void GetApproximateSerializationSizeIsLargerThanRealWithAscii(int stringLength)
+    {
+        var message = RandomString(stringLength);
+        var data = new LogMessageData(message, TelemetryLogLevel.DEBUG, DateTimeOffset.UtcNow)
+        {
+            StackTrace = RandomString(stringLength),
+        };
+
+        var serializedString = JsonConvert.SerializeObject(data);
+        var bytes = Encoding.UTF8.GetBytes(serializedString);
+        var expectedLength = bytes.Length;
+
+        data.GetApproximateSerializationSize().Should().BeGreaterThanOrEqualTo(expectedLength);
+    }
+
+    [Theory]
+    [InlineData(10)]
+    [InlineData(100)]
+    [InlineData(1_000)]
+    [InlineData(10_000)]
+    public void GetApproximateSerializationSizeIsRoughlySimilarWithAscii(int stringLength)
+    {
+        var message = RandomString(stringLength);
+        var data = new LogMessageData(message, TelemetryLogLevel.DEBUG, DateTimeOffset.UtcNow)
+        {
+            StackTrace = RandomString(stringLength),
+        };
+
+        var serializedString = JsonConvert.SerializeObject(data);
+        var bytes = Encoding.UTF8.GetBytes(serializedString);
+        var realLength = bytes.Length;
+
+        // expected for ascii is actually ~3x real life, so we end up being pretty conservative in our estimates
+        data.GetApproximateSerializationSize().Should().BeLessThan(3 * realLength);
+    }
+
+    [Fact]
+    public void GetApproximateSerializationSizeIsLargerThanRealWithUnicode()
+    {
+        var message = "☚℈⏁⽐⇔⮕⭝⹊✆⯹⸘Ⲿ⍤⹯❾⼢⟞⾨⃄▔⨿Ⲳⷽⱋ⛠⢙✍₥╓ↆ☂⠈⽧⤌⨔◬⽨⌤⩊⪠⎱Ⅳ⻙⑪⅙⪢⒌➇⮡⭎∣⼴➴⠹⭺⮐❢∂⅚⵩⥕⍎⭡✌⤭≁⢺Ⓑ⩏⭈⫋₡┐⛉℺⒤☙⎇ⴥ▁❚ⴁⲃ⾪⿪⺯⢋⼲╙⚱“ↇ⟴⏻⺭ⱀ⢜⧇⁇⡶";
+        var data = new LogMessageData(message, TelemetryLogLevel.DEBUG, DateTimeOffset.UtcNow);
+
+        var serializedString = JsonConvert.SerializeObject(data);
+        var bytes = Encoding.UTF8.GetBytes(serializedString);
+        var expectedLength = bytes.Length;
+
+        data.GetApproximateSerializationSize().Should().BeGreaterThanOrEqualTo(expectedLength);
+    }
+
+    [Fact]
+    public void SeparatesLogsIntoBatches()
+    {
+        var collector = new RedactedErrorLogCollector();
+
+        // using a big string to make sure we don't exceed queue size
+        var log = new LogMessageData(RandomString(10_000), TelemetryLogLevel.WARN, DateTimeOffset.UtcNow);
+        var logSize = log.GetApproximateSerializationSize();
+        var logsPerBatch = RedactedErrorLogCollector.MaximumBatchSizeBytes / logSize;
+
+        // Filling 3.5 to avoid rounding issues etc
+        var logsToSend = (logsPerBatch * 3) + (logsPerBatch / 2);
+        var expectedBatches = 4;
+        logsToSend.Should().BeLessThan(RedactedErrorLogCollector.MaximumQueueSize);
+
+        for (var i = 0; i < logsToSend; i++)
+        {
+            collector.EnqueueLog(log);
+        }
+
+        var logs = collector.GetLogs();
+        logs.Should().NotBeNull();
+        logs.Sum(x => x.Count).Should().Be(logsToSend);
+        logs.Count.Should().Be(expectedBatches);
+        var batchSizes = logs.Select(batch => batch.Sum(log => log.GetApproximateSerializationSize()));
+        batchSizes.Should().OnlyContain(size => size <= RedactedErrorLogCollector.MaximumBatchSizeBytes);
+    }
+
+    [Fact]
+    public void RejectsOverSizedLogs()
+    {
+        var collector = new RedactedErrorLogCollector();
+
+        var log = new LogMessageData(RandomString(2_000_000), TelemetryLogLevel.WARN, DateTimeOffset.UtcNow);
+        log.GetApproximateSerializationSize().Should().BeGreaterOrEqualTo(RedactedErrorLogCollector.MaximumBatchSizeBytes);
+
+        collector.EnqueueLog(log);
+
+        var logs = collector.GetLogs();
+        logs.Should().BeNull();
+    }
+
+    private static string RandomString(int length)
+    {
+        const string options = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ,!\"£$%^&*()[]{}<>`¬";
+        var chars = new char[length];
+        var random = new Random();
+
+        for (int i = 0; i < chars.Length; i++)
+        {
+            chars[i] = options[random.Next(options.Length)];
+        }
+
+        return new string(chars);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerSchedulerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerSchedulerTests.cs
@@ -24,7 +24,7 @@ public class TelemetryControllerSchedulerTests
 
     public TelemetryControllerSchedulerTests()
     {
-        _scheduler = new TelemetryController.Scheduler(FlushInterval, _processExit, _clock, _delayFactory);
+        _scheduler = new TelemetryController.Scheduler(FlushInterval, () => NeverComplete, _processExit, _clock, _delayFactory);
     }
 
     [Fact]
@@ -55,6 +55,7 @@ public class TelemetryControllerSchedulerTests
 
         // t = 5s;
         _scheduler.ShouldFlushTelemetry.Should().BeTrue(); // triggered by first initialization, Next flush at 65s
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue();
 
         // wait for the next loop - delay should be FlushInterval
         _delayFactory.Task = delay =>
@@ -68,11 +69,13 @@ public class TelemetryControllerSchedulerTests
 
         // t = 65s;
         _scheduler.ShouldFlushTelemetry.Should().BeTrue();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue();
 
         await _scheduler.WaitForNextInterval(); // next flush at 125s
 
         // t = 125s;
         _scheduler.ShouldFlushTelemetry.Should().BeTrue();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue();
 
         // we'll interrupt the next delay with a process exit signal
         mutex.Reset();
@@ -92,11 +95,100 @@ public class TelemetryControllerSchedulerTests
         await waitTask;
 
         _scheduler.ShouldFlushTelemetry.Should().BeTrue(); // final flush
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task TypicalLoop_WithLogsQueueTrigger()
+    {
+        var queueGenerator = new QueueTaskGenerator();
+        _scheduler = GetScheduler(queueGenerator);
+
+        // t = 0; should not send initially
+        _scheduler.ShouldFlushTelemetry.Should().BeFalse();
+
+        // we expect an infinite flush interval, because initialization is not complete
+        // we'll fast-forward to 5s for now
+        var delayMutex = new ManualResetEventSlim();
+        _delayFactory.Task = delay =>
+        {
+            delay.Should().Be(Timeout.InfiniteTimeSpan);
+            _clock.UtcNow += FiveSeconds;
+            delayMutex.Set();
+            return NeverComplete;
+        };
+
+        var waitTask = _scheduler.WaitForNextInterval();
+        waitTask.IsFaulted.Should().BeFalse();
+        _scheduler.SetTracerInitialized();
+        delayMutex.Wait();
+
+        await waitTask;
+
+        // t = 5s;
+        _scheduler.ShouldFlushTelemetry.Should().BeTrue(); // triggered by first initialization, Next flush at 65s
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue();
+
+        // wait for the next loop - delay should be FlushInterval
+        // fast-forward 5s for now, and fire the queue
+        _delayFactory.Task = delay =>
+        {
+            _clock.UtcNow += FiveSeconds;
+            delayMutex.Set();
+            return NeverComplete;
+        };
+
+        var queueTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        queueGenerator.Task = () => queueTcs.Task;
+
+        waitTask = _scheduler.WaitForNextInterval();
+        waitTask.IsFaulted.Should().BeFalse();
+        delayMutex.Wait();
+        queueTcs.SetResult(true); // this triggers the queue task
+
+        await waitTask;
+
+        // t = 10s;
+        _scheduler.ShouldFlushTelemetry.Should().BeFalse(); // not a complete interval
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue(); // triggered by queue
+
+        // same deal again
+        delayMutex.Reset();
+        queueTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        queueGenerator.Task = () => queueTcs.Task;
+
+        waitTask = _scheduler.WaitForNextInterval();
+        waitTask.IsFaulted.Should().BeFalse();
+        delayMutex.Wait();
+        queueTcs.SetResult(true); // this triggers the queue task
+
+        // t = 15s;
+        _scheduler.ShouldFlushTelemetry.Should().BeFalse(); // not a complete interval
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue(); // triggered by queue
+
+        // now lets run the next interval properly
+        queueGenerator.Task = () => NeverComplete;
+
+        _delayFactory.Task = delay =>
+        {
+            delay.Should().Be(TimeSpan.FromSeconds(50));
+            _clock.UtcNow += delay;
+            return Task.CompletedTask;
+        };
+        await _scheduler.WaitForNextInterval(); // next flush at 125s
+
+        // t = 125s;
+        _scheduler.ShouldFlushTelemetry.Should().BeTrue();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue();
+     }
 
     [Fact]
     public async Task DoesNotFlushTelemetryUntilInitialized()
     {
+        // queue immediately indicates it's overfull
+        var queue = new QueueTaskGenerator { Task = () => Task.CompletedTask };
+        _scheduler = GetScheduler(queue);
+
         // increment a full flush interval each time
         _delayFactory.Task = delay =>
         {
@@ -105,15 +197,19 @@ public class TelemetryControllerSchedulerTests
         };
 
         _scheduler.ShouldFlushTelemetry.Should().BeFalse();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeFalse(); // even though queue is ready, can't flush yet
 
         await _scheduler.WaitForNextInterval();
         _scheduler.ShouldFlushTelemetry.Should().BeFalse();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeFalse();
 
         await _scheduler.WaitForNextInterval();
         _scheduler.ShouldFlushTelemetry.Should().BeFalse();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeFalse();
 
         await _scheduler.WaitForNextInterval();
         _scheduler.ShouldFlushTelemetry.Should().BeFalse();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeFalse();
 
         // don't increment this time
         _delayFactory.Task = delay => NeverComplete;
@@ -121,6 +217,7 @@ public class TelemetryControllerSchedulerTests
         _scheduler.SetTracerInitialized();
         await _scheduler.WaitForNextInterval();
         _scheduler.ShouldFlushTelemetry.Should().BeTrue();
+        _scheduler.ShouldFlushRedactedErrorLogs.Should().BeTrue();
     }
 
     [Fact]
@@ -188,13 +285,20 @@ public class TelemetryControllerSchedulerTests
         _scheduler.ShouldFlushTelemetry.Should().BeTrue();
     }
 
-    private TelemetryController.Scheduler GetScheduler()
-        => new(FlushInterval, _processExit, _clock, _delayFactory);
+    private TelemetryController.Scheduler GetScheduler(QueueTaskGenerator queueTaskGenerator = null)
+        => new(FlushInterval, (queueTaskGenerator ?? new()).GetTask, _processExit, _clock, _delayFactory);
 
     private class DelayFactory : TelemetryController.Scheduler.IDelayFactory
     {
         public Func<TimeSpan, Task> Task { get; set; } = _ => System.Threading.Tasks.Task.CompletedTask;
 
         public Task Delay(TimeSpan delay) => Task(delay);
+    }
+
+    private class QueueTaskGenerator
+    {
+        public Func<Task> Task { get; set; } = () => NeverComplete;
+
+        public Task GetTask() => Task();
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -37,6 +37,7 @@ public class TelemetryControllerTests
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
+            new RedactedErrorLogCollector(),
             transportManager,
             _flushInterval);
 
@@ -58,6 +59,7 @@ public class TelemetryControllerTests
             collector,
             new DependencyTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
+            new RedactedErrorLogCollector(),
             transportManager,
             _flushInterval);
 
@@ -88,6 +90,7 @@ public class TelemetryControllerTests
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
+            new RedactedErrorLogCollector(),
             transportManager,
             _flushInterval);
 
@@ -105,6 +108,7 @@ public class TelemetryControllerTests
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
+            new RedactedErrorLogCollector(),
             transportManager,
             _flushInterval);
 
@@ -149,6 +153,7 @@ public class TelemetryControllerTests
             new ConfigurationTelemetry(),
             new DependencyTelemetryCollector(),
             new NullMetricsTelemetryCollector(),
+            new RedactedErrorLogCollector(),
             transportManager,
             _flushInterval);
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.DTOs;
 using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -90,6 +91,29 @@ public class TelemetryDataBuilderTests
         var heartbeatData = builder.BuildHeartbeatData(_application, _host, _namingSchemaVersion);
         heartbeatData.Should().NotBeNull();
         heartbeatData.SeqId.Should().Be(3);
+    }
+
+    [Fact]
+    public void WhenHasApplicationAndHostData_GeneratesLogTelemetry()
+    {
+        var builder = new TelemetryDataBuilder();
+        var logs = new List<LogMessageData>
+            {
+                new("This is my debug log", TelemetryLogLevel.DEBUG, DateTimeOffset.UtcNow),
+                new("This is my warn log", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow),
+                new("This is my error log", TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow),
+            };
+
+        var result = builder.BuildLogsTelemetryData(_application, _host, logs, _namingSchemaVersion);
+
+        result.Should().NotBeNull();
+        result.Application.Should().Be(_application);
+        result.SeqId.Should().Be(1);
+        result.Payload.Should()
+              .NotBeNull()
+              .And.BeOfType<LogsPayload>()
+              .Which.Logs.Should()
+              .BeSameAs(logs);
     }
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -85,7 +85,8 @@ namespace Datadog.Trace.Tests
                 };
                 Tracer.Configure(oldSettings);
 
-                var span = Tracer.Instance.StartActive("Test span");
+                var scope = Tracer.Instance.StartActive("Test span");
+                (scope.Span as Span).IsRootSpan.Should().BeTrue();
 
                 var newSettings = new TracerSettings
                 {
@@ -100,7 +101,7 @@ namespace Datadog.Trace.Tests
 
                 Tracer.Configure(newSettings);
 
-                span.Dispose();
+                scope.Dispose();
 
                 var spans = agent.WaitForSpans(count: 1);
                 var received = spans.Should().ContainSingle().Subject;


### PR DESCRIPTION
## Summary of changes

- Implements the `logs` telemetry payload
- Adds a `RedactedErrorLogSink` and `RedactedErrorLogCollector`
- Update `DatadogLogging` to send error logs to telemetry

## Reason for change

We want to collect redacted-error logs in telemetry

## Implementation details

You can review commit-by-commit.

The main moving parts here:
- `RedactedErrorLoggingConfiguration` - should we send redacted error logs to telemetry.
- `RedactedErrorLogSink` - if enabled by configuration, this is the Serilog sink that gets the Error logs and writes them to...
- `RedactedErrorLogCollector` - the singleton instance that "collects" the logs. It is responsible for notifying the `TelemetryController` when it needs to flush, but otherwise, it holds a queue of logs to send. 
- `TelemetryController` - the scheduler needed to be updated to handle the fact that we may need to send logs as part of the flush loop.

Note that this PR does _not_ include the redaction or de-duplication of the logs. That is implemented in separate, stacked, PRs for ease of reviewing.

## Test coverage

Unit tests + integration tests

## Other details

Supersedes this original implementation:
- https://github.com/DataDog/dd-trace-dotnet/pull/3543

Part 2 of a stack of PRs
- https://github.com/DataDog/dd-trace-dotnet/pull/4832
- https://github.com/DataDog/dd-trace-dotnet/pull/4833 (this PR)
- https://github.com/DataDog/dd-trace-dotnet/pull/4834
- https://github.com/DataDog/dd-trace-dotnet/pull/4835

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
