### PR TITLE
Fix localstack not starting issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "4566:4566"
     volumes:
-      - "./tracer/build_data/localstack:/tmp/localstack"
+      - "./tracer/build_data/localstack:/tmp"
 
   elasticsearch7_arm64:
     image: elasticsearch:7.10.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,7 @@ services:
     ports:
       - "4566:4566"
     volumes:
-      - "./.localstack:/tmp/localstack"
+      - "./.localstack:/tmp"
 
   aerospike:
     # pinning to a known good version because latest version (6.3.0.5 at time of issue)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
@@ -76,6 +77,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 settings.AddSimpleScrubber("peer.service: localhost", "peer.service: aws_sqs");
                 settings.AddSimpleScrubber("peer.service: localstack", "peer.service: aws_sqs");
                 settings.AddSimpleScrubber("peer.service: localstack_arm64", "peer.service: aws_sqs");
+                settings.AddSimpleScrubber("aws.queue.url: localstack_arm64", "peer.service: aws_sqs");
+                settings.AddRegexScrubber(new Regex(@"sqs\..+\.localhost.*\.localstack.*\.cloud:4566"), "localhost:00000");
+
                 if (!string.IsNullOrWhiteSpace(host))
                 {
                     settings.AddSimpleScrubber(host, "localhost:00000");


### PR DESCRIPTION
## Summary of changes

All our integration tests are failing because `localstack` won't start up

## Reason for change

Everything is borked because localstack is not starting in integration tests. Doing some tests and examining the localstack image, found this in the logs:

```
2023-11-20 10:36:21 ERROR: 'rm -rf "/tmp/localstack"': exit code 1; output: b"rm: cannot remove '/tmp/localstack': Device or resource busy\n"
```

## Implementation details

Tried something on a whim and it seemed to work, so 🤞 

## Test coverage

This is the test 

## Other details

:sorry:

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
