### PR TITLE
[ASM] Add the vale of the cookie/header name in source

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -331,13 +331,13 @@ internal class IastRequestContext
     private void AddCookieData(string name, string value)
     {
         _taintedObjects.TaintInputString(value, new Source(SourceType.GetByte(SourceTypeName.CookieValue), name, value));
-        _taintedObjects.TaintInputString(name, new Source(SourceType.GetByte(SourceTypeName.CookieName), name, null));
+        _taintedObjects.TaintInputString(name, new Source(SourceType.GetByte(SourceTypeName.CookieName), name, name));
     }
 
     private void AddHeaderData(string name, string value)
     {
         _taintedObjects.TaintInputString(value, new Source(SourceType.GetByte(SourceTypeName.RequestHeaderValue), name, value));
-        _taintedObjects.TaintInputString(name, new Source(SourceType.GetByte(SourceTypeName.RequestHeaderName), name, null));
+        _taintedObjects.TaintInputString(name, new Source(SourceType.GetByte(SourceTypeName.RequestHeaderName), name, name));
     }
 
     internal void OnExecutedSinkTelemetry(IastInstrumentedSinks sink)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -85,6 +85,26 @@ public class AspNetCore5IastTestsSpanTelemetryIastEnabled : AspNetCore5IastTests
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();
     }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task TestCookieNameRequest()
+    {
+        var filename = "Iast.CookieName.AspNetCore5.TelemetryEnabled";
+        var url = "/Iast/TestCookieName";
+        AddCookies(new Dictionary<string, string>() { { "cookiename", "cookievalue" } });
+        IncludeAllHttpSpans = true;
+        await TryStartApp();
+        var agent = Fixture.Agent;
+        var spans = await SendRequestsAsync(agent, new string[] { url });
+        var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddIastScrubbing();
+        await VerifyHelper.VerifySpans(spansFiltered, settings)
+                          .UseFileName(filename)
+                          .DisableRequireUniquePrefix();
+    }
 }
 
 public class AspNetCore5IastTestsOneVulnerabilityPerRequestIastEnabled : AspNetCore5IastTestsVariableVulnerabilityPerRequestIastEnabled

--- a/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
@@ -1,0 +1,92 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/testcookiename,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.TestCookieName (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/testcookiename,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/testcookiename,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/TestCookieName,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "PATH_TRAVERSAL",
+      
+      "evidence": {
+        "valueParts": [
+          {
+            "value": "cookiename",
+            "source": 0
+          }
+        ]
+      }
+    }
+  ],
+  "sources": [
+    {
+      "origin": "http.request.cookie.name",
+      "name": "cookiename",
+      "value": "cookiename"
+    }
+  ]
+},
+      _dd.p.dm: -0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.iast.telemetry.executed.propagation: 1.0,
+      _dd.iast.telemetry.executed.sink.path_traversal: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_cookie_name: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_cookie_value: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_header: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_header_name: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_parameter: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_parameter_name: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_path: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_path_parameter: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_query: 1.0,
+      _dd.iast.telemetry.request.tainted:,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/testcookiename,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: testcookiename,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/testcookiename,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  }
+]

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -334,6 +334,29 @@ namespace Samples.Security.AspNetCore5.Controllers
             return Content("Sending NoHttpOnlyCookie");
         }
 
+        [HttpGet("TestCookieName")]
+        public IActionResult TestCookieName()
+        {
+            var cookieName = Request.Cookies.Keys.First(x => x == "cookiename");
+
+            try
+            {
+                if (!string.IsNullOrEmpty(cookieName))
+                {
+                    var result = System.IO.File.ReadAllText(cookieName);
+                    return Content($"file content: " + result);
+                }
+                else
+                {
+                    return BadRequest($"No file was provided");
+                }
+            }
+            catch
+            {
+                return Content("The provided file " + cookieName + " could not be opened");
+            }
+        }
+
         [HttpGet("NoSameSiteCookie")]
         [Route("NoSameSiteCookie")]
         public IActionResult NoSameSiteCookie()


### PR DESCRIPTION
## Summary of changes

In order to comply with the naming conventions of all the IAST teams, a source of type "cookie name" or "header name" should have the name in both name and value fields of the source.

## Reason for change

To return the same json data as the other IAST teams.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
