### PR TITLE
[Profiler] Adjust Linux smoke test to avoid flakiness

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/UnwinderCrash.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/UnwinderCrash.cs
@@ -24,7 +24,13 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
         [TestAppFact("Samples.Computer01")]
         public void CheckThatProfilerDoesNotCrashWhileUnwinding2SignalFrames(string appName, string framework, string appAssembly)
         {
-            var runner = new SmokeTestRunner(appName, framework, appAssembly, Scenario, _output);
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, Scenario, _output)
+            {
+                // this can be flaky time to time
+                // We just want to make sure that at least one pprof file was written to disk
+                // and the process did not crash.
+                MinimumExpectedNbPprofFiles = 1
+            };
             runner.RunAndCheck();
         }
     }


### PR DESCRIPTION
## Summary of changes

Check that we have at least one pprof files and the test did not crashed.

## Reason for change

This issue/flake occurs mainly on Alpine but we want to prevent it for happening on glibc linux distro machine too.
So to prevent the flakiness, we just check that we have at least one pprof file on disk.

## Implementation details

- Change minimum required pprof files on disk

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
