### PR TITLE
Disable redacted error logs by default

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -258,7 +258,7 @@ internal static class DatadogLoggingFactory
         var telemetryEnabled = config.WithKeys(ConfigurationKeys.Telemetry.Enabled).AsBool(true);
         if (telemetryEnabled)
         {
-            return config.WithKeys(ConfigurationKeys.Telemetry.TelemetryLogsEnabled).AsBool(true)
+            return config.WithKeys(ConfigurationKeys.Telemetry.TelemetryLogsEnabled).AsBool(false)
                        ? new RedactedErrorLoggingConfiguration(TelemetryFactory.RedactedErrorLogs) // use the global collector
                        : null;
         }


### PR DESCRIPTION
## Summary of changes

Changes the default for redacted telemetry logs

## Reason for change

We don't want to roll this out widely just yet

## Implementation details

Default to false

## Test coverage

Meh

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
