### PR TITLE
Handle ctrl+c in dd-dotnet

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Program.cs
@@ -45,7 +45,8 @@ internal class Program
         var builder = new CommandLineBuilder(rootCommand)
             .UseLocalizationResources(localizationResources)
             .UseHelp()
-            .UseParseErrorReporting();
+            .UseParseErrorReporting()
+            .CancelOnProcessTermination();
 
         builder.UseHelpBuilder(
             _ =>


### PR DESCRIPTION
## Summary of changes

dd-dotnet currently does not terminate the child process when receiving ctrl+c, so it's left hanging.

## Reason for change

## Implementation details

There was already all the logic in RunCommand (taken from dd-trace), the cancellation token was just not wired properly.

## Test coverage

Tested locally.