### PR TITLE
Add null reference checks to RabbitMq integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/AmqpTimestamp.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/AmqpTimestamp.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicConsumeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicConsumeIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -44,9 +46,13 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="arguments">The original arguments setting</param>
         /// <param name="consumer">The original consumer setting</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget, TConsumer>(TTarget instance, string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, TConsumer consumer)
+        internal static CallTargetState OnMethodBegin<TTarget, TConsumer>(TTarget instance, string? queue, bool autoAck, string? consumerTag, bool noLocal, bool exclusive, IDictionary<string, object>? arguments, TConsumer consumer)
         {
-            QueueHelper.SetQueue(consumer, queue);
+            if (consumer is not null && queue is not null)
+            {
+                QueueHelper.SetQueue(consumer, queue);
+            }
+
             return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Consumer, queue: queue));
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverAsyncIntegration.cs
@@ -3,9 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
@@ -51,11 +54,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="basicProperties">The message properties.</param>
         /// <param name="body">The message body.</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, TBasicProperties basicProperties, TBody body)
+        internal static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string? consumerTag, ulong deliveryTag, bool redelivered, string? exchange, string? routingKey, TBasicProperties basicProperties, TBody body)
             where TBasicProperties : IBasicProperties
-            where TBody : IBody // ReadOnlyMemory<byte> body in 6.0.0
+            where TBody : IBody, IDuckType // ReadOnlyMemory<byte> body in 6.0.0
         {
-            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
+            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverAsyncIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverAsyncIntegration.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             where TBasicProperties : IBasicProperties
             where TBody : IBody, IDuckType // ReadOnlyMemory<byte> body in 6.0.0
         {
-            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
+            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, redelivered, exchange, routingKey, basicProperties, body);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -3,9 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
@@ -51,11 +54,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="basicProperties">The message properties.</param>
         /// <param name="body">The message body.</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, TBasicProperties basicProperties, TBody body)
+        internal static CallTargetState OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string? consumerTag, ulong deliveryTag, bool redelivered, string? exchange, string? routingKey, TBasicProperties basicProperties, TBody body)
             where TBasicProperties : IBasicProperties
-            where TBody : IBody // ReadOnlyMemory<byte> body in 6.0.0
+            where TBody : IBody, IDuckType // ReadOnlyMemory<byte> body in 6.0.0
         {
-            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, consumerTag, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
+            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicDeliverIntegration.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             where TBasicProperties : IBasicProperties
             where TBody : IBody, IDuckType // ReadOnlyMemory<byte> body in 6.0.0
         {
-            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, deliveryTag, redelivered, exchange, routingKey, basicProperties, body);
+            return RabbitMQIntegration.BasicDeliver_OnMethodBegin(instance, redelivered, exchange, routingKey, basicProperties, body);
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/BasicGetIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -41,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="queue">The queue name of the message</param>
         /// <param name="autoAck">The original autoAck argument</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool autoAck)
+        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string? queue, bool autoAck)
         {
             return new CallTargetState(scope: null, state: queue, startTime: DateTimeOffset.UtcNow);
         }
