### PR TITLE
Fix the system-test docker images once and for all

### DIFF
--- a/tracer/build/_build/docker/system-tests.dockerfile
+++ b/tracer/build/_build/docker/system-tests.dockerfile
@@ -4,10 +4,11 @@ ARG LIBRARY_VERSION
 ARG APPSEC_EVENT_RULES_VERSION
 ARG LIBDDWAF_VERSION
 
-COPY ${LINUX_PACKAGE} /datadog-dotnet-apm.tar.gz
-RUN echo ${LIBRARY_VERSION} | cat > LIBRARY_VERSION \
-  && echo ${LIBDDWAF_VERSION} | cat > LIBDDWAF_VERSION \
-  && echo ${APPSEC_EVENT_RULES_VERSION} | cat > APPSEC_EVENT_RULES_VERSION
+RUN mkdir /binaries \
+  && echo ${LIBRARY_VERSION} | cat > /binaries/LIBRARY_VERSION \
+  && echo ${LIBDDWAF_VERSION} | cat > /binaries/LIBDDWAF_VERSION \
+  && echo ${APPSEC_EVENT_RULES_VERSION} | cat > /binaries/APPSEC_EVENT_RULES_VERSION
+COPY ${LINUX_PACKAGE} /binaries/datadog-dotnet-apm.tar.gz
 
 FROM scratch
-COPY --from=collect /* /
+COPY --from=collect /binaries/* /


### PR DESCRIPTION
## Summary of changes

Fix the dockerfile so we don't copy in the whole of `busybox`

## Reason for change

We were copying the whole of `busybox` into `scratch`

## Implementation details

Copy the files into the `/binaries` subdirectory instead of the root so we don't copy the world

## Test coverage

Built it locally and it looks good.

## Other details
Please let this be the last time

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
