### PR TITLE
Add workaround for Rider bug

### DIFF
--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -11,7 +11,8 @@
     <DelaySign>false</DelaySign>
 
     <!-- WebClient is obsolete -->
-    <NoWarn>SYSLIB0014</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>SYSLIB0014;NU1902;NU1903</NoWarn>
   </PropertyGroup>
 
   <!-- StyleCop -->

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -9,7 +9,8 @@
     <!-- When building standalone (see below) we have to exclude <netcoreapp3.1 from the targets otherwise the SDK has a fit -->
     <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <NoWarn>NU5100</NoWarn>
+    <!-- NU190* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>NU5100;NU1902;NU1903</NoWarn>
     <RootNamespace>Datadog.Trace.Tools.Runner</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>false</DebugSymbols>

--- a/tracer/src/Datadog.Trace.Tools.Shared/Datadog.Trace.Tools.Shared.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Shared/Datadog.Trace.Tools.Shared.csproj
@@ -7,7 +7,8 @@
     <Nullable>enable</Nullable>
     
     <!-- Disable the warnings about commenting public members - This library is not exposed publicly -->
-    <NoWarn>CS1591;SA1600;SA1602</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>CS1591;SA1600;SA1602;NU1902;NU1903</NoWarn>
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <!--<TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>-->
-    <NoWarn>SA1300</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>SA1300;NU1902;NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -10,6 +10,10 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <!-- Stop NuGet from complaining about vulnerable packages -->
     <NuGetAudit>false</NuGetAudit>
+
+    <!-- WebClient is obsolete -->
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>SYSLIB0014;NU1902;NU1903</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -22,7 +22,8 @@
     <NuGetAudit>false</NuGetAudit>
 
     <!-- WebClient is obsolete -->
-    <NoWarn>SYSLIB0014</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>SYSLIB0014;NU1902;NU1903</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
## Summary of changes

Fixes unable to build in Rider: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors

## Reason for change

Rider fails to build with version 2023.3.1:

```
Error NU1902 : Warning As Error: Package 'Microsoft.NETCore.App' 2.1.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-5633-f33j-c6f7
```

## Implementation details

Specifically exclude those errors

## Test coverage

It works on my machine...

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
