### PR TITLE
[CI] Delete previously generated files on Windows

### DIFF
--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           dotnet-version: '8.0.100-rc.2.23502.2'
 
-      - name: "Removing existing generated files"
-        run: Get-ChildItem –Path ".\tracer\src\Datadog.Trace\Generated" -Recurse -File | Remove-Item
-
       - name: "Regenerating package versions"
         run: .\tracer\build.ps1 BuildTracerHome
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -373,6 +373,13 @@ partial class Build
         .After(CompileManagedLoader)
         .Executes(() =>
         {
+            // Removes previously generated files
+            // This is mostly to avoid forgetting to remove deprecated files (class name change or path change)
+            if (IsWin)
+            {
+                EnsureCleanDirectory(DatadogTraceDirectory / "Generated");
+            }
+
             var include = TracerDirectory.GlobFiles(
                 "src/**/*.csproj"
             );


### PR DESCRIPTION
## Summary of changes

On windows, delete source generated files to make sure we don't commit useless files for nothing.

## Reason for change

My brain is too slow to understand why the generated source verification github actions fails. So this extra code shall help him in the future. More seriously, this is mostly to avoid forgetting to remove deprecated files (class name change or path change).

## Implementation details

Clean the "Generated" folder. Stop doing it manually in the verification github action.

## Test coverage
We'll see with this PR. Works locally on Mac and Windows.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
