### PR TITLE
Add dd-dotnet to path on Windows

### DIFF
--- a/shared/src/msi-installer/Product.wxs
+++ b/shared/src/msi-installer/Product.wxs
@@ -42,9 +42,6 @@
       <ComponentGroupRef Id="Shared.Files" />
       <ComponentGroupRef Id="Shared.Files.NativeLoader.32"/> <!-- 32-bit native files are always included, even in 64-bit builds -->
 
-      <ComponentGroupRef Id="dd_dotnet.cmd"/>
-      <ComponentGroupRef Id="dd_dotnet.exe"/>
-
       <ComponentGroupRef Id="ContinuousProfiler.EnvironmentVariables.Machine"/>
       <ComponentGroupRef Id="ContinuousProfiler.Files"/>
       <ComponentGroupRef Id="ContinuousProfiler.Files.Native.32"/> <!-- 32-bit native files are always included, even in 64-bit builds -->
@@ -60,6 +57,8 @@
 
       <!-- Only include 64-bit native files in the 64-bit build -->
       <?if $(var.Win64) = yes ?>
+      <ComponentGroupRef Id="dd_dotnet.cmd"/>
+      <ComponentGroupRef Id="dd_dotnet.exe"/>
       <ComponentGroupRef Id="Shared.Files.NativeLoader.64"/>
       <ComponentGroupRef Id="ContinuousProfiler.Files.Native.64"/>
       <ComponentGroupRef Id="Tracer.Files.Native.64"/>

--- a/shared/src/msi-installer/Product.wxs
+++ b/shared/src/msi-installer/Product.wxs
@@ -20,8 +20,10 @@
     <Property Id="ARPURLINFOABOUT">https://datadoghq.com/</Property>
     <Property Id="ARPHELPLINK">https://datadoghq.com/support/</Property>
     <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER"/>
-
-    <Property Id="INSTALLFOLDER">
+    <Property Id="PATHSHORTCUT" Value="1" />
+    <Property Id="DD_DOTNET_LINK" Value="https://docs.datadoghq.com/tracing/troubleshooting/dotnet_diagnostic_tool/" />
+      
+      <Property Id="INSTALLFOLDER">
       <RegistrySearch Id="RegistrySearch" Type="raw" Root="HKLM" Win64="$(var.Win64)" Key="Software\$(var.Company)\$(var.ProductName)" Name="InstallPath"/>
     </Property>
 

--- a/shared/src/msi-installer/Tracer/Files.wxs
+++ b/shared/src/msi-installer/Tracer/Files.wxs
@@ -38,6 +38,7 @@
       </Component>
     </ComponentGroup>
 
+    <?if $(var.Win64) = yes ?>
     <ComponentGroup Id="dd_dotnet.cmd" Directory="INSTALLFOLDER">
         <Component>
             <File Id="dd_dotnet.cmd"
@@ -54,5 +55,6 @@
             </File>
         </Component>
     </ComponentGroup>
+    <?endif ?>
   </Fragment>
 </Wix>

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -17,7 +17,8 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>datadog-dotnet-apm-2.42.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
+    <OutputName>datadog-dotnet-apm-2.42.0-$(Platform)</OutputName>
+    <!-- -The regex recognizes this line -->
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
     <DefineConstants>InstallerVersion=2.42.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
   </PropertyGroup>
@@ -71,6 +72,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Strings.wxl" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ContinuousProfiler\" />
+    <Folder Include="shared\" />
+    <Folder Include="Tracer\" />
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -17,8 +17,7 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>datadog-dotnet-apm-2.42.0-$(Platform)</OutputName>
-    <!-- -The regex recognizes this line -->
+    <OutputName>datadog-dotnet-apm-2.42.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
     <DefineConstants>InstallerVersion=2.42.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
   </PropertyGroup>
@@ -72,11 +71,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Strings.wxl" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="ContinuousProfiler\" />
-    <Folder Include="shared\" />
-    <Folder Include="Tracer\" />
   </ItemGroup>
   <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />

