### PR TITLE
Try to fix the pipeline monitor

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5928,7 +5928,9 @@ stages:
 
     steps:
     - template: steps/install-latest-dotnet-sdk.yml
-    - bash: dotnet run $(Build.BuildId)
+    - bash: |
+        dotnet run $(Build.BuildId)
+        exit $?
       displayName: "Run"
       workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"
 

--- a/tracer/tools/PipelineMonitor/Program.cs
+++ b/tracer/tools/PipelineMonitor/Program.cs
@@ -1,7 +1,7 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
-using System.Diagnostics;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Datadog.Trace;
 using Datadog.Trace.Configuration;
 using PipelineMonitor;
@@ -23,10 +23,15 @@ Console.WriteLine("Processing pipeline: " + buildId);
 Build? buildData;
 TimelineData? timeline;
 
+var jsonOpts = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+{
+    UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+};
+
 try
 {
     var json = await _cli.GetStringAsync(azDoApi + buildId);
-    buildData = JsonSerializer.Deserialize<Build>(json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+    buildData = JsonSerializer.Deserialize<Build>(json, jsonOpts);
 
     if (buildData is null || string.IsNullOrEmpty(buildData._Links.Timeline.Href))
     {
@@ -44,7 +49,7 @@ catch (Exception ex)
 try
 {
     var jsonTimeline = await _cli.GetStringAsync(buildData._Links.Timeline.Href);
-    timeline = JsonSerializer.Deserialize<TimelineData>(jsonTimeline, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+    timeline = JsonSerializer.Deserialize<TimelineData>(jsonTimeline, jsonOpts);
 
     if (timeline is null)
     {

--- a/tracer/tools/PipelineMonitor/Timeline.cs
+++ b/tracer/tools/PipelineMonitor/Timeline.cs
@@ -2,39 +2,29 @@ namespace PipelineMonitor
 {
     public class TimelineData
     {
-        public string LastChangedBy { get; set; }
+        public string LastChangedBy { get; set; } = null!;
         public DateTime LastChangedOn { get; set; }
         public Guid Id { get; set; }
         public int ChangeId { get; set; }
-        public Uri Url { get; set; }
-        public List<Record> Records { get; set; }
+        public Uri Url { get; set; } = null!;
+        public List<Record> Records { get; set; } = null!;
     }
 
     public class Record
     {
-        private object PreviousAttempts { get; set; }
         public Guid Id { get; set; }
         public Guid? ParentId { get; set; }
-        public string Type { get; set; }
-        public string Name { get; set; }
+        public string Type { get; set; } = null!;
+        public string Name { get; set; } = null!;
         public DateTime? StartTime { get; set; }
         public DateTime? FinishTime { get; set; }
-        public string CurrentOperation { get; set; }
         public int? PercentComplete { get; set; }
-        public string State { get; set; }
-        public string Result { get; set; }
-        public string ResultCode { get; set; }
-        public int ChangeId { get; set; }
-        public DateTime? LastModified { get; set; }
-        public string WorkerName { get; set; }
-        public string Details { get; set; }
+        public string State { get; set; } = null!;
+        public string Result { get; set; } = null!;
+        public string WorkerName { get; set; } = null!;
         public int ErrorCount { get; set; }
-        public int WarningCount { get; set; }
-        public string Url { get; set; }
-        public Log Log { get; set; }
-        public Task Task { get; set; }
+        public Log Log { get; set; } = null!;
         public int Attempt { get; set; }
-        public string Identifier { get; set; }
 
         public bool IsStage
         {
@@ -49,16 +39,6 @@ namespace PipelineMonitor
 
     public class Log
     {
-        public int Id { get; set; }
-        public string Type { get; set; }
-        public Uri Url { get; set; }
+        public Uri Url { get; set; } = null!;
     }
-
-    public class Task
-    {
-        public Guid Id { get; set; }
-        public string Name { get; set; }
-        public string Version { get; set; }
-    }
-
 }


### PR DESCRIPTION
## Summary of changes

Fix the pipeline monitor we run at the end of the pipeline

## Reason for change

It broke sometime last week. Because the URL we use now returns different JSON 🤨 

## Implementation details

Remove properties we don't use, and skip missing properties. Bypasses the issue as it was an unused property that changed

## Test coverage

Tested it locally, we'll see if it works for the PR

## Other details
Yeah, CI Visibility works, but this gets us more details

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
