### PR TITLE
Add null reference checks to StackExchange.Redis integration 

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/RedisHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/RedisHelper.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Text;
@@ -18,7 +20,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RedisHelper));
 
-        internal static Scope CreateScope(Tracer tracer, IntegrationId integrationId, string integrationName, string host, string port, string rawCommand, long? databaseIndex)
+        internal static Scope? CreateScope(Tracer tracer, IntegrationId integrationId, string integrationName, string? host, string? port, string rawCommand, long? databaseIndex)
         {
             if (!Tracer.Instance.Settings.IsIntegrationEnabled(integrationId))
             {
@@ -35,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
             }
 
             string serviceName = tracer.CurrentTraceSettings.Schema.Database.GetServiceName(ServiceName);
-            Scope scope = null;
+            Scope? scope = null;
 
             try
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/RedisTags.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/RedisTags.cs
@@ -3,7 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using Datadog.Trace.Configuration;
+#nullable enable
+
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Tagging;
 
@@ -16,16 +17,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
         public override string SpanKind => SpanKinds.Client;
 
         [Tag(Trace.Tags.InstrumentationName)]
-        public string InstrumentationName { get; set; }
+        public string? InstrumentationName { get; set; }
 
         [Tag(Trace.Tags.RedisRawCommand)]
-        public string RawCommand { get; set; }
+        public string? RawCommand { get; set; }
 
         [Tag(Trace.Tags.OutHost)]
-        public string Host { get; set; }
+        public string? Host { get; set; }
 
         [Tag(Trace.Tags.OutPort)]
-        public string Port { get; set; }
+        public string? Port { get; set; }
 
         // Always use metrics for "number like" tags. Even though it's not really a "metric"
         // that should be summed/averaged, it's important to record it as such so that we
@@ -37,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
 
     internal partial class RedisV1Tags : RedisTags
     {
-        private string _peerServiceOverride = null;
+        private string? _peerServiceOverride = null;
 
         // Use a private setter for setting the "peer.service" tag so we avoid
         // accidentally setting the value ourselves and instead calculate the
@@ -45,14 +46,14 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis
         // However, this can still be set from ITags.SetTag so the user can
         // customize the value if they wish.
         [Tag(Trace.Tags.PeerService)]
-        public string PeerService
+        public string? PeerService
         {
             get => _peerServiceOverride ?? Host;
             private set => _peerServiceOverride = value;
         }
 
         [Tag(Trace.Tags.PeerServiceSource)]
-        public string PeerServiceSource
+        public string? PeerServiceSource
         {
             get
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration_2_6_45.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteAsyncImplIntegration_2_6_45.cs
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 {
@@ -38,12 +41,26 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
     {
         internal static CallTargetState OnMethodBegin<TTarget, TMessage, TProcessor, TServerEndPoint, TDefaultValue>(TTarget instance, TMessage message, TProcessor resultProcessor, object state, TServerEndPoint serverEndPoint, TDefaultValue defaultValue)
             where TTarget : IConnectionMultiplexer
-            where TMessage : IMessageData
+            where TMessage : IMessageData, IDuckType
         {
-            string rawCommand = message.CommandAndKey ?? "COMMAND";
-            StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
+            if (message.Instance is null)
+            {
+                return CallTargetState.GetDefault();
+            }
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            string rawCommand = message.CommandAndKey ?? "COMMAND";
+            // Assuming that instance.Instance is not null, because we're calling an instance method
+            var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
+
+            var scope = RedisHelper.CreateScope(
+                Tracer.Instance,
+                StackExchangeRedisHelper.IntegrationId,
+                StackExchangeRedisHelper.IntegrationName,
+                hostAndPort.Host,
+                hostAndPort.Port,
+                rawCommand,
+                StackExchangeRedisHelper.GetDb(message.Db));
+
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration.cs
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 {
@@ -49,12 +52,26 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TMessage, TProcessor, TServerEndPoint>(TTarget instance, TMessage message, TProcessor resultProcessor, TServerEndPoint serverEndPoint)
             where TTarget : IConnectionMultiplexer
-            where TMessage : IMessageData
+            where TMessage : IMessageData, IDuckType
         {
-            string rawCommand = message.CommandAndKey ?? "COMMAND";
-            StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
+            if (message.Instance is null)
+            {
+                return CallTargetState.GetDefault();
+            }
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            string rawCommand = message.CommandAndKey ?? "COMMAND";
+            // Assuming that instance.Instance is not null, because we're calling an instance method
+            var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
+
+            var scope = RedisHelper.CreateScope(
+                Tracer.Instance,
+                StackExchangeRedisHelper.IntegrationId,
+                StackExchangeRedisHelper.IntegrationName,
+                hostAndPort.Host,
+                hostAndPort.Port,
+                rawCommand,
+                StackExchangeRedisHelper.GetDb(message.Db));
+
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration_2_6_45.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/ConnectionMultiplexerExecuteSyncImplIntegration_2_6_45.cs
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 {
@@ -38,12 +41,26 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
     {
         internal static CallTargetState OnMethodBegin<TTarget, TMessage, TProcessor, TServerEndPoint, TDefaultValue>(TTarget instance, TMessage message, TProcessor resultProcessor, TServerEndPoint serverEndPoint, TDefaultValue defaultValue)
             where TTarget : IConnectionMultiplexer
-            where TMessage : IMessageData
+            where TMessage : IMessageData, IDuckType
         {
-            string rawCommand = message.CommandAndKey ?? "COMMAND";
-            StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
+            if (message.Instance is null)
+            {
+                return CallTargetState.GetDefault();
+            }
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, StackExchangeRedisHelper.IntegrationId, StackExchangeRedisHelper.IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            string rawCommand = message.CommandAndKey ?? "COMMAND";
+            // Assuming that instance.Instance is not null, because we're calling an instance method
+            var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Configuration);
+
+            var scope = RedisHelper.CreateScope(
+                Tracer.Instance,
+                StackExchangeRedisHelper.IntegrationId,
+                StackExchangeRedisHelper.IntegrationName,
+                hostAndPort.Host,
+                hostAndPort.Port,
+                rawCommand,
+                StackExchangeRedisHelper.GetDb(message.Db));
+
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IConnectionMultiplexer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IConnectionMultiplexer.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 {
     /// <summary>
@@ -13,6 +15,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <summary>
         /// Gets the conection configuration
         /// </summary>
-        string Configuration { get; }
+        string? Configuration { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IMessageData.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IMessageData.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
@@ -15,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <summary>
         /// Gets message command and key
         /// </summary>
-        public string CommandAndKey { get; }
+        public string? CommandAndKey { get; }
 
         [DuckField]
         public int Db { get; }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IRedisBase.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/IRedisBase.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/MultiplexerData.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/MultiplexerData.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
@@ -16,6 +18,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <summary>
         /// Multiplexer configuration
         /// </summary>
-        public string Configuration;
+        public string? Configuration;
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteAsyncIntegration.cs
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 {
@@ -43,12 +46,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TMessage, TProcessor, TServerEndPoint>(TTarget instance, TMessage message, TProcessor resultProcessor, TServerEndPoint serverEndPoint)
             where TTarget : IRedisBase
-            where TMessage : IMessageData
+            where TMessage : IMessageData, IDuckType
         {
-            string rawCommand = message.CommandAndKey ?? "COMMAND";
-            StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Multiplexer.Configuration);
+            if (message.Instance is null)
+            {
+                return CallTargetState.GetDefault();
+            }
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            string rawCommand = message.CommandAndKey ?? "COMMAND";
+            var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Multiplexer.Configuration);
+
+            var scope = RedisHelper.CreateScope(
+                Tracer.Instance,
+                IntegrationId,
+                IntegrationName,
+                hostAndPort.Host,
+                hostAndPort.Port,
+                rawCommand,
+                StackExchangeRedisHelper.GetDb(message.Db));
+
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteSyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/RedisExecuteSyncIntegration.cs
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 {
@@ -43,12 +46,25 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// <returns>Calltarget state value</returns>
         internal static CallTargetState OnMethodBegin<TTarget, TMessage, TProcessor, TServerEndPoint>(TTarget instance, TMessage message, TProcessor resultProcessor, TServerEndPoint serverEndPoint)
             where TTarget : IRedisBase
-            where TMessage : IMessageData
+            where TMessage : IMessageData, IDuckType
         {
-            string rawCommand = message.CommandAndKey ?? "COMMAND";
-            StackExchangeRedisHelper.HostAndPort hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Multiplexer.Configuration);
+            if (message.Instance is null)
+            {
+                return CallTargetState.GetDefault();
+            }
 
-            Scope scope = RedisHelper.CreateScope(Tracer.Instance, IntegrationId, IntegrationName, hostAndPort.Host, hostAndPort.Port, rawCommand, StackExchangeRedisHelper.GetDb(message.Db));
+            string rawCommand = message.CommandAndKey ?? "COMMAND";
+            var hostAndPort = StackExchangeRedisHelper.GetHostAndPort(instance.Multiplexer.Configuration);
+
+            var scope = RedisHelper.CreateScope(
+                Tracer.Instance,
+                IntegrationId,
+                IntegrationName,
+                hostAndPort.Host,
+                hostAndPort.Port,
+                rawCommand,
+                StackExchangeRedisHelper.GetDb(message.Db));
+
             if (scope is not null)
             {
                 return new CallTargetState(scope);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/StackExchangeRedisHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/StackExchange/StackExchangeRedisHelper.cs
@@ -3,8 +3,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 {
@@ -21,19 +24,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
         /// </summary>
         /// <param name="config">The config</param>
         /// <returns>The host and port</returns>
-        public static HostAndPort GetHostAndPort(string config)
+        public static HostAndPort GetHostAndPort(string? config)
         {
-            string host = null;
-            string port = null;
+            string? host = null;
+            string? port = null;
 
             if (config != null)
             {
                 // config can contain several settings separated by commas:
                 // hostname:port,name=MyName,keepAlive=180,syncTimeout=10000,abortConnect=False
                 // split in commas, find the one without '=', split that one on ':'
-                string[] hostAndPort = config.Split(',')
-                                             .FirstOrDefault(p => !p.Contains("="))
-                                            ?.Split(':');
+                var hostAndPort = config.Split(',')
+                                        .FirstOrDefault(p => !p.Contains("="))
+                                       ?.Split(':');
 
                 if (hostAndPort != null)
                 {
@@ -54,10 +57,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Redis.StackExchange
 
         internal readonly struct HostAndPort
         {
-            public readonly string Host;
-            public readonly string Port;
+            public readonly string? Host;
+            public readonly string? Port;
 
-            public HostAndPort(string host, string port)
+            public HostAndPort(string? host, string? port)
             {
                 Host = host;
                 Port = port;


### PR DESCRIPTION
## Summary of changes

Fix the null checks in the StackExchange.Redis integration

## Reason for change

We know we're getting some `NullReferenceException` in the StackExchange.Redis integration

## Implementation details

Sprinkle some #nullable enable and watch the errors shout. Duck-typing null issues were the culprit again

## Test coverage

Covered by existing tests

## Other details

The source of the errors that prompted this were this code we're instrumenting:

https://github.com/StackExchange/StackExchange.Redis/blob/main/src/StackExchange.Redis/RedisBase.cs#L43C8-L48

Note that the `message` can be `null` - we weren't checking for that previously.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
