### PR TITLE
[ASM] Division by zero could happen if param was 0 and apisecurity is enabled

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/OverheadController.cs
+++ b/tracer/src/Datadog.Trace/Sampling/OverheadController.cs
@@ -64,5 +64,5 @@ internal class OverheadController
         }
     }
 
-    private static int ComputeSamplingParameter(int pct) => (int)Math.Round(100m / pct);
+    private static int ComputeSamplingParameter(int pct) => pct == 0 ? pct : (int)Math.Round(100m / pct);
 }

--- a/tracer/src/Datadog.Trace/Sampling/OverheadController.cs
+++ b/tracer/src/Datadog.Trace/Sampling/OverheadController.cs
@@ -64,5 +64,5 @@ internal class OverheadController
         }
     }
 
-    private static int ComputeSamplingParameter(int pct) => pct == 0 ? pct : (int)Math.Round(100m / pct);
+    private static int ComputeSamplingParameter(int pct) => pct <= 0 ? 0 : (int)Math.Round(100m / pct);
 }


### PR DESCRIPTION
## Summary of changes

Division by zero could happen in case of a rate configured to 0

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
