### PR TITLE
Add redaction of telemetry error logs

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -517,6 +517,7 @@
       <type fullname="System.Diagnostics.DebuggerHiddenAttribute" />
       <type fullname="System.Diagnostics.DebuggerStepThroughAttribute" />
       <type fullname="System.Diagnostics.DebuggerTypeProxyAttribute" />
+      <type fullname="System.Diagnostics.StackTraceHiddenAttribute" />
       <type fullname="System.Diagnostics.Stopwatch" />
       <type fullname="System.Double" />
       <type fullname="System.EntryPointNotFoundException" />
@@ -665,6 +666,7 @@
       <type fullname="System.Reflection.TypeAttributes" />
       <type fullname="System.Reflection.TypeInfo" />
       <type fullname="System.ResolveEventArgs" />
+      <type fullname="System.Runtime.CompilerServices.AsyncIteratorStateMachineAttribute" />
       <type fullname="System.Runtime.CompilerServices.AsyncStateMachineAttribute" />
       <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder" />
       <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1" />

--- a/tracer/src/Datadog.Trace/Logging/Internal/ExceptionRedactor.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/ExceptionRedactor.cs
@@ -1,0 +1,448 @@
+﻿// <copyright file="ExceptionRedactor.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Security;
+using System.Text;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Logging.Internal;
+
+internal static class ExceptionRedactor
+{
+    internal const string StackFrameAt = "   at ";
+    internal const string Redacted = "REDACTED";
+    private const string InFileLineNum = "in {0}:line {1}";
+
+    /// <summary>
+    /// Redacts a stacktrace by replacing non-Datadog and non-BCL stack frames with REDACTED.
+    /// Uses code based on the <a href="https://github.com/dotnet/runtime/blob/v7.0.2/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs" >.NET Core <c>StackTrace</c></a> code and the
+    /// <a href="https://referencesource.microsoft.com/#mscorlib/system/diagnostics/stacktrace.cs" >.NET Framework <c>StackTrace</c></a>
+    /// Records the _type_ of the Exception instead of the exception message
+    /// </summary>
+    /// <param name="exception">The exception to generate the redacted stack trace for</param>
+    /// <returns>The redacted stack trace</returns>
+    public static string Redact(Exception exception)
+    {
+        var exceptionType = exception.GetType().FullName ?? "Unknown Exception";
+        var stackTrace = new StackTrace(exception);
+
+        var stackFrameCount = stackTrace.FrameCount;
+        if (stackFrameCount == 0)
+        {
+            return exceptionType;
+        }
+
+        var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+        sb.AppendLine(exceptionType);
+
+        RedactStackTrace(sb, stackTrace);
+
+        return StringBuilderCache.GetStringAndRelease(sb);
+    }
+
+    // internal for testing
+    internal static void RedactStackTrace(StringBuilder sb, StackTrace stackTrace)
+    {
+        for (var i = 0; i < stackTrace.FrameCount; i++)
+        {
+            var frame = stackTrace.GetFrame(i);
+            var methodInfo = frame?.GetMethod();
+            if (frame is null || methodInfo is null)
+            {
+                continue;
+            }
+
+            if (ShouldRedactFrame(methodInfo))
+            {
+                sb.Append(StackFrameAt);
+                sb.AppendLine(Redacted);
+                continue;
+            }
+
+            AppendFrame(sb, frame);
+        }
+    }
+
+    private static bool ShouldRedactFrame(MethodBase mb)
+        => mb.DeclaringType switch
+        {
+            null => true, // "global" function
+            // TODO: grab the list of assemblies we instrument from the trimming file (etc)
+            // NOTE: Keep this in sync with InstrumentationDefinitions SourceGenerator implementation in Sources.BuildInstrumentedAssemblies.IsKnownAssemblyPrefix()
+            { Assembly.FullName: { } name } => !(name.StartsWith("Datadog.", StringComparison.Ordinal)
+                                              || name.StartsWith("mscorlib,", StringComparison.Ordinal) // note that this uses ',' not '.' as it's the full assembly name
+                                              || name.StartsWith("Microsoft.", StringComparison.Ordinal)
+                                              || name.StartsWith("System.", StringComparison.Ordinal)
+                                              || name.StartsWith("Azure.", StringComparison.Ordinal)
+                                              || name.StartsWith("AWSSDK.", StringComparison.Ordinal)),
+            _ => true, // no assembly
+        };
+
+#if NETFRAMEWORK
+    private static void AppendFrame(StringBuilder sb, StackFrame sf)
+    {
+        var displayFilenames = true;
+        var mb = sf.GetMethod();
+        if (mb != null)
+        {
+            // We want a newline at the end of every line except for the last
+            sb.Append(StackFrameAt);
+
+            var t = mb.DeclaringType;
+             // if there is a type (non global method) print it
+            if (t != null)
+            {
+                sb.Append(t.FullName!.Replace('+', '.'));
+                sb.Append(".");
+            }
+
+            sb.Append(mb.Name);
+
+            // deal with the generic portion of the method
+            if (mb is MethodInfo && ((MethodInfo)mb).IsGenericMethod)
+            {
+                Type[] typars = ((MethodInfo)mb).GetGenericArguments();
+                sb.Append("[");
+                var k = 0;
+                var fFirstTyParam = true;
+                while (k < typars.Length)
+                {
+                    if (fFirstTyParam == false)
+                    {
+                        sb.Append(",");
+                    }
+                    else
+                    {
+                        fFirstTyParam = false;
+                    }
+
+                    sb.Append(typars[k].Name);
+                    k++;
+                }
+
+                sb.Append("]");
+            }
+
+            // arguments printing
+            sb.Append("(");
+            ParameterInfo[] pi = mb.GetParameters();
+            var fFirstParam = true;
+            for (var j = 0; j < pi.Length; j++)
+            {
+                if (fFirstParam == false)
+                {
+                    sb.Append(", ");
+                }
+                else
+                {
+                    fFirstParam = false;
+                }
+
+                var typeName = "<UnknownType>";
+                if (pi[j].ParameterType != null)
+                {
+                    typeName = pi[j].ParameterType.Name;
+                }
+
+                sb.Append(typeName + " " + pi[j].Name);
+            }
+
+            sb.Append(")");
+
+            // source location printing
+            if (displayFilenames && sf.GetILOffset() != -1)
+            {
+                // If we don't have a PDB or PDB-reading is disabled for the module,
+                // then the file name will be null.
+                string? fileName = null;
+
+                // Getting the filename from a StackFrame is a privileged operation - we won't want
+                // to disclose full path names to arbitrarily untrusted code.  Rather than just omit
+                // this we could probably trim to just the filename so it's still mostly usefull.
+                try
+                {
+                    fileName = sf.GetFileName();
+                }
+                catch (NotSupportedException)
+                {
+                    // Having a deprecated stack modifier on the callstack (such as Deny) will cause
+                    // a NotSupportedException to be thrown.  Since we don't know if the app can
+                    // access the file names, we'll conservatively hide them.
+                    displayFilenames = false;
+                }
+                catch (SecurityException)
+                {
+                    // If the demand for displaying filenames fails, then it won't
+                    // succeed later in the loop.  Avoid repeated exceptions by not trying again.
+                    displayFilenames = false;
+                }
+
+                if (fileName != null)
+                {
+                    // tack on " in c:\tmp\MyFile.cs:line 5"
+                    sb.Append(' ');
+                    sb.AppendFormat(CultureInfo.InvariantCulture, InFileLineNum, fileName, sf.GetFileLineNumber());
+                }
+            }
+
+            // Can't get IsLastFrameFromForeignExceptionStackTrace as it's internal unfortunately, so,
+            // if (sf.GetIsLastFrameFromForeignExceptionStackTrace())
+            // {
+            //     sb.Append(Environment.NewLine);
+            //     sb.Append(Environment.GetResourceString("Exception_EndStackTraceFromPreviousThrow"));
+            // }
+            sb.AppendLine();
+        }
+    }
+#else
+    private static void AppendFrame(StringBuilder sb, StackFrame sf)
+    {
+        // Passing a default string for "at" in case SR.UsingResourceKeys() is true
+        // as this is a special case and we don't want to have "Word_At" on stack traces.
+        // We also want to pass in a default for inFileLineNumber.
+        var mb = sf.GetMethod()!;
+        if (ShowInStackTrace(mb))
+        {
+            sb.Append(StackFrameAt);
+
+            var isAsync = false;
+            var declaringType = mb.DeclaringType;
+            var methodName = mb.Name;
+            var methodChanged = false;
+            if (declaringType != null && declaringType.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false))
+            {
+                isAsync = typeof(IAsyncStateMachine).IsAssignableFrom(declaringType);
+                if (isAsync || typeof(IEnumerator).IsAssignableFrom(declaringType))
+                {
+                    methodChanged = TryResolveStateMachineMethod(ref mb, out declaringType);
+                }
+            }
+
+            // if there is a type (non global method) print it
+            // ResolveStateMachineMethod may have set declaringType to null
+            if (declaringType != null)
+            {
+                // Append t.FullName, replacing '+' with '.'
+                var fullName = declaringType.FullName!;
+                for (var i = 0; i < fullName.Length; i++)
+                {
+                    var ch = fullName[i];
+                    sb.Append(ch == '+' ? '.' : ch);
+                }
+
+                sb.Append('.');
+            }
+
+            sb.Append(mb.Name);
+
+            // deal with the generic portion of the method
+            if (mb is MethodInfo mi && mi.IsGenericMethod)
+            {
+                Type[] typars = mi.GetGenericArguments();
+                sb.Append('[');
+                var k = 0;
+                var fFirstTyParam = true;
+                while (k < typars.Length)
+                {
+                    if (!fFirstTyParam)
+                    {
+                        sb.Append(',');
+                    }
+                    else
+                    {
+                        fFirstTyParam = false;
+                    }
+
+                    sb.Append(typars[k].Name);
+                    k++;
+                }
+
+                sb.Append(']');
+            }
+
+            ParameterInfo[]? pi = null;
+            try
+            {
+                pi = mb.GetParameters();
+            }
+            catch
+            {
+                // The parameter info cannot be loaded, so we don't
+                // append the parameter list.
+            }
+
+            if (pi != null)
+            {
+                // arguments printing
+                sb.Append('(');
+                var fFirstParam = true;
+                for (var j = 0; j < pi.Length; j++)
+                {
+                    if (!fFirstParam)
+                    {
+                        sb.Append(", ");
+                    }
+                    else
+                    {
+                        fFirstParam = false;
+                    }
+
+                    var typeName = "<UnknownType>";
+                    if (pi[j].ParameterType != null)
+                    {
+                        typeName = pi[j].ParameterType.Name;
+                    }
+
+                    sb.Append(typeName);
+                    var parameterName = pi[j].Name;
+                    if (parameterName != null)
+                    {
+                        sb.Append(' ');
+                        sb.Append(parameterName);
+                    }
+                }
+
+                sb.Append(')');
+            }
+
+            if (methodChanged)
+            {
+                // Append original method name e.g. +MoveNext()
+                sb.Append('+');
+                sb.Append(methodName);
+                sb.Append('(').Append(')');
+            }
+
+            // source location printing
+            if (sf!.GetILOffset() != -1)
+            {
+                // If we don't have a PDB or PDB-reading is disabled for the module,
+                // then the file name will be null.
+                var fileName = sf.GetFileName();
+
+                if (fileName != null)
+                {
+                    // tack on " in c:\tmp\MyFile.cs:line 5"
+                    sb.Append(' ');
+                    sb.AppendFormat(CultureInfo.InvariantCulture, InFileLineNum, fileName, sf.GetFileLineNumber());
+                }
+
+                // don't bother showing IL offsets
+            }
+
+            // Can't get IsLastFrameFromForeignExceptionStackTrace as it's internal unfortunately, so,
+            // we won't get these error boundaries in the redacted logs
+            // if (sf.IsLastFrameFromForeignExceptionStackTrace && !isAsync)
+            // {
+            //     sb.AppendLine();
+            //     sb.Append("--- End of stack trace from previous location ---");
+            // }
+
+            sb.AppendLine();
+        }
+    }
+
+    private static bool ShowInStackTrace(MethodBase mb)
+    {
+        if ((mb.MethodImplementationFlags & MethodImplAttributes.AggressiveInlining) != 0)
+        {
+            // Aggressive Inlines won't normally show in the StackTrace; however for Tier0 Jit and
+            // cross-assembly AoT/R2R these inlines will be blocked until Tier1 Jit re-Jits
+            // them when they will inline. We don't show them in the StackTrace to bring consistency
+            // between this first-pass asm and fully optimized asm.
+            return false;
+        }
+
+#if NET6_0_OR_GREATER
+        try
+        {
+            if (mb.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false))
+            {
+                // Don't show where StackTraceHidden is applied to the method.
+                return false;
+            }
+
+            Type? declaringType = mb.DeclaringType;
+            // Methods don't always have containing types, for example dynamic RefEmit generated methods.
+            if (declaringType != null &&
+                declaringType.IsDefined(typeof(StackTraceHiddenAttribute), inherit: false))
+            {
+                // Don't show where StackTraceHidden is applied to the containing Type of the method.
+                return false;
+            }
+        }
+        catch
+        {
+            // Getting the StackTraceHiddenAttribute has failed, behave as if it was not present.
+            // One of the reasons can be that the method mb or its declaring type use attributes
+            // defined in an assembly that is missing.
+        }
+#endif
+        return true;
+    }
+
+    private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
+    {
+        declaringType = method.DeclaringType!;
+
+        Type? parentType = declaringType.DeclaringType;
+        if (parentType == null)
+        {
+            return false;
+        }
+
+        static MethodInfo[]? GetDeclaredMethods(Type type) =>
+            type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+        MethodInfo[]? methods = GetDeclaredMethods(parentType);
+        if (methods == null)
+        {
+            return false;
+        }
+
+        foreach (MethodInfo candidateMethod in methods)
+        {
+            StateMachineAttribute[]? attributes = (StateMachineAttribute[])Attribute.GetCustomAttributes(candidateMethod, typeof(StateMachineAttribute), inherit: false);
+            if (attributes == null)
+            {
+                continue;
+            }
+
+            bool foundAttribute = false, foundIteratorAttribute = false;
+            foreach (StateMachineAttribute asma in attributes)
+            {
+                if (asma.StateMachineType == declaringType)
+                {
+                    foundAttribute = true;
+#if NETCOREAPP3_1_OR_GREATER
+                    foundIteratorAttribute |= asma is IteratorStateMachineAttribute || asma is AsyncIteratorStateMachineAttribute;
+#else
+                    foundIteratorAttribute |= asma is IteratorStateMachineAttribute;
+#endif
+                }
+            }
+
+            if (foundAttribute)
+            {
+                // If this is an iterator (sync or async), mark the iterator as changed, so it gets the + annotation
+                // of the original method. Non-iterator async state machines resolve directly to their builder methods
+                // so aren't marked as changed.
+                method = candidateMethod;
+                declaringType = candidateMethod.DeclaringType!;
+                return foundIteratorAttribute;
+            }
+        }
+
+        return false;
+    }
+#endif
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/ExceptionRedactor.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/ExceptionRedactor.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security;
 using System.Text;
