### PR TITLE
[ASM] Downgrade middleware log if no current span found

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
@@ -105,7 +105,7 @@ internal class BlockingMiddleware
             }
             else
             {
-                Log.Error("No span available, can't check the request");
+                Log.Debug("No span available, can't check the request");
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
@@ -134,7 +134,7 @@ internal class BlockingMiddleware
                     }
                     else
                     {
-                        Log.Error("No span available, can't report the request");
+                        Log.Debug("No span available, can't report the request");
                     }
                 }
             }


### PR DESCRIPTION
## Summary of changes

It's not an error as it can happen if the aspnetcore integration has been disabled for example.
To fix later: maybe create a span, in case there's none or just run security checks at least to ensure protection

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