--- a/shared/src/msi-installer/WixUI_InstallDir_Custom.wxs
+++ b/shared/src/msi-installer/WixUI_InstallDir_Custom.wxs
@@ -24,9 +24,38 @@ Patch dialog sequence:
 -->
 
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?include $(sys.CURRENTDIR)\Config.wxi?>
   <Fragment>
+      
     <UI Id="WixUI_InstallDir_Custom">
-      <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8"/>
+        <Dialog Id="MyInstallDirDlg" Width="370" Height="270" Title="!(loc.InstallDirDlg_Title)">
+            <Control Id="Next" Type="PushButton" X="236" Y="243" Width="56" Height="17" Default="yes" Text="!(loc.WixUINext)" />
+            <Control Id="Back" Type="PushButton" X="180" Y="243" Width="56" Height="17" Text="!(loc.WixUIBack)" />
+            <Control Id="Cancel" Type="PushButton" X="304" Y="243" Width="56" Height="17" Cancel="yes" Text="!(loc.WixUICancel)">
+                <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
+            </Control>
+
+            <Control Id="Description" Type="Text" X="25" Y="23" Width="280" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallDirDlgDescription)" />
+            <Control Id="Title" Type="Text" X="15" Y="6" Width="200" Height="15" Transparent="yes" NoPrefix="yes" Text="!(loc.InstallDirDlgTitle)" />
+            <Control Id="BannerBitmap" Type="Bitmap" X="0" Y="0" Width="370" Height="44" TabSkip="no" Text="!(loc.InstallDirDlgBannerBitmap)" />
+            <Control Id="BannerLine" Type="Line" X="0" Y="44" Width="370" Height="0" />
+            <Control Id="BottomLine" Type="Line" X="0" Y="234" Width="370" Height="0" />
+
+            <Control Id="FolderLabel" Type="Text" X="20" Y="60" Width="290" Height="30" NoPrefix="yes" Text="!(loc.InstallDirDlgFolderLabel)" />
+            <Control Id="Folder" Type="PathEdit" X="20" Y="100" Width="320" Height="18" Property="WIXUI_INSTALLDIR" Indirect="yes" />
+            <Control Id="ChangeFolder" Type="PushButton" X="20" Y="120" Width="56" Height="17" Text="!(loc.InstallDirDlgChange)" />
+
+            <?if $(var.Win64) = yes ?>
+            <Control Id="PathCheckBox" Type="CheckBox" X="20" Y="160" Width="290" Height="17" Property="PATHSHORTCUT" CheckBoxValue="1" Text="Add dd-dotnet to path" />
+            <Control Id="PathLink" Type="Hyperlink" X="20" Y="180" Width="290" Height="20" Property="DD_DOTNET_LINK" Text="Learn more about dd-dotnet">
+                <Text>
+                    <![CDATA[<a href="https://docs.datadoghq.com/tracing/troubleshooting/dotnet_diagnostic_tool/">Learn more about dd-dotnet</a>]]>
+                </Text>
+            </Control>
+            <?endif ?>
+        </Dialog>
+
+        <TextStyle Id="WixUI_Font_Normal" FaceName="Tahoma" Size="8"/>
       <TextStyle Id="WixUI_Font_Bigger" FaceName="Tahoma" Size="12"/>
       <TextStyle Id="WixUI_Font_Title" FaceName="Tahoma" Size="9" Bold="yes"/>
 
@@ -36,7 +65,7 @@ Patch dialog sequence:
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal"/>
       <Property Id="WixUI_Mode" Value="InstallDir"/>
-
+        
       <DialogRef Id="BrowseDlg"/>
       <DialogRef Id="DiskCostDlg"/>
       <DialogRef Id="ErrorDlg"/>
@@ -57,17 +86,17 @@ Patch dialog sequence:
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg">Installed AND PATCH</Publish>
 
       <Publish Dialog="LicenseAgreementDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg">1</Publish>
