### PR TITLE
Fix `NullReferenceException` in SQS integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsCommon.cs
@@ -65,12 +65,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
         [return: NotNullIfNotNull(nameof(queueUrl))]
         public static string? GetQueueName(string? queueUrl)
         {
-            if (queueUrl is null)
+            if (string.IsNullOrEmpty(queueUrl))
             {
                 return queueUrl;
             }
 
-            var lastSeparationIndex = queueUrl.LastIndexOf('/') + 1;
+            var lastSeparationIndex = queueUrl!.LastIndexOf('/') + 1;
             return queueUrl.Substring(lastSeparationIndex);
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsCommon.cs
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
@@ -21,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
         internal const string IntegrationName = nameof(Configuration.IntegrationId.AwsSqs);
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.AwsSqs;
 
-        public static Scope CreateScope(Tracer tracer, string operation, out AwsSqsTags tags, ISpanContext parentContext = null, string spanKind = SpanKinds.Client)
+        public static Scope? CreateScope(Tracer tracer, string operation, out AwsSqsTags? tags, ISpanContext? parentContext = null, string spanKind = SpanKinds.Client)
         {
             tags = null;
 
@@ -31,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return null;
             }
 
-            Scope scope = null;
+            Scope? scope = null;
 
             try
             {
@@ -59,7 +62,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             return scope;
         }
 
-        public static string GetQueueName(string queueUrl)
+        [return: NotNullIfNotNull(nameof(queueUrl))]
+        public static string? GetQueueName(string? queueUrl)
         {
             if (queueUrl is null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -47,8 +49,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueName = request.QueueName;
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueName = request.QueueName;
+            }
 
             return new CallTargetState(scope);
         }
@@ -66,7 +71,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
         internal static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, in CallTargetState state)
             where TResponse : ICreateQueueResponse
         {
-            if (state.Scope?.Span.Tags is AwsSqsTags tags)
+            if (response.Instance is not null
+                && state.Scope?.Span.Tags is AwsSqsTags tags)
             {
                 tags.QueueUrl = response.QueueUrl;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueAsyncIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueName is not null)
             {
                 tags.QueueName = request.QueueName;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -45,8 +47,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueName = request.QueueName;
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueName = request.QueueName;
+            }
 
             return new CallTargetState(scope);
         }
