### PR TITLE
[Build] Fix Tracer Native Build on MacOS ARM64

### DIFF
--- a/shared/src/native-src/logger.h
+++ b/shared/src/native-src/logger.h
@@ -153,20 +153,6 @@ std::string Logger::GetLogPath(const std::string& file_name_suffix)
     return log_path.string();
 }
 
-#ifdef MACOS
-template <class T>
-void WriteToStream(std::ostringstream& oss, T const& x)
-{
-    if constexpr (std::is_same<T, ::shared::WSTRING>::value)
-    {
-        oss << ::shared::ToString(x);
-    }
-    else
-    {
-        oss << x;
-    }
-}
-#else
 
 // On Debian buster, we only have libstdc++ 8 which does not have a definition for the std::same_as concept
 // and std::remove_cvref_t struct.
@@ -206,9 +192,8 @@ template <class T>
 concept IsWstring = same_as<T, ::shared::WSTRING> ||
                     // check if it's WCHAR[N] or WCHAR*
                     same_as<remove_cvref_t<std::remove_pointer_t<std::decay_t<T>>>, WCHAR>;
-
 template <IsWstring T>
-void  WriteToStream(std::ostringstream& oss, T const& x)
+void WriteToStream(std::ostringstream& oss, T const& x)
 {
     if constexpr (std::is_same_v<T, ::shared::WSTRING>)
     {
@@ -229,7 +214,6 @@ void WriteToStream(std::ostringstream& oss, T const& x)
 {
     oss << x;
 }
-#endif
 
 template <typename... Args>
 static std::string LogToString(Args const&... args)

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -387,19 +387,17 @@ WSTRING DebuggerMethodRewriter::GetInstrumentationId(RejitHandlerModule* moduleH
     }
 
 #ifdef MACOS
-    std::wstringstream instrumentationIdStream;
+    std::stringstream instrumentationIdStream;
+    instrumentationIdStream << "M" << methodProbes.size() << "L" << lineProbes.size() << "S"
+                            << spanOnMethodProbes.size();
 #else
     WSTRINGSTREAM instrumentationIdStream;
-#endif
     instrumentationIdStream << WStr("M") << methodProbes.size() << WStr("L") << lineProbes.size() << WStr("S")
                             << spanOnMethodProbes.size();
+#endif
 
 #ifdef MACOS
-    // Convert std::wstring to WSTRING
-    std::wstring temp = instrumentationIdStream.str();
-    WSTRING converted(temp.begin(), temp.end());
-
-    return converted;
+    return shared::ToWSTRING(instrumentationIdStream.str());
 #else
     return instrumentationIdStream.str();
 #endif


### PR DESCRIPTION
## Summary of changes

Fix broken build on MacOS (M1) laptops

## Reason for change

Broken :p

## Implementation details

Apple Clang also supports `concept` so remove the `MACOS` specific function and use the `WriteToStream` template function.
Also have specific string building for MacOS

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