-      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="InstallDirDlg">LicenseAccepted = "1"</Publish>
+      <Publish Dialog="LicenseAgreementDlg" Control="Next" Event="NewDialog" Value="MyInstallDirDlg">LicenseAccepted = "1"</Publish>
 
-      <Publish Dialog="InstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
-      <Publish Dialog="InstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
-      <Publish Dialog="InstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
-      <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
-      <Publish Dialog="InstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
+      <Publish Dialog="MyInstallDirDlg" Control="Back" Event="NewDialog" Value="LicenseAgreementDlg">1</Publish>
+      <Publish Dialog="MyInstallDirDlg" Control="Next" Event="SetTargetPath" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+      <Publish Dialog="MyInstallDirDlg" Control="Next" Event="DoAction" Value="WixUIValidatePath" Order="2">NOT WIXUI_DONTVALIDATEPATH</Publish>
+      <Publish Dialog="MyInstallDirDlg" Control="Next" Event="SpawnDialog" Value="InvalidDirDlg" Order="3"><![CDATA[NOT WIXUI_DONTVALIDATEPATH AND WIXUI_INSTALLDIR_VALID<>"1"]]></Publish>
+      <Publish Dialog="MyInstallDirDlg" Control="Next" Event="NewDialog" Value="VerifyReadyDlg" Order="4">WIXUI_DONTVALIDATEPATH OR WIXUI_INSTALLDIR_VALID="1"</Publish>
+      <Publish Dialog="MyInstallDirDlg" Control="ChangeFolder" Property="_BrowseProperty" Value="[WIXUI_INSTALLDIR]" Order="1">1</Publish>
+      <Publish Dialog="MyInstallDirDlg" Control="ChangeFolder" Event="SpawnDialog" Value="BrowseDlg" Order="2">1</Publish>
 
-      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg" Order="1">NOT Installed</Publish>
+      <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MyInstallDirDlg" Order="1">NOT Installed</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="MaintenanceTypeDlg" Order="2">Installed AND NOT PATCH</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="WelcomeDlg" Order="2">Installed AND PATCH</Publish>
 

--- a/shared/src/msi-installer/WixUI_InstallDir_Custom.wxs
+++ b/shared/src/msi-installer/WixUI_InstallDir_Custom.wxs
@@ -65,7 +65,7 @@ Patch dialog sequence:
 
       <Property Id="DefaultUIFont" Value="WixUI_Font_Normal"/>
       <Property Id="WixUI_Mode" Value="InstallDir"/>
-        
+
       <DialogRef Id="BrowseDlg"/>
       <DialogRef Id="DiskCostDlg"/>
       <DialogRef Id="ErrorDlg"/>

--- a/shared/src/msi-installer/shared/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/shared/EnvironmentVariables.wxs
@@ -12,12 +12,18 @@
   
         <Environment Id="COR_PROFILER_PATH_32" Name="COR_PROFILER_PATH_32" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x86\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
         <Environment Id="CORECLR_PROFILER_PATH_32" Name="CORECLR_PROFILER_PATH_32" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x86\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
-        <?if $(var.Win64) = yes ?>
-          <Environment Id="PATH" Name="PATH" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64" Part="last" />
+        <?if $(var.Win64) = yes ?>         
           <Environment Id="COR_PROFILER_PATH_64" Name="COR_PROFILER_PATH_64" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
           <Environment Id="CORECLR_PROFILER_PATH_64" Name="CORECLR_PROFILER_PATH_64" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
         <?endif ?>
       </Component>
+      <?if $(var.Win64) = yes ?>
+      <Component Id="EnvironmentVariablePath" Guid="{5804E0CA-7126-4774-A715-42AE37B9E421}" Win64="$(var.Win64)">
+        <Condition>PATHSHORTCUT = 1</Condition>
+        <CreateFolder/>
+        <Environment Id="PATH" Name="PATH" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64" Part="last" />        
+      </Component>
+      <?endif ?>
     </ComponentGroup>
   
     <ComponentGroup Id="Shared.EnvironmentVariables.IIS" Directory="INSTALLFOLDER">

