### PR TITLE
Fix recheck interval in DiscoveryService

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -75,7 +75,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 tcpTimeout: TimeSpan.FromSeconds(15),
                 initialRetryDelayMs: 500,
                 maxRetryDelayMs: 5_000,
-                recheckIntervalMs: 30_00);
+                recheckIntervalMs: 30_000);
 
         public static DiscoveryService Create(
             ImmutableExporterSettings exporterSettings,


### PR DESCRIPTION
## Summary of changes

Fixes the check interval to be 30s instead of 3s

## Reason for change

Pretty sure this is a type

## Implementation details

`3_000` -> `30_000`

## Test coverage

N/A

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
