### PR TITLE
Add null reference checks to SNS integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/AwsSnsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/AwsSnsCommon.cs
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Tagging;
@@ -21,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
         internal const string IntegrationName = nameof(Configuration.IntegrationId.AwsSns);
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.AwsSns;
 
-        public static Scope CreateScope(Tracer tracer, string operation, string spanKind, out AwsSnsTags tags, ISpanContext parentContext = null)
+        public static Scope? CreateScope(Tracer tracer, string operation, string spanKind, out AwsSnsTags? tags, ISpanContext? parentContext = null)
         {
             tags = null;
 
@@ -31,13 +34,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
                 return null;
             }
 
-            Scope scope = null;
+            Scope? scope = null;
 
             try
             {
                 tags = tracer.CurrentTraceSettings.Schema.Messaging.CreateAwsSnsTags(spanKind);
-                string serviceName = tracer.CurrentTraceSettings.GetServiceName(tracer, DatadogAwsSnsServiceName);
-                string operationName = GetOperationName(tracer, spanKind);
+                var serviceName = tracer.CurrentTraceSettings.GetServiceName(tracer, DatadogAwsSnsServiceName);
+                var operationName = GetOperationName(tracer, spanKind);
                 scope = tracer.StartActiveInternal(operationName, parent: parentContext, tags: tags, serviceName: serviceName);
                 var span = scope.Span;
 
@@ -59,7 +62,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             return scope;
         }
 
-        public static string GetTopicName(string topicArn)
+        [return: NotNullIfNotNull(nameof(topicArn))]
+        public static string? GetTopicName(string? topicArn)
         {
             if (topicArn is null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/ContextPropagation.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -27,8 +29,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             sb.Append('}');
 
             var resultString = Util.StringBuilderCache.GetStringAndRelease(sb);
-            byte[] bytes = Encoding.UTF8.GetBytes(resultString);
-            MemoryStream stream = new MemoryStream(bytes);
+            var bytes = Encoding.UTF8.GetBytes(resultString);
+            var stream = new MemoryStream(bytes);
             messageAttributes[SnsKey] = CachedMessageHeadersHelper<TMessageRequest>.CreateMessageAttributeValue(stream);
         }
 
@@ -43,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
             {
                 // In .NET Fx and Net Core 2.1, removing an element while iterating on keys throws.
 #if !NETCOREAPP2_1_OR_GREATER
-                List<string> attributesToRemove = null;
+                List<string>? attributesToRemove = null;
 #endif
                 // Make sure we do not propagate any other datadog header here in the rare cases where users would have added them manually
                 foreach (var attribute in carrier.MessageAttributes.Keys)

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/IAmazonSNSRequestWithTopicArn.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/IAmazonSNSRequestWithTopicArn.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 {
     /// <summary>
@@ -13,6 +15,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
         /// <summary>
         /// Gets the Amazon Resource Name (ARN) of the topic
         /// </summary>
-        string TopicArn { get; }
+        string? TopicArn { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/IContainsMessageAttributes.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/IContainsMessageAttributes.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System.Collections;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
@@ -15,6 +17,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
         /// <summary>
         /// Gets or sets the message attributes
         /// </summary>
-        IDictionary MessageAttributes { get; set;  }
+        IDictionary? MessageAttributes { get; set;  }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/IPublishRequest.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/IPublishRequest.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 {
     /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SNS/PublishAsyncIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -48,13 +50,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SNS
 
             var requestProxy = request.DuckCast<IPublishRequest>();
 
-            var scope = AwsSnsCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, out AwsSnsTags tags);
-            tags.TopicArn = requestProxy.TopicArn;
-            tags.TopicName = AwsSnsCommon.GetTopicName(requestProxy.TopicArn);
-
-            if (scope?.Span.Context != null)
+            var scope = AwsSnsCommon.CreateScope(Tracer.Instance, Operation, SpanKinds.Producer, out var tags);
+            if (tags is not null && requestProxy.TopicArn is not null)
             {
-                ContextPropagation.InjectHeadersIntoMessage<TPublishRequest>(requestProxy, scope.Span.Context);
+                tags.TopicArn = requestProxy.TopicArn;
+                tags.TopicName = AwsSnsCommon.GetTopicName(requestProxy.TopicArn);
+            }
+
+            if (scope?.Span.Context is { } context)
+            {
+                ContextPropagation.InjectHeadersIntoMessage<TPublishRequest>(requestProxy, context);
             }
 
             return new CallTargetState(scope);


### PR DESCRIPTION
## Summary of changes

Fix the null checks in the SNS integration

## Reason for change

We know we're getting some `NullReferenceException` in the SNS integration

## Implementation details

Sprinkle some `#nullable enable` and watch the errors shout

## Test coverage

Covered by existing tests

## Other details

`NullReferenceException`s are so embarrassing
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
