### PR TITLE
[CI] Make sure all Linux images use Clang 16.0.6

### DIFF
--- a/tracer/build/_build/docker/alpine.build.dockerfile
+++ b/tracer/build/_build/docker/alpine.build.dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.6
+
+FROM alpine:3.14 as base
+
+RUN apk update \
+        && apk upgrade \
+        && apk add --no-cache \
+        cmake \
+        git \
+        make \
+        alpine-sdk \
+        autoconf \
+        libtool \
+        automake \
+        xz-dev \
+        build-base \
+        python3 \
+        linux-headers \
+        libexecinfo-dev
+
+## snapshot 
+
+FROM base AS build-llvm-clang
+
+COPY alpine_build_patch_llvm_clang.sh alpine_build_patch_llvm_clang.sh
+
+# build and install llvm/clang
+RUN git clone --depth 1 --branch llvmorg-16.0.6 https://github.com/llvm/llvm-project.git && \
+    # download patches to apply
+    chmod +x alpine_build_patch_llvm_clang.sh && \
+    ./alpine_build_patch_llvm_clang.sh && \
+    \
+    # setup build folder
+    cd llvm-project && \
+    mkdir build && \
+    cd build && \
+    \
+    # build llvm/clang
+    cmake  -DCOMPILER_RT_BUILD_GWP_ASAN=OFF -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;lld" -DCMAKE_BUILD_TYPE=Release -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=1 -DENABLE_LINKER_BUILD_ID=ON -DCLANG_VENDOR=Alpine -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-alpine-linux-musl -DLLVM_HOST_TRIPLE=x86_64-alpine-linux-musl  -G "Unix Makefiles" ../llvm && \
+    make -j$(nproc)
+
+FROM base as final
+RUN --mount=target=/llvm-project,from=build-llvm-clang,source=llvm-project,rw cd /llvm-project/build && make install

--- a/tracer/build/_build/docker/alpine.build.dockerfile
+++ b/tracer/build/_build/docker/alpine.build.dockerfile
@@ -36,7 +36,7 @@ RUN git clone --depth 1 --branch llvmorg-16.0.6 https://github.com/llvm/llvm-pro
     cd build && \
     \
     # build llvm/clang
-    cmake  -DCOMPILER_RT_BUILD_GWP_ASAN=OFF -DLLVM_ENABLE_PROJECTS="clang;compiler-rt;lld" -DCMAKE_BUILD_TYPE=Release -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=1 -DENABLE_LINKER_BUILD_ID=ON -DCLANG_VENDOR=Alpine -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-alpine-linux-musl -DLLVM_HOST_TRIPLE=x86_64-alpine-linux-musl  -G "Unix Makefiles" ../llvm && \
+    cmake  -DCOMPILER_RT_BUILD_GWP_ASAN=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra;compiler-rt;lld" -DCMAKE_BUILD_TYPE=Release -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=1 -DENABLE_LINKER_BUILD_ID=ON -DCLANG_VENDOR=Alpine -DLLVM_DEFAULT_TARGET_TRIPLE=x86_64-alpine-linux-musl -DLLVM_HOST_TRIPLE=x86_64-alpine-linux-musl  -G "Unix Makefiles" ../llvm && \
     make -j$(nproc)
 
 FROM base as final

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,4 +1,4 @@
-﻿FROM alpine:3.14 as base
+﻿FROM gleocadie/alpine-clang16 as base
 ARG DOTNETSDK_VERSION
 
 ENV \
@@ -37,7 +37,6 @@ RUN apk update \
         icu-libs \
         \
         # our dependencies
-        clang \
         cmake \
         git \
         bash \

