### PR TITLE
Fix memory dumps on artifact tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3396,6 +3396,12 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
         enable_crash_dumps: true
 
+    - publish: tracer/build_data
+      displayName: Uploading tool_artifacts_tests_windows logs
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
+
     - task: PublishTestResults@2
       displayName: publish test results
       inputs:
@@ -3499,6 +3505,16 @@ stages:
       parameters:
         baseImage: $(baseImage)
         command: "BuildAndRunDdDotnetArtifactTests --framework net7.0"
+
+    - script: |
+        sudo chmod -R 644 tracer/build_data/dumps/* || true
+      displayName: Make dumps uploadable to AzDo
+      condition: succeededOrFailed()
+
+    - publish: tracer/build_data
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
 
     - task: PublishTestResults@2
       displayName: publish test results

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -24,6 +24,22 @@ namespace Datadog.Trace.TestHelpers
             : base(messageSink)
         {
             FluentAssertions.Formatting.Formatter.AddFormatter(new DiffPaneModelFormatter());
+
+            Task memoryDumpTask = null;
+
+            if (bool.Parse(Environment.GetEnvironmentVariable("enable_crash_dumps") ?? "false"))
+            {
+                var progress = new Progress<string>(message => messageSink.OnMessage(new DiagnosticMessage(message)));
+
+                try
+                {
+                    MemoryDumpHelper.InitializeAsync(progress).GetAwaiter().GetResult();
+                }
+                catch (Exception ex)
+                {
+                    messageSink.OnMessage(new DiagnosticMessage($"MemoryDumpHelper initialization failed: {ex}"));
+                }
+            }
         }
 
         public CustomTestFramework(IMessageSink messageSink, Type typeTestedAssembly)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
@@ -6,7 +6,7 @@
 using Xunit;
 using Xunit.Abstractions;
 
-[assembly: TestFramework("Datadog.Trace.Tools.Runner.ArtifactTests.CustomTestFramework", "Datadog.Trace.Tools.Runner.ArtifactTests")]
+[assembly: TestFramework("Datadog.Trace.Tools.dd_dotnet.ArtifactTests.CustomTestFramework", "Datadog.Trace.Tools.dd_dotnet.ArtifactTests")]
 
 namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests;
 

--- a/tracer/test/test-applications/integrations/Samples.Console/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Console/Program.cs
@@ -10,6 +10,8 @@ namespace Samples.Console_
     {
         private static async Task Main(string[] args)
         {
+            Thread.Sleep(Timeout.Infinite); // Look Ma I'm frozen!
+
             // Just to make extra sure that the tracer is loaded, if properly configured
             _ = WebRequest.CreateHttp("http://localhost");
             await Task.Yield();


### PR DESCRIPTION
## Summary of changes

Uploading the memory dumps in artifact tests is broken for a variety of reasons.

## Reason for change

Those poor little dumps feel lonely on their CI agent.

## Test coverage

Making Samples.Console freeze on purpose to test.