### PR TITLE
Change the echo output in Samples.Console

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/RunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/RunCommandTests.cs
@@ -92,7 +92,7 @@ public class RunCommandTests : ConsoleTestHelper
 
             var output = process.StandardOutput.ReadLine();
 
-            output.Should().Be("Hello World!");
+            output.Should().Be("Echo: Hello World!");
         }
         finally
         {

--- a/tracer/test/test-applications/integrations/Samples.Console/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Console/Program.cs
@@ -38,7 +38,7 @@ namespace Samples.Console_
                 if (string.Equals(args[0], "echo", StringComparison.OrdinalIgnoreCase))
                 {
                     Console.WriteLine("Ready");
-                    Console.WriteLine(Console.ReadLine());
+                    Console.WriteLine($"Echo: {Console.ReadLine()}");
                 }
 
                 if (string.Equals(args[0], "wait", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
## Summary of changes

The `Datadog.Trace.Tools.dd_dotnet.ArtifactTests.RunComandTests.RedirectInput` test is randomly failing because the echo message contains a BOM (`∩╗┐Hello World!`). By adding a prefix to the message, we should be able to figure out if the BOM is inserted in the input or the output.

## Reason for change

Flaky test.