### PR TITLE
[Profiler] Fix code hotspot feature tests

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -105,8 +105,8 @@ public:
         auto sample = std::make_shared<Sample>(rawSample.Timestamp, runtimeId == nullptr ? std::string_view() : std::string_view(runtimeId), rawSample.Stack.size());
         if (rawSample.LocalRootSpanId != 0 && rawSample.SpanId != 0)
         {
-            sample->AddNumericLabel(NumericLabel{Sample::LocalRootSpanIdLabel, rawSample.LocalRootSpanId});
-            sample->AddNumericLabel(NumericLabel{Sample::SpanIdLabel, rawSample.SpanId});
+            sample->AddNumericLabel(SpanLabel{Sample::LocalRootSpanIdLabel, rawSample.LocalRootSpanId});
+            sample->AddNumericLabel(SpanLabel{Sample::SpanIdLabel, rawSample.SpanId});
         }
 
         // compute thread/appdomain details

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -24,6 +24,7 @@ typedef std::vector<int64_t> Values;
 typedef std::pair<std::string_view, std::string> Label;
 typedef std::list<Label> Labels;
 typedef std::pair<std::string_view, int64_t> NumericLabel;
+typedef std::pair<std::string_view, uint64_t> SpanLabel;
 typedef std::list<NumericLabel> NumericLabels;
 typedef std::vector<FrameInfoView> CallStack;
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/CodeHotspot/CodeHotspotTest.cs
@@ -299,12 +299,12 @@ namespace Datadog.Profiler.IntegrationTests.CodeHotspot
                 {
                     if (label.Name == "local root span id")
                     {
-                        localRootSpanId = ulong.Parse(label.Value);
+                        localRootSpanId = (ulong)long.Parse(label.Value);
                     }
 
                     if (label.Name == "span id")
                     {
-                        spanId = ulong.Parse(label.Value);
+                        spanId = (ulong)long.Parse(label.Value);
                     }
                 }
 


### PR DESCRIPTION
## Summary of changes

Fix code hotspots tests.

## Reason for change

In the pprof format numeric values are of `long` type. When extracting them, we just convert them into string and when needed we apply the corresponding transformation.
Except that, parsing back a `long string` into a `ulong` can throw:
```
20:09:24 [DBG]   Error Message:
20:09:24 [DBG]    System.OverflowException : Value was either too large or too small for a UInt64.
```
We just need to parse it back to `long` then cast into `ulong`.
### Why it's breaking now ?
Before the [PR](https://github.com/DataDog/dd-trace-dotnet/pull/4827) , it was ok, because the tracer was emitting 63bits span id. So no negative values, `long` -> `string` and parse back to `ulong` was ~safe. 

## Implementation details

Main thing:
- use `long.Parse` then cast into `ulong`.

Additional:
- use `uint64_t` instead of `int64_t`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
