### PR TITLE
[Dynamic Instrumentation] Improved snapshot pruning algorithm

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ProbeStatuses/ProbeStatusPoller.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ProbeStatuses/ProbeStatusPoller.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Debugger.ProbeStatuses
 
         private readonly ProbeStatusSink _probeStatusSink;
         private readonly TimeSpan _shortPeriod = TimeSpan.FromSeconds(10);
-        private readonly TimeSpan _longPeriod = TimeSpan.FromSeconds(60);
+        private readonly TimeSpan _longPeriod = TimeSpan.FromMinutes(60);
         private readonly HashSet<FetchProbeStatus> _probes = new();
         private readonly object _locker = new object();
         private Timer _pollerTimer;

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/SnapshotPruner.cs
@@ -1,0 +1,356 @@
+// <copyright file="SnapshotPruner.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DatadogDebugger.Util
+{
+    internal enum State
+    {
+        Object,
+        String,
+        NotCaptured,
+        Escape
+    }
+
+    internal class SnapshotPruner
+    {
+        private const string NotCapturedReason = "notCapturedReason";
+        private const string Depth = "depth";
+        private const string Pruned = "{\"pruned\":true}";
+
+        private readonly Stack<Node> _stack = new Stack<Node>();
+
+        private State? _state = State.Object;
+        private int _currentLevel;
+        private int _strMatchIdx;
+        private Func<State> _onStringMatches;
+        private string _matchingString;
+        private Node _root;
+
+        private SnapshotPruner(string snapshot)
+        {
+            var index = 0;
+            foreach (var c in snapshot)
+            {
+                _state = Parse(this, c, index++);
+
+                if (_state == null)
+                {
+                    break;
+                }
+            }
+        }
+
+        public static string Prune(string snapshot, int maxTargetedSize, int minLevel)
+        {
+            int delta = snapshot.Length - maxTargetedSize;
+            if (delta <= 0)
+            {
+                return snapshot;
+            }
+
+            var snapshotPruner = new SnapshotPruner(snapshot);
+            var leaves = snapshotPruner.GetLeaves(minLevel);
+
+            var sortedLeaves = new SortedSet<Node>(new NodeComparer());
+            foreach (var leaf in leaves)
+            {
+                sortedLeaves.Add(leaf);
+            }
+
+            int total = 0;
+            Dictionary<int, Node> nodes = new Dictionary<int, Node>();
+            while (sortedLeaves.Any())
+            {
+                Node leaf = sortedLeaves.Min;
+                sortedLeaves.Remove(leaf);
+
+                nodes[leaf.Start] = leaf;
+                total += leaf.Size() - Pruned.Length;
+                if (total > delta)
+                {
+                    break;
+                }
+
+                Node parent = leaf.Parent;
+                if (parent == null)
+                {
+                    break;
+                }
+
+                parent.Pruned++;
+                if (parent.Pruned >= parent.Children.Count && parent.Level >= minLevel)
+                {
+                    parent.NotCaptured = true;
+                    parent.NotCapturedDepth = true;
+                    sortedLeaves.Add(parent);
+                    foreach (var child in parent.Children)
+                    {
+                        nodes.Remove(child.Start);
+                        total -= child.Size() - Pruned.Length;
+                    }
+                }
+            }
+
+            List<Node> prunedNodes = nodes.Values.OrderBy(n => n.Start).ToList();
+            StringBuilder sb = new StringBuilder();
+            sb.Append(snapshot.Substring(0, prunedNodes[0].Start));
+            for (int i = 1; i < prunedNodes.Count; i++)
+            {
+                sb.Append(Pruned);
+                int nextSegmentStart = prunedNodes[i - 1].End + 1;
+                int nextSegmentLength = prunedNodes[i].Start - nextSegmentStart;
+                sb.Append(snapshot.Substring(nextSegmentStart, nextSegmentLength));
+            }
+
+            sb.Append(Pruned);
+            int lastSegmentStart = prunedNodes[prunedNodes.Count - 1].End + 1;
+            if (lastSegmentStart < snapshot.Length)
+            {
+                sb.Append(snapshot.Substring(lastSegmentStart));
+            }
+
+            return sb.ToString();
+        }
+
+        private IEnumerable<Node> GetLeaves(int minLevel)
+        {
+            return _root?.GetLeaves(minLevel) ?? Enumerable.Empty<Node>();
+        }
+
+        internal State? Parse(SnapshotPruner pruner, char c, int index)
+        {
+            switch (_state)
+            {
+                case State.Object:
+                    return ParseObject(pruner, c, index);
+                case State.String:
+                    return ParseString(pruner, c);
+                case State.NotCaptured:
+                    return ParseNotCaptured(pruner, c);
+                case State.Escape:
+                    return ParseEscape(pruner, c);
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
+
+        internal State? ParseObject(SnapshotPruner pruner, char c, int index)
+        {
+            switch (c)
+            {
+                case '{':
+                    var node = new Node(index, pruner._currentLevel++);
+                    if (pruner._stack.Any())
+                    {
+                        node.Parent = pruner._stack.Peek();
+                        node.Parent.Children.Add(node);
+                    }
+
+                    pruner._stack.Push(node);
+                    return State.Object;
+
+                case '}':
+                    var completedNode = pruner._stack.Pop();
+                    completedNode.End = index;
+                    pruner._currentLevel--;
+                    if (!pruner._stack.Any())
+                    {
+                        pruner._root = completedNode;
+                        return null;
+                    }
+
+                    return State.Object;
+
+                case '"':
+                    pruner._strMatchIdx = 0;
+                    pruner._matchingString = NotCapturedReason;
+                    pruner._onStringMatches = () =>
+                    {
+                        var lastNode = pruner._stack.Peek();
+                        if (lastNode == null)
+                        {
+                            throw new InvalidOperationException("Stack is empty");
+                        }
+
+                        lastNode.NotCaptured = true;
+                        return State.NotCaptured;
+                    };
+                    return State.String;
+
+                default:
+                    return State.Object;
+            }
+        }
+
+        internal State? ParseString(SnapshotPruner pruner, char c)
+        {
+            switch (c)
+            {
+                case '"':
+                    if (pruner._strMatchIdx == pruner._matchingString.Length)
+                    {
+                        return pruner._onStringMatches();
+                    }
+
+                    return State.Object;
+
+                case '\\':
+                    pruner._strMatchIdx = -1;
+                    return State.Escape;
+
+                default:
+                    if (pruner._strMatchIdx > -1)
+                    {
+                        if (c != pruner._matchingString[pruner._strMatchIdx++])
+                        {
+                            pruner._strMatchIdx = -1;
+                        }
+                    }
+
+                    return State.String;
+            }
+        }
+
+        internal State? ParseNotCaptured(SnapshotPruner pruner, char c)
+        {
+            switch (c)
+            {
+                case '"':
+                    pruner._strMatchIdx = 0;
+                    pruner._matchingString = Depth;
+                    pruner._onStringMatches = () =>
+                    {
+                        var lastNode = pruner._stack.Peek();
+                        if (lastNode == null)
+                        {
+                            throw new InvalidOperationException("Stack is empty");
+                        }
+
+                        lastNode.NotCapturedDepth = true;
+                        return State.Object;
+                    };
+                    return State.String;
+
+                case ' ':
+                case ':':
+                case '\n':
+                case '\t':
+                case '\r':
+                    return State.NotCaptured;
+
+                default:
+                    return State.Object;
+            }
+        }
+
+        internal State? ParseEscape(SnapshotPruner pruner, char c)
+        {
+            return State.String;
+        }
+
+        private class NodeComparer : IComparer<Node>
+        {
+            public int Compare(Node x, Node y)
+            {
+                // First compare by notCapturedDepth, with true values being 'greater' than false
+                int comparison = -x.NotCapturedDepth.CompareTo(y.NotCapturedDepth);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                // Then by level, in descending order (larger levels 'less' than smaller ones)
+                comparison = -x.Level.CompareTo(y.Level);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                // Then by notCaptured, with true values being 'greater' than false
+                comparison = -x.NotCaptured.CompareTo(y.NotCaptured);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                // Finally by size, in descending order (larger sizes 'less' than smaller ones)
+                comparison = -x.Size().CompareTo(y.Size());
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                // If all else is equal (which shouldn't happen in a well-defined priority queue),
+                // we differentiate by reference, ensuring that two different objects are never considered equal.
+                return ReferenceEquals(x, y) ? 0 : -1;
+            }
+        }
+
+        internal class Node : IComparable<Node>
+        {
+            public Node(int start, int level)
+            {
+                Start = start;
+                Level = level;
+            }
+
+            public int Pruned { get; set; }
+
+            public Node Parent { get; set; }
+
+            public List<Node> Children { get; } = new List<Node>();
+
+            public int Start { get; }
+
+            public int End { get; set; }
+
+            public int Level { get; }
+
+            public bool NotCaptured { get; set; }
+
+            public bool NotCapturedDepth { get; set; }
+
+            public IEnumerable<Node> GetLeaves(int minLevel)
+            {
+                if (!Children.Any() && Level >= minLevel)
+                {
+                    return new[] { this };
+                }
+
+                return Children.SelectMany(child => child.GetLeaves(minLevel));
+            }
+
+            public int Size() => End - Start + 1;
+
+            public int CompareTo(Node other)
+            {
+                int comparison = NotCapturedDepth.CompareTo(other.NotCapturedDepth);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                comparison = Level.CompareTo(other.Level);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                comparison = NotCaptured.CompareTo(other.NotCaptured);
+                if (comparison != 0)
+                {
+                    return comparison;
+                }
+
+                return Size().CompareTo(other.Size());
+            }
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LargeSnapshotTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LargeSnapshotTest.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -8,7 +8,7 @@
       "snapshot": {
         "captures": {
           "lines": {
-            "21": {
+            "20": {
               "arguments": {
                 "bo": {
                   "fields": {
@@ -64802,39 +64802,25 @@
                                           "value": "BigObject"
                                         },
                                         {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
+                                          "pruned": true
                                         },
                                         {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
+                                          "pruned": true
                                         },
                                         {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
+                                          "pruned": true
                                         },
                                         {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
+                                          "pruned": true
                                         },
                                         {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
+                                          "pruned": true
                                         },
                                         {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
+                                          "pruned": true
                                         },
                                         {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
+                                          "pruned": true
                                         }
                                       ],
                                       "size": 30,
@@ -64851,142 +64837,7 @@
                                       "value": "The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog."
                                     },
                                     "Children": {
-                                      "elements": [
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "notCapturedReason": "depth",
-                                          "type": "BigObject",
-                                          "value": "BigObject"
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        },
-                                        {
-                                          "pruned": true
-                                        }
-                                      ],
-                                      "size": 30,
-                                      "type": "List`1"
+                                      "pruned": true
                                     }
                                   },
                                   "type": "BigObject",
@@ -72903,7 +72754,7 @@
           "location": {
             "file": "LargeSnapshotTest.cs",
             "lines": [
-              21
+              20
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LargeSnapshotTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LargeSnapshotTest.verified.txt
@@ -1,0 +1,30 @@
+[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LargeSnapshotTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LargeSnapshotTest.verified.txt
@@ -4,20 +4,6 @@
     "debugger": {
       "diagnostics": {
         "exception": null,
-        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
-        "probeVersion": 0,
-        "runtimeId": "scrubbed",
-        "status": "INSTALLED"
-      }
-    },
-    "message": "Installed probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
-    "service": "probes"
-  },
-  {
-    "ddsource": "dd_debugger",
-    "debugger": {
-      "diagnostics": {
-        "exception": null,
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
         "probeVersion": 0,
         "runtimeId": "scrubbed",

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -695,6 +695,11 @@ public class ProbesTests : TestHelper
     /// </summary>
     private void SkipOverTestIfNeeded(ProbeTestDescription testDescription)
     {
+        if (testDescription.TestType == typeof(LargeSnapshotTest) && !EnvironmentTools.IsWindows())
+        {
+            throw new SkipException("Should run only on Windows. Different approvals between Windows/Linux.");
+        }
+
         if (testDescription.TestType == typeof(AsyncInstanceMethod) && !EnvironmentTools.IsWindows())
         {
             throw new SkipException("Can't use WindowsNamedPipes on non-Windows");

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_OneLevel_LevelSliced.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_OneLevel_LevelSliced.verified.txt
@@ -3,6 +3,11 @@
   return: {
     locals: {
       local0: {
+        fields: {
+          SimpleClass: {
+            pruned: true
+          }
+        },
         type: ComplexClass,
         value: ComplexClass
       }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_ThreeLevel_AllSliced.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_ThreeLevel_AllSliced.verified.txt
@@ -1,8 +1,11 @@
-﻿{
+{
   entry: {},
   return: {
     locals: {
       local0: {
+        fields: {
+          pruned: true
+        },
         type: VeryComplexClass,
         value: VeryComplexClass
       }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SnapshotSlicerTests.SnapshotBiggerThanMaxSize_TwoLevel_OneSliced.verified.txt
@@ -1,4 +1,4 @@
-﻿{
+{
   entry: {},
   return: {
     locals: {
@@ -9,6 +9,11 @@
             type: VeryComplexClass
           },
           ComplexClass: {
+            fields: {
+              SimpleClass: {
+                pruned: true
+              }
+            },
             type: ComplexClass,
             value: ComplexClass
           }

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
@@ -14,7 +14,6 @@ namespace Samples.Probes.TestRuns.SmokeTests
             PingPong(GetPopulatedBigObject());
         }
 
-        [LogMethodProbeTestData]
         private BigObject PingPong(BigObject bo)
         {
             var bo2 = new BigObject().Populate();

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Samples.Probes.TestRuns.SmokeTests
 {
-    [LogLineProbeTestData(lineNumber: 21)]
+    [LogLineProbeTestData(lineNumber: 20, skipOnFrameworks: new[] { "net5.0", "net462", "netcoreapp3.1", "netcoreapp3.0", "netcoreapp2.1"})]
     internal class LargeSnapshotTest : IRun
     {
         public void Run()

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    [LogLineProbeTestData(lineNumber: 21)]
+    internal class LargeSnapshotTest : IRun
+    {
+        public void Run()
+        {
+            PingPong(GetPopulatedBigObject());
+        }
+
+        [LogMethodProbeTestData]
+        private BigObject PingPong(BigObject bo)
+        {
+            var bo2 = new BigObject().Populate();
+            return bo2;
+        }
+
+        private BigObject GetPopulatedBigObject() => new BigObject().Populate();
+    }
+
+    public class BigObject
+    {
+        public string AtoZ { get; set; } = "The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog.";
+
+        public List<BigObject> Children { get; set; } = new();
+
+        public BigObject Populate(int currentDepth = 5, int currentBreadth = 30)
+        {
+            if (currentDepth == 0)
+            {
+                return this;
+            }
+
+            for (int i = 0; i < currentBreadth; i++)
+            {
+                BigObject child = new BigObject();
+                child.Populate(currentDepth - 1, currentBreadth);
+                this.Children.Add(child);
+            }
+
+            return this;
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/LargeSnapshotTest.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Samples.Probes.TestRuns.SmokeTests
 {
     [LogLineProbeTestData(lineNumber: 20, skipOnFrameworks: new[] { "net5.0", "net462", "netcoreapp3.1", "netcoreapp3.0", "netcoreapp2.1"})]
-    internal class LargeSnapshotTest : IRun
+    public class LargeSnapshotTest : IRun
     {
         public void Run()
         {


### PR DESCRIPTION
## Summary of changes
Implemented a JSON snapshot pruning algorithm for Dynamic Instrumentation to ensure log messages stay within the 1 MB limit of the Event Platform. This addresses the issue of snapshots exceeding this limit due to varying capturing depth and live object details.

## Reason for change
Dynamic Instrumentation probes currently generate snapshots that may exceed the Event Platform's 1 MB limit per log message. This limitation is encountered after serialization, necessitating an efficient pruning algorithm.

## Implementation details
[Internal Pruning Algorithm RFC](https://docs.google.com/document/d/18BZlVT4ybI9v7Qn4DuFRQj6sq23C7A7tfUojWO-zGjE)

## Test coverage
- LargeSnapshotTest