### PR TITLE
Re-instate the building of the system-test docker images

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3758,6 +3758,20 @@ stages:
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)
 
+      - bash: |
+          echo "Creating dispatch event for https://github.com/DataDog/dd-trace-dotnet/actions/workflows/create-system-test-docker-base-images.yml with ref=$(Build.SourceBranch) and azdo_build_id=$(Build.BuildId) and is_release_version=False"
+          curl \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token $GITHUB_TOKEN"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/create-system-test-docker-base-images.yml/dispatches \
+            -d '{"ref":"$(Build.SourceBranch)","inputs":{"azdo_build_id":"$(Build.BuildId)"}}'
+        displayName: Start the generation of docker base images on GitHub Actions worfklow
+        condition: eq(variables['isMainBranch'], true)
+        env:
+          GITHUB_TOKEN: $(GITHUB_TOKEN)
+
 - stage: throughput
   condition: and(succeeded(), eq(variables.isMainRepository, true))
   dependsOn: [package_linux, package_arm64, build_windows_tracer, generate_variables, merge_commit_id]

--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -39,7 +39,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest
+        tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot
         platforms: 'linux/amd64' 
         context: ${{inputs.artifacts_path}}
         build-args: |

--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -1,15 +1,10 @@
-name: 'Build Rel-Env base images'
-description: 'Builds the reliability-environment docker base images'
+name: 'Build System-test base images'
+description: 'Builds the system-test docker base images'
 
 inputs:
   artifacts_path:
     description: 'The location of the assets to use in the current workflow'
     required: true
-
-  is_release_version:
-    description: 'Is this run generating release artifacts? Set to "True" to publish `:latest` tags, otherwise generates `:latest-snapshot` tags'
-    required: true
-    default: 'False'
 
   package_version:
     description: 'The package version of the assets being used'
@@ -36,18 +31,6 @@ runs:
       id: buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Generate image tags
-      id: docker-base-image-tags
-      shell: bash
-      run: |
-        if [ "$is_release_version" = "True" ]; then
-          echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest" >> $GITHUB_OUTPUT
-        else
-          echo "tag-names=ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot" >> $GITHUB_OUTPUT
-        fi
-      env:
-        is_release_version: "${{ inputs.is_release_version}}"
-
     - name: Login to Docker
       shell: bash
       run: docker login -u publisher -p ${{ inputs.github_token }} ghcr.io
@@ -56,7 +39,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ${{ steps.docker-base-image-tags.outputs.tag-names }}
+        tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest
         platforms: 'linux/amd64' 
         context: ${{inputs.artifacts_path}}
         build-args: |

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -1,14 +1,10 @@
-name: "Create Rel Env docker base images"
+name: "Create System Test docker base images"
 on:
   # This GitHub Action is invoked automatically from the main Azure DevOps
   # build when building the main branch (a snapshot). It is launched from
   # Azure DevOps instead of using a GitHub event, as it requires the assets
   # that are created by the Azure DevOps build. The build only produces
   # snapshots, not releases.
-  #
-  # The `auto_create_rel_env_release_images` workflow also invokes the
-  # `create-rel-env-docker-base-images` GitHub Action, which creates
-  # the release/latest (not snapshot) version of the images.
   workflow_dispatch:
     inputs:
       azdo_build_id:
@@ -45,10 +41,9 @@ jobs:
       env:
         AzureDevopsBuildId: "${{ github.event.inputs.azdo_build_id }}"
 
-    - uses: ./.github/actions/create-rel-env-docker-base-images
+    - uses: ./.github/actions/create-system-test-docker-base-images
       name: 'Create rel-env docker images'
       with:
         artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
-        is_release_version: "${{ github.event.inputs.is_release_version}}"
         package_version: "${{steps.versions.outputs.version}}"
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary of changes

Apparently these rel-env images aren't _only_ used for the relenv

## Reason for change

System tests done be broke

## Implementation details

Partially reverted #4810 and renamed `rel-env` to `system-test`

## Test coverage

Nah

## Other details
:oops::sorry:

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
