### PR TITLE
Revert "Add CorProfilerInfo7::ApplyMetadata call"

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -701,13 +701,6 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     Logger::Info("*** CallTarget_RewriterCallback() Finished: ", caller->type.name, ".", caller->name,
                  "() [IsVoid=", isVoid, ", IsStatic=", isStatic,
                  ", IntegrationType=", integration_definition->integration_type.name, ", Arguments=", numArgs, "]");
-
-    hr = this->m_corProfiler->info_->ApplyMetaData(module_id);
-    if (FAILED(hr))
-    {
-        Logger::Warn("*** CallTarget_RewriterCallback() Finished: Error applying metadata to module_id: ", module_id);
-    }
-
     return S_OK;
 }
 


### PR DESCRIPTION
Reverts DataDog/dd-trace-dotnet#4296

We added the call to ApplyMetadata with the hope of fixing some mysterious issues, but instead it brought new ones (crashes with NGEN'd System.Web.dll: https://github.com/kevingosse/ProfilerNgenCrash).

Since it doesn't look like we actually _need_ to call ApplyMetadata, I'm removing it for now.