### PR TITLE
Run ARM64 integration tests against .NET 8

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2600,8 +2600,8 @@ stages:
             publishTargetFramework: net5.0
           net6_0:
             publishTargetFramework: net6.0
-          net7_0:
-            publishTargetFramework: net7.0
+          net8_0:
+            publishTargetFramework: net8.0
       workspace:
         clean: all
       pool:


### PR DESCRIPTION
## Summary of changes

Run the ARM64 Linux integration tests against .NET 8

## Reason for change

This was missed before

## Implementation details

Replaced the .NET 7 job with a .NET 8 job. We _could_ have added an extra one, but seeing as the arm64 VMs are typically the slowest to be available, we probably don't want to add extra pressure here? Chose to remove the .NET 7 one because .NET 5 is the lowest supported version (and exercises a different runtime target). I was torn between .NET 6 and 7, but 7 will be out of support sooner so 🤷‍♂️ 

## Test coverage

This PR is the test...
