### PR TITLE
Make the agent check less verbose

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/AgentConnectivityCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/AgentConnectivityCheck.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             }
             catch (Exception ex)
             {
-                Utils.WriteError(ErrorDetectingAgent(settings.AgentUri.ToString(), ex.ToString()));
+                Utils.WriteError(ErrorDetectingAgent(settings.AgentUri.ToString(), ex.Message));
                 return false;
             }
 


### PR DESCRIPTION
## Summary of changes

When failing to contact the agent, write the error message instead of the full exception.

## Reason for change

When porting the diagnostics from dd-trace to dd-dotnet, I switched to dumping the full exception to understand what was wrong, and forgot to revert. 
The full exception is too verbose.
