### PR TITLE
Add de-duplication of telemetry logs

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/EventIdHash.cs
@@ -30,13 +30,15 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
     internal static class EventIdHash
     {
         /// <summary>
-        /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>. The
+        /// Compute a 32-bit hash of the provided <paramref name="messageTemplate"/>.
+        /// and optionally a <paramref name="stackTrace"/>. The
         /// resulting hash value can be uses as an event id in lieu of transmitting the
         /// full template string.
         /// </summary>
         /// <param name="messageTemplate">A message template.</param>
+        /// <param name="stackTrace">An optional stack trace to consider in the calculation.</param>
         /// <returns>A 32-bit hash of the template.</returns>
-        public static uint Compute(string messageTemplate)
+        public static uint Compute(string messageTemplate, string? stackTrace = null)
         {
             if (messageTemplate == null)
             {
@@ -52,6 +54,16 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
                     hash += messageTemplate[i];
                     hash += (hash << 10);
                     hash ^= (hash >> 6);
+                }
+
+                if (stackTrace is not null)
+                {
+                    for (var i = 0; i < stackTrace.Length; ++i)
+                    {
+                        hash += stackTrace[i];
+                        hash += (hash << 10);
+                        hash ^= (hash >> 6);
+                    }
                 }
 
                 hash += (hash << 3);

--- a/tracer/src/Datadog.Trace/Logging/Internal/RedactedErrorLogSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/RedactedErrorLogSink.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Collectors;
-using Datadog.Trace.Telemetry.DTOs;
 using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Events;
 
@@ -33,12 +32,8 @@ internal class RedactedErrorLogSink : ILogEventSink
         }
 
         // Note: we're using the raw message template here to remove any chance of including customer information
-        var telemetryLog = new LogMessageData(logEvent.MessageTemplate.Text, ToLogLevel(logEvent.Level), logEvent.Timestamp)
-        {
-            StackTrace = logEvent.Exception is { } ex ? ExceptionRedactor.Redact(ex) : null
-        };
-
-        _collector.EnqueueLog(telemetryLog);
+        var stackTrace = logEvent.Exception is { } ex ? ExceptionRedactor.Redact(ex) : null;
+        _collector.EnqueueLog(logEvent.MessageTemplate.Text, ToLogLevel(logEvent.Level), logEvent.Timestamp, stackTrace);
     }
 
     private static TelemetryLogLevel ToLogLevel(LogEventLevel logEventLevel)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/RedactedErrorLogCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/RedactedErrorLogCollectorTests.cs
@@ -4,9 +4,9 @@
 // </copyright>
 
 using System;
-using System.IO;
 using System.Linq;
 using System.Text;
+using Datadog.Trace.Logging.Internal;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Collectors;
 using Datadog.Trace.Telemetry.DTOs;
