### PR TITLE
Crank up the artifact tests timeout

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -89,7 +89,7 @@ public abstract class ConsoleTestHelper : ToolTestHelper
         var completed = await Task.WhenAny(
                             helper.Task,
                             startedTask.Task,
-                            Task.Delay(TimeSpan.FromSeconds(30)));
+                            Task.Delay(TimeSpan.FromMinutes(30)));
 
         if (completed == startedTask.Task)
         {


### PR DESCRIPTION
## Summary of changes

Somehow the test still times out. Making the timeout unreasonably big to investigate whether the process is actually stuck, and if not then figure out how long it takes.

## Reason for change

Still timing out.

## Implementation details

Put a bigger value for the timeout.
<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
