### PR TITLE
Stop recording individual integration telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationOrigins.cs
@@ -51,6 +51,12 @@ internal enum ConfigurationOrigins
     Default,
 
     /// <summary>
+    /// Set when the value is calculated from multiple sources
+    /// </summary>
+    [Description("calculated")]
+    Calculated,
+
+    /// <summary>
     /// Set where it is difficult/not possible to determine the source of a config
     /// </summary>
     [Description("unknown")]

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -184,6 +184,23 @@ namespace Datadog.Trace.Configuration
             // but we can't send it to the static collector, as this settings object may never be "activated"
             Telemetry = new ConfigurationTelemetry();
             settings.CollectTelemetry(Telemetry);
+
+            // Record the final disabled settings values in the telemetry, we can't quite get this information
+            // through the IntegrationTelemetryCollector currently so record it here instead
+            StringBuilder? sb = null;
+
+            foreach (var setting in IntegrationsInternal.Settings)
+            {
+                if (setting.EnabledInternal == false)
+                {
+                    sb ??= StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+                    sb.Append(setting.IntegrationNameInternal);
+                    sb.Append(';');
+                }
+            }
+
+            var value = sb is null ? null : StringBuilderCache.GetStringAndRelease(sb);
+            Telemetry.Record(ConfigurationKeys.DisabledIntegrations, value, recordValue: true, ConfigurationOrigins.Calculated);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs
@@ -69,7 +69,5 @@ namespace Datadog.Trace.Configuration
         HardcodedSecret,
         IbmMq,
         Remoting,
-        // If you add an integration here, please don't forget to impact the allow / block list of telemetry config
-        // In the telemetry repository. (and keep that comment at the bottom :))
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettings.cs
@@ -25,13 +25,14 @@ namespace Datadog.Trace.Configuration
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         [PublicApi]
         public IntegrationSettings(string integrationName, IConfigurationSource? source)
-            : this(integrationName, source, TelemetryFactory.Config)
+            : this(integrationName, source, false)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettings_Ctor);
         }
 
-        internal IntegrationSettings(string integrationName, IConfigurationSource? source, IConfigurationTelemetry telemetry)
+        internal IntegrationSettings(string integrationName, IConfigurationSource? source, bool unusedParamNotToUsePublicApi)
         {
+            // unused parameter is to give us a non-public API we can use
             if (integrationName is null)
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(integrationName));
@@ -44,7 +45,8 @@ namespace Datadog.Trace.Configuration
                 return;
             }
 
-            var config = new ConfigurationBuilder(source, telemetry);
+            // We don't record these in telemetry, because they're blocked anyway
+            var config = new ConfigurationBuilder(source, NullConfigurationTelemetry.Instance);
             EnabledInternal = config
                      .WithKeys(
                           string.Format(ConfigurationKeys.Integrations.Enabled, integrationName),

--- a/tracer/src/Datadog.Trace/Configuration/IntegrationSettingsCollection.cs
+++ b/tracer/src/Datadog.Trace/Configuration/IntegrationSettingsCollection.cs
@@ -6,7 +6,6 @@
 #nullable enable
 
 using System;
-using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Telemetry;
@@ -28,14 +27,14 @@ namespace Datadog.Trace.Configuration
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         [PublicApi]
         public IntegrationSettingsCollection(IConfigurationSource source)
-            : this(source, TelemetryFactory.Config)
+            : this(source, false)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.IntegrationSettingsCollection_Ctor_Source);
         }
 
-        internal IntegrationSettingsCollection(IConfigurationSource source, IConfigurationTelemetry telemetry)
+        internal IntegrationSettingsCollection(IConfigurationSource source, bool unusedParamNotToUsePublicApi)
         {
-            _settings = GetIntegrationSettings(source, telemetry);
+            _settings = GetIntegrationSettings(source);
         }
 
         internal IntegrationSettings[] Settings => _settings;
@@ -61,12 +60,11 @@ namespace Datadog.Trace.Configuration
                     "Returning default settings, changes will not be saved",
                     integrationName);
 
-                // Use null telemetry as no telemetry will be recorded for "incorrect" values like this
-                return new IntegrationSettings(integrationName, source: null, NullConfigurationTelemetry.Instance);
+                return new IntegrationSettings(integrationName, source: null, false);
             }
         }
 
