### PR TITLE
Fix bugs with DogStatsD when using named pipes or UDS

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -296,10 +296,8 @@ namespace Datadog.Trace
                 switch (settings.ExporterInternal.MetricsTransport)
                 {
                     case MetricsTransportType.NamedPipe:
-                        // Environment variables for windows named pipes are not explicitly passed to statsd.
-                        // They are retrieved within the vendored code, so there is nothing to pass.
-                        // Passing anything through StatsdConfig may cause bugs when windows named pipes should be used.
                         Log.Information("Using windows named pipes for metrics transport.");
+                        config.PipeName = settings.ExporterInternal.MetricsPipeNameInternal;
                         break;
 #if NETCOREAPP3_1_OR_GREATER
                     case MetricsTransportType.UDS:

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -307,7 +307,13 @@ namespace Datadog.Trace
 #endif
                     case MetricsTransportType.UDP:
                     default:
-                        config.StatsdServerName = settings.ExporterInternal.AgentUriInternal.DnsSafeHost;
+                        // If the customer has enabled UDS traces but _not_ UDS metrics, then the AgentUri will have
+                        // the UDS path set for it, and the DnsSafeHost returns "". Ideally, we would expose
+                        // a TracesAgentUri and MetricsAgentUri or something like that instead. This workaround
+                        // is a horrible hack, but I can't bear to touch ExporterSettings until it's had an
+                        // extensive tidy up, so this should do for now
+                        var traceHostname = settings.ExporterInternal.AgentUriInternal.DnsSafeHost;
+                        config.StatsdServerName = string.IsNullOrEmpty(traceHostname) ? "127.0.0.1" : traceHostname;
                         config.StatsdPort = settings.ExporterInternal.DogStatsdPortInternal;
                         break;
                 }

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentRestorerAttribute.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentRestorerAttribute.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="EnvironmentRestorerAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Datadog.Trace.TestHelpers;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class EnvironmentRestorerAttribute : BeforeAfterTestAttribute
+{
+    private readonly string[] _variables;
+    private readonly Dictionary<string, string> _originalVariables;
+
+    public EnvironmentRestorerAttribute(params string[] args)
+    {
+        _variables = args;
+        _originalVariables = new(args.Length);
+    }
+
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        foreach (var variable in _variables)
+        {
+            _originalVariables[variable] = Environment.GetEnvironmentVariable(variable);
+            // clear variable
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+
+        base.Before(methodUnderTest);
+    }
+
+    public override void After(MethodInfo methodUnderTest)
+    {
+        foreach (var variable in _originalVariables)
+        {
+            Environment.SetEnvironmentVariable(variable.Key, variable.Value);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -110,13 +110,15 @@ namespace Datadog.Trace.Tests
             */
         }
 
-        [Theory]
+        [SkippableTheory]
         [InlineData(null, null, null)] // Should default to udp
         [InlineData("http://127.0.0.1:1234", null, null)]
         [InlineData(null, "127.0.0.1", null)]
         [InlineData(null, "127.0.0.1", "1234")]
         public void CanCreateDogStatsD_UDP_FromTraceAgentSettings(string agentUri, string agentHost, string port)
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
             var settings = new TracerSettings(new NameValueConfigurationSource(new()
             {
                 { ConfigurationKeys.AgentUri, agentUri },
@@ -139,9 +141,12 @@ namespace Datadog.Trace.Tests
                      .And.BeOfType<DogStatsdService>();
         }
 
-        [Fact]
+        [SkippableFact]
         public void CanCreateDogStatsD_NamedPipes_FromTraceAgentSettings()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+            SkipOn.Platform(SkipOn.PlatformValue.Linux);
+
             using var agent = MockTracerAgent.Create(_output, new WindowsPipesConfig($"trace-{Guid.NewGuid()}", $"metrics-{Guid.NewGuid()}") { UseDogstatsD = true });
 
             var settings = new TracerSettings(new NameValueConfigurationSource(new()

--- a/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -167,6 +167,7 @@ namespace Datadog.Trace.Tests
         {
             // UDP Datagrams over UDP are not supported on Windows
             SkipOn.Platform(SkipOn.PlatformValue.Windows);
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
 
             var tracesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             var metricsPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -193,6 +194,8 @@ namespace Datadog.Trace.Tests
         [SkippableFact]
         public void CanCreateDogStatsD_UDS_FallsBackToUdp_FromTraceAgentSettings()
         {
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
             var tracesPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
             using var udsAgent = MockTracerAgent.Create(_output, new UnixDomainSocketConfig(tracesPath, null) { UseDogstatsD = false });
             using var udpAgent = MockTracerAgent.Create(_output, useStatsd: true);


### PR DESCRIPTION
## Summary of changes

- Explicitly pass in the calculated pipename to StatsD when using named pipes
- Correctly fallback when using UDS for traces and UDP for metrics
- Add tests for `StatsDService` creation

## Reason for change

If there's no `PipeName` set, no `ServerName` set, and no environment variables set, StatsD throws an `ArgumentNullException`

Similarly, if `DD_TRACE_AGENT_URL` is set to a `unix://` path, and the metrics socket is not in the default location, stats falls back to UDP, but we then currently fail to create the StatsDService.

## Implementation details

- Explicitly pass the named pipe through the config.
- Add workaround for UDS/UDP combo by checking for an empty host
- Added an `[EnvironmentRestorer]` attribute for use in testing to make it easier to clear and restore env vars

## Test coverage

Happy path is already covered by named pipe tests - the specific error is hard to reproduce with current infrastructure.

For the UDS/UDP combo, reproduced in unit tests, which are now passing after the fix

## Other details

These errors may well be coming from lib-injection which appears to use `/opt/datadog/apm/inject/run/dsd.socket` for metrics rather than the expected `/var/run/datadog/dsd.socket`

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
