### PR TITLE
Update CosmosDb snapshots and csproj to ignore .NET Standard warning

### DIFF
--- a/tracer/test/snapshots/CosmosTests.SubmitTraces_SchemaV0.verified.txt
+++ b/tracer/test/snapshots/CosmosTests.SubmitTraces_SchemaV0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -14,6 +14,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -38,6 +40,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -62,6 +66,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -86,6 +92,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -111,6 +119,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -136,6 +146,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -161,6 +173,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -186,6 +200,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -209,6 +225,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -232,6 +250,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -255,6 +275,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -278,6 +300,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -302,6 +326,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,
@@ -326,6 +352,8 @@
       out.host: https://localhost:00000/,
       runtime-id: Guid_1,
       span.kind: client,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/snapshots/CosmosTests.SubmitTraces_SchemaV1.verified.txt
+++ b/tracer/test/snapshots/CosmosTests.SubmitTraces_SchemaV1.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -17,6 +17,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -45,6 +47,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -73,6 +77,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -101,6 +107,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -130,6 +138,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -159,6 +169,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -188,6 +200,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -217,6 +231,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -244,6 +260,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: out.host
     },
     Metrics: {
@@ -271,6 +289,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: out.host
     },
     Metrics: {
@@ -298,6 +318,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: out.host
     },
     Metrics: {
@@ -325,6 +347,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: out.host
     },
     Metrics: {
@@ -353,6 +377,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {
@@ -381,6 +407,8 @@
       runtime-id: Guid_1,
       span.kind: client,
       version: 1.0.0,
+      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
+      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet,
       _dd.peer.service.source: db.name
     },
     Metrics: {

--- a/tracer/test/test-applications/integrations/Samples.CosmosDb/Samples.CosmosDb.csproj
+++ b/tracer/test/test-applications/integrations/Samples.CosmosDb/Samples.CosmosDb.csproj
@@ -11,6 +11,12 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- System.Runtime.CompilerServices.Unsafe doesn't support netcoreapp2.1-->
+    <!-- https://andrewlock.net/stop-lying-about-netstandard-2-support/-->
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="$(ApiVersion)" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of changes

Updates the snapshots for CosmosDb (as they aren't run on CI) and also updates the `Samples.CosmosDb.csproj` to ignore the .NET Standard 2.0 warning that seems to popup for the later versions of the NuGet.

## Reason for change

Snapshots weren't updated as they don't get run on CI.
Also ran the latest to make sure that everything still works.

## Implementation details

- Ran integration tests, updated snapshots
- Updated to latest `Microsoft.Azure.Cosmos` of `v3.37.0`, saw the build error, suppressed the error, ran the snapshots snapshots passed.

## Test coverage

- These aren't run on CI, so local only.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
