### PR TITLE
Add null reference checks to elasticsearch7 integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/IApiCallDetails.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/IApiCallDetails.cs
@@ -3,12 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
 {
     internal interface IApiCallDetails
     {
-        public Uri Uri { get; }
+        public Uri? Uri { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/IElasticsearchResponse.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/IElasticsearchResponse.cs
@@ -3,10 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
 {
     internal interface IElasticsearchResponse
     {
-        IApiCallDetails ApiCall { get; }
+        IApiCallDetails? ApiCall { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_RequestAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_RequestAsync_Integration.cs
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Util.Http;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
@@ -44,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, THttpMethod, TPostData, TRequestParameters>(TTarget instance, THttpMethod method, string path, CancellationToken cancellationToken, TPostData postData, TRequestParameters requestParameters)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV7Constants.IntegrationId, method.ToString(), requestParameters, out var tags);
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV7Constants.IntegrationId, method?.ToString(), requestParameters, out var tags);
 
             return new CallTargetState(scope, tags);
         }
@@ -60,11 +63,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
         /// <param name="state">Calltarget state value</param>
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         internal static TResponse OnAsyncMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, in CallTargetState state)
-            where TResponse : IElasticsearchResponse
+            where TResponse : IElasticsearchResponse, IDuckType
         {
-            var uri = response?.ApiCall?.Uri;
-
-            if (uri != null)
+            if (response.Instance is not null && response.ApiCall?.Uri is { } uri)
             {
                 var tags = (ElasticsearchTags)state.State;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_Request_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/V7/Transport_Request_Integration.cs
@@ -3,9 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Util.Http;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
@@ -42,7 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, THttpMethod, TPostData, TRequestParameters>(TTarget instance, THttpMethod method, string path, TPostData postData, TRequestParameters requestParameters)
         {
-            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV7Constants.IntegrationId, method.ToString(), requestParameters, out var tags);
+            var scope = ElasticsearchNetCommon.CreateScope(Tracer.Instance, ElasticsearchV7Constants.IntegrationId, method?.ToString(), requestParameters, out var tags);
 
             return new CallTargetState(scope, tags);
         }
@@ -58,11 +61,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
         /// <param name="state">Calltarget state value</param>
         /// <returns>A response value, in an async scenario will be T of Task of T</returns>
         internal static CallTargetReturn<TResponse> OnMethodEnd<TTarget, TResponse>(TTarget instance, TResponse response, Exception exception, in CallTargetState state)
-            where TResponse : IElasticsearchResponse
+            where TResponse : IElasticsearchResponse, IDuckType
         {
-            var uri = response?.ApiCall?.Uri;
-
-            if (uri != null)
+            if (response.Instance is not null && response.ApiCall?.Uri is { } uri)
             {
                 var tags = (ElasticsearchTags)state.State;
 
@@ -74,7 +75,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch.V7
             }
 
             state.Scope.DisposeWithException(exception);
-            return new CallTargetReturn<TResponse>(response);
+            return new CallTargetReturn<TResponse>(response!);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Fix the null checks in the elasticsearch7 integration

## Reason for change

We know we're getting some `NullReferenceException` in the elasticsearch7 integration

## Implementation details

Sprinkle some #nullable enable and watch the errors shout

## Test coverage

Covered by existing tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