--- a/tracer/build/_build/docker/alpine_build_patch_llvm_clang.sh
+++ b/tracer/build/_build/docker/alpine_build_patch_llvm_clang.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+git clone -n --depth=1 https://git.alpinelinux.org/aports &&
+    pushd aports &&
+    git sparse-checkout set --no-cone main/llvm16 main/clang16 &&
+    git checkout &&
+    popd &&
+    # copy patches
+    cp aports/main/llvm16/*.patch llvm-project &&
+    cp aports/main/clang16/*.patch llvm-project/clang &&
+    # apply patches
+    for j in llvm-project llvm-project/clang; do
+    pushd $j;
+    for i in `ls .`; do
+		case ${i%::*} in
+           # This patch enables Fortify source feature by default (https://www.gnu.org/software/libc/manual/html_node/Source-Fortification.html)
+           # Before clang-16, this patch was not applied, and fortify was activated only if the compilation
+           # option _FORTIFY_SOURCE was set to a value greater than 0.
+           # Starting from clang-16, they activated it by default but our code breaks because stdio fortified functions call `__builtin_va_arg_pack()`
+           # which is not implemented by LLVM/Clang folks. https://bugs.llvm.org/show_bug.cgi?id=7219 and https://bugs.llvm.org/show_bug.cgi?id=7219
+           # By not applying this patch, we make sure that our rebuilt clang-16 behaves the same as older clang versions.
+            *002-fortify-enable.patch)
+                echo "Skipped - ${i%::*}"
+                ;;
+			*.patch)
+				echo "${i%::*}"
+				patch -p1 -i "${i%::*}" || return 1
+				;;
+		esac
+	done
+    popd
+    done &&
+    # cleanup
+    rm -rf aports

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -57,7 +57,8 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     ./llvm.sh 16 all && \
     ln -s `which clang-16` /usr/bin/clang && \
     ln -s `which clang++-16` /usr/bin/clang++ && \
-    ln -s `which clang-tidy-16` /usr/bin/clang-tidy
+    ln -s `which clang-tidy-16` /usr/bin/clang-tidy && \
+    ln -s `which run-clang-tidy-16` /usr/bin/run-clang-tidy
 
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -40,14 +40,19 @@ RUN apt-get update \
         gdb \
         cppcheck \
 		zlib1g-dev \
+        \
+        # required to install clang
+        lsb-release \
+        software-properties-common \
+        gnupg \
+        \
     && gem install --version 1.6.0 --user-install git \
     && gem install --version 2.7.6 dotenv \
     && gem install --version 1.14.2 --minimal-deps --no-document fpm \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Clang
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y lsb-release wget software-properties-common gnupg && \
-    wget https://apt.llvm.org/llvm.sh && \
+RUN wget https://apt.llvm.org/llvm.sh && \
     chmod u+x llvm.sh && \
     ./llvm.sh 16 all && \
     ln -s `which clang-16` /usr/bin/clang && \

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -56,7 +56,8 @@ RUN wget https://apt.llvm.org/llvm.sh && \
     chmod u+x llvm.sh && \
     ./llvm.sh 16 all && \
     ln -s `which clang-16` /usr/bin/clang && \
-    ln -s `which clang++-16` /usr/bin/clang++
+    ln -s `which clang++-16` /usr/bin/clang++ && \
+    ln -s `which clang-tidy-16` /usr/bin/clang-tidy
 
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -27,9 +27,6 @@ RUN apt-get update \
         curl \
         cmake \
         make \
-        llvm \
-        clang \
-        clang-tidy \
         gcc \
         build-essential \
         rpm \
@@ -47,6 +44,14 @@ RUN apt-get update \
     && gem install --version 2.7.6 dotenv \
     && gem install --version 1.14.2 --minimal-deps --no-document fpm \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Clang
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y lsb-release wget software-properties-common gnupg && \
+    wget https://apt.llvm.org/llvm.sh && \
+    chmod u+x llvm.sh && \
+    ./llvm.sh 16 all && \
+    ln -s `which clang-16` /usr/bin/clang && \
+    ln -s `which clang++-16` /usr/bin/clang++
 
 # Install the .NET SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \


### PR DESCRIPTION
## Summary of changes

Install clang 16 on all Linux build images.

## Reason for change

We use different clang version to build Tracer and Profiler native binaries (Centos7 clang 16, Alpine Clang 11, Debian Buster  Clang 7). Aligning compiler version on all 3 distros would benefit the binaries (e.g.: optimization) but also the code (e.g.: using C++20 and above to benefit from new features).

## Implementation details

* Alpine: create a build image where Clang 16 was built from source and apply required patches for musl.
* Debian Buster: use `llvm.sh` script to install Clang 16
* CentOS7: Updating the build with the latest release (we were using 16.0.2)

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
