### PR TITLE
[ASM] Add client IP feature to the AspNetMvc integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/AspNetMvcIntegration.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web.Routing;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AspNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
@@ -159,6 +160,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     if (headers is not null)
                     {
                         SpanContextPropagator.Instance.AddHeadersToSpanAsTags(span, headers.Value, tracer.Settings.HeaderTagsInternal, SpanContextPropagator.HttpRequestHeadersTagPrefix);
+                    }
+
+                    if (tracer.Settings.IpHeaderEnabled || Security.Instance.Enabled)
+                    {
+                        Headers.Ip.RequestIpExtractor.AddIpToTags(httpContext.Request.UserHostAddress, httpContext.Request.IsSecureConnection, key => httpContext.Request.Headers[key], tracer.Settings.IpHeader, tags);
                     }
 
                     tags.AspNetRoute = routeUrl;

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=discovery.scans_url=_Health_wp-config_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=discovery.scans_url=_Health_wp-config_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -65,12 +67,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -118,12 +122,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -171,12 +177,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -224,12 +232,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.body_url=_Home_UploadJson_body={-DictionaryProperty-- {-a---[$slice]-} }.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.body_url=_Home_UploadJson_body={-DictionaryProperty-- {-a---[$slice]-} }.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -76,12 +78,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -140,12 +144,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -204,12 +210,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -268,12 +276,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.body_url=_Home_UploadStruct_body={-Property1-- -[$slice]-}.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.body_url=_Home_UploadStruct_body={-Property1-- -[$slice]-}.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -76,12 +78,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -140,12 +144,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -204,12 +210,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -268,12 +276,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.body_url=_Home_Upload_body={-Property1-- -[$slice]-}.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.body_url=_Home_Upload_body={-Property1-- -[$slice]-}.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -76,12 +78,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -140,12 +144,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -204,12 +210,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -268,12 +276,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint-&q=help_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint-&q=help_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -74,12 +76,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -136,12 +140,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -198,12 +204,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -260,12 +268,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -74,12 +76,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -136,12 +140,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -198,12 +204,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -260,12 +268,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.query_url=_Health_-arg&[$slice]_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.query_url=_Health_-arg&[$slice]_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -65,12 +67,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -118,12 +122,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -171,12 +177,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -224,12 +232,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.query_url=_Health_-arg=[$slice]_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.request.query_url=_Health_-arg=[$slice]_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -74,12 +76,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -136,12 +140,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -198,12 +204,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -260,12 +268,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.response.headers.no_cookies_url=_Home_LangHeader_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Classic.enableSecurity=True.__test=server.response.headers.no_cookies_url=_Home_LangHeader_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -65,12 +67,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -118,12 +122,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -171,12 +177,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -224,12 +232,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=discovery.scans_url=_Health_wp-config_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=discovery.scans_url=_Health_wp-config_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -75,12 +77,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -138,12 +142,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -201,12 +207,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -264,12 +272,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/wp-config,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.body_url=_Home_UploadJson_body={-DictionaryProperty-- {-a---[$slice]-} }.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.body_url=_Home_UploadJson_body={-DictionaryProperty-- {-a---[$slice]-} }.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -77,12 +79,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -142,12 +146,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -207,12 +213,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -272,12 +280,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadJson,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.body_url=_Home_UploadStruct_body={-Property1-- -[$slice]-}.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.body_url=_Home_UploadStruct_body={-Property1-- -[$slice]-}.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -77,12 +79,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -142,12 +146,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -207,12 +213,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -272,12 +280,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/UploadStruct,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.body_url=_Home_Upload_body={-Property1-- -[$slice]-}.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.body_url=_Home_Upload_body={-Property1-- -[$slice]-}.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -77,12 +79,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -142,12 +146,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -207,12 +213,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -272,12 +280,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: POST,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/Upload,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint-&q=help_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint-&q=help_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -75,12 +77,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -138,12 +142,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -201,12 +207,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -264,12 +272,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint?&q=help,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.path_params_url=_Health_params_appscan_fingerprint_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -75,12 +77,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -138,12 +142,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -201,12 +207,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -264,12 +272,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/params/appscan_fingerprint,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.query_url=_Health_-arg&[$slice]_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.query_url=_Health_-arg&[$slice]_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -65,12 +67,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -118,12 +122,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -171,12 +177,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -224,12 +232,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg&[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.query_url=_Health_-arg=[$slice]_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.request.query_url=_Health_-arg=[$slice]_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -75,12 +77,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -138,12 +142,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -201,12 +207,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -264,12 +272,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Health/?arg=[$slice],
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.response.headers.no_cookies_url=_Home_LangHeader_body=null.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.Integrated.enableSecurity=True.__test=server.response.headers.no_cookies_url=_Home_LangHeader_body=null.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -76,12 +78,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -140,12 +144,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -204,12 +210,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -268,12 +276,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/Home/LangHeader,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 86.242.244.246,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Classic.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: user,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/user,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -66,12 +68,14 @@
       aspnet.controller: user,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 403,
       http.url: http://localhost:00000/user,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-ips_url=_.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: home,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 86.242.244.246,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmData.Integrated.enableSecurity=True.__test=blocking-user_url=_user.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: user,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/user,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server
     }
   },
@@ -66,12 +68,14 @@
       aspnet.controller: user,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 403,
       http.url: http://localhost:00000/user,
       http.useragent: Mistake Not...,
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmRulesToggle.Classic.enableSecurity=True._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmRulesToggle.Classic.enableSecurity=True._.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/health,
       http.useragent: Mistake Not... (sql power injector),
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -113,12 +115,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/health,
       http.useragent: Mistake Not... (sql power injector),
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }

--- a/tracer/test/snapshots/Security.AspNetMvc5AsmRulesToggle.Integrated.enableSecurity=True._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5AsmRulesToggle.Integrated.enableSecurity=True._.verified.txt
@@ -12,12 +12,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/health,
       http.useragent: Mistake Not... (sql power injector),
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }
@@ -115,12 +117,14 @@
       aspnet.controller: health,
       aspnet.route: {controller}/{action}/{id},
       env: integration_tests,
+      http.client_ip: 127.0.0.1,
       http.method: GET,
       http.request.headers.host: localhost:00000,
       http.status_code: 200,
       http.url: http://localhost:00000/health,
       http.useragent: Mistake Not... (sql power injector),
       language: dotnet,
+      network.client.ip: ::1,
       span.kind: server,
       _dd.origin: appsec
     }


### PR DESCRIPTION
## Summary of changes
Adds the client IP tags to spans generated by the AspNetMvc integration

## Reason for change
When the client IP feature is enabled, we add the IP tag to our `aspnet.request` spans and `aspnet-webapi.request` spans, but we don't currently add this information to our `aspnet-mvc.request` spans. We have a user who would like to see this information on the MVC spans, so it seems reasonable to add.

## Implementation details
Invokes the RequestIPExtractor to add the IP to the `aspnet-mvc.request` span

## Test coverage
Covered by snapshot testing in our AspNetMvc5 ASM integration tests

## Other details
N/A