### PR TITLE
Try to fix flake in hardcoded secrets test

### DIFF
--- a/tracer/src/Datadog.Trace/IAST/Analyzers/HardcodedSecretsAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/IAST/Analyzers/HardcodedSecretsAnalyzer.cs
@@ -17,7 +17,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Iast.Analyzers;
 
-internal class HardcodedSecretsAnalyzer
+internal class HardcodedSecretsAnalyzer : IDisposable
 {
     private const int UserStringsArraySize = 100;
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<HardcodedSecretsAnalyzer>();
@@ -113,7 +113,7 @@ internal class HardcodedSecretsAnalyzer
             if (_instance == null)
             {
                 _instance = new HardcodedSecretsAnalyzer(TimeSpan.FromMilliseconds(Iast.Instance.Settings.RegexTimeout));
-                LifetimeManager.Instance.AddShutdownTask(_instance.RunShutdown);
+                LifetimeManager.Instance.AddShutdownTask(_instance.Dispose);
             }
         }
     }
@@ -213,7 +213,7 @@ internal class HardcodedSecretsAnalyzer
         return res;
     }
 
-    private void RunShutdown()
+    public void Dispose()
     {
         try
         {

--- a/tracer/src/Datadog.Trace/Iast/Iast.cs
+++ b/tracer/src/Datadog.Trace/Iast/Iast.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Threading;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Analyzers;
@@ -41,7 +42,7 @@ internal class Iast
         _settings = settings ?? IastSettings.FromDefaultSources();
         if (_settings.Enabled)
         {
-            HardcodedSecretsAnalyzer.Initialize();
+            HardcodedSecretsAnalyzer.Initialize(TimeSpan.FromMilliseconds(_settings.RegexTimeout));
         }
 
         _overheadController = new OverheadController(_settings.MaxConcurrentRequests, _settings.RequestSampling);


### PR DESCRIPTION
## Summary of changes

- Made `HardcodedSecretsAnalyzer` mostly non-static
- Used a big timeout in the tests

## Reason for change

We saw some flake in the unit tests due to timeouts.

## Implementation details

Refactored the analyzer slightly so that things are stored in an instance instead of in a static. That means we can more easily pass in a timeout (and avoid shared state in general).

Used a fixture in the unit tests so we don't re-initialize the regexes for every test data

## Test coverage

Covered by existing tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
