### PR TITLE
Un-skip manual instrumentation tests and fix flake

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -21,7 +21,7 @@ public class ManualInstrumentationTests : TestHelper
     {
     }
 
-    [SkippableFact(Skip = "Their flaky, need to address the root cause around Tracer lifetimes")]
+    [SkippableFact]
     [Trait("RunOnWindows", "True")]
     public async Task ManualAndAutomatic()
     {
@@ -39,7 +39,7 @@ public class ManualInstrumentationTests : TestHelper
         await VerifyHelper.VerifySpans(spans, settings);
     }
 
-    [SkippableFact(Skip = "Their flaky, need to address the root cause around Tracer lifetimes")]
+    [SkippableFact]
     [Trait("RunOnWindows", "True")]
     public async Task ManualOnly()
     {

--- a/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ManualAndAutomatic.verified.txt
@@ -92,7 +92,6 @@
       language: dotnet,
       runtime-id: Guid_1,
       Updated-key: Updated Value,
-      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
@@ -115,7 +114,6 @@
       env: updated-env,
       language: dotnet,
       Updated-key: Updated Value,
-      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     }
@@ -158,7 +156,6 @@
       language: dotnet,
       runtime-id: Guid_1,
       Updated-key: Updated Value,
-      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },

--- a/tracer/test/snapshots/ManualInstrumentationTests.ManualOnly.verified.txt
+++ b/tracer/test/snapshots/ManualInstrumentationTests.ManualOnly.verified.txt
@@ -67,7 +67,6 @@
       language: dotnet,
       runtime-id: Guid_1,
       Updated-key: Updated Value,
-      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
@@ -90,7 +89,6 @@
       env: updated-env,
       language: dotnet,
       Updated-key: Updated Value,
-      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     }
@@ -107,7 +105,6 @@
       language: dotnet,
       runtime-id: Guid_1,
       Updated-key: Updated Value,
-      version: updated-version,
       _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
       _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Program.cs
@@ -34,7 +34,6 @@ await Tracer.Instance.ForceFlushAsync();
 // Reconfigure the tracer
 var settings = TracerSettings.FromDefaultSources();
 settings.ServiceName = "updated-name";
-settings.ServiceVersion = "updated-version";
 settings.Environment = "updated-env";
 settings.GlobalTags = new Dictionary<string, string> { { "Updated-key", "Updated Value" } };
 Tracer.Configure(settings);


### PR DESCRIPTION
## Summary of changes

- Add workaround for manual-instrumentation test flake
- Unskip the manual instrumentation tests

## Reason for change

#4938 introduced integration tests for manual and manual+automatic instrumentation. Unfortunately, we had to skip them in #4949 because they were flaky. This PR removes the flake, and so unskips the tests.

## Implementation details

This PR _doesn't_ resolve the underlying issue, it just removes the flake from the test.

The underlying cause of the flake is:

- Serialized spans have a `TraceContext`, which contains a reference to a `Tracer` instance
- During serialization, a `TraceChunkModel` is created, which records (among other things) the `DefaultServiceName` by calling `spans[0].TraceContext.Tracer.DefaultServiceName`
- The span formatter code uses the `DefaultServiceName` to decide whether to add the `version` tag (it should currently _only_ be added to spans for which `service` == `DefaultServiceName`).

The trouble is that in normal operation, `TraceContext.Tracer.DefaultServiceName` _doesn't_ necessarily point to the `DefaultServiceName` _at the time the span was serialized_. Rather, it points to the _current_ `TracerManager` instance. 

In the integration tests, we were reconfiguring the tracer multiple times, so there was a high chance that the `TracerManager` used to _create_ the spans was different to the _current_ global `TracerManager` when that span was serialized in the background, which in turn meant the service version tag might not be added.

The "fix" in the integration tests is to simply not set the service version. If there's no version to add, there's no chance of flake. Obviously this doesn't fix the underlying issue, but the solution to the underlying problem isn't entirely obvious, could be breaking depend on how we decide to do it, and should be uncommon in normal customer usage

## Test coverage

Unskipped some integration tests, and updated the snapshots to remove the version tags.

## Other details

I wanted to get these running again because we need them for the v3 work.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
