### PR TITLE
Add dd-dotnet to path on Linux

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -235,7 +235,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{A0C5FBBB
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "artifacts", "artifacts", "{CC53E5C5-9D3E-4AD9-A9CA-D2190463EB5B}"
 	ProjectSection(SolutionItems) = preProject
+		tracer\build\artifacts\after-remove.sh = tracer\build\artifacts\after-remove.sh
 		tracer\build\artifacts\createLogPath.sh = tracer\build\artifacts\createLogPath.sh
+		tracer\build\artifacts\after-install.sh = tracer\build\artifacts\after-install.sh
 		tracer\build\artifacts\dd-dotnet.cmd = tracer\build\artifacts\dd-dotnet.cmd
 		tracer\build\artifacts\dd-dotnet.sh = tracer\build\artifacts\dd-dotnet.sh
 	EndProjectSection
@@ -1327,7 +1329,6 @@ Global
 		{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26}.Release|Any CPU.Build.0 = Release|Any CPU
-
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -917,6 +917,8 @@ partial class Build
                     $"-v {Version}",
                     packageType == "tar" ? "" : "--prefix /opt/datadog",
                     $"--chdir {assetsDirectory}",
+                    $"--after-install {BuildDirectory / "artifacts" / FileNames.AfterInstallScript}",
+                    $"--after-remove {BuildDirectory / "artifacts" / FileNames.AfterRemoveScript}",
                     "createLogPath.sh",
                     "dd-dotnet.sh",
                     "netstandard2.0/",

--- a/tracer/build/_build/Projects.cs
+++ b/tracer/build/_build/Projects.cs
@@ -50,5 +50,7 @@ public static class FileNames
 
     public const string LoaderConf = "loader.conf";
     public const string CreateLogPathScript = "createLogPath.sh";
+    public const string AfterInstallScript = "after-install.sh";
+    public const string AfterRemoveScript = "after-remove.sh";
 
 }

--- a/tracer/build/artifacts/after-install.sh
+++ b/tracer/build/artifacts/after-install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+ln -sf /opt/datadog/dd-dotnet.sh /usr/bin/dd-dotnet
+/opt/datadog/createLogPath.sh

--- a/tracer/build/artifacts/after-remove.sh
+++ b/tracer/build/artifacts/after-remove.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm /usr/bin/dd-dotnet

--- a/tracer/build/artifacts/dd-dotnet.sh
+++ b/tracer/build/artifacts/dd-dotnet.sh
@@ -3,7 +3,7 @@
 TRACER_VERSION="2.42.0"
 
 # Get the directory of the script
-DIR=$(dirname "$0")
+DIR=$(dirname "$(readlink -f "$0")")
 
 # Check the OS
 OS_NAME="$(uname -s)"
@@ -34,13 +34,13 @@ fi
 contains_word() {
   local string="$1"
   local word="$2"
-  
+
   for token in $string; do
     if [ "$token" = "$word" ]; then
       return 0  # word found
     fi
   done
-  
+
   return 1  # word not found
 }
 


### PR DESCRIPTION
## Summary of changes

Add dd-dotnet to path on Linux.
Also add  call to createLogPath.sh in the after-install script.

## Reason for change

Ease of use.

## Implementation details

Creating a symlink from /usr/bin/dd-dotnet to /opt/datadog/dd-dotnet.sh

## Test coverage

It works on my WSL/Docker.