### PR TITLE
Tiny cleanup of static `Tracer` instance usages

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -61,8 +61,9 @@ namespace Datadog.Trace.Activity
             }
 
             // Fixup "version" tag
-            if (Tracer.Instance.Settings.ServiceVersionInternal is null
-                && span.GetTag("service.version") is { Length: > 1 } otelServiceVersion)
+            var tracer = span.Context.TraceContext.Tracer;
+            if (tracer.Settings.ServiceVersionInternal is null
+             && span.GetTag("service.version") is { Length: > 1 } otelServiceVersion)
             {
                 span.SetTag(Tags.Version, otelServiceVersion);
             }
@@ -96,7 +97,7 @@ namespace Datadog.Trace.Activity
 
             // Later: Support config 'span_name_as_resource_name'
             // Later: Support config 'span_name_remappings'
-            if (Tracer.Instance.Settings.OpenTelemetryLegacyOperationNameEnabled && activity5 is not null && string.IsNullOrEmpty(span.OperationName))
+            if (tracer.Settings.OpenTelemetryLegacyOperationNameEnabled && activity5 is not null && string.IsNullOrEmpty(span.OperationName))
             {
                 span.OperationName = activity5.Source.Name switch
                 {

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -26,8 +26,6 @@ namespace Datadog.Trace.Activity
         internal static void UpdateSpanFromActivity<TInner>(TInner activity, Span span)
             where TInner : IActivity
         {
-            var activity5 = activity as IActivity5;
-
             AgentConvertSpan(activity, span);
         }
 
@@ -61,7 +59,8 @@ namespace Datadog.Trace.Activity
             }
 
             // Fixup "version" tag
-            var tracer = span.Context.TraceContext.Tracer;
+            // Fallback to static instance if no tracer associated with the trace
+            var tracer = span.Context.TraceContext?.Tracer ?? Tracer.Instance;
             if (tracer.Settings.ServiceVersionInternal is null
              && span.GetTag("service.version") is { Length: > 1 } otelServiceVersion)
             {

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -38,6 +38,11 @@ namespace Datadog.Trace.ExtensionMethods
         public static void SetTraceSamplingPriority(this ISpan span, SamplingPriority samplingPriority)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanExtensions_SetTraceSamplingPriority);
+            SetTraceSamplingPriorityInternal(span, samplingPriority);
+        }
+
+        internal static void SetTraceSamplingPriorityInternal(this ISpan span, SamplingPriority samplingPriority)
+        {
             if (span == null) { ThrowHelper.ThrowArgumentNullException(nameof(span)); }
 
             if (span.Context is SpanContext { TraceContext: { } traceContext })

--- a/tracer/src/Datadog.Trace/SpanContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/SpanContextExtractor.cs
@@ -31,11 +31,21 @@ namespace Datadog.Trace
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextExtractor_Ctor);
         }
 
+        internal SpanContextExtractor(bool unusedParamNotToUsePublicApi)
+        {
+            // unused parameter is to give us a non-public API we can use
+        }
+
         /// <inheritdoc />
         [PublicApi]
         public ISpanContext? Extract<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextExtractor_Extract);
+            return ExtractInternal(carrier, getter);
+        }
+
+        internal static ISpanContext? ExtractInternal<TCarrier>(TCarrier carrier, Func<TCarrier, string, IEnumerable<string?>> getter)
+        {
             var spanContext = SpanContextPropagator.Instance.Extract(carrier, getter);
             if (spanContext is not null
              && Tracer.Instance.TracerManager.DataStreamsManager is { IsEnabled: true } dsm

--- a/tracer/src/Datadog.Trace/SpanContextInjector.cs
+++ b/tracer/src/Datadog.Trace/SpanContextInjector.cs
@@ -45,7 +45,11 @@ namespace Datadog.Trace
         public void Inject<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext context)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanContextInjector_Inject);
+            InjectInternal(carrier, setter, context);
+        }
 
+        internal static void InjectInternal<TCarrier>(TCarrier carrier, Action<TCarrier, string, string> setter, ISpanContext context)
+        {
             if (context is SpanContext spanContext)
             {
                 SpanContextPropagator.Instance.Inject(spanContext, carrier, setter);

--- a/tracer/src/Datadog.Trace/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.cs
@@ -31,7 +31,11 @@ namespace Datadog.Trace
         public static void SetUser(this ISpan span, UserDetails userDetails)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanExtensions_SetUser);
+            SetUserInternal(span, userDetails);
+        }
 
+        internal static void SetUserInternal(this ISpan span, UserDetails userDetails)
+        {
             if (span is null)
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(span));
@@ -96,7 +100,11 @@ namespace Datadog.Trace
         public static ISpan SetTag(this ISpan span, string key, double? value)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.SpanExtensions_SetTag);
+            return span.SetTagInternal(key, value);
+        }
 
