### PR TITLE
Wire up the DD_TRACE_BATCH_INTERVAL setting

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -558,7 +558,7 @@ namespace Datadog.Trace.Agent
                     return;
                 }
 
-                if (hasDequeuedTraces)
+                if (hasDequeuedTraces && _batchInterval > 0)
                 {
                     Thread.Sleep(_batchInterval);
                 }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -271,7 +271,7 @@ namespace Datadog.Trace
 
             var statsAggregator = StatsAggregator.Create(api, settings, discoveryService);
 
-            return new AgentWriter(api, statsAggregator, statsd, maxBufferSize: settings.TraceBufferSize);
+            return new AgentWriter(api, statsAggregator, statsd, maxBufferSize: settings.TraceBufferSize, batchInterval: settings.TraceBatchInterval);
         }
 
         protected virtual IDiscoveryService GetDiscoveryService(ImmutableTracerSettings settings)


### PR DESCRIPTION
## Summary of changes

Use the value of `DD_TRACE_BATCH_INTERVAL` in the AgentWriter to change the batch interval in the serialization thread.
Also, allow to completely disable the delay.

## Reason for change

The AWS Lambda waits on the traces to be flushed before finishing the invocation, so the delay is getting in the way.

## Implementation details

Fun fact, the setting existed from the very beginning but apparently I forgot to pass the value to the AgentWriter :awkward-monkey:

## Test coverage

One could argue that the setting would have been implemented properly if I added tests to begin with. But I can't really think of a good way to test this.