@@ -23,10 +23,10 @@ public class RedactedErrorLogCollectorTests
     {
         var collector = new RedactedErrorLogCollector();
         var messagesToSend = RedactedErrorLogCollector.MaximumQueueSize * 2;
-        while (messagesToSend > 0)
+        for (var i = messagesToSend; i > 0; i--)
         {
-            collector.EnqueueLog(new("Something", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
-            messagesToSend--;
+            // Make messages unique to avoid de-duplication
+            collector.EnqueueLog(new($"Something {i}", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
         }
 
         var logs = collector.GetLogs();
@@ -40,21 +40,19 @@ public class RedactedErrorLogCollectorTests
         var collector = new RedactedErrorLogCollector();
         var threshold = RedactedErrorLogCollector.QueueSizeTrigger;
         var task = collector.WaitForLogsAsync();
-        var messages = 0;
-        while (messages < threshold)
+        for (var i = 0; i < threshold; i++)
         {
-            collector.EnqueueLog(new("Something", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
-            messages++;
+            // make the messages unique to avoid de-duplication
+            collector.EnqueueLog(new($"Something {i}", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
             task.IsCompleted.Should().BeFalse();
         }
 
         // sending one more message should complete the task
         // and should remain completed subsequently
-        messages = 0;
-        while (messages < 100)
+        for (var i = 0; i < 100; i++)
         {
-            collector.EnqueueLog(new("Something", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
-            messages++;
+            // make the messages unique to avoid de-duplication
+            collector.EnqueueLog(new($"Something {i + threshold}", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
             task.IsCompleted.Should().BeTrue();
         }
     }
@@ -119,7 +117,8 @@ public class RedactedErrorLogCollectorTests
         var collector = new RedactedErrorLogCollector();
 
         // using a big string to make sure we don't exceed queue size
-        var log = new LogMessageData(RandomString(10_000), TelemetryLogLevel.WARN, DateTimeOffset.UtcNow);
+        var randomString = RandomString(10_000);
+        var log = new LogMessageData(randomString + "_", TelemetryLogLevel.WARN, DateTimeOffset.UtcNow);
         var logSize = log.GetApproximateSerializationSize();
         var logsPerBatch = RedactedErrorLogCollector.MaximumBatchSizeBytes / logSize;
 
@@ -130,7 +129,8 @@ public class RedactedErrorLogCollectorTests
 
         for (var i = 0; i < logsToSend; i++)
         {
-            collector.EnqueueLog(log);
+            // using a different log each time to avoid de-duplication
+            collector.EnqueueLog(new LogMessageData(randomString + i, TelemetryLogLevel.WARN, DateTimeOffset.UtcNow));
         }
 
         var logs = collector.GetLogs();
@@ -153,6 +153,196 @@ public class RedactedErrorLogCollectorTests
 
         var logs = collector.GetLogs();
         logs.Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_OnlySendsSingleLog()
+    {
+        var collector = new RedactedErrorLogCollector();
+        const string message = "This is my message";
+
+        // Add multiple identical messages
+        for (var i = 0; i < 5; i++)
+        {
+            collector.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow));
+        }
+
+        var logs = collector.GetLogs();
+
+        logs.Should()
+            .NotBeNull()
+            .And.ContainSingle()
+            .Which.Should()
+            .ContainSingle()
+            .Subject.Message.Should()
+            .Be(message); // TODO: Verify instance count
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndIncludesExceptionFromSameLocation_OnlySendsSingleLog()
+    {
+        const string message = "This is my message";
+        var collector = new RedactedErrorLogCollector();
+
+        // Add multiple identical messages with exception from same location
+        for (var i = 0; i < 5; i++)
+        {
+            var ex = GetException1();
+            collector.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow)
+            {
+                StackTrace = ExceptionRedactor.Redact(ex)
+            });
+        }
+
+        var logs = collector.GetLogs();
+
+        logs.Should()
+            .NotBeNull()
+            .And.ContainSingle()
+            .Which.Should()
+            .ContainSingle()
+            .Subject.Message.Should()
+            .Be(message); // TODO: Verify instance count
+
+        Exception GetException1()
+        {
+            try
+            {
+                throw new Exception(nameof(GetException1));
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndIncludesExceptionFromDifferentLocation_SendsDifferentLog()
+    {
+        const string message = "This is my message";
+        var collector = new RedactedErrorLogCollector();
+
+        // Add multiple identical messages with exception from same location
+        for (var i = 0; i < 5; i++)
+        {
+            var ex = GetException1();
+            collector.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow)
+            {
+                StackTrace = ExceptionRedactor.Redact(ex)
+            });
+        }
+
+        // Add multiple identical messages with exception from different location
+        for (var i = 0; i < 5; i++)
+        {
+            var ex = GetException2();
+            collector.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow)
+            {
+                StackTrace = ExceptionRedactor.Redact(ex)
+            });
+        }
+
+        var batch = collector.GetLogs()
+                             .Should()
+                             .HaveCount(1)
+                             .And.ContainSingle()
+                             .Subject;
+
+        batch.Should().HaveCount(2);
+        batch[0].Message.Should().Be("This is my message");
+        batch[1].Message.Should().Be("This is my message");
+
+        Exception GetException1()
+        {
+            try
+            {
+                throw new Exception(nameof(GetException1));
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+
+        Exception GetException2()
+        {
+            try
+            {
+                throw new Exception(nameof(GetException1));
+            }
+            catch (Exception ex)
+            {
+                return ex;
+            }
+        }
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndSendsBatchInBetween_SendsSingleLogPerBatch()
+    {
+        const string message = "This is my message";
+        var collector = new RedactedErrorLogCollector();
+
+        // Add multiple identical messages
+        for (var i = 0; i < 5; i++)
+        {
+            collector.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow));
+        }
+
+        var firstBatch = collector.GetLogs();
+
+        // Add multiple identical messages
+        for (var i = 0; i < 5; i++)
+        {
+            collector.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow));
+        }
+
+        var secondBatch = collector.GetLogs();
+        var thirdBatch = collector.GetLogs();
+
+        firstBatch.Should()
+                  .NotBeNull()
+                  .And.ContainSingle()
+                  .Which.Should()
+                  .ContainSingle()
+                  .Subject.Message.Should()
+                  .Be(message);
+
+        secondBatch.Should()
+                  .NotBeNull()
+                  .And.ContainSingle()
+                  .Which.Should()
+                  .ContainSingle()
+                  .Subject.Message.Should()
+                  .Be(message);
+
+        thirdBatch.Should().BeNull();
+    }
+
+    [Fact]
+    public void WhenDeDupeEnabled_AndOverfills_GroupsAllIntoSingleBatch()
+    {
+        const string message = "This is my message";
+        var collector = new RedactedErrorLogCollector();
+        var messagesToSend = RedactedErrorLogCollector.MaximumQueueSize * 2;
+
+        // Add too many identical messages
+        for (var i = 0; i < messagesToSend; i++)
+        {
+            collector.EnqueueLog(new LogMessageData(message, TelemetryLogLevel.ERROR, DateTimeOffset.UtcNow));
+        }
+
+        var logs = collector.GetLogs();
+        collector.GetLogs().Should().BeNull();
+
+        logs.Should()
+            .NotBeNull()
+            .And.ContainSingle()
+            .Subject.Should()
+            .ContainSingle()
+            .Subject.Message.Should()
+            .Be(message);
     }
 
     private static string RandomString(int length)


### PR DESCRIPTION
## Summary of changes

Adds de-duplication of error messages

## Reason for change

We want to de-duplicate errors as much as possible to reduce load. Given that we're only using the (static) message templates and the redacted stack traces, we should be able to get significant reducations.

## Implementation details

Uses the message template (+ stack trace if present) to generate a hash. Check if the hash has already been seen before writing the log message. 

> Ideally we would do this check in the _sink_ rather than the _collector_. But the collector needs to know the "latest" counts for a log so that it can add it to the payload when the logs are sent, hence the current implementation. 

This implementation will need to be updated with the number of times the log was seen, once the intake supports it. We _could_ add a suffix to the message but hopefully the intake will just support it directly soon.

When a new batch is emitted, we reset the log count. Technically I think there's a small race condition which would cause a duplicate log message to be "dropped" entirely under the following conditions:

- The log message (`MESSAGE`) has been previously seen `3` times (it's present in the `logCounts` dictionary).
- `EnqueueLog` is called, which takes a reference to the `logCounts` dictionary
- `EmitBatch` swaps out the dictionary, and starts processing the log messages in the batch, adding the counts. It records the log message for `MESSAGE` with the existing count (`3`)
- `EnqueueLog` checks its `logCounts` dictionary, updates the count to `4`, and discards the log
- The "wrong" count is sent.

_Ideally_ we would either send the correct count, `4`, or we would emit the log in the next batch. However, I don't think this is a big enough issue to worry about (unless there's an easy solution I'm missing)! 

## Test coverage

Updated tests to check the deduplication works as expected

## Other details

Supersedes (and re-implements):
- https://github.com/DataDog/dd-trace-dotnet/pull/3807

Part 4 in a stack of PRs
- https://github.com/DataDog/dd-trace-dotnet/pull/4832
- https://github.com/DataDog/dd-trace-dotnet/pull/4833
- https://github.com/DataDog/dd-trace-dotnet/pull/4834
- https://github.com/DataDog/dd-trace-dotnet/pull/4835 (this PR)

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