+using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Logging.Internal;
@@ -76,14 +77,14 @@ internal static class ExceptionRedactor
         => mb.DeclaringType switch
         {
             null => true, // "global" function
-            // TODO: grab the list of assemblies we instrument from the trimming file (etc)
             // NOTE: Keep this in sync with InstrumentationDefinitions SourceGenerator implementation in Sources.BuildInstrumentedAssemblies.IsKnownAssemblyPrefix()
             { Assembly.FullName: { } name } => !(name.StartsWith("Datadog.", StringComparison.Ordinal)
                                               || name.StartsWith("mscorlib,", StringComparison.Ordinal) // note that this uses ',' not '.' as it's the full assembly name
                                               || name.StartsWith("Microsoft.", StringComparison.Ordinal)
                                               || name.StartsWith("System.", StringComparison.Ordinal)
                                               || name.StartsWith("Azure.", StringComparison.Ordinal)
-                                              || name.StartsWith("AWSSDK.", StringComparison.Ordinal)),
+                                              || name.StartsWith("AWSSDK.", StringComparison.Ordinal)
+                                              || InstrumentationDefinitions.IsInstrumentedAssembly(name)),
             _ => true, // no assembly
         };
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/RedactedErrorLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/RedactedErrorLogSink.cs
@@ -4,6 +4,9 @@
 // </copyright>
 
 #nullable enable
