### PR TITLE
Properly update global tags for log submission 

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionManager.cs
@@ -31,14 +31,15 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
         public static DirectLogSubmissionManager Create(
             DirectLogSubmissionManager? previous,
-            ImmutableDirectLogSubmissionSettings settings,
+            ImmutableTracerSettings settings,
+            ImmutableDirectLogSubmissionSettings directLogSettings,
             ImmutableAzureAppServiceSettings? azureAppServiceSettings,
             string serviceName,
             string env,
             string serviceVersion,
             IGitMetadataTagsProvider gitMetadataTagsProvider)
         {
-            var formatter = new LogFormatter(settings, azureAppServiceSettings, serviceName, env, serviceVersion, gitMetadataTagsProvider);
+            var formatter = new LogFormatter(settings, directLogSettings, azureAppServiceSettings, serviceName, env, serviceVersion, gitMetadataTagsProvider);
             if (previous is not null)
             {
                 // Only the formatter uses settings that are configurable in code.
@@ -47,15 +48,15 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 return new DirectLogSubmissionManager(previous.Settings, previous.Sink, formatter);
             }
 
-            if (!settings.IsEnabled)
+            if (!directLogSettings.IsEnabled)
             {
-                return new DirectLogSubmissionManager(settings, new NullDirectSubmissionLogSink(), formatter);
+                return new DirectLogSubmissionManager(directLogSettings, new NullDirectSubmissionLogSink(), formatter);
             }
 
-            var apiFactory = LogsTransportStrategy.Get(settings);
-            var logsApi = new LogsApi(settings.ApiKey, apiFactory);
+            var apiFactory = LogsTransportStrategy.Get(directLogSettings);
+            var logsApi = new LogsApi(directLogSettings.ApiKey, apiFactory);
 
-            return new DirectLogSubmissionManager(settings, new DirectSubmissionLogSink(logsApi, formatter, settings.BatchingOptions), formatter);
+            return new DirectLogSubmissionManager(directLogSettings, new DirectSubmissionLogSink(logsApi, formatter, directLogSettings.BatchingOptions), formatter);
         }
 
         public async Task DisposeAsync()

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/DirectLogSubmissionSettings.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
                                                   validator: null);
 
             var globalTags = config
-                            .WithKeys(ConfigurationKeys.DirectLogSubmission.GlobalTags, ConfigurationKeys.GlobalTags, "DD_TRACE_GLOBAL_TAGS")
+                            .WithKeys(ConfigurationKeys.DirectLogSubmission.GlobalTags)
                             .AsDictionary();
 
             DirectLogSubmissionGlobalTags = globalTags?.Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LogFormatter.cs" company="Datadog">
+// <copyright file="LogFormatter.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -32,13 +32,13 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
         private readonly string? _env;
         private readonly string? _version;
         private readonly IGitMetadataTagsProvider _gitMetadataTagsProvider;
-        private string? _tags;
         private bool _gitMetadataAdded;
 
         private string? _ciVisibilityDdTags;
 
         public LogFormatter(
-            ImmutableDirectLogSubmissionSettings settings,
+            ImmutableTracerSettings settings,
+            ImmutableDirectLogSubmissionSettings directLogSettings,
             ImmutableAzureAppServiceSettings? aasSettings,
             string serviceName,
             string env,
@@ -46,15 +46,20 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             IGitMetadataTagsProvider gitMetadataTagsProvider)
         {
             _gitMetadataTagsProvider = gitMetadataTagsProvider;
-            _source = string.IsNullOrEmpty(settings.Source) ? null : settings.Source;
+            _source = string.IsNullOrEmpty(directLogSettings.Source) ? null : directLogSettings.Source;
             _service = string.IsNullOrEmpty(serviceName) ? null : serviceName;
-            _host = string.IsNullOrEmpty(settings.Host) ? null : settings.Host;
-            _tags = EnrichTagsWithAasMetadata(settings.GlobalTags, aasSettings);
+            _host = string.IsNullOrEmpty(directLogSettings.Host) ? null : directLogSettings.Host;
+
+            var globalTags = directLogSettings.GlobalTags is { Count: > 0 } ? directLogSettings.GlobalTags : settings.GlobalTagsInternal;
+
+            Tags = EnrichTagsWithAasMetadata(ImmutableDirectLogSubmissionSettings.StringifyGlobalTags(globalTags), aasSettings);
             _env = string.IsNullOrEmpty(env) ? null : env;
             _version = string.IsNullOrEmpty(version) ? null : version;
         }
 
         internal delegate LogPropertyRenderingDetails FormatDelegate<T>(JsonTextWriter writer, in T state);
