### PR TITLE
Tiny fix for crashing if `DD_PROFILER_ENABLED` is not set

### DIFF
--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExtensions.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExtensions.cs
@@ -44,6 +44,6 @@ public static class DatadogExtensions
                 break;
         }
 
-        return cfg.AddDiagnoser(new DatadogDiagnoser(enableProfiler!.Value));
+        return cfg.AddDiagnoser(new DatadogDiagnoser(enableProfiler.Value));
     }
 }

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExtensions.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogExtensions.cs
@@ -33,7 +33,7 @@ public static class DatadogExtensions
     {
         var cfg = config.AddLogger(DatadogSessionLogger.Default);
 
-        enableProfiler ??= (EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled) ?? string.Empty).ToBoolean();
+        enableProfiler ??= (EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.ProfilingEnabled) ?? string.Empty).ToBoolean() ?? false;
         switch (enableProfiler)
         {
             case true:


### PR DESCRIPTION
## Summary of changes

Fix crash when trying to run Benchmarks.Trace locally

## Reason for change

Was trying to run benchmarks locally, and getting crashes

## Implementation details

Add a fallback default for `enableProfiler` so that we don't get `NullReferenceExceptions`

## Test coverage

Ran it locally, it works

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