@@ -59,12 +61,12 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         internal static CallTargetReturn<TResult> OnMethodEnd<TTarget, TResult>(TTarget instance, TResult basicGetResult, Exception exception, in CallTargetState state)
             where TResult : IBasicGetResult, IDuckType
         {
-            string queue = (string)state.State;
+            string? queue = (string)state.State;
             DateTimeOffset? startTime = state.StartTime;
 
-            SpanContext propagatedContext = null;
-            IBasicProperties basicProperties = null;
-            string messageSize = null;
+            SpanContext? propagatedContext = null;
+            IBasicProperties? basicProperties = null;
+            string? messageSize = null;
 
             if (basicGetResult.Instance != null)
             {
@@ -86,7 +88,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            using (var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
+            using (var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out var tags, Command, parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, startTime: startTime))
             {
                 if (scope != null)
                 {
@@ -103,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                         scope.Span.SetException(exception);
                     }
 
-                    if (basicProperties != null)
+                    if (basicProperties != null && tags is not null)
                     {
                         RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(
                             Tracer.Instance,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ContextPropagation.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +17,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
     {
         public IEnumerable<string> Get(IDictionary<string, object> carrier, string key)
         {
-            if (carrier.TryGetValue(key, out object value) && value is byte[] bytes)
+            if (carrier.TryGetValue(key, out var value) && value is byte[] bytes)
             {
                 return new[] { Encoding.UTF8.GetString(bytes) };
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ExchangeDeclareIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -42,10 +44,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="nowait">The original nowait setting</param>
         /// <param name="arguments">The original arguments setting</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string exchange, string type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object> arguments)
+        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string? exchange, string? type, bool passive, bool durable, bool autoDelete, bool @internal, bool nowait, IDictionary<string, object>? arguments)
             where TTarget : IModelBase
         {
-            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange, host: instance?.Session.Connection.Endpoint.HostName));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, exchange: exchange, host: instance.Session?.Connection?.Endpoint?.HostName));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IAmqpTcpEndpoint.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IAmqpTcpEndpoint.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
@@ -17,5 +19,5 @@ internal struct IAmqpTcpEndpoint
     /// Gets the hostname of this AmqpTcpEndpoint.
     /// </summary>
     [Duck]
-    public string HostName;
+    public string? HostName;
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicGetResult.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicGetResult.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
     /// <summary>
@@ -13,7 +15,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <summary>
         /// Gets the message body of the result
         /// </summary>
-        IBody Body { get; }
+        IBody? Body { get; }
 
         /// <summary>
         /// Gets the message properties

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBasicProperties.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
@@ -16,7 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// Gets or sets the headers of the message
         /// </summary>
         /// <returns>Message headers</returns>
-        IDictionary<string, object> Headers { get; set; }
+        IDictionary<string, object>? Headers { get; set; }
 
         /// <summary>
         /// Gets the delivery mode of the message

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBody.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IBody.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
 {
     /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IConnection.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IConnection.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
@@ -17,5 +19,5 @@ internal struct IConnection
     /// Gets the endpoint
     /// </summary>
     [Duck]
-    public IAmqpTcpEndpoint Endpoint;
+    public IAmqpTcpEndpoint? Endpoint;
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IConsumer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IConsumer.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
@@ -17,5 +19,5 @@ internal struct IConsumer
     /// Gets the model.
     /// </summary>
     [Duck]
-    public IModelBase Model;
+    public IModelBase? Model;
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IModelBase.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/IModelBase.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
@@ -16,5 +18,5 @@ internal interface IModelBase : IDuckType
     /// Gets the session associated to this model
     /// </summary>
     [Duck]
-    public ISession Session { get; }
+    public ISession? Session { get; }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ISession.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/ISession.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.DuckTyping;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
@@ -17,5 +19,5 @@ internal struct ISession
     /// Gets the connection.
     /// </summary>
     [Duck]
-    public IConnection Connection;
+    public IConnection? Connection;
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueBindIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -38,10 +40,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="routingKey">The original routingKey argument.</param>
         /// <param name="arguments">The original arguments setting</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, string exchange, string routingKey, IDictionary<string, object> arguments)
+        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string? queue, string? exchange, string? routingKey, IDictionary<string, object>? arguments)
             where TTarget : IModelBase
         {
-            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey, host: instance?.Session.Connection.Endpoint.HostName));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, exchange: exchange, routingKey: routingKey, host: instance?.Session?.Connection?.Endpoint?.HostName));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/QueueDeclareIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -41,10 +43,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         /// <param name="nowait">The original nowait setting</param>
         /// <param name="arguments">The original arguments setting</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object> arguments)
+        internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, string? queue, bool passive, bool durable, bool exclusive, bool autoDelete, bool nowait, IDictionary<string, object>? arguments)
             where TTarget : IModelBase
         {
-            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, host: instance?.Session.Connection.Endpoint.HostName));
+            return new CallTargetState(RabbitMQIntegration.CreateScope(Tracer.Instance, out _, Command, SpanKinds.Client, queue: queue, host: instance?.Session?.Connection?.Endpoint?.HostName));
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQIntegration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -30,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.RabbitMQ;
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RabbitMQIntegration));
 
-        internal static Scope CreateScope(Tracer tracer, out RabbitMQTags tags, string command, string spanKind, string host = null, ISpanContext parentContext = null, DateTimeOffset? startTime = null, string queue = null, string exchange = null, string routingKey = null)
+        internal static Scope? CreateScope(Tracer tracer, out RabbitMQTags? tags, string command, string spanKind, string? host = null, ISpanContext? parentContext = null, DateTimeOffset? startTime = null, string? queue = null, string? exchange = null, string? routingKey = null)
         {
             tags = null;
 
@@ -40,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 return null;
             }
 
-            Scope scope = null;
+            Scope? scope = null;
 
             try
             {
@@ -90,7 +92,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             };
         }
 