-        private static IntegrationSettings[] GetIntegrationSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
+        private static IntegrationSettings[] GetIntegrationSettings(IConfigurationSource source)
         {
             var integrations = new IntegrationSettings[IntegrationRegistry.Names.Length];
 
@@ -76,7 +74,7 @@ namespace Datadog.Trace.Configuration
 
                 if (name != null)
                 {
-                    integrations[i] = new IntegrationSettings(name, source, telemetry);
+                    integrations[i] = new IntegrationSettings(name, source, false);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Configuration
 
             DisabledIntegrationNamesInternal = new HashSet<string>(disabledIntegrationNames, StringComparer.OrdinalIgnoreCase);
 
-            IntegrationsInternal = new IntegrationSettingsCollection(source, _telemetry);
+            IntegrationsInternal = new IntegrationSettingsCollection(source, unusedParamNotToUsePublicApi: false);
 
             ExporterInternal = new ExporterSettings(source, _telemetry);
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 7;
+    public const int Length = 8;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -36,6 +36,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated => "calculated",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
@@ -56,6 +57,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
@@ -76,6 +78,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
@@ -96,6 +99,7 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "calculated",
             "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 7;
+    public const int Length = 8;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -36,6 +36,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated => "calculated",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
@@ -56,6 +57,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
@@ -76,6 +78,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
@@ -96,6 +99,7 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "calculated",
             "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 7;
+    public const int Length = 8;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -36,6 +36,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated => "calculated",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
@@ -56,6 +57,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
@@ -76,6 +78,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
@@ -96,6 +99,7 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "calculated",
             "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/ConfigurationOriginsExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class ConfigurationOriginsExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 7;
+    public const int Length = 8;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins"/> value.
@@ -36,6 +36,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig => "remote_config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig => "app.config",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default => "default",
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated => "calculated",
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown => "unknown",
             _ => value.ToString(),
         };
@@ -56,6 +57,7 @@ internal static partial class ConfigurationOriginsExtensions
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default,
+            Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated,
             Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown,
         };
 
@@ -76,6 +78,7 @@ internal static partial class ConfigurationOriginsExtensions
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.RemoteConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.AppConfig),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Default),
+            nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Calculated),
             nameof(Datadog.Trace.Configuration.Telemetry.ConfigurationOrigins.Unknown),
         };
 
@@ -96,6 +99,7 @@ internal static partial class ConfigurationOriginsExtensions
             "remote_config",
             "app.config",
             "default",
+            "calculated",
             "unknown",
         };
 }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -201,7 +201,7 @@ namespace Datadog.Trace
 
         protected virtual IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager)
         {
-            return new GitMetadataTagsProvider(settings, scopeManager);
+            return new GitMetadataTagsProvider(settings, scopeManager, TelemetryFactory.Config);
         }
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTelemetryAgent.cs
@@ -374,13 +374,13 @@ namespace Datadog.Trace.TestHelpers
                 var contractResolver = (DefaultContractResolver)serializer.ContractResolver;
                 var name = jo[contractResolver.GetResolvedPropertyName(nameof(ConfigurationKeyValue.Name))]?.ToString();
                 var jToken = jo[contractResolver.GetResolvedPropertyName(nameof(ConfigurationKeyValue.Value))];
-                object value = jToken.Type switch
+                object value = jToken?.Type switch
                 {
                     JTokenType.Null => null,
                     JTokenType.Boolean => jToken.Value<bool>(),
                     JTokenType.Integer => jToken.Value<int>(),
                     JTokenType.Float => jToken.Value<double>(),
-                    _ => jToken.ToString()
+                    _ => jToken?.ToString()
                 };
 
                 var origin = jo[contractResolver.GetResolvedPropertyName(nameof(ConfigurationKeyValue.Origin))]?.ToString();

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableTracerSettingsTests.cs
@@ -76,14 +76,15 @@ namespace Datadog.Trace.Tests.Configuration
             var immutable = tracerSettings.Build();
             var immutableTelemetry = immutable.Telemetry;
 
-            // Just basic check that we have the same number of config values
+            // Basic check that all the telemetry in the settings are _also_ in the immutable settings
+            // The immutable tracer settings may add additional config (e.g. the disabled integrations telemetry)
             immutableTelemetry.Should()
                               .BeOfType<ConfigurationTelemetry>()
                               .Which
                               .GetQueueForTesting()
-                              .Count.Should()
-                              .Be(config.GetQueueForTesting().Count)
-                              .And.NotBe(0);
+                              .Should()
+                              .NotBeEmpty()
+                              .And.ContainInOrder(config.GetQueueForTesting());
         }
 
         [Fact]
@@ -92,6 +93,58 @@ namespace Datadog.Trace.Tests.Configuration
             var settings = new ImmutableTracerSettings(NullConfigurationSource.Instance);
             var result = settings.ToString();
             result.Should().Be(typeof(ImmutableTracerSettings).FullName);
