### PR TITLE
[Tests] Ignore UDS telemetry test on windows

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -197,13 +197,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [InlineData(false)]
         public async Task WhenUsingUdsAgent_UsesUdsTelemetry(bool? enableDependencies)
         {
+            if (EnvironmentTools.IsWindows())
+            {
+                throw new SkipException("Trace agent doesn't support UDS on Windows, so this test isn't needed, even though it works (but is slightly flaky)");
+            }
+
             EnvironmentHelper.EnableUnixDomainSockets();
             EnableDependencies(enableDependencies);
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 


### PR DESCRIPTION
## Summary of changes

Skip UDS test telemetry test on windows

## Reason for change

UDS isn't supported by the trace agent so it's not worth the hassle to fix this flaky test (happened twice last week)

## Implementation details

Just skipped the test on windows.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
