### PR TITLE
More workarounds for Rider/NuGet bug

### DIFF
--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -12,7 +12,7 @@
 
     <!-- WebClient is obsolete -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>SYSLIB0014;NU1902;NU1903</NoWarn>
+    <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <!-- StyleCop -->

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -5,7 +5,8 @@
     <TargetFramework>net7.0</TargetFramework>
     <RollForward>LatestMajor</RollForward>
     <RootNamespace></RootNamespace>
-    <NoWarn>CS0649;CS0169;SA1652</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>CS0649;CS0169;SA1652;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <NukeRootDirectory>..\..\..</NukeRootDirectory>
     <NukeScriptDirectory>..\..</NukeScriptDirectory>
     <NukeExcludeDirectoryBuild>True</NukeExcludeDirectoryBuild>

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -13,7 +13,8 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <NoWarn>NU5100;NU5128</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == '' ">bin\$(Configuration)\packages</PackageOutputPath>
     <DefineConstants Condition=" '$(ExtraDefineConstants)' != '' ">$(DefineConstants);$(ExtraDefineConstants)</DefineConstants>
   </PropertyGroup>

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -9,7 +9,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <NoWarn>NU5100;NU5128</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>NU5100;NU5128;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <PackageOutputPath Condition="'$(PackageOutputPath)' == '' ">bin\$(Configuration)\packages</PackageOutputPath>
   </PropertyGroup>
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -10,7 +10,7 @@
     <TargetFrameworks>net8.0;net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp3.0;netcoreapp2.2;netcoreapp2.1;</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <!-- NU190* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>NU5100;NU1902;NU1903</NoWarn>
+    <NoWarn>NU5100;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <RootNamespace>Datadog.Trace.Tools.Runner</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DebugSymbols>false</DebugSymbols>

--- a/tracer/src/Datadog.Trace.Tools.Shared/Datadog.Trace.Tools.Shared.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Shared/Datadog.Trace.Tools.Shared.csproj
@@ -8,7 +8,7 @@
     
     <!-- Disable the warnings about commenting public members - This library is not exposed publicly -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>CS1591;SA1600;SA1602;NU1902;NU1903</NoWarn>
+    <NoWarn>CS1591;SA1600;SA1602;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -8,11 +8,11 @@
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <NoWarn>NU5100</NoWarn>
     <RootNamespace>Datadog.Trace.Tools.dd_dotnet</RootNamespace>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
-    <NoWarn>SA1300</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>SA1300;NU5100;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
 
     <AssemblyName>dd-dotnet</AssemblyName>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Datadog.Trace.Tools.dd_dotnet.ArtifactTests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!--<TargetFrameworks>net461;netcoreapp2.1;netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>-->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>SA1300;NU1902;NU1903</NoWarn>
+    <NoWarn>SA1300;NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Datadog.Trace.Tools.dd_dotnet.IntegrationTests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Datadog.Trace.Tools.dd_dotnet.IntegrationTests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
-    <NoWarn>SA1300</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>SA1300;NU1901;NU1902;NU1903;NU1904</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.Tests/Datadog.Trace.Tools.dd_dotnet.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.Tests/Datadog.Trace.Tools.dd_dotnet.Tests.csproj
@@ -4,7 +4,8 @@
 
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <NoWarn>SA1300</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>SA1300;NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -13,7 +13,7 @@
 
     <!-- WebClient is obsolete -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>SYSLIB0014;NU1902;NU1903;NU1904</NoWarn>
+    <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -13,7 +13,7 @@
 
     <!-- WebClient is obsolete -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>SYSLIB0014;NU1902;NU1903</NoWarn>
+    <NoWarn>SYSLIB0014;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -13,7 +13,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\..\Datadog.Trace.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <NoWarn>1591</NoWarn>
+    <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
+    <NoWarn>1591;NU1901;NU1902;NU1903;NU1904</NoWarn>
 
      <!-- Tell Visual Studio to not create a new launchSettings.json file, even though we have AspNetCore assets -->
     <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>

--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -23,7 +23,7 @@
 
     <!-- WebClient is obsolete -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
-    <NoWarn>SYSLIB0014;NU1902;NU1903</NoWarn>
+    <NoWarn>SYSLIB0014;NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5/Samples.Elasticsearch.V5.csproj
@@ -8,7 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <!--  Ignore package version outside of dependency constraint: NEST 5.3.0 requires Newtonsoft.Json (>= 9.0.0 && < 10.0.0)  -->
-    <NoWarn>NU1608</NoWarn>
+    <NoWarn>$(NoWarn);NU1608</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GrpcDotNet/Samples.GrpcDotNet.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <!-- Suppress warnings about lowercase variable names in generated code -->
-    <NoWarn>0618;NETSDK1138;CS8981</NoWarn>
+    <NoWarn>$(NoWarn);0618;NETSDK1138;CS8981</NoWarn>
 
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.43.0</ApiVersion>
     <DefineConstants Condition="'$(ApiVersion)'&gt;='2.29.0'">$(DefineConstants);GRPC_2_29</DefineConstants>

--- a/tracer/test/test-applications/integrations/Samples.GrpcLegacy/Samples.GrpcLegacy.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GrpcLegacy/Samples.GrpcLegacy.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <!-- Suppress warnings about lowercase variable names in generated code -->
-    <NoWarn>0618;NETSDK1138;CS8981</NoWarn>
+    <NoWarn>$(NoWarn);0618;NETSDK1138;CS8981</NoWarn>
 
     <ApiVersion Condition="'$(ApiVersion)' == ''">2.45.0</ApiVersion>
 


### PR DESCRIPTION
## Summary of changes

Add more ignores for NuGet audit stuff we don't want

## Reason for change

It breaks in Rider sometimes. It's [a fixed bug](https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors) but not in a released version yet.

## Implementation details

More `<NoWarn>`

## Test coverage

It works for me

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
