### PR TITLE
Remove pre-.NET8 workaround for MacOS in CI

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -534,13 +534,7 @@ partial class Build
                 {
                     var project = Solution.GetProject(Projects.AppSecUnitTests);
                     var testDir = project.Directory;
-
-                    // FIXME: This is a hack for the .NET 8 RC2 on macos, where it's
-                    // failing to load MSBuild, so can't get the target frameworks here
-                    // so hardcoding to use the default test frameworks for now
-                    var frameworks = IsOsx
-                        ? TestingFrameworks.Select(x => (string) x).ToArray()
-                        : project.GetTargetFrameworks();
+                    var frameworks = project.GetTargetFrameworks();
 
                     var testBinFolder = testDir / "bin" / BuildConfiguration;
 


### PR DESCRIPTION
## Summary of changes

Removes a hack we had to use pre .NET 8 GA

## Reason for change

It was a hack, it's not necessary any more

## Implementation details

Revert the hack

## Test coverage

Ran a build, it worked