-        internal static long GetHeadersSize(IDictionary<string, object> headers)
+        internal static long GetHeadersSize(IDictionary<string, object>? headers)
         {
             if (headers == null)
             {
@@ -107,7 +109,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             return size;
         }
 
-        internal static void SetDataStreamsCheckpointOnProduce(Tracer tracer, Span span, RabbitMQTags tags, IDictionary<string, object> headers, int messageSize)
+        internal static void SetDataStreamsCheckpointOnProduce(Tracer tracer, Span span, RabbitMQTags tags, IDictionary<string, object>? headers, int messageSize)
         {
             var dataStreamsManager = tracer.TracerManager.DataStreamsManager;
             if (dataStreamsManager == null || headers == null || !dataStreamsManager.IsEnabled)
@@ -131,7 +133,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             }
         }
 
-        internal static void SetDataStreamsCheckpointOnConsume(Tracer tracer, Span span, RabbitMQTags tags, IDictionary<string, object> headers, int messageSize, long messageTimestamp)
+        internal static void SetDataStreamsCheckpointOnConsume(Tracer tracer, Span span, RabbitMQTags tags, IDictionary<string, object>? headers, int messageSize, long messageTimestamp)
         {
             var dataStreamsManager = tracer.TracerManager.DataStreamsManager;
             if (dataStreamsManager == null || headers == null || !dataStreamsManager.IsEnabled)
@@ -158,9 +160,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
             }
         }
 
-        internal static CallTargetState BasicDeliver_OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, string consumerTag, ulong deliveryTag, bool redelivered, string exchange, string routingKey, TBasicProperties basicProperties, TBody body)
+        internal static CallTargetState BasicDeliver_OnMethodBegin<TTarget, TBasicProperties, TBody>(TTarget instance, ulong deliveryTag, bool redelivered, string? exchange, string? routingKey, TBasicProperties basicProperties, TBody body)
             where TBasicProperties : IBasicProperties
-            where TBody : IBody // ReadOnlyMemory<byte> body in 6.0.0
+            where TBody : IBody, IDuckType // ReadOnlyMemory<byte> body in 6.0.0
         {
             if (IsActiveScopeRabbitMQ(Tracer.Instance))
             {
@@ -170,14 +172,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 return CallTargetState.GetDefault();
             }
 
-            string queue = null;
+            string? queue = null;
 
-            if (QueueHelper.TryGetQueue(instance, out var queueInner))
+            // instance can't be null because these are called from instance methods
+            if (QueueHelper.TryGetQueue(instance!, out var queueInner))
             {
                 queue = queueInner;
             }
 
-            SpanContext propagatedContext = null;
+            SpanContext? propagatedContext = null;
 
             // try to extract propagated context values from headers
             if (basicProperties?.Headers != null)
@@ -192,24 +195,31 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ
                 }
             }
 
-            var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out RabbitMQTags tags, "basic.deliver", parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, exchange: exchange, routingKey: routingKey);
+            var scope = RabbitMQIntegration.CreateScope(Tracer.Instance, out var tags, "basic.deliver", parentContext: propagatedContext, spanKind: SpanKinds.Consumer, queue: queue, exchange: exchange, routingKey: routingKey);
             if (tags != null)
             {
-                tags.MessageSize = body?.Length.ToString() ?? "0";
+                if (body.Instance is not null)
+                {
+                    tags.MessageSize = body.Length.ToString() ?? "0";
+                }
+
+                if (scope is not null)
+                {
+                    var timeInQueue = basicProperties != null && basicProperties.Timestamp.UnixTime != 0 ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - basicProperties.Timestamp.UnixTime : 0;
+                    RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(
+                        Tracer.Instance,
+                        scope.Span,
+                        tags,
+                        basicProperties?.Headers,
+                        body?.Length ?? 0,
+                        timeInQueue);
+                }
             }
 
-            var timeInQueue = basicProperties != null && basicProperties.Timestamp.UnixTime != 0 ? DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - basicProperties.Timestamp.UnixTime : 0;
-            RabbitMQIntegration.SetDataStreamsCheckpointOnConsume(
-                Tracer.Instance,
-                scope.Span,
-                tags,
-                basicProperties?.Headers,
-                body?.Length ?? 0,
-                timeInQueue);
             return new CallTargetState(scope);
         }
 
-        internal static bool IsActiveScopeRabbitMQ(Tracer tracer)
+        private static bool IsActiveScopeRabbitMQ(Tracer tracer)
         {
             var scope = tracer.InternalActiveScope;
             var parent = scope?.Span;


### PR DESCRIPTION
## Summary of changes

Fix the null checks in the RabbitMq  integration

## Reason for change

We know we're getting some `NullReferenceException` in the RabbitMq integration

## Implementation details

Sprinkle some `#nullable enable` and watch the errors shout. Duck-typing null issues were the culprit again. There's a lot of potentially dubious nullability in the duck types in this one, so tried to be conservative, but will do a thorough test on this one too.

## Test coverage

Covered by existing tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
