### PR TITLE
Handle exception in MSMQ integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/IMessageQueue.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/IMessageQueue.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
 {
     /// <summary>
@@ -36,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         ///   T:System.ArgumentException:
         ///     The machine name is not valid, possibly because the syntax is not valid.
         /// </summary>
-        string MachineName { get; }
+        string? MachineName { get; }
 
         /// <summary>
         ///     Gets the queue's path. Setting the System.Messaging.MessageQueue.Path
@@ -51,6 +53,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         ///   T:System.ArgumentException:
         ///     The path is not valid, possibly because the syntax is not valid.
         /// </summary>
-        string Path { get; }
+        string? Path { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_Purge_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_Purge_Integration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -35,6 +37,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         internal static CallTargetState OnMethodBegin<TMessageQueue>(TMessageQueue instance)
             where TMessageQueue : IMessageQueue
         {
+            // Given this is an instance method, it's safe to assume instance.Instance is not null
             var scope = MsmqCommon.CreateScope(Tracer.Instance, Command, SpanKinds.Client, instance);
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_ReceiveCurrent_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_ReceiveCurrent_Integration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -43,6 +45,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         internal static CallTargetState OnMethodBegin<TMessageQueue>(TMessageQueue instance, TimeSpan timeout, int action, object cursorHandle, object messagePropertyFilter, object messageQueueTransaction, MessageQueueTransactionType messageQueueTransactionType)
             where TMessageQueue : IMessageQueue
         {
+            // Given this is an instance method, it's safe to assume instance.Instance is not null
             var scope = MsmqCommon.CreateScope(Tracer.Instance, action != 0 ? CommandPeek : CommandReceive, SpanKinds.Consumer, instance);
             return new CallTargetState(scope);
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_SendInternal_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MessageQueue_SendInternal_Integration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -36,9 +38,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
         /// <param name="messageQueueTransaction">Message queue transaction can be null</param>
         /// <param name="messageQueueTransactionType">Message queue transaction type can be null</param>
         /// <returns>Calltarget state value</returns>
-        internal static CallTargetState OnMethodBegin<TMessageQueue>(TMessageQueue instance, object message, object messageQueueTransaction, MessageQueueTransactionType messageQueueTransactionType)
+        internal static CallTargetState OnMethodBegin<TMessageQueue>(TMessageQueue instance, object? message, object? messageQueueTransaction, MessageQueueTransactionType messageQueueTransactionType)
             where TMessageQueue : IMessageQueue
         {
+            // Given this is an instance method, it's safe to assume instance.Instance is not null
             var scope = MsmqCommon.CreateScope(Tracer.Instance, Command, SpanKinds.Producer, instance, messageQueueTransaction != null || messageQueueTransactionType != MessageQueueTransactionType.None);
             return new CallTargetState(scope);
         }


### PR DESCRIPTION
## Summary of changes

- Handles a case where spans are not being created in some cases for MSMQ
- Adds some nullability checks

## Reason for change

MSMQ is something special. The `bool MessageQueue.Transactional` property [can apparently throw an exception](https://learn.microsoft.com/en-us/dotnet/api/system.messaging.messagequeue.transactional?view=netframework-4.8.1) in some low-permission scenarios. When that happens, we currently don't generate any spans.

## Implementation details

Just wrapped the tag creation in a try-catch. It's _possible_ we would be able to work around the issue entirely by diving into the internals, but there's not an obvious route to go, it _potentially_ would count as a security bypass, and no-ones clamoring for it, so this is the safest option IMO.

## Test coverage

Covered by existing integration tests, small enough change I don't think it warrants anything else

## Other details

Nullability updates were just for completeness, I didn't find any null ref issues

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