+
+using System.Collections.Generic;
+using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Collectors;
 using Datadog.Trace.Telemetry.DTOs;

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -53,6 +53,8 @@ internal class TelemetryController : ITelemetryController
         _metrics = metrics ?? throw new ArgumentNullException(nameof(metrics));
         _transportManager = transportManager ?? throw new ArgumentNullException(nameof(transportManager));
         _redactedErrorLogs = redactedErrorLogs;
+        // We use Task.Delay(Timeout.Infinite) here as "a Task that never completes".
+        // It simplifies some of the logic we need to do in the scheduler
         var redactedErrorLogsTask = () => _redactedErrorLogs?.WaitForLogsAsync() ?? Task.Delay(Timeout.Infinite);
         _scheduler = new(flushInterval, redactedErrorLogsTask, _processExit);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -334,7 +334,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             allLogs.Should()
                    .ContainSingle()
                    .Which.Message.Should()
-                   .StartWith("Unable to parse custom sampling rules");
+                   .Be("Unable to parse custom sampling rules");
         }
 
         private static void AssertService(MockTracerAgent mockAgent, string expectedServiceName, string expectedServiceVersion)

--- a/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tests/Datadog.Trace.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -352,7 +352,7 @@ namespace Datadog.Trace.Tests.Logging
                                     .Subject;
 
             errorLog.Level.Should().Be(TelemetryLogLevel.ERROR);