+        internal static ISpan SetTagInternal(this ISpan span, string key, double? value)
+        {
             if (span is null)
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(span));

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetrySpecialTagRemapperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetrySpecialTagRemapperTests.cs
@@ -7,6 +7,9 @@ using System;
 using System.Collections.Generic;
 using Datadog.Trace.Activity;
 using Datadog.Trace.Activity.DuckTypes;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Sampling;
 using Moq;
 using Xunit;
 
@@ -15,6 +18,17 @@ namespace Datadog.Trace.Tests
     [Collection(nameof(OpenTelemetrySpecialTagRemapperTests))]
     public class OpenTelemetrySpecialTagRemapperTests
     {
+        private readonly Tracer _tracer;
+
+        public OpenTelemetrySpecialTagRemapperTests()
+        {
+            var settings = new TracerSettings();
+            var writerMock = new Mock<IAgentWriter>();
+            var samplerMock = new Mock<ITraceSampler>();
+
+            _tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);
+        }
+
         [Fact]
         public void OperationName_Tag_Should_Override_OperationName()
         {
@@ -25,11 +39,13 @@ namespace Datadog.Trace.Tests
             var tagObjects = new Dictionary<string, object>
             {
                 { "http.request.method", "GET" },
-                { "operation.name", expected }
+                { "operation.name", inputValue }
             };
             activityMock.Setup(x => x.TagObjects).Returns(tagObjects);
 
-            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow);
+            var spanContext = _tracer.CreateSpanContext(parent: null, serviceName: null, traceId: new TraceId(0, 1), spanId: 1);
+            var span = new Span(spanContext, DateTimeOffset.UtcNow);
+            using var scope = new Scope(parent: null, span, new AsyncLocalScopeManager(), finishOnClose: true);
             OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span);
 
             Assert.Equal(expected, span.OperationName);
@@ -48,7 +64,9 @@ namespace Datadog.Trace.Tests
             };
             activityMock.Setup(x => x.TagObjects).Returns(tagObjects);
 
-            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow);
+            var spanContext = _tracer.CreateSpanContext(parent: null, serviceName: null, traceId: new TraceId(0, 1), spanId: 1);
+            var span = new Span(spanContext, DateTimeOffset.UtcNow);
+            using var scope = new Scope(parent: null, span, new AsyncLocalScopeManager(), finishOnClose: true);
             OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span);
 
             Assert.Equal(expected, span.ResourceName);
@@ -67,7 +85,9 @@ namespace Datadog.Trace.Tests
             };
             activityMock.Setup(x => x.TagObjects).Returns(tagObjects);
 
-            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow);
+            var spanContext = _tracer.CreateSpanContext(parent: null, serviceName: null, traceId: new TraceId(0, 1), spanId: 1);
+            var span = new Span(spanContext, DateTimeOffset.UtcNow);
+            using var scope = new Scope(parent: null, span, new AsyncLocalScopeManager(), finishOnClose: true);
             OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span);
 
             Assert.Equal(expected, span.ServiceName);
@@ -86,7 +106,9 @@ namespace Datadog.Trace.Tests
             };
             activityMock.Setup(x => x.TagObjects).Returns(tagObjects);
 
-            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow);
+            var spanContext = _tracer.CreateSpanContext(parent: null, serviceName: null, traceId: new TraceId(0, 1), spanId: 1);
+            var span = new Span(spanContext, DateTimeOffset.UtcNow);
+            using var scope = new Scope(parent: null, span, new AsyncLocalScopeManager(), finishOnClose: true);
             OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span);
 
             Assert.Equal(expected, span.Type);
@@ -106,7 +128,9 @@ namespace Datadog.Trace.Tests
             };
             activityMock.Setup(x => x.TagObjects).Returns(tagObjects);
 
-            var span = new Span(new SpanContext(1, 1), DateTimeOffset.UtcNow);
+            var spanContext = _tracer.CreateSpanContext(parent: null, serviceName: null, traceId: new TraceId(0, 1), spanId: 1);
+            var span = new Span(spanContext, DateTimeOffset.UtcNow);
+            using var scope = new Scope(parent: null, span, new AsyncLocalScopeManager(), finishOnClose: true);
             OtlpHelpers.UpdateSpanFromActivity(activityMock.Object, span);
 
             Assert.Equal(expected, span.GetMetric(Tags.Analytics));


### PR DESCRIPTION
## Summary of changes

- Use the static `Tracer` instance associated with a span in `OtelHelpers`
- Create some "internal" versions of methods that we need for the initial implementation of v3

## Reason for change

While tracking down flakiness in a manual instrumentation sample I'm working on, I noticed that we're accessing the global tracer version. _Technically_ that may have different settings than the tracer used to create the span, and we should use that instead AFAIK.

The "internal" methods are just to make it easier to incrementally work on the v3-public-api changes. Moving those changes here will reduce the footprint of the v3 PRs when they land.

## Implementation details

We expose the tracer instance that created the span at `Span.Context.TracerContext.Tracer`.

The other changes are just creating "internal" versions of methods

## Test coverage

Should be covered by existing.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
