### PR TITLE
Stop caching exceptions in lazy

### DIFF
--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/ObfuscatorFactory.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/ObfuscatorFactory.cs
@@ -14,9 +14,14 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
 
         internal static ObfuscatorBase GetObfuscator(double timeoutInMs, string pattern, IDatadogLogger logger, bool reportQueryString = true)
         {
-            if (string.IsNullOrEmpty(pattern) || !reportQueryString)
+            if (string.IsNullOrEmpty(pattern))
             {
                 return new NullObfuscator();
+            }
+
+            if (!reportQueryString)
+            {
+                return new RedactAllObfuscator();
             }
 
             try

--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/ObfuscatorFactory.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/ObfuscatorFactory.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
             }
             catch (Exception ex)
             {
-                Log.Error(ex, "Exception occured when create query string obfuscator");
+                Log.Error(ex, "Exception occurred creating query string obfuscator");
                 return new RedactAllObfuscator();
             }
         }

--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/RedactAllObfuscator.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/RedactAllObfuscator.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="RedactAllObfuscator.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Util.Http.QueryStringObfuscation;
+
+internal class RedactAllObfuscator : ObfuscatorBase
+{
+    internal override string Obfuscate(string queryString)
+    {
+        return string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary of changes

The create the `Obfuscator` could result in an exception. As the `Obfuscator` is wrapped in an `Lazy<T>`, if the creation fails, the exception will be cached and all clients trying to retrieve the `Obfuscator` will receive an exception instead.

## Implementation details

In the case where the creation of the `Obfuscator` we create a simpler obfuscator that just redacts everything.

## Test coverage

Covered by existing test.