+
+        internal string? Tags { get; private set; }
 
         private string? EnrichTagsWithAasMetadata(string globalTags, ImmutableAzureAppServiceSettings? aasSettings)
         {
@@ -63,7 +68,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
                 return string.IsNullOrEmpty(globalTags) ? null : globalTags;
             }
 
-            var aasTags = $"{Tags.AzureAppServicesResourceId}{KeyValueTagSeparator}{aasSettings.ResourceId}";
+            var aasTags = $"{Trace.Tags.AzureAppServicesResourceId}{KeyValueTagSeparator}{aasSettings.ResourceId}";
 
             return string.IsNullOrEmpty(globalTags) ? aasTags : aasTags + TagSeparator + globalTags;
         }
@@ -84,7 +89,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             if (gitMetadata != GitMetadata.Empty)
             {
                 var gitMetadataTags = $"{CommonTags.GitCommit}{KeyValueTagSeparator}{gitMetadata.CommitSha},{CommonTags.GitRepository}{KeyValueTagSeparator}{RemoveScheme(gitMetadata.RepositoryUrl)}";
-                _tags = string.IsNullOrEmpty(_tags) ? gitMetadataTags : $"{_tags}{TagSeparator}{gitMetadataTags}";
+                Tags = string.IsNullOrEmpty(Tags) ? gitMetadataTags : $"{Tags}{TagSeparator}{gitMetadataTags}";
             }
 
             _gitMetadataAdded = true;