-            errorLog.Message.Should().StartWith(errorMessage);
+            errorLog.Message.Should().Be(errorMessage);
             errorLog.StackTrace.Should().NotBeNull();
 
             // No more logs, so should still be null

--- a/tracer/test/Datadog.Trace.Tests/Logging/ExceptionRedactorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ExceptionRedactorTests.cs
@@ -131,7 +131,7 @@ public class ExceptionRedactorTests
         var redactedFrames = redacted.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
         // assumes that all methods in the call stack include one of these in the namespace
         // We actually filter based on assembly name so this isn't guaranteed, but works in tests
-        var allowedPrefixes = new[] { "Datadog", "Microsoft", "System", "REDACTED" };
+        var allowedPrefixes = new[] { "Datadog", "Microsoft", "System", "Xunit", "REDACTED" };
         redactedFrames.Should().OnlyContain(x => allowedPrefixes.Any(x.Contains));
 
         var originalFrames = stackTrace.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
@@ -173,10 +173,6 @@ public class ExceptionRedactorTests
             typeof(VerifyTests.VerifierSettings).GetProperty(nameof(VerifyTests.VerifierSettings.StrictJson))?.GetMethod,
             typeof(VerifyTests.VerifierSettings).GetProperty(nameof(VerifyTests.VerifierSettings.StrictJson))?.SetMethod,
             typeof(VerifyTests.SerializationSettings).GetConstructor(Array.Empty<Type>()),
