### PR TITLE
[Build] Update deb/rpm packaging with arm64 variant (APMON-377)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,6 +180,21 @@ package:
       allow_failure: false
   script:
     - ../.gitlab/build-deb-rpm.sh
+  variables:
+    ARCH: amd64
+
+package-arm:
+  extends: .package-arm
+  rules:
+    - if: $DOTNET_PACKAGE_VERSION
+      when: on_success
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+      when: manual
+      allow_failure: false
+  script:
+    - ../.gitlab/build-deb-rpm.sh
+  variables:
+    ARCH: arm64
 
 .release-package:
   stage: deploy

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -6,9 +6,13 @@ if [ -n "$CI_COMMIT_TAG" ] && [ -z "$DOTNET_PACKAGE_VERSION" ]; then
   DOTNET_PACKAGE_VERSION=${CI_COMMIT_TAG##v}
 fi
 
+if [ -z "$ARCH" ]; then
+  ARCH=amd64
+fi
+
 curl --location --fail \
   --output datadog-dotnet-apm.old \
-  "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$DOTNET_PACKAGE_VERSION/datadog-dotnet-apm_${DOTNET_PACKAGE_VERSION}_amd64.deb"
+  "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$DOTNET_PACKAGE_VERSION/datadog-dotnet-apm_${DOTNET_PACKAGE_VERSION}_$ARCH.deb"
 
 fpm --input-type deb \
   --output-type dir \


### PR DESCRIPTION
## Summary of changes
Adds an arm64 packaging step for docker/baremetal

## Reason for change
This adds Single Step support for .NET ARM64

## Implementation details
Updates the gitlab CI with a ARM64 packaging step that is nearly identical to the AMD64 packaging step.

## Test coverage
Will conduct manual testing with guidance from the onboarding team

## Other details
N/A