### PR TITLE
Enable diagnostic messages in dd-dotnet artifact tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <None Remove="applicationHost.config" />
+    <None Remove="xunit.runner.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -15,6 +16,9 @@
 
   <ItemGroup>
     <Content Include="applicationHost.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="xunit.runner.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/xunit.runner.json
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/xunit.runner.json
@@ -1,0 +1,5 @@
+﻿{
+  "shadowCopy": false,
+  "diagnosticMessages": true,
+  "internalDiagnosticMessages": true
+}


### PR DESCRIPTION
## Summary of changes

Enable diagnostic messages in dd-dotnet artifact tests.

## Reason for change

I'm hoping it will shed some light on why the tests sometimes timeout.

## Implementation details

Added xunit.runner.json file.