@@ -64,7 +69,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
         internal static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, in CallTargetState state)
             where TResponse : ICreateQueueResponse
         {
-            if (state.Scope?.Span.Tags is AwsSqsTags tags)
+            if (response.Instance is not null
+                && state.Scope?.Span.Tags is AwsSqsTags tags)
             {
                 tags.QueueUrl = response.QueueUrl;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/CreateQueueIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueName is not null)
             {
                 tags.QueueName = request.QueueName;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -47,9 +49,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageAsyncIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -47,9 +49,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchAsyncIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageBatchIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -45,9 +47,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteMessageIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -45,9 +47,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -47,9 +49,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueAsyncIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/DeleteQueueIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -45,9 +47,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageAsyncIntegration.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Consumer);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -47,9 +49,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Consumer);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Consumer);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -45,9 +47,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Consumer);
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Consumer);
+            if (tags is not null)
+            {
+                tags.QueueUrl = request.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
+            }
 
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ReceiveMessageIntegration.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             }
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Consumer);
-            if (tags is not null)
+            if (tags is not null && request.QueueUrl is not null)
             {
                 tags.QueueUrl = request.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(request.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -46,11 +48,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
+            // we can't use generic constraints for this duck typing, because we need the original type
+            // for the InjectHeadersIntoMessage<TSendMessageRequest> call below
             var requestProxy = request.DuckCast<ISendMessageRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
-            tags.QueueUrl = requestProxy.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
+            if (tags is not null)
+            {
+                tags.QueueUrl = requestProxy.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            }
 
             if (scope?.Span.Context != null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageAsyncIntegration.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var requestProxy = request.DuckCast<ISendMessageRequest>();
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
-            if (tags is not null)
+            if (tags is not null && requestProxy.QueueUrl is not null)
             {
                 tags.QueueUrl = requestProxy.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -46,11 +48,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
+            // we can't use generic constraints for this duck typing, because we need the original type
+            // for the InjectHeadersIntoMessage<TSendMessageRequest> call below
             var requestProxy = request.DuckCast<ISendMessageBatchRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
-            tags.QueueUrl = requestProxy.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
+            if (tags is not null)
+            {
+                tags.QueueUrl = requestProxy.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            }
 
             if (scope?.Span?.Context != null && requestProxy.Entries.Count > 0)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchAsyncIntegration.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var requestProxy = request.DuckCast<ISendMessageBatchRequest>();
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
-            if (tags is not null)
+            if (tags is not null && requestProxy.QueueUrl is not null)
             {
                 tags.QueueUrl = requestProxy.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -44,11 +46,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
+            // we can't use generic constraints for this duck typing, because we need the original type
+            // for the InjectHeadersIntoMessage<TSendMessageRequest> call below
             var requestProxy = request.DuckCast<ISendMessageBatchRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
-            tags.QueueUrl = requestProxy.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
+            if (tags is not null)
+            {
+                tags.QueueUrl = requestProxy.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            }
 
             if (scope?.Span?.Context != null && requestProxy.Entries.Count > 0)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageBatchIntegration.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var requestProxy = request.DuckCast<ISendMessageBatchRequest>();
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
-            if (tags is not null)
+            if (tags is not null && requestProxy.QueueUrl is not null)
             {
                 tags.QueueUrl = requestProxy.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -44,11 +46,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 return CallTargetState.GetDefault();
             }
 
+            // we can't use generic constraints for this duck typing, because we need the original type
+            // for the InjectHeadersIntoMessage<TSendMessageRequest> call below
             var requestProxy = request.DuckCast<ISendMessageRequest>();
 
-            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out AwsSqsTags tags, spanKind: SpanKinds.Producer);
-            tags.QueueUrl = requestProxy.QueueUrl;
-            tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
+            if (tags is not null)
+            {
+                tags.QueueUrl = requestProxy.QueueUrl;
+                tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);
+            }
 
             if (scope?.Span.Context != null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/SendMessageIntegration.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
             var requestProxy = request.DuckCast<ISendMessageRequest>();
 
             var scope = AwsSqsCommon.CreateScope(Tracer.Instance, Operation, out var tags, spanKind: SpanKinds.Producer);
-            if (tags is not null)
+            if (tags is not null && requestProxy.QueueUrl is not null)
             {
                 tags.QueueUrl = requestProxy.QueueUrl;
                 tags.QueueName = AwsSqsCommon.GetQueueName(requestProxy.QueueUrl);


### PR DESCRIPTION
## Summary of changes

- Add `#nullable enable` to SQS integrations
- Handle `NullReferenceException`

## Reason for change

Our integration tests for the latest SQS package (3.7.300) are broken in this PR https://github.com/DataDog/dd-trace-dotnet/pull/4846. Examining the logs showed a `NullReferenceException` which led us here.

Note that this does _not_ fix the tests for 3.7.300. However, I'm not sure if that's an "us" issue or a "them" issue, but the callstack implies "them" to me (or, more likely, localstack)

<details><summary>Call stack after fixing the nullable issue</summary><code><pre>Amazon.SQS.AmazonSQSException: The service returned an error with Error Code InternalError and HTTP Body: 
 ---> Amazon.Runtime.Internal.HttpErrorResponseException: Exception of type 'Amazon.Runtime.Internal.HttpErrorResponseException' was thrown.
   at Amazon.Runtime.HttpWebRequestMessage.ProcessHttpResponseMessage(HttpResponseMessage responseMessage)
   at Amazon.Runtime.HttpWebRequestMessage.GetResponseAsync(CancellationToken cancellationToken)
   at Amazon.Runtime.Internal.HttpHandler`1.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.Unmarshaller.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.SQS.Internal.ValidationResponseHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.ErrorHandler.InvokeAsync[T](IExecutionContext executionContext)
   --- End of inner exception stack trace ---
   at Amazon.Runtime.Internal.HttpErrorResponseExceptionHandler.HandleExceptionStream(IRequestContext requestContext, IWebResponseData httpErrorResponse, HttpErrorResponseException exception, Stream responseStream)
   at Amazon.Runtime.Internal.HttpErrorResponseExceptionHandler.HandleExceptionAsync(IExecutionContext executionContext, HttpErrorResponseException exception)
   at Amazon.Runtime.Internal.ExceptionHandler`1.HandleAsync(IExecutionContext executionContext, Exception exception)
   at Amazon.Runtime.Internal.ErrorHandler.ProcessExceptionAsync(IExecutionContext executionContext, Exception exception)
   at Amazon.Runtime.Internal.ErrorHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.Signer.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.EndpointDiscoveryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.EndpointDiscoveryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CredentialsRetriever.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.RetryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.RetryHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.CallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.ErrorCallbackHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Amazon.Runtime.Internal.MetricsHandler.InvokeAsync[T](IExecutionContext executionContext)
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations.TaskContinuationGenerator`4.SyncCallbackHandler.ContinuationAction(Task`1 previousTask, TTarget target, CallTargetState state) in /project/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator`1.cs:line 139
   at Datadog.Trace.ClrProfiler.CallTarget.Handlers.Continuations.TaskContinuationGenerator`4.SyncCallbackHandler.ContinuationAction(Task`1 previousTask, TTarget target, CallTargetState state) in /project/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/Continuations/TaskContinuationGenerator`1.cs:line 139
   at Samples.AWS.SQS.AsyncHelpers.CreateSqsQueueAsync(AmazonSQSClient sqsClient) in /project/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs:line 67
   at Samples.AWS.SQS.AsyncHelpers.SendAndReceiveMessages(AmazonSQSClient sqsClient) in /project/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs:line 29
   at Samples.AWS.SQS.Program.Main(String[] args) in /project/tracer/test/test-applications/integrations/Samples.AWS.SQS/Program.cs:line 19
   at Samples.AWS.SQS.Program.<Main>(String[] args)  { MachineName: ".", Process: "[4669 dotnet]", AppDomain: "[1 Samples.AWS.SQS]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.42.0.0" }
</pre></code></details>

## Implementation details

Added `#nullable enable` everywhere and some `if (x is not null)`

## Test coverage

- Full test suite against master passes
- Full test suite against 3.7.300 still fails, but now it's just the internal error shown above instead of a `NullReferenceException`

## Other details

While doing this I tried to "fix" the use of `DuckCast` by making it a constraint. I subsequently realized it was written like this intentionally (I did check the original PR first, but there was nothing in there pointing out why), and it broke everything when I fixed it. 

Added comments to the code to avoid anyone else being Chesterton's Fence-d.


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