-            typeof(Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.GetMethod,
-            typeof(Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.SetMethod,
-            typeof(Serilog.Log).GetMethod(nameof(Serilog.Log.CloseAndFlush)),
-            typeof(Serilog.Log).GetMethod(nameof(Serilog.Log.Error), types: new[] { typeof(string) }),
         };
 
         public static TheoryData<object> MethodsToNotRedact() => new()
@@ -190,6 +186,10 @@ public class ExceptionRedactorTests
             typeof(Datadog.Trace.Vendors.Serilog.Log).GetMethod(nameof(Serilog.Log.CloseAndFlush)),
             typeof(StringBuilder).GetMethod(nameof(StringBuilder.Clear)),
             typeof(string).GetMethod(nameof(string.IndexOf),  types: new[] { typeof(char) }),
+            typeof(Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.GetMethod,
+            typeof(Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.SetMethod,
+            typeof(Serilog.Log).GetMethod(nameof(Serilog.Log.CloseAndFlush)),
+            typeof(Serilog.Log).GetMethod(nameof(Serilog.Log.Error), types: new[] { typeof(string) }),
             typeof(System.Threading.Tasks.Task).GetMethod(nameof(System.Threading.Tasks.Task.Wait), types: Array.Empty<Type>()),
             typeof(System.Data.SqlClient.SqlCommand).GetMethod(nameof(System.Data.SqlClient.SqlCommand.Clone)),
             typeof(System.Data.SQLite.SQLiteCommand).GetProperty(nameof(System.Data.SQLite.SQLiteCommand.CommandType))?.GetMethod,

--- a/tracer/test/Datadog.Trace.Tests/Logging/ExceptionRedactorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ExceptionRedactorTests.cs
@@ -1,0 +1,253 @@
+﻿// <copyright file="ExceptionRedactorTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Datadog.Trace.Logging.Internal;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging;
+
+public class ExceptionRedactorTests
+{
+    [Theory]
+    [InlineData(typeof(Exception))]
+    [InlineData(typeof(InvalidOperationException))]
+    [InlineData(typeof(ArgumentException))]
+    public void Redact_UsesExceptionTypeForEmptyException(Type exceptionType)
+    {
+        var ex = (Exception)Activator.CreateInstance(exceptionType);
+        var redacted = ExceptionRedactor.Redact(ex);
+
+        redacted.Should().Be(exceptionType.FullName);
+    }
+
+    [Fact]
+    public void Redact_IncludesExceptionTypeWhenHaveStackFrames()
+    {
+        var ex = InvokeException();
+        var redacted = ExceptionRedactor.Redact(ex);
+
+        redacted.Should().StartWith("System.Exception" + Environment.NewLine);
+
+        // remove first line (exception) from redacted exception before comparing
+        var redactedStackTrace = string.Join(Environment.NewLine, redacted.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries).Skip(1));
+        HasExpectedFrames(new StackTrace(ex), redactedStackTrace);
+    }
+
+    [Fact]
+    public void RedactStackTrace_IsEmptyForEmptyException()
+    {
+        var ex = new Exception();
+        var stackTrace = new StackTrace(ex);
+
+        var sb = new StringBuilder();
+        ExceptionRedactor.RedactStackTrace(sb, stackTrace);
+        var redacted = sb.ToString();
+
+        redacted.Should().BeEmpty();
+    }
+
+    [Theory]
+    [MemberData(nameof(TestData.MethodsToRedact), MemberType = typeof(TestData))]
+    public void RedactStackTrace_RedactsUserCode(object method)
+    {
+        var methodBase = method.Should().NotBeNull().And.BeAssignableTo<MethodBase>().Subject;
+        var stackFrame = new TestStackFrame(methodBase);
+        var stackTrace = new StackTrace(stackFrame);
+
+        var sb = new StringBuilder();
+        ExceptionRedactor.RedactStackTrace(sb, stackTrace);
+        var redacted = sb.ToString();
+
+        redacted.Should().Be($"{ExceptionRedactor.StackFrameAt}{ExceptionRedactor.Redacted}" + Environment.NewLine);
+    }
+
+    [Theory]
+    [MemberData(nameof(TestData.MethodsToNotRedact), MemberType = typeof(TestData))]
+    public void RedactStackTrace_DoesNotRedactBclAndDatadog(object method)
+    {
+        var methodBase = method.Should().NotBeNull().And.BeAssignableTo<MethodBase>().Subject;
+        var stackFrame = new TestStackFrame(methodBase);
+        var stackTrace = new StackTrace(stackFrame);
+
+        var sb = new StringBuilder();
+        ExceptionRedactor.RedactStackTrace(sb, stackTrace);
+        var redacted = sb.ToString();
+
+        redacted.Should().Be(stackTrace.ToString());
+    }
+
+    [Theory]
+    [MemberData(nameof(TestData.ToStringTestData), MemberType = typeof(TestData))]
+    public void RedactStackTrace_ContainsExpectedStrings(StackTrace stackTrace, string expectedToString)
+    {
+        var sb = new StringBuilder();
+        ExceptionRedactor.RedactStackTrace(sb, stackTrace);
+        var redacted = sb.ToString();
+
+        if (expectedToString.Length == 0)
+        {
+            redacted.Should().BeEmpty();
+            return;
+        }
+
+        redacted.Should().Contain(expectedToString);
+        redacted.Should().EndWith(Environment.NewLine);
+
+        HasExpectedFrames(stackTrace, redacted);
+    }
+
+    [Fact]
+    public unsafe void RedactStackTrace_WorksWithFunctionPointerSignature()
+    {
+        // This is separate from Redact_ContainsExpectedStrings since unsafe cannot be used for iterators
+        var stackTrace = TestData.FunctionPointerParameter(null);
+        var sb = new StringBuilder();
+        ExceptionRedactor.RedactStackTrace(sb, stackTrace);
+        var redacted = sb.ToString();
+
+#if NET8_0_OR_GREATER
+        // https://github.com/dotnet/runtime/issues/11354
+        redacted.Should().Contain("Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.FunctionPointerParameter( x)");
+#else
+        redacted.Should().Contain("Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.FunctionPointerParameter(IntPtr x)");
+#endif
+        redacted.Should().EndWith(Environment.NewLine);
+
+        HasExpectedFrames(stackTrace, redacted);
+    }
+
+    private static void HasExpectedFrames(StackTrace stackTrace, string redacted)
+    {
+        var redactedFrames = redacted.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+        // assumes that all methods in the call stack include one of these in the namespace
+        // We actually filter based on assembly name so this isn't guaranteed, but works in tests
+        var allowedPrefixes = new[] { "Datadog", "Microsoft", "System", "REDACTED" };
+        redactedFrames.Should().OnlyContain(x => allowedPrefixes.Any(x.Contains));
+
+        var originalFrames = stackTrace.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+        redactedFrames.Length.Should().Be(originalFrames.Length);
+        for (var i = 0; i < redactedFrames.Length; i++)
+        {
+            if (redactedFrames[i].Contains("REDACTED"))
+            {
+                continue;
+            }
+
+            redactedFrames[i].Should().Be(originalFrames[i]);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+    private static Exception InvokeException()
+    {
+        try
+        {
+            ThrowException();
+            return null;
+        }
+        catch (Exception ex)
+        {
+            return ex;
+        }
+    }
+
+    private static void ThrowException() => throw new Exception();
+
+    public static class TestData
+    {
+        public static TheoryData<object> MethodsToRedact() => new()
+        {
+            typeof(AssertionExtensions).GetMethod(nameof(AssertionExtensions.Should), types: new[] { typeof(object) }),
+            typeof(Xunit.Assert).GetMethod(nameof(Assert.False), types: new[] { typeof(bool) }),
+            typeof(VerifyTests.VerifierSettings).GetMethod(nameof(VerifyTests.VerifierSettings.DisableClipboard)),
+            typeof(VerifyTests.VerifierSettings).GetProperty(nameof(VerifyTests.VerifierSettings.StrictJson))?.GetMethod,
+            typeof(VerifyTests.VerifierSettings).GetProperty(nameof(VerifyTests.VerifierSettings.StrictJson))?.SetMethod,
+            typeof(VerifyTests.SerializationSettings).GetConstructor(Array.Empty<Type>()),
+            typeof(Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.GetMethod,
+            typeof(Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.SetMethod,
+            typeof(Serilog.Log).GetMethod(nameof(Serilog.Log.CloseAndFlush)),
+            typeof(Serilog.Log).GetMethod(nameof(Serilog.Log.Error), types: new[] { typeof(string) }),
+        };
+
+        public static TheoryData<object> MethodsToNotRedact() => new()
+        {
+            typeof(ExceptionRedactorTests.TestData).GetMethod(nameof(NoParameters)),
+            typeof(Datadog.Trace.Tracer).GetMethod(nameof(Tracer.UnsafeSetTracerInstance), BindingFlags.Static | BindingFlags.NonPublic),
+            typeof(Datadog.Trace.Tracer).GetProperty(nameof(Tracer.Instance))?.GetMethod,
+            typeof(Datadog.Trace.Tracer).GetProperty(nameof(Tracer.Instance))?.SetMethod,
+            typeof(Datadog.Trace.Vendors.Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.GetMethod,
+            typeof(Datadog.Trace.Vendors.Serilog.Log).GetProperty(nameof(Serilog.Log.Logger))?.SetMethod,
+            typeof(Datadog.Trace.Vendors.Serilog.Log).GetMethod(nameof(Serilog.Log.CloseAndFlush)),
+            typeof(StringBuilder).GetMethod(nameof(StringBuilder.Clear)),
+            typeof(string).GetMethod(nameof(string.IndexOf),  types: new[] { typeof(char) }),
+            typeof(System.Threading.Tasks.Task).GetMethod(nameof(System.Threading.Tasks.Task.Wait), types: Array.Empty<Type>()),
+            typeof(System.Data.SqlClient.SqlCommand).GetMethod(nameof(System.Data.SqlClient.SqlCommand.Clone)),
+            typeof(System.Data.SQLite.SQLiteCommand).GetProperty(nameof(System.Data.SQLite.SQLiteCommand.CommandType))?.GetMethod,
+            typeof(System.Data.SQLite.SQLiteCommand).GetProperty(nameof(System.Data.SQLite.SQLiteCommand.CommandType))?.SetMethod,
+#if !NETFRAMEWORK
+            typeof(Microsoft.CodeAnalysis.DiagnosticDescriptor).GetProperty(nameof(Microsoft.CodeAnalysis.DiagnosticDescriptor.Id))?.GetMethod,
+            typeof(Microsoft.Extensions.DependencyInjection.ServiceCollection).GetMethod(nameof(Microsoft.Extensions.DependencyInjection.ServiceCollection.Contains), types: new[] { typeof(Microsoft.Extensions.DependencyInjection.ServiceDescriptor) }),
+#endif
+        };
+
+        public static IEnumerable<object[]> ToStringTestData()
+        {
+            yield return new object[] { new StackTrace(InvokeException()), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.ThrowException()" };
+            yield return new object[] { new StackTrace(new Exception()), string.Empty };
+            yield return new object[] { NoParameters(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.NoParameters()" };
+            yield return new object[] { OneParameter(1), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.OneParameter(Int32 x)" };
+            yield return new object[] { TwoParameters(1, null), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.TwoParameters(Int32 x, String y)" };
+            yield return new object[] { Generic<int>(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.Generic[T]()" };
+            yield return new object[] { Generic<int, string>(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.Generic[T1,T2]()" };
+            yield return new object[] { new ClassWithConstructor().StackTrace, "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.ClassWithConstructor..ctor()" };
+        }
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static unsafe StackTrace FunctionPointerParameter(delegate*<void> x) => new();
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        public static StackTrace NoParameters() => new();
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        private static StackTrace OneParameter(int x) => new();
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        private static StackTrace TwoParameters(int x, string y) => new();
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        private static StackTrace Generic<T>() => new();
+
+        [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
+        private static StackTrace Generic<T1, T2>() => new();
+
+        private class ClassWithConstructor
+        {
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            public ClassWithConstructor() => StackTrace = new StackTrace();
+
+            public StackTrace StackTrace { get; }
+        }
+    }
+
+    public class TestStackFrame : StackFrame
+    {
+        private readonly MethodBase _methodBase;
+
+        public TestStackFrame(MethodBase methodBase)
+        {
+            _methodBase = methodBase;
+        }
+
+        public override MethodBase GetMethod() => _methodBase;
+    }
+}


### PR DESCRIPTION
## Summary of changes

Adds redaction of stack traces to error logs

## Reason for change

We only want to include stack frames from assemblies that we know are safe i.e. with known prefixes or which we implement.

## Implementation details

Added an `ExceptionRedactor` class. This uses code based on `StackTrace.ToString()` from [CoreClr](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs) and [.NET Framework](https://referencesource.microsoft.com/#mscorlib/system/diagnostics/stacktrace.cs). These produce slightly different stack traces, so vendored both for consistency with `Exception.ToString()`.

The stack trace redactor removes any line that isn't in a `Microsoft`, `Datadog`, or `System` assembly (among others), as well as in any of the assemblies we instrument (thanks to https://github.com/DataDog/dd-trace-dotnet/pull/4832)

We also only include the type of the exception, not the exception message

## Test coverage

Unit tests for the `ExceptionRedactor` based on the `StackTrace.ToString()` tests in the BCL. No integration tests here, but I'm not to worried about that

## Other details

Supersedes (and re-implements) this PR:
- https://github.com/DataDog/dd-trace-dotnet/pull/3751

Part 3 in a stack of PRs

- https://github.com/DataDog/dd-trace-dotnet/pull/4832
- https://github.com/DataDog/dd-trace-dotnet/pull/4833
- https://github.com/DataDog/dd-trace-dotnet/pull/4834 (this PR)
- https://github.com/DataDog/dd-trace-dotnet/pull/4835

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