@@ -92,7 +97,8 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
 
         private string? RemoveScheme(string url)
         {
-            return url switch {
+            return url switch
+            {
                 { } when url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) => url.Substring("https://".Length),
                 { } when url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) => url.Substring("http://".Length),
                 _ => url
@@ -286,10 +292,10 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
 
             EnrichTagsStringWithGitMetadata();
 
-            if (_tags is not null && !renderingDetails.HasRenderedTags)
+            if (Tags is not null && !renderingDetails.HasRenderedTags)
             {
                 writer.WritePropertyName(TagsPropertyName, escape: false);
-                writer.WriteValue(_tags);
+                writer.WriteValue(Tags);
             }
 
             writer.WriteEndObject();
@@ -336,7 +342,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             var service = _service;
             if (span is not null)
             {
-                if (span.GetTag(Tags.Env) is { } spanEnv && spanEnv != env)
+                if (span.GetTag(Trace.Tags.Env) is { } spanEnv && spanEnv != env)
                 {
                     ddTags = GetCIVisiblityDDTagsString(spanEnv);
                 }
@@ -390,7 +396,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             environment = environment.Replace(":", string.Empty);
 
             var ddtags = $"env:{environment},datadog.product:citest";
-            if (_tags is { Length: > 0 } globalTags)
+            if (Tags is { Length: > 0 } globalTags)
             {
                 ddtags += "," + globalTags;
             }

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using Datadog.Trace.Configuration;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
         private ImmutableDirectLogSubmissionSettings(
             string host,
             string source,
-            string globalTags,
+            IReadOnlyDictionary<string, string> globalTags,
             Uri intakeUrl,
             string apiKey,
             bool isEnabled,
@@ -63,7 +64,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
 
         public string Source { get; }
 
-        public string GlobalTags { get; }
+        public IReadOnlyDictionary<string, string> GlobalTags { get; }
 
         public Uri IntakeUrl { get; }
 
@@ -135,7 +136,6 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 validationErrors.Add($"Missing required settings '{ConfigurationKeys.ApiKey}'.");
             }
 
-            var stringifiedTags = StringifyGlobalTags(globalTags);
             var enabledIntegrations = new bool[IntegrationRegistry.Ids.Count];
             var enabledIntegrationNames = new List<string>(SupportedIntegrations.Length);
 
@@ -168,7 +168,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             return new ImmutableDirectLogSubmissionSettings(
                 host: host ?? string.Empty,
                 source: source ?? string.Empty,
-                globalTags: stringifiedTags,
+                globalTags: new ReadOnlyDictionary<string, string>(globalTags),
                 intakeUrl: intakeUri!,
                 apiKey: apiKey ?? string.Empty,
                 isEnabled: isEnabled,
@@ -179,7 +179,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 batchingOptions);
         }
 
-        private static string StringifyGlobalTags(IDictionary<string, string> globalTags)
+        public static string StringifyGlobalTags(IReadOnlyDictionary<string, string> globalTags)
         {
             if (globalTags.Count == 0)
             {
@@ -206,7 +206,7 @@ namespace Datadog.Trace.Logging.DirectSubmission
             return new ImmutableDirectLogSubmissionSettings(
                 host: string.Empty,
                 source: string.Empty,
-                globalTags: string.Empty,
+                globalTags: new Dictionary<string, string>(),
                 intakeUrl: new Uri("http://localhost"),
                 apiKey: string.Empty,
                 isEnabled: false,

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettings.cs
@@ -179,26 +179,6 @@ namespace Datadog.Trace.Logging.DirectSubmission
                 batchingOptions);
         }
 
-        public static string StringifyGlobalTags(IReadOnlyDictionary<string, string> globalTags)
-        {
-            if (globalTags.Count == 0)
-            {
-                return string.Empty;
-            }
-
-            var sb = new StringBuilder();
-            foreach (var tagPair in globalTags)
-            {
-                sb.Append(tagPair.Key)
-                  .Append(':')
-                  .Append(tagPair.Value)
-                  .Append(',');
-            }
-
-            // remove final joiner
-            return sb.ToString(startIndex: 0, length: sb.Length - 1);
-        }
-
         public static ImmutableDirectLogSubmissionSettings CreateNullSettings()
         {
             var emptyList = new List<string>(0);

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -128,6 +128,7 @@ namespace Datadog.Trace
             var gitMetadataTagsProvider = GetGitMetadataTagsProvider(settings, scopeManager);
             logSubmissionManager = DirectLogSubmissionManager.Create(
                 logSubmissionManager,
+                settings,
                 settings.LogSubmissionSettings,
                 settings.AzureAppServiceMetadata,
                 defaultServiceName,

--- a/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.TestHelpers
     internal class LogSettingsHelper
     {
         public static LogFormatter GetFormatter() => new(
-            new ImmutableTracerSettings(new TracerSettings()),
+            new ImmutableTracerSettings(new TracerSettings(null, Configuration.Telemetry.NullConfigurationTelemetry.Instance)),
             GetValidSettings(),
             aasSettings: null,
             serviceName: "MyTestService",

--- a/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LogSettingsHelper.cs" company="Datadog">
+// <copyright file="LogSettingsHelper.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -16,6 +16,7 @@ namespace Datadog.Trace.TestHelpers
     internal class LogSettingsHelper
     {
         public static LogFormatter GetFormatter() => new(
+            new ImmutableTracerSettings(new TracerSettings()),
             GetValidSettings(),
             aasSettings: null,
             serviceName: "MyTestService",

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/DirectLogSubmissionSettingsTests.cs
@@ -59,36 +59,6 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
         }
 
         [Fact]
-        public void LogSpecificGlobalTagsFallBackToTracerGlobalTags()
-        {
-            var expected = new Dictionary<string, string> { { "test1", "value1" }, { "test2", "value2" }, };
-
-            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()
-            {
-                { ConfigurationKeys.GlobalTags, "test1:value1, test2:value2" },
-            }));
-
-            tracerSettings.LogSubmissionSettings.DirectLogSubmissionGlobalTags
-                          .Should()
-                          .BeEquivalentTo(expected);
-        }
-
-        [Fact]
-        public void LogSpecificGlobalTagsFallBackToLegacyGlobalTags()
-        {
-            var expected = new Dictionary<string, string> { { "test1", "value1" }, { "test2", "value2" }, };
-
-            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(new()
-            {
-                { "DD_TRACE_GLOBAL_TAGS", "test1:value1, test2:value2" },
-            }));
-
-            tracerSettings.LogSubmissionSettings.DirectLogSubmissionGlobalTags
-               .Should()
-               .BeEquivalentTo(expected);
-        }
-
-        [Fact]
         public void LogSpecificGlobalTagsOverrideTracerGlobalTags()
         {
             var expected = new Dictionary<string, string> { { "test1", "value1" }, { "test2", "value2" }, };

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Formatting/LogFormatterTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="LogFormatterTests.cs" company="Datadog">
+// <copyright file="LogFormatterTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -12,7 +12,6 @@ using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
 using Datadog.Trace.Logging.DirectSubmission.Sink.PeriodicBatching;
-using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Tests.PlatformHelpers;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
@@ -30,11 +29,13 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
         private const string Version = "1.0.0";
         private readonly JsonTextWriter _writer;
         private readonly StringBuilder _sb;
-        private readonly ImmutableDirectLogSubmissionSettings _settings;
+        private readonly ImmutableTracerSettings _tracerSettings;
+        private readonly ImmutableDirectLogSubmissionSettings _directLogSettings;
 
         public LogFormatterTests()
         {
-            _settings = ImmutableDirectLogSubmissionSettings.Create(
+            _tracerSettings = new ImmutableTracerSettings(new TracerSettings());
+            _directLogSettings = ImmutableDirectLogSubmissionSettings.Create(
                 host: Host,
                 source: Source,
                 intakeUrl: "http://localhost",
@@ -43,7 +44,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
                 globalTags: new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } },
                 enabledLogShippingIntegrations: new List<string> { nameof(IntegrationId.ILogger) },
                 batchingOptions: new BatchingSinkOptions(batchSizeLimit: 100, queueLimit: 1000, TimeSpan.FromSeconds(2)));
-            _settings.IsEnabled.Should().BeTrue();
+            _directLogSettings.IsEnabled.Should().BeTrue();
 
             _sb = new StringBuilder();
             _writer = LogFormatter.GetJsonWriter(_sb);
@@ -146,7 +147,8 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Formatting
             var aasSettings = isInAas ? GetAasSettings() : null;
 
             var formatter = new LogFormatter(
-                _settings,
+                _tracerSettings,
+                _directLogSettings,
                 aasSettings: aasSettings,
                 serviceName: Service,
                 env: Env,

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/ImmutableDirectLogSubmissionSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ImmutableDirectLogSubmissionSettingsTests.cs" company="Datadog">
+// <copyright file="ImmutableDirectLogSubmissionSettingsTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission
             logSettings.ApiKey.Should().Be(apiKey);
             logSettings.Host.Should().Be(hostName);
             logSettings.IntakeUrl?.ToString().Should().Be("http://localhost:1234/");
-            logSettings.GlobalTags.Should().BeOneOf("someothertag:someothervalue,sometag:value", "sometag:value,someothertag:someothervalue");
+            logSettings.GlobalTags.Should().BeEquivalentTo(new KeyValuePair<string, string>[] { new("someothertag", "someothervalue"), new("sometag", "value") });
             logSettings.IsEnabled.Should().BeTrue();
             logSettings.MinimumLevel.Should().Be(DirectSubmissionLogLevel.Information);
             logSettings.Source.Should().Be("csharp");


### PR DESCRIPTION
## Summary of changes

Ensure that the dynamic config global tags are properly applied to log submission.

## Implementation details

ImmutableDirectLogSubmissionSettings does not implement the fallback on DD_TAGS when DD_LOGS_DIRECT_SUBMISSION_TAGS is not set. Instead, that logic is now in LogFormatter.
Since a new LogFormatter is created when the tracer is reconfigured, it will pick the new value of DD_TAGS pushed with dynamic config.

## Test coverage

Added test cases to the dynamic config unit tests, to validate that the value of DD_TAGS is propagated to the LogFormatter.

## Other details

Stacked on top of https://github.com/DataDog/dd-trace-dotnet/pull/4901