### PR TITLE
Add manual+automatic instrumentation tests + fix `SetUser` bug

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -557,6 +557,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Amazon.Lambda.Runti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Remoting", "tracer\test\test-applications\integrations\Samples.Remoting\Samples.Remoting.csproj", "{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.ManualInstrumentation", "tracer\test\test-applications\integrations\Samples.ManualInstrumentation\Samples.ManualInstrumentation.csproj", "{F24EB026-65FB-4247-ABF8-942B11ADAB64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1329,6 +1331,10 @@ Global
 		{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F24EB026-65FB-4247-ABF8-942B11ADAB64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F24EB026-65FB-4247-ABF8-942B11ADAB64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F24EB026-65FB-4247-ABF8-942B11ADAB64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F24EB026-65FB-4247-ABF8-942B11ADAB64}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1545,6 +1551,7 @@ Global
 		{4E9535E2-C918-4C39-9F1B-F182C185DE64} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 		{18A6904A-5AFD-4816-AC3F-9F5E433720B5} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{23EA38E3-0BF1-40DF-A52D-C34EA2FB3F26} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{F24EB026-65FB-4247-ABF8-942B11ADAB64} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/src/Datadog.Trace/AspNetCoreAvailabilityChecker.cs
+++ b/tracer/src/Datadog.Trace/AspNetCoreAvailabilityChecker.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="AspNetCoreAvailabilityChecker.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETFRAMEWORK
+
+using System;
+
+namespace Datadog.Trace;
+
+internal static class AspNetCoreAvailabilityChecker
+{
+    private static readonly Lazy<bool> IsAvailable = new(CheckForRequiredTypes);
+
+    private static bool CheckForRequiredTypes()
+    {
+        try
+        {
+            // Try to load the HttpContext type
+            // Assumes that this is only called when we would expect the type to
+            // already be loaded, for example inside an ASP.NET Core request.
+            // As this is only checked _once_, it assumes the customer doesn't call
+            // this API both _before_ ASP.NET Core types are loaded _and_ afterwards.
+            var httpContextType = Type.GetType("Microsoft.AspNetCore.Http.HttpContext, Microsoft.AspNetCore.Http.Abstractions", throwOnError: false);
+            return httpContextType is not null;
+        }
+        catch
+        {
+            // Problem loading the type, so assume we're not in aspnetcore
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Should be called when ASP.NET Core is expected to be loaded,
+    /// and checks if ASP.NET Core types are available
+    /// </summary>
+    public static bool IsAspNetCoreAvailable() => IsAvailable.Value;
+}
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="ManualInstrumentationTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using VerifyXunit;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests;
+
+[UsesVerify]
+public class ManualInstrumentationTests : TestHelper
+{
+    public ManualInstrumentationTests(ITestOutputHelper output)
+        : base("ManualInstrumentation", output)
+    {
+    }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task ManualAndAutomatic()
+    {
+        const int expectedSpans = 36;
+        using var telemetry = this.ConfigureTelemetry();
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var assert = new AssertionScope();
+        using var process = RunSampleAndWaitForExit(agent);
+
+        var spans = agent.WaitForSpans(expectedSpans);
+        spans.Should().HaveCount(expectedSpans);
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+
+        await VerifyHelper.VerifySpans(spans, settings);
+    }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task ManualOnly()
+    {
+        EnvironmentHelper.SetAutomaticInstrumentation(false);
+        const int expectedSpans = 29;
+        using var telemetry = this.ConfigureTelemetry();
+        using var agent = EnvironmentHelper.GetMockAgent();
+        using var assert = new AssertionScope();
+        using var process = RunSampleAndWaitForExit(agent);
+
+        var spans = agent.WaitForSpans(expectedSpans);
+        spans.Should().HaveCount(expectedSpans);
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+
+        await VerifyHelper.VerifySpans(spans, settings);
+    }
+}

--- a/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
@@ -1,0 +1,751 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Manual-1.Initial,
+    Resource: Manual-1.Initial,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: Manual-1.Initial.HttpClient,
+    Resource: Manual-1.Initial.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.ManualInstrumentation-http-client,
+    Type: http,
+    ParentId: Id_3,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/?q=1.Initial,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_5,
+    SpanId: Id_6,
+    Name: Manual-1.Initial.HttpListener,
+    Resource: Manual-1.Initial.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_8,
+    Name: Manual-2.Reconfigured,
+    Resource: Manual-2.Reconfigured,
+    Service: updated-name,
+    Tags: {
+      env: updated-env,
+      language: dotnet,
+      runtime-id: Guid_1,
+      Updated-key: Updated Value,
+      version: updated-version,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_9,
+    Name: Manual-2.Reconfigured.HttpClient,
+    Resource: Manual-2.Reconfigured.HttpClient,
+    Service: updated-name,
+    ParentId: Id_8,
+    Tags: {
+      env: updated-env,
+      language: dotnet,
+      Updated-key: Updated Value,
+      version: updated-version,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_7,
+    SpanId: Id_10,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: updated-name-http-client,
+    Type: http,
+    ParentId: Id_9,
+    Tags: {
+      component: HttpMessageHandler,
+      env: updated-env,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/?q=2.Reconfigured,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      Updated-key: Updated Value,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_11,
+    SpanId: Id_12,
+    Name: Manual-2.Reconfigured.HttpListener,
+    Resource: Manual-2.Reconfigured.HttpListener,
+    Service: updated-name,
+    Tags: {
+      content: PONG,
+      env: updated-env,
+      language: dotnet,
+      runtime-id: Guid_1,
+      Updated-key: Updated Value,
+      version: updated-version,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_13,
+    SpanId: Id_14,
+    Name: Manual-3.HttpDisabled,
+    Resource: Manual-3.HttpDisabled,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_13,
+    SpanId: Id_15,
+    Name: Manual-3.HttpDisabled.HttpClient,
+    Resource: Manual-3.HttpDisabled.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_14,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_16,
+    SpanId: Id_17,
+    Name: Manual-3.HttpDisabled.HttpListener,
+    Resource: Manual-3.HttpDisabled.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_18,
+    SpanId: Id_19,
+    Name: Manual-4.DefaultsReinstated,
+    Resource: Manual-4.DefaultsReinstated,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_18,
+    SpanId: Id_20,
+    Name: Manual-4.DefaultsReinstated.HttpClient,
+    Resource: Manual-4.DefaultsReinstated.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_19,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_18,
+    SpanId: Id_21,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.ManualInstrumentation-http-client,
+    Type: http,
+    ParentId: Id_20,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/?q=4.DefaultsReinstated,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_22,
+    SpanId: Id_23,
+    Name: Manual-4.DefaultsReinstated.HttpListener,
+    Resource: Manual-4.DefaultsReinstated.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_24,
+    SpanId: Id_25,
+    Name: Manual-5.Ext.HttpListener,
+    Resource: Manual-5.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_26,
+    SpanId: Id_27,
+    Name: Manual-5.Ext.Outer,
+    Resource: Manual-5.Ext.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      usr.email: test@example.com,
+      usr.id: my-id,
+      usr.name: Bits,
+      usr.role: Mascot,
+      usr.scope: test-scope,
+      usr.session_id: abc123,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  },
+  {
+    TraceId: Id_26,
+    SpanId: Id_28,
+    Name: Manual-5.Ext.Inner,
+    Resource: Manual-5.Ext.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_27,
+    Error: 1,
+    Tags: {
+      Custom: Some-Value,
+      env: integration_tests,
+      error.msg: Exception of type 'CustomException' was thrown.,
+      error.stack:
+CustomException: Exception of type 'CustomException' was thrown.
+,
+      error.type: CustomException,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      Some-Number: 123.0
+    }
+  },
+  {
+    TraceId: Id_26,
+    SpanId: Id_29,
+    Name: Manual-5.Ext.HttpClient,
+    Resource: Manual-5.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_28,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_26,
+    SpanId: Id_30,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.ManualInstrumentation-http-client,
+    Type: http,
+    ParentId: Id_29,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/?q=5.Ext,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_32,
+    Name: Manual-6.EventSdk.Custom.Outer,
+    Resource: Manual-6.EventSdk.Custom.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      appsec.events.custom-event-meta.key-1: val-1,
+      appsec.events.custom-event-meta.key-2: val-2,
+      appsec.events.custom-event-meta.track: true,
+      appsec.events.custom-event.track: true,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.appsec.events.custom-event-meta.sdk: true,
+      _dd.appsec.events.custom-event.sdk: true,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_33,
+    Name: Manual-6.EventSdk.Custom.Inner,
+    Resource: Manual-6.EventSdk.Custom.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_32,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_34,
+    Name: Manual-6.Ext.HttpClient,
+    Resource: Manual-6.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_33,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_35,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.ManualInstrumentation-http-client,
+    Type: http,
+    ParentId: Id_34,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/?q=6.Ext,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_36,
+    SpanId: Id_37,
+    Name: Manual-6.Ext.HttpListener,
+    Resource: Manual-6.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_38,
+    SpanId: Id_39,
+    Name: Manual-7.EventSdk.Success.Outer,
+    Resource: Manual-7.EventSdk.Success.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      appsec.events.users.login.success.key-1: val-1,
+      appsec.events.users.login.success.key-2: val-2,
+      appsec.events.users.login.success.track: true,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      usr.id: my-id,
+      _dd.appsec.events.users.login.success.sdk: true,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_38,
+    SpanId: Id_40,
+    Name: Manual-7.EventSdk.Success.Inner,
+    Resource: Manual-7.EventSdk.Success.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_39,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_38,
+    SpanId: Id_41,
+    Name: Manual-7.Ext.HttpClient,
+    Resource: Manual-7.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_40,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_38,
+    SpanId: Id_42,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.ManualInstrumentation-http-client,
+    Type: http,
+    ParentId: Id_41,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/?q=7.Ext,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_43,
+    SpanId: Id_44,
+    Name: Manual-7.Ext.HttpListener,
+    Resource: Manual-7.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_46,
+    Name: Manual-8.EventSdk.Failure.Outer,
+    Resource: Manual-8.EventSdk.Failure.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      appsec.events.users.login.failure.key-1: val-1,
+      appsec.events.users.login.failure.key-2: val-2,
+      appsec.events.users.login.failure.track: true,
+      appsec.events.users.login.failure.usr.exists: true,
+      appsec.events.users.login.failure.usr.id: my-id,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.appsec.events.users.login.failure.sdk: true,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_47,
+    Name: Manual-8.EventSdk.Failure.Inner,
+    Resource: Manual-8.EventSdk.Failure.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_46,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_48,
+    Name: Manual-8.Ext.HttpClient,
+    Resource: Manual-8.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_47,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_49,
+    Name: http.request,
+    Resource: GET localhost:00000/?/,
+    Service: Samples.ManualInstrumentation-http-client,
+    Type: http,
+    ParentId: Id_48,
+    Tags: {
+      component: HttpMessageHandler,
+      env: integration_tests,
+      http-client-handler-type: System.Net.Http.HttpClientHandler,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Guid_2/?q=8.Ext,
+      out.host: localhost,
+      runtime-id: Guid_1,
+      span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_50,
+    SpanId: Id_51,
+    Name: Manual-8.Ext.HttpListener,
+    Resource: Manual-8.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_52,
+    SpanId: Id_53,
+    Name: Manual-9.CustomContext.HttpListener,
+    Resource: Manual-9.CustomContext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/ManualInstrumentationTests.ManualOnly.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ManualOnly.verified.txt
@@ -1,0 +1,573 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: Manual-1.Initial,
+    Resource: Manual-1.Initial,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: Manual-1.Initial.HttpClient,
+    Resource: Manual-1.Initial.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_4,
+    SpanId: Id_5,
+    Name: Manual-1.Initial.HttpListener,
+    Resource: Manual-1.Initial.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_6,
+    SpanId: Id_7,
+    Name: Manual-2.Reconfigured,
+    Resource: Manual-2.Reconfigured,
+    Service: updated-name,
+    Tags: {
+      env: updated-env,
+      language: dotnet,
+      runtime-id: Guid_1,
+      Updated-key: Updated Value,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_6,
+    SpanId: Id_8,
+    Name: Manual-2.Reconfigured.HttpClient,
+    Resource: Manual-2.Reconfigured.HttpClient,
+    Service: updated-name,
+    ParentId: Id_7,
+    Tags: {
+      env: updated-env,
+      language: dotnet,
+      Updated-key: Updated Value,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_9,
+    SpanId: Id_10,
+    Name: Manual-2.Reconfigured.HttpListener,
+    Resource: Manual-2.Reconfigured.HttpListener,
+    Service: updated-name,
+    Tags: {
+      content: PONG,
+      env: updated-env,
+      language: dotnet,
+      runtime-id: Guid_1,
+      Updated-key: Updated Value,
+      version: updated-version,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_11,
+    SpanId: Id_12,
+    Name: Manual-3.HttpDisabled,
+    Resource: Manual-3.HttpDisabled,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_11,
+    SpanId: Id_13,
+    Name: Manual-3.HttpDisabled.HttpClient,
+    Resource: Manual-3.HttpDisabled.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_12,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_14,
+    SpanId: Id_15,
+    Name: Manual-3.HttpDisabled.HttpListener,
+    Resource: Manual-3.HttpDisabled.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_16,
+    SpanId: Id_17,
+    Name: Manual-4.DefaultsReinstated,
+    Resource: Manual-4.DefaultsReinstated,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_16,
+    SpanId: Id_18,
+    Name: Manual-4.DefaultsReinstated.HttpClient,
+    Resource: Manual-4.DefaultsReinstated.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_17,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_19,
+    SpanId: Id_20,
+    Name: Manual-4.DefaultsReinstated.HttpListener,
+    Resource: Manual-4.DefaultsReinstated.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_21,
+    SpanId: Id_22,
+    Name: Manual-5.Ext.HttpListener,
+    Resource: Manual-5.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_24,
+    Name: Manual-5.Ext.Outer,
+    Resource: Manual-5.Ext.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      usr.email: test@example.com,
+      usr.id: my-id,
+      usr.name: Bits,
+      usr.role: Mascot,
+      usr.scope: test-scope,
+      usr.session_id: abc123,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_25,
+    Name: Manual-5.Ext.Inner,
+    Resource: Manual-5.Ext.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_24,
+    Error: 1,
+    Tags: {
+      Custom: Some-Value,
+      env: integration_tests,
+      error.msg: Exception of type 'CustomException' was thrown.,
+      error.stack:
+CustomException: Exception of type 'CustomException' was thrown.
+,
+      error.type: CustomException,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      Some-Number: 123.0
+    }
+  },
+  {
+    TraceId: Id_23,
+    SpanId: Id_26,
+    Name: Manual-5.Ext.HttpClient,
+    Resource: Manual-5.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_25,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_27,
+    SpanId: Id_28,
+    Name: Manual-6.EventSdk.Custom.Outer,
+    Resource: Manual-6.EventSdk.Custom.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      appsec.events.custom-event-meta.key-1: val-1,
+      appsec.events.custom-event-meta.key-2: val-2,
+      appsec.events.custom-event-meta.track: true,
+      appsec.events.custom-event.track: true,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.appsec.events.custom-event-meta.sdk: true,
+      _dd.appsec.events.custom-event.sdk: true,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_27,
+    SpanId: Id_29,
+    Name: Manual-6.EventSdk.Custom.Inner,
+    Resource: Manual-6.EventSdk.Custom.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_28,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_27,
+    SpanId: Id_30,
+    Name: Manual-6.Ext.HttpClient,
+    Resource: Manual-6.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_29,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_31,
+    SpanId: Id_32,
+    Name: Manual-6.Ext.HttpListener,
+    Resource: Manual-6.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_34,
+    Name: Manual-7.EventSdk.Success.Outer,
+    Resource: Manual-7.EventSdk.Success.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      appsec.events.users.login.success.key-1: val-1,
+      appsec.events.users.login.success.key-2: val-2,
+      appsec.events.users.login.success.track: true,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      usr.id: my-id,
+      _dd.appsec.events.users.login.success.sdk: true,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_35,
+    Name: Manual-7.EventSdk.Success.Inner,
+    Resource: Manual-7.EventSdk.Success.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_34,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_33,
+    SpanId: Id_36,
+    Name: Manual-7.Ext.HttpClient,
+    Resource: Manual-7.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_35,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_37,
+    SpanId: Id_38,
+    Name: Manual-7.Ext.HttpListener,
+    Resource: Manual-7.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_40,
+    Name: Manual-8.EventSdk.Failure.Outer,
+    Resource: Manual-8.EventSdk.Failure.Outer,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      appsec.events.users.login.failure.key-1: val-1,
+      appsec.events.users.login.failure.key-2: val-2,
+      appsec.events.users.login.failure.track: true,
+      appsec.events.users.login.failure.usr.exists: true,
+      appsec.events.users.login.failure.usr.id: my-id,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.appsec.events.users.login.failure.sdk: true,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_41,
+    Name: Manual-8.EventSdk.Failure.Inner,
+    Resource: Manual-8.EventSdk.Failure.Inner,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_40,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_39,
+    SpanId: Id_42,
+    Name: Manual-8.Ext.HttpClient,
+    Resource: Manual-8.Ext.HttpClient,
+    Service: Samples.ManualInstrumentation,
+    ParentId: Id_41,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    }
+  },
+  {
+    TraceId: Id_43,
+    SpanId: Id_44,
+    Name: Manual-8.Ext.HttpListener,
+    Resource: Manual-8.Ext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_45,
+    SpanId: Id_46,
+    Name: Manual-9.CustomContext.HttpListener,
+    Resource: Manual-9.CustomContext.HttpListener,
+    Service: Samples.ManualInstrumentation,
+    Tags: {
+      content: PONG,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.agent_psr: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/ManualInstrumentationTests.ManualOnly.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ManualOnly.verified.txt
@@ -67,6 +67,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       Updated-key: Updated Value,
+      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
@@ -89,6 +90,7 @@
       env: updated-env,
       language: dotnet,
       Updated-key: Updated Value,
+      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     }

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
@@ -29,6 +29,7 @@ using (Tracer.Instance.StartActive($"Manual-{++count}.Initial"))
 {
     await SendHttpRequest("Initial");
 }
+await Tracer.Instance.ForceFlushAsync();
 
 // Reconfigure the tracer
 var settings = TracerSettings.FromDefaultSources();
@@ -44,6 +45,7 @@ using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
 {
     await SendHttpRequest("Reconfigured");
 }
+await Tracer.Instance.ForceFlushAsync();
 
 // reconfigure with Http disabled
 settings = TracerSettings.FromDefaultSources();
@@ -65,6 +67,7 @@ using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
 {
     await SendHttpRequest("HttpDisabled");
 }
+await Tracer.Instance.ForceFlushAsync();
 
 // go back to the defaults
 Tracer.Configure(TracerSettings.FromDefaultSources());
@@ -73,6 +76,7 @@ using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
 {
     await SendHttpRequest("DefaultsReinstated");
 }
+await Tracer.Instance.ForceFlushAsync();
 
 // nested manual + extensions
 using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.ExtensionMethods;
+using Samples;
+
+var count = 0;
+var port = args.FirstOrDefault(arg => arg.StartsWith("Port="))?.Split('=')[1] ?? "9000";
+Console.WriteLine($"Port {port}");
+var server = WebServer.Start(port, out var url);
+var client = new HttpClient();
+server.RequestHandler = HandleHttpRequests;
+
+// Manually enable debug logs
+GlobalSettings.SetDebugEnabled(true);
+LogCurrentSettings(Tracer.Instance, "Initial");
+
+// Manual + automatic before reconfiguration
+using (Tracer.Instance.StartActive($"Manual-{++count}.Initial"))
+{
+    await SendHttpRequest("Initial");
+}
+
+// Reconfigure the tracer
+var settings = TracerSettings.FromDefaultSources();
+settings.ServiceName = "updated-name";
+settings.ServiceVersion = "updated-version";
+settings.Environment = "updated-env";
+settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
+Tracer.Configure(settings);
+LogCurrentSettings(Tracer.Instance, "Reconfigured");
+
+// Manual + automatic
+using (Tracer.Instance.StartActive($"Manual-{++count}.Reconfigured"))
+{
+    await SendHttpRequest("Reconfigured");
+}
+
+// reconfigure with Http disabled
+settings = TracerSettings.FromDefaultSources();
+// net core
+var httpIntegration = settings.Integrations["HttpMessageHandler"];
+httpIntegration.Enabled = false;
+httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+httpIntegration.AnalyticsSampleRate = 1.0;
+// net FX
+httpIntegration = settings.Integrations["WebRequest"];
+httpIntegration.Enabled = false;
+httpIntegration.AnalyticsEnabled = false; // just setting them because why not
+httpIntegration.AnalyticsSampleRate = 1.0;
+Tracer.Configure(settings);
+LogCurrentSettings(Tracer.Instance, "HttpDisabled");
+
+// send a trace with it disabled
+using (Tracer.Instance.StartActive($"Manual-{++count}.HttpDisabled"))
+{
+    await SendHttpRequest("HttpDisabled");
+}
+
+// go back to the defaults
+Tracer.Configure(TracerSettings.FromDefaultSources());
+LogCurrentSettings(Tracer.Instance, "DefaultsReinstated");
+using (Tracer.Instance.StartActive($"Manual-{++count}.DefaultsReinstated"))
+{
+    await SendHttpRequest("DefaultsReinstated");
+}
+
+// nested manual + extensions
+using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.Ext.Outer"))
+{
+    s1.Span.SetTraceSamplingPriority(SamplingPriority.UserKeep);
+
+    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.Ext.Inner");
+    s2.Span.SetException(new CustomException());
+    s2.Span.SetTag("Custom", "Some-Value");
+    s2.Span.SetTag("Some-Number", 123);
+    s2.Span.SetUser(
+        new UserDetails("my-id")
+        {
+            Email = "test@example.com",
+            Name = "Bits",
+            Role = "Mascot",
+            Scope = "test-scope",
+            PropagateId = true,
+            SessionId = "abc123"
+        });
+
+    await SendHttpRequest("Ext");
+}
+
+// nested manual + eventSDK
+using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Custom.Outer"))
+{
+    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Custom.Inner");
+    EventTrackingSdk.TrackCustomEvent("custom-event");
+    EventTrackingSdk.TrackCustomEvent("custom-event-meta", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+    await SendHttpRequest("Ext");
+}
+
+using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Success.Outer"))
+{
+    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Success.Inner");
+    EventTrackingSdk.TrackUserLoginSuccessEvent("my-id");
+    EventTrackingSdk.TrackUserLoginSuccessEvent("my-id", new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+    await SendHttpRequest("Ext");
+}
+
+using (Tracer.Instance.StartActive($"Manual-{++count}.EventSdk.Failure.Outer"))
+{
+    using var s2 = Tracer.Instance.StartActive($"Manual-{count}.EventSdk.Failure.Inner");
+    EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true);
+    EventTrackingSdk.TrackUserLoginFailureEvent("my-id", true, new Dictionary<string, string> { { "key-1", "val-1" }, { "key-2", "val-2" }, });
+    await SendHttpRequest("Ext");
+}
+
+// Custom context
+var parent = new SpanContext(traceId: 1234567, 7654321, SamplingPriority.AutoKeep, "manual-parent");
+var createSpan = new SpanCreationSettings
+{
+    FinishOnClose = false,
+    StartTime = DateTimeOffset.Now.AddHours(-1),
+    Parent = parent,
+};
+using (var s1 = Tracer.Instance.StartActive($"Manual-{++count}.CustomContext", createSpan))
+{
+    s1.Span.ServiceName = Tracer.Instance.DefaultServiceName;
+    await SendHttpRequest("CustomContext");
+}
+
+// Manually disable debug logs
+GlobalSettings.SetDebugEnabled(false);
+
+// Force flush
+await Tracer.Instance.ForceFlushAsync();
+    
+// Force process to end, otherwise the background listener thread lives forever in .NET Core.
+// Apparently listener.GetContext() doesn't throw an exception if listener.Stop() is called,
+// like it does in .NET Framework.
+server.Dispose();
+Environment.Exit(0);
+return;
+
+async Task SendHttpRequest(string name)
+{
+    var q = $"{count}.{name}";
+    using var scope = Tracer.Instance.StartActive($"Manual-{q}.HttpClient");
+    await client.GetAsync(url + $"?q={q}");
+    Console.WriteLine("Received response for client.GetAsync(String)");
+}
+
+void HandleHttpRequests(HttpListenerContext context)
+{
+    var query = context.Request.QueryString["q"];
+    using var scope = Tracer.Instance.StartActive($"Manual-{query}.HttpListener");
+    Console.WriteLine("[HttpListener] received request");
+
+    // read request content and headers
+    using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+    {
+        string requestContent = reader.ReadToEnd();
+        Console.WriteLine($"[HttpListener] request content: {requestContent}");
+    }
+
+    // write response content
+    scope.Span.SetTag("content", "PONG");
+    var responseBytes = Encoding.UTF8.GetBytes("PONG");
+    context.Response.ContentEncoding = Encoding.UTF8;
+    context.Response.ContentLength64 = responseBytes.Length;
+    context.Response.OutputStream.Write(responseBytes, 0, responseBytes.Length);
+    // we must close the response
+    context.Response.Close();
+}
+
+static void LogCurrentSettings(Tracer tracer, string step)
+{
+    var settings = tracer.Settings;
+    Console.WriteLine($"Current tracer settings for {step}: ");
+
+    WriteLog(settings.Environment);
+    WriteLog(settings.ServiceName);
+    WriteLog(settings.ServiceVersion);
+    var globalTags = string.Join(". ", settings.GlobalTags.Select(x => $"{x.Key}:{x.Value}"));
+    WriteLog(globalTags);
+
+    static void WriteLog(object argument, [CallerArgumentExpression(nameof(argument))] string paramName = null)
+    {
+        Console.WriteLine($"  {paramName}: {argument}");
+    }
+}
+
+class CustomException : Exception
+{
+}

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "Samples.ManualInstrumentation": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-$(Platform)\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+        "DD_VERSION": "1.0.0",
+        "DD_INSTRUMENTATION_TELEMETRY_ENABLED": "true",
+        "DD_TRACE_ACTIVITY_LISTENER_ENABLED": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Polyfill" Version="1.32.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+    <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary of changes

- Adds integration tests (i.e. snapshots etc) for manual only and manual+automatic instrumentation
- Fix a bug in `SetUser` when used in non-aspnetcore scenario

## Reason for change

I wanted to add these integration tests as part of the v3 work, but found that if you call `span.SetUser()` from an app that _doesn't_ reference ASP.NET Core, you'd get an exception:

```
17:39:18 [DBG]  StandardError:
17:39:18 [DBG]  Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.AspNetCore.Http.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.
17:39:18 [DBG]  File name: 'Microsoft.AspNetCore.Http.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'
17:39:18 [DBG]     at Datadog.Trace.SpanExtensions.RunBlockingCheck(Span span, String userId)
17:39:18 [DBG]     at Datadog.Trace.SpanExtensions.SetUserInternal(ISpan span, UserDetails userDetails) in C:\repos\dd-trace-dotnet\tracer\src\Datadog.Trace\SpanExtensions.cs:line 88
17:39:18 [DBG]     at Datadog.Trace.SpanExtensions.SetUser(ISpan span, UserDetails userDetails) in C:\repos\dd-trace-dotnet\tracer\src\Datadog.Trace\SpanExtensions.cs:line 34
17:39:18 [DBG]     at Program.<Main>$(String[] args) in C:\repos\dd-trace-dotnet\tracer\test\test-applications\integrations\Samples.ManualInstrumentation\Program.cs:line 49
17:39:18 [DBG]     at Program.<Main>(String[] args)
```

This was reproduced in the sample app, whether or not ASM was enabled.

Note that this is only an issue in the public APIs, because while we access the types directly in integrations, and in the `AspNetCoreDiagnosticObserver`, those code paths are only called when we know aspnetcore is available.

## Implementation details

Attempt to load the `HttpContext` type before we first use it. Only do the check once for performance reasons, though this does have a small chance of returning a false negative, and effectively disabling the blocking here.

A "safe" alternative would be to keep checking on every call if you get a negative result, but then you pay the type load perf hit everytime, instead of just once. The tradeoff seemed reasonable to me, but also happy to rethink if others disagree.

## Test coverage

Adds testing for the "manual only" and "manual+automatic" scenarios. Incidentally tests the ASM fix too.

## Other details

There was some rare, slightly concerning, flake in the tags added to the spans. Sometimes, the custom `ServiceVersion` tag is omitted 🤷 

I'm pretty sure the issue is down to the fact we're "reconfiguring" the tracer after sending spans. When we reconfigure the tracer, we schedule the "old" tracer to shutdown in the background. That means that briefly there's an overlap between the new and old tracers. My _theory_ is that _somewhere_ we're using the `static Tracer.Instance` tracer during serialization, instead of the `ITracer` and/or the associated settings that was used to _create_ the `Span` (and is stored in `TraceContext`).