### PR TITLE
[Profiler/CI] Align Cppcheck commandline linux/windows

### DIFF
--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -315,7 +315,7 @@ partial class Build
             {
                 var project = ProfilerSolution.GetProject(projectName);
                 var cppCheckResultFile = ProfilerBuildDataDirectory / $"{project.Name}-cppcheck-{platform}";
-                CppCheck.Value($"--enable=all  --project={project.Path} --xml --output-file={cppCheckResultFile}.xml");
+                CppCheck.Value($"--inline-suppr  --enable=all  --project={project.Path} --xml --output-file={cppCheckResultFile}.xml  --suppressions-list={ProfilerDirectory}/cppcheck-suppressions.txt ");
             }
 
             foreach (var platform in new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86 })
@@ -650,7 +650,6 @@ partial class Build
 
             foreach (var platform in platforms)
             {
-                
                 DotNetBuild(s => s
                                 .SetFramework(Framework)
                                 .SetProjectFile(sampleApp)
@@ -670,7 +669,6 @@ partial class Build
         .Triggers(CheckTestResultForProfilerWithSanitizer)
         .Executes(() =>
         {
-            
             RunSampleWithSanitizer(MSBuildTargetPlatform.x64, SanitizerKind.Ubsan);
         });
 


### PR DESCRIPTION
## Summary of changes

Make sure CppCheck has the same command-line on Windows and Linux.

## Reason for change

To make sure on Windows and Linux, same false positives are filtered out. (using inline suppression or file suppression)

## Implementation details

update command line.
## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