--- a/shared/src/msi-installer/shared/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/shared/EnvironmentVariables.wxs
@@ -7,13 +7,15 @@
     <ComponentGroup Id="Shared.EnvironmentVariables.Machine" Directory="INSTALLFOLDER">
       <Component Id="EnvironmentVariablesShared" Guid="{C314A305-9C24-4E46-9ECF-E5EEA703BDEA}" Win64="$(var.Win64)">
         <CreateFolder/>
-        <Environment Id="COR_PROFILER" Name="COR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
+
+  	    <Environment Id="COR_PROFILER" Name="COR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
         <Environment Id="CORECLR_PROFILER" Name="CORECLR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
   
         <Environment Id="COR_PROFILER_PATH_32" Name="COR_PROFILER_PATH_32" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x86\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
         <Environment Id="CORECLR_PROFILER_PATH_32" Name="CORECLR_PROFILER_PATH_32" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x86\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
-  
+  		  
         <?if $(var.Win64) = yes ?>
+          <Environment Id="PATH" Name="PATH" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64" Part="last" />
           <Environment Id="COR_PROFILER_PATH_64" Name="COR_PROFILER_PATH_64" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
           <Environment Id="CORECLR_PROFILER_PATH_64" Name="CORECLR_PROFILER_PATH_64" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
         <?endif ?>

--- a/shared/src/msi-installer/shared/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/shared/EnvironmentVariables.wxs
@@ -7,13 +7,11 @@
     <ComponentGroup Id="Shared.EnvironmentVariables.Machine" Directory="INSTALLFOLDER">
       <Component Id="EnvironmentVariablesShared" Guid="{C314A305-9C24-4E46-9ECF-E5EEA703BDEA}" Win64="$(var.Win64)">
         <CreateFolder/>
-
   	    <Environment Id="COR_PROFILER" Name="COR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
         <Environment Id="CORECLR_PROFILER" Name="CORECLR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
   
         <Environment Id="COR_PROFILER_PATH_32" Name="COR_PROFILER_PATH_32" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x86\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
         <Environment Id="CORECLR_PROFILER_PATH_32" Name="CORECLR_PROFILER_PATH_32" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x86\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />
-  		  
         <?if $(var.Win64) = yes ?>
           <Environment Id="PATH" Name="PATH" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64" Part="last" />
           <Environment Id="COR_PROFILER_PATH_64" Name="COR_PROFILER_PATH_64" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x64\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />

--- a/shared/src/msi-installer/shared/EnvironmentVariables.wxs
+++ b/shared/src/msi-installer/shared/EnvironmentVariables.wxs
@@ -7,7 +7,7 @@
     <ComponentGroup Id="Shared.EnvironmentVariables.Machine" Directory="INSTALLFOLDER">
       <Component Id="EnvironmentVariablesShared" Guid="{C314A305-9C24-4E46-9ECF-E5EEA703BDEA}" Win64="$(var.Win64)">
         <CreateFolder/>
-  	    <Environment Id="COR_PROFILER" Name="COR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
+        <Environment Id="COR_PROFILER" Name="COR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
         <Environment Id="CORECLR_PROFILER" Name="CORECLR_PROFILER" Action="set" Permanent="no" System="yes" Value="$(var.ProfilerCLSID)" Part="all" />
   
         <Environment Id="COR_PROFILER_PATH_32" Name="COR_PROFILER_PATH_32" Action="set" Permanent="no" System="yes" Value="[INSTALLFOLDER]win-x86\Datadog.Trace.ClrProfiler.Native.dll" Part="all" />


### PR DESCRIPTION
## Summary of changes

Add dd-dotnet to path on Windows, for ease of use.

Also, remove it from the x86 installer to avoid conflicts if the customer install both x86 and x64 MSIs.

## Reason for change

Easier onboarding, typing the full path by hand is painful.
