### PR TITLE
Record duplicate log count in log-message data

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/RedactedErrorLogCollector.cs
@@ -47,8 +47,7 @@ internal class RedactedErrorLogCollector
             var eventId = EventIdHash.Compute(log.Message, log.StackTrace);
             if (logCounts.TryGetValue(eventId, out var count) && count > 1)
             {
-                // TODO: Add the count to the message (not yet supported in Telemetry)
-                // log.InstanceCount = count - 1;
+                log.Count = count;
             }
 
             if (batchSize + logSize < MaximumBatchSizeBytes)

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
@@ -13,18 +13,15 @@ namespace Datadog.Trace.Telemetry.DTOs;
 
 internal class LogMessageData
 {
+    private const int TagsCharacterCount = 10; // "tags":"",
+    private const int StackTraceCharacterCount = 17; // "stack_trace":"",
+    private const int CountCharacterCount = 12; // "count":123, (assuming <1000 count per message)
+
     private const int FixedSerializationCharacterCount =
-        7 /*message*/ +
-        5 /*level*/ +
-        5 /*level value*/ +
-        4 /*tags*/ +
-        11 /*stack_trace*/ +
-        11 /* tracer_time */ +
-        10 /* tracer_time value */ +
-        5 /* count */ +
-        3 /* count value (assuming <1000 per message) */ +
-        10 /* tracer_time value */ +
-        15 /* json ,"{}  etc*/;
+        13 /* "message":"", */ +
+        16 /* "level":"ERROR", */ +
+        25 /* "tracer_time":1700220630, */ +
+        1 /* {} (-1 for trailing comma) */;
 
     public LogMessageData(string message, TelemetryLogLevel level, DateTimeOffset timestamp)
     {
@@ -53,5 +50,10 @@ internal class LogMessageData
     public int? Count { get; set; }
 
     public int GetApproximateSerializationSize()
-        => Encoding.UTF8.GetMaxByteCount(FixedSerializationCharacterCount + Message.Length + (StackTrace?.Length ?? 0) + (Tags?.Length ?? 0));
+        => Encoding.UTF8.GetMaxByteCount(
+            FixedSerializationCharacterCount
+          + Message.Length
+          + (StackTrace?.Length is { } s ? s + StackTraceCharacterCount : 0)
+          + (Tags?.Length is { } t ? t + TagsCharacterCount : 0)
+          + (Count.HasValue ? CountCharacterCount : 0));
 }

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/LogMessageData.cs
@@ -21,6 +21,9 @@ internal class LogMessageData
         11 /*stack_trace*/ +
         11 /* tracer_time */ +
         10 /* tracer_time value */ +
+        5 /* count */ +
+        3 /* count value (assuming <1000 per message) */ +
+        10 /* tracer_time value */ +
         15 /* json ,"{}  etc*/;
 
     public LogMessageData(string message, TelemetryLogLevel level, DateTimeOffset timestamp)
@@ -43,6 +46,11 @@ internal class LogMessageData
     /// Gets or sets unix timestamp (in seconds) for the log
     /// </summary>
     public long TracerTime { get; set; }
+
+    /// <summary>
+    /// Gets or Sets the number of occurrences of the log message
+    /// </summary>
+    public int? Count { get; set; }
 
     public int GetApproximateSerializationSize()
         => Encoding.UTF8.GetMaxByteCount(FixedSerializationCharacterCount + Message.Length + (StackTrace?.Length ?? 0) + (Tags?.Length ?? 0));

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -243,7 +243,7 @@ internal class TelemetryController : ITelemetryController
                 foreach (var batch in batches)
                 {
                     var logPayload = _dataBuilder.BuildLogsTelemetryData(application, host, batch, _namingVersion);
-                    Log.Debug("Pushing diagnostic logs");
+                    Log.Debug<int>("Pushing diagnostic logs batch containing {LogCount} logs", batch.Count);
                     await _transportManager.TryPushTelemetry(logPayload).ConfigureAwait(false);
                 }
             }


### PR DESCRIPTION
## Summary of changes

- Add the `count` parameter in `LogMessageData` so we know how many times an error occured
- Tweaks the "log message size" calculation

## Reason for change

Support was recently added for this extra field which tells us how many times a message we de-duplicated

## Implementation details

Add the field to the `LogMessageData`. We were already calculating this, just didn't have anywhere to put it.

Also tweaked the log-message approximate size calculation to be more accurate/easier to calculate

## Test coverage

Updated unit tests to check for the presence (and absence) of the `count` field.

## Other details
Will test against staging to double check everything still works correctly

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
