### PR TITLE
Add fix for null key in `SecurityCoordinator`

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -203,7 +203,10 @@ internal readonly partial struct SecurityCoordinator
         var formData = new Dictionary<string, object>(_context.Request.Form.Keys.Count);
         foreach (string key in _context.Request.Form.Keys)
         {
-            formData.Add(key, _context.Request.Form[key]);
+            // key could be null, but it's not a valid key in a dictionary
+            // Using [] instead of Add to avoid potential duplicate key
+            // but it does mean there's a (tiny) chance of overwriting the key
+            formData[key ?? string.Empty] = _context.Request.Form[key];
         }
 
         return formData;


### PR DESCRIPTION
## Summary of changes

Avoid calling `Dictionary<>.Add(key, value)` with a `null` key

## Reason for change

Spotted in logs

## Implementation details

Do a `?? string.Empty`. This _potentially_ gives a duplicate key, so working around that. This seems like it should be a rare error, so I think this is ok, but we could also do something like `?? <null>` for example to give more chance of being unique?

## Test coverage

There doesn't appear to be any...

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
