### PR TITLE
Try enabling crash dumps in artifact tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3394,6 +3394,7 @@ stages:
       displayName: Build and Test dd-dotnet
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        enable_crash_dumps: true
 
     - task: PublishTestResults@2
       displayName: publish test results

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2123,21 +2123,28 @@ partial class Build
        .After(CopyDdDotnet)
        .Executes(async () =>
        {
-           var isDebugRun = await IsDebugRun();
-           var project = Solution.GetProject(Projects.DdDotnetArtifactsTests);
+           try
+           {
+               var isDebugRun = await IsDebugRun();
+               var project = Solution.GetProject(Projects.DdDotnetArtifactsTests);
 
-           DotNetTest(config => config
-                   .SetProjectFile(project)
-                   .SetConfiguration(BuildConfiguration)
-                   .SetFramework(Framework)
-                   .SetTestTargetPlatform(TargetPlatform)
-                   .EnableNoRestore()
-                   .EnableNoBuild()
-                   .SetIsDebugRun(isDebugRun)
-                   .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
-                   .SetLogsDirectory(TestLogsDirectory)
-                   .EnableTrxLogOutput(GetResultsDirectory(project))
-                   .WithDatadogLogger());
+               DotNetTest(config => config
+                       .SetProjectFile(project)
+                       .SetConfiguration(BuildConfiguration)
+                       .SetFramework(Framework)
+                       .SetTestTargetPlatform(TargetPlatform)
+                       .EnableNoRestore()
+                       .EnableNoBuild()
+                       .SetIsDebugRun(isDebugRun)
+                       .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
+                       .SetLogsDirectory(TestLogsDirectory)
+                       .EnableTrxLogOutput(GetResultsDirectory(project))
+                       .WithDatadogLogger());
+           }
+           finally
+           {
+               CopyDumpsToBuildData();
+           }
        });
 
     Target CopyServerlessArtifacts => _ => _

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ConsoleTestHelper.cs
@@ -94,6 +94,16 @@ public abstract class ConsoleTestHelper : ToolTestHelper
             throw new Exception("The target process unexpectedly exited");
         }
 
+        // Try to capture a memory dump before giving up
+        if (MemoryDumpHelper.CaptureMemoryDump(helper.Process))
+        {
+            Output.WriteLine("Successfully captured a memory dump");
+        }
+        else
+        {
+            Output.WriteLine("Failed to capture a memory dump");
+        }
+
         throw new TimeoutException("Timeout when waiting for the target process to start");
     }
 


### PR DESCRIPTION
## Summary of changes

There are some random failures in the artifact tests, where the target console app timeouts at startup. Try to capture a memory dump when that happens.

## Reason for change

Haven't been able to reproduce the issue otherwise.

## Implementation details

Just reusing the existing helpers.