### PR TITLE
[Profiler] Adjust profiler tests for .NET 8

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -46,15 +46,10 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
                     new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |cg: |fn:ThrowExceptions |fg: |sg:(object state)"),
                     new StackFrame("|lm:System.Private.CoreLib |ns:System.Threading |ct:Thread |cg: |fn:StartCallback |fg: |sg:()"));
             }
-            else if (framework == "net7.0")
+            else if (framework == "net7.0" || framework == "net8.0")
             {
                 expectedStack = new StackTrace(
                     new StackFrame("|lm:Samples.ExceptionGenerator |ns:Samples.ExceptionGenerator |ct:ParallelExceptionsScenario |cg: |fn:ThrowExceptions |fg: |sg:(object state)"));
-            }
-            else if (framework == "net8.0")
-            {
-                // TODO: Update this to suport .NET 8
-                return;
             }
             else
             {

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Signature/SignatureTest.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
+
 using System;
 using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
@@ -40,18 +41,12 @@ namespace Datadog.Profiler.IntegrationTests.Signature
             CheckExceptionsInProfiles(framework, exceptionSamples);
         }
 
-        private void CheckExceptionsInProfiles(string framework, (string Type, string Message, long Count, StackTrace Stacktrace)[] exceptionSamples)
+        private static void CheckExceptionsInProfiles(string framework, (string Type, string Message, long Count, StackTrace Stacktrace)[] exceptionSamples)
         {
-            PlatformID os = Environment.OSVersion.Platform;
+            var os = Environment.OSVersion.Platform;
             StackTrace stack;
-            if (os == PlatformID.Unix)
+            if (os == PlatformID.Unix && framework != "net8.0")
             {
-                if (framework == "net8.0")
-                {
-                    // TODO: fix this - they may have fixed the bug in .NET 8!
-                    return;
-                }
-
                 // BUG on Linux: invalid TKey instead of TVal
                 stack = new StackTrace(
                     new StackFrame("|lm:Samples.Computer01 |ns:Samples.Computer01 |ct:GenericClass |cg:<TKey, TKey> |fn:ThrowFromGeneric |fg:<T0> |sg:(T0 element, TKey key1, TKey value, TKey key2)"),


### PR DESCRIPTION
## Summary of changes

Adjust checks for profiler tests for .NET 8

## Reason for change

really ?
## Implementation details

Adjust the checks according to the CLR version.

## Test coverage

The current tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