+        }
+
+        [Fact]
+        public void RecordsDisabledSettingsInTelemetry()
+        {
+            var source = new NameValueConfigurationSource(new()
+            {
+                { "DD_TRACE_FOO_ENABLED", "true" },
+                { "DD_TRACE_FOO_ANALYTICS_ENABLED", "true" },
+                { "DD_TRACE_FOO_ANALYTICS_SAMPLE_RATE", "0.2" },
+                { "DD_TRACE_BAR_ENABLED", "false" },
+                { "DD_TRACE_BAR_ANALYTICS_ENABLED", "false" },
+                { "DD_BAZ_ENABLED", "false" },
+                { "DD_BAZ_ANALYTICS_ENABLED", "false" },
+                { "DD_BAZ_ANALYTICS_SAMPLE_RATE", "0.6" },
+                { "DD_TRACE_Kafka_ENABLED", "true" },
+                { "DD_TRACE_Kafka_ANALYTICS_ENABLED", "true" },
+                { "DD_TRACE_Kafka_ANALYTICS_SAMPLE_RATE", "0.2" },
+                { "DD_TRACE_GraphQL_ENABLED", "false" },
+                { "DD_TRACE_GraphQL_ANALYTICS_ENABLED", "false" },
+                { "DD_Wcf_ENABLED", "false" },
+                { "DD_Wcf_ANALYTICS_ENABLED", "false" },
+                { "DD_Wcf_ANALYTICS_SAMPLE_RATE", "0.2" },
+                { "DD_Msmq_ENABLED", "true" },
+                { "DD_TRACE_stackexchangeredis_ENABLED", "false" },
+                { ConfigurationKeys.DisabledIntegrations, "foobar;MongoDb;Msmq" },
+            });
+
+            var expected = new[] { "MongoDb", "Msmq", "GraphQL", "Wcf", "StackExchangeRedis" };
+
+            var telemetry = new ConfigurationTelemetry();
+            var tracerSettings = new TracerSettings(source, telemetry);
+            var immutable = tracerSettings.Build();
+
+            var config = immutable
+                        .Telemetry
+                        .Should()
+                        .BeOfType<ConfigurationTelemetry>()
+                        .Subject;
+
+            var entry = config.GetQueueForTesting()
+                              .Where(x => x.Key == ConfigurationKeys.DisabledIntegrations)
+                              .OrderByDescending(x => x.SeqId)
+                              .Should()
+                              .HaveCountGreaterThan(0)
+                              .And.Subject.First();
+
+            entry.Key.Should().Be(ConfigurationKeys.DisabledIntegrations);
+            entry.StringValue.Should().NotBeNullOrEmpty();
+            entry.StringValue!.Split(';')
+                  .Should()
+                  .Contain(expected);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsSnapshotTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsSnapshotTests.cs
@@ -80,19 +80,6 @@ public class TracerSettingsSnapshotTests
     }
 
     [Fact]
-    public void Snapshot_RecordsUpdatesToIntegrationSetting()
-    {
-        var collector = new ConfigurationTelemetry();
-        var settings = new TracerSettings(NullConfigurationSource.Instance);
-        var snapshot = new TracerSettingsSnapshot(settings);
-        settings.Integrations[nameof(IntegrationId.Grpc)].Enabled = false;
-
-        snapshot.RecordChanges(settings, collector);
-        var configKey = string.Format(ConfigurationKeys.Integrations.Enabled, nameof(IntegrationId.Grpc));
-        collector.GetData().Should().ContainSingle(x => x.Name == configKey);
-    }
-
-    [Fact]
     public void Snapshot_RecordsUpdatesToLogSettings()
     {
         var collector = new ConfigurationTelemetry();


### PR DESCRIPTION
## Summary of changes

- Stops recording the individual "integration enabled" settings in telemetry
- Record the disabled settings as a single telemetry entry
- Record the `DD_GIT_*` settings when extracted from source link

## Reason for change

Currently, every time we add a new `IntegrationId`, we have to update the block list on dd-go. This adds a lot of friction. Ultimately, it's pointless recording these settings if we're going to block them anyway!

As an alternative, we record explicitly disabled settings using the (existing) `DD_DISABLED_INTEGRATIONS` key, which means we're actually getting _more_ information than we did previously.

Additionally, updated the `GitMetadataTagsProvider` to record the extracted values in telemetry when we fallback to sourcelink

## Implementation details

Switched to the `Null` telemetry instance for the setting extraction in Telemetry. In the `ImmutableTracerSettings`, after building the immutable integration settings and recording the telemetry, we record an extra value in it - all the integrations that were _actually_ disabled.

As a side-point, also added the `calculated` telemetry origin, which has been discussed with instrumentation telemetry, and is perfect for this.

## Test coverage

- Added unit test for the recording of the integration telemetry settings
- Did a manual check that the Git settings are recorded, as we don't seem to have any unit tests for the `GitConfigurationProvider`. Considered adding an integration test

> I think ideally we should refactor the `GitConfigurationProvider` to make the behavior testable, but I'll do that in a separate PR

## Other details

The important point is: no more dd-go PRs when we add a new integration (we _do_ need to do them for new _configuration_ values though!)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
