### PR TITLE
Small fixes for `MockTracerAgent` and `MockHttpParser` parsing

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/DataCollectorLogger.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Coverage.Collector
                         fileSizeLimitBytes: fileConfig.MaxLogFileSizeBytes,
                         shared: true);
 
-                _datadogLogger = new DatadogSerilogLogger(loggerConfiguration.CreateLogger(), new NullLogRateLimiter());
+                _datadogLogger = new DatadogSerilogLogger(loggerConfiguration.CreateLogger(), new NullLogRateLimiter(), fileConfig.LogDirectory);
             }
         }
 

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -249,6 +249,9 @@
       <type fullname="System.IO.Compression.CompressionMode" />
       <type fullname="System.IO.Compression.DeflateStream" />
       <type fullname="System.IO.Compression.GZipStream" />
+      <type fullname="System.IO.Compression.ZipArchive" />
+      <type fullname="System.IO.Compression.ZipArchiveEntry" />
+      <type fullname="System.IO.Compression.ZipArchiveMode" />
    </assembly>
    <assembly fullname="System.IO.FileSystem">
       <type fullname="System.IO.Directory" />

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -37,6 +37,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
+    <Reference Include="System.IO.Compression" />
   </ItemGroup>
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -144,7 +144,7 @@ internal static class DatadogLoggingFactory
             rateLimiter = new NullLogRateLimiter();
         }
 
-        return new DatadogSerilogLogger(internalLogger, rateLimiter);
+        return new DatadogSerilogLogger(internalLogger, rateLimiter, config.File?.LogDirectory);
     }
 
     private static bool IsExcludedMessage(string messageTemplateText)

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
@@ -22,13 +22,16 @@ namespace Datadog.Trace.Logging
         private readonly ILogRateLimiter _rateLimiter;
         private ILogger _logger;
 
-        public DatadogSerilogLogger(ILogger logger, ILogRateLimiter rateLimiter)
+        public DatadogSerilogLogger(ILogger logger, ILogRateLimiter rateLimiter, string? fileLogDirectory)
         {
             _logger = logger;
             _rateLimiter = rateLimiter;
+            FileLogDirectory = fileLogDirectory;
         }
 
-        public static DatadogSerilogLogger NullLogger { get; } = new(SilentLogger.Instance, new NullLogRateLimiter());
+        public static DatadogSerilogLogger NullLogger { get; } = new(SilentLogger.Instance, new NullLogRateLimiter(), null);
+
+        public string? FileLogDirectory { get; }
 
         public bool IsEnabled(LogEventLevel level) => _logger.IsEnabled(level);
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
@@ -13,6 +13,8 @@ namespace Datadog.Trace.Logging
 {
     internal interface IDatadogLogger
     {
+        public string? FileLogDirectory { get; }
+
         bool IsEnabled(LogEventLevel level);
 
         void Debug(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/DebugLogReader.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/DebugLogReader.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="DebugLogReader.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+
+namespace Datadog.Trace.Logging.TracerFlare;
+
+internal static class DebugLogReader
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebugLogReader));
+
+    public static bool TryToCreateSentinelFile(string logDirectory, string flareRequestId)
+    {
+        // Assuming the log directory is accessible and writeable
+        // If it isn't this will return false anyway, but we do an extra check, just to be sure
+        try
+        {
+            // Using the dotnet-tracer-sentinel-*.log pattern means it gets automatically cleaned up by the log cleaning task
+            var filePath = Path.Combine(logDirectory, $"dotnet-tracer-sentinel-{flareRequestId}.log");
+            using var file = File.Open(filePath, FileMode.CreateNew, FileAccess.Write);
+
+            // if we got this far, the file was created
+            return true;
+        }
+        catch (IOException)
+        {
+            // expected, the file already exists
+            Log.Information("Sentinel file for config {FlareRequestID} found in {LogDirectory}", flareRequestId, logDirectory);
+            return false;
+        }
+        catch (Exception ex)
+        {
+            // check if the log directory exists, to see if this is an "expected" consequence
+            if (Directory.Exists(logDirectory))
+            {
+                // strange error
+                Log.Warning(ex, "Error creating sentinel file for config {FlareRequestID} in {LogDirectory}", flareRequestId, logDirectory);
+            }
+            else
+            {
+                Log.Warning(ex, "Error creating sentinel file for config {FlareRequestID} in {LogDirectory}: Directory does not exist", flareRequestId, logDirectory);
+            }
+
+            return false;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/DebugLogReader.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/DebugLogReader.cs
@@ -6,14 +6,18 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Util.Streams;
 
 namespace Datadog.Trace.Logging.TracerFlare;
 
 internal static class DebugLogReader
 {
+    public const long MaximumCompressedSizeBytes = 29_000_000; // 31457280 would be 30MiB, we go to 29MB to be safe
     private const string SentinelFilePrefix = "dotnet-tracer-sentinel-";
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DebugLogReader));
 
@@ -53,24 +57,31 @@ internal static class DebugLogReader
         }
     }
 
-    public static async Task WriteDebugLogArchiveToStream(Stream writeTo, string logDirectory)
+    public static Task WriteDebugLogArchiveToStream(Stream writeTo, string logDirectory)
+        => WriteDebugLogArchiveToStream(writeTo, logDirectory, StreamHasCapacity);
+
+    public static async Task WriteDebugLogArchiveToStream(Stream writeTo, string logDirectory, Func<FileInfo, long, bool> streamHasCapacityFunc)
     {
         try
         {
-            using var archive = new ZipArchive(writeTo, ZipArchiveMode.Create, true);
+            using var monitoringStream = new WriteCountingStream(writeTo);
+            using var archive = new ZipArchive(monitoringStream, ZipArchiveMode.Create, true);
 
             // Only sending .log files to avoid the risk of sending files we don't want.
             // Also not recurrsing, in-case they have a weird log setup
             // Grabbing all the filenames once, as we could be creating more in the background, and don't
             // want to run into any modified enumerable issues etc
-            var filesToUpload = Directory.GetFiles(logDirectory, "*.log", SearchOption.TopDirectoryOnly);
-            if (filesToUpload.Length == 0)
+            var allFiles = Directory.GetFiles(logDirectory, "*.log", SearchOption.TopDirectoryOnly);
+            if (allFiles.Length == 0)
             {
                 // no files to upload
                 return;
             }
 
-            foreach (var filePath in filesToUpload)
+            // we want to upload the most recent files, and leave the older files if we're oversized,
+            // so grab the FileInfo for each file, and sort by most recent
+            var filesToUpload = new List<FileInfo>();
+            foreach (var filePath in allFiles)
             {
                 try
                 {
@@ -81,21 +92,90 @@ internal static class DebugLogReader
                         continue;
                     }
 
-                    var entry = archive.CreateEntry(filename);
+                    var fileInfo = new FileInfo(filePath);
+                    filesToUpload.Add(fileInfo);
+                }
+                catch (Exception e)
+                {
+                    Log.Warning(e, "Error reading file {Filename} when preparing tracer flare zip", filePath);
+                }
+            }
+
+            // order by most recently modified (note swapped order in compareto)
+            filesToUpload.Sort((info1, info2) => info2.LastWriteTimeUtc.CompareTo(info1.LastWriteTimeUtc));
+
+            foreach (var fileDetails in filesToUpload)
+            {
+                var remainingSize = MaximumCompressedSizeBytes - monitoringStream.BytesWritten;
+                if (!streamHasCapacityFunc(fileDetails, remainingSize))
+                {
+                    Log.Warning(
+                        "File {FileName} with uncompressed length {Length} may cause compressed size to exceed {MaxFileSize}. Ignoring remaining files",
+                        fileDetails.FullName,
+                        fileDetails.Length,
+                        MaximumCompressedSizeBytes);
+                    break;
+                }
+
+                try
+                {
+                    // There's a SmallestSize for .NET 5+ but it doesn't give much benefit
+                    // and we would rather not add the extra memory pressure for little gain
+                    var entry = archive.CreateEntry(fileDetails.Name, CompressionLevel.Optimal);
                     using var entryStream = entry.Open();
                     // Have to allow FileShare.ReadWrite as the logger will already have it open for writing
-                    using var file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    using var file = File.Open(fileDetails.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
                     await file.CopyToAsync(entryStream).ConfigureAwait(false);
+                    await entryStream.FlushAsync().ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
-                    Log.Warning(ex, "Error recording file {Filename} in tracer flare zip", filePath);
+                    Log.Warning(ex, "Error recording file {Filename} in tracer flare zip", fileDetails.FullName);
                 }
             }
         }
         catch (Exception e)
         {
             Log.Warning(e, "Error creating sanitized debug log stream for tracer flare");
+        }
+    }
+
+    internal static bool StreamHasCapacity(FileInfo fileDetails, long remainingCapacity)
+    {
+        // we estimate that the file compresses _roughly_ 10x, so if we're going to exceed that
+        // we bail out. That means that we may miss some older smaller files, but at least we
+        // have a clear cut off.
+        var estimatedFileSize = fileDetails.Length / 10;
+        return remainingCapacity >= estimatedFileSize;
+    }
+
+    public class WriteCountingStream(Stream innerStream) : LeaveOpenDelegatingStream(innerStream)
+    {
+        public long BytesWritten { get; private set; }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            BytesWritten += count;
+            base.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            BytesWritten += count;
+            return base.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            BytesWritten += count;
+            return base.BeginWrite(buffer, offset, count, callback!, state);
+        }
+
+        public override void WriteByte(byte value)
+        {
+            BytesWritten++;
+            base.WriteByte(value);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/DebugLogReader.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/DebugLogReader.cs
@@ -7,6 +7,8 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
+using System.Threading.Tasks;
 
 namespace Datadog.Trace.Logging.TracerFlare;
 
@@ -47,6 +49,46 @@ internal static class DebugLogReader
             }
 
             return false;
+        }
+    }
+
+    public static async Task WriteDebugLogArchiveToStream(Stream writeTo, string logDirectory)
+    {
+        try
+        {
+            using var archive = new ZipArchive(writeTo, ZipArchiveMode.Create, true);
+
+            // Only sending .log files to avoid the risk of sending files we don't want.
+            // Also not recurrsing, in-case they have a weird log setup
+            // Grabbing all the filenames once, as we could be creating more in the background, and don't
+            // want to run into any modified enumerable issues etc
+            var filesToUpload = Directory.GetFiles(logDirectory, "*.log", SearchOption.TopDirectoryOnly);
+            if (filesToUpload.Length == 0)
+            {
+                // no files to upload
+                return;
+            }
+
+            foreach (var filePath in filesToUpload)
+            {
+                try
+                {
+                    var filename = Path.GetFileName(filePath);
+                    var entry = archive.CreateEntry(filename);
+                    using var entryStream = entry.Open();
+                    // Have to allow FileShare.ReadWrite as the logger will already have it open for writing
+                    using var file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                    await file.CopyToAsync(entryStream).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    Log.Warning(ex, "Error recording file {Filename} in tracer flare zip", filePath);
+                }
+            }
+        }
+        catch (Exception e)
+        {
+            Log.Warning(e, "Error creating sanitized debug log stream for tracer flare");
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Util/Streams/DelegatingStream.cs
+++ b/tracer/src/Datadog.Trace/Util/Streams/DelegatingStream.cs
@@ -1,0 +1,95 @@
+﻿// <copyright file="DelegatingStream.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Util.Streams;
+
+/// <summary>
+/// A simple <see cref="Stream"/> implementation that delegates to an inner stream implementation
+/// </summary>
+internal abstract class DelegatingStream(Stream innerStream) : Stream
+{
+    private readonly Stream _innerStream = innerStream;
+
+    public override bool CanRead => _innerStream.CanRead;
+
+    public override bool CanSeek => _innerStream.CanSeek;
+
+    public override bool CanWrite => _innerStream.CanWrite;
+
+    public override bool CanTimeout => _innerStream.CanTimeout;
+
+    public override long Length => _innerStream.Length;
+
+    public override long Position
+    {
+        get => _innerStream.Position;
+        set => _innerStream.Position = value;
+    }
+
+    public override int ReadTimeout
+    {
+        get => _innerStream.ReadTimeout;
+        set => _innerStream.ReadTimeout = value;
+    }
+
+    public override int WriteTimeout
+    {
+        get => _innerStream.WriteTimeout;
+        set => _innerStream.WriteTimeout = value;
+    }
+
+    public override void Flush() => _innerStream.Flush();
+
+    public override Task FlushAsync(CancellationToken cancellationToken) => _innerStream.FlushAsync(cancellationToken);
+
+    public override long Seek(long offset, SeekOrigin origin) => _innerStream.Seek(offset, origin);
+
+    public override void SetLength(long value) => _innerStream.SetLength(value);
+
+    public override int Read(byte[] buffer, int offset, int count) => _innerStream.Read(buffer, offset, count);
+
+    public override int ReadByte() => _innerStream.ReadByte();
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+
+    public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        => _innerStream.BeginRead(buffer, offset, count, callback!, state);
+
+    public override int EndRead(IAsyncResult asyncResult) => _innerStream.EndRead(asyncResult);
+
+    public override void Write(byte[] buffer, int offset, int count) => _innerStream.Write(buffer, offset, count);
+
+    public override void WriteByte(byte value) => _innerStream.WriteByte(value);
+
+    public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+
+    public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        => _innerStream.BeginWrite(buffer, offset, count, callback!, state);
+
+    public override void EndWrite(IAsyncResult asyncResult) => _innerStream.EndWrite(asyncResult);
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _innerStream.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+#if NETCOREAPP
+    public override ValueTask DisposeAsync() => _innerStream.DisposeAsync();
+#endif
+}

--- a/tracer/src/Datadog.Trace/Util/Streams/LeaveOpenDelegatingStream.cs
+++ b/tracer/src/Datadog.Trace/Util/Streams/LeaveOpenDelegatingStream.cs
@@ -1,0 +1,35 @@
+﻿// <copyright file="LeaveOpenDelegatingStream.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Util.Streams;
+
+/// <summary>
+/// A simple <see cref="Stream"/> implementation that delegates to an inner stream implementation
+/// but does not close the stream when disposed/closed
+/// </summary>
+internal abstract class LeaveOpenDelegatingStream(Stream innerStream) : DelegatingStream(innerStream)
+{
+    public override void Close()
+    {
+        // Override so that we don't dispose the inner stream
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        // Override so that we don't dispose the inner stream
+    }
+
+#if NETCOREAPP
+    public override ValueTask DisposeAsync()
+    {
+        // Override so that we don't dispose the inner stream
+        return default;
+    }
+#endif
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
@@ -27,7 +27,8 @@ namespace Datadog.Trace.TestHelpers
             // Read POST
             await helper.ReadUntil(stringBuilder, stopChar: ' ').ConfigureAwait(false);
 
-            var method = stringBuilder.ToString();
+            // This will have a null character prefixed on it because of reasons
+            var method = stringBuilder.ToString(1, stringBuilder.Length - 1);
             stringBuilder.Clear();
 
             // Read /path?request

--- a/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
@@ -3,9 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -22,113 +20,50 @@ namespace Datadog.Trace.TestHelpers
         public static async Task<MockHttpRequest> ReadRequest(Stream stream)
         {
             var headers = new HttpHeaders();
-            char currentChar = char.MinValue;
-            int streamPosition = 0;
-
-            // https://tools.ietf.org/html/rfc2616#section-4.2
-            const int bufferSize = 10;
+            var helper = new StreamReaderHelper(stream);
 
             var stringBuilder = new StringBuilder();
 
-            var chArray = new byte[bufferSize];
-
-            async Task GoNextChar()
-            {
-                var bytesRead = await stream.ReadAsync(chArray, offset: 0, count: 1).ConfigureAwait(false);
-                if (bytesRead == 0)
-                {
-                    ThrowHelper.ThrowInvalidOperationException($"Unexpected end of stream at position {streamPosition}");
-                }
-
-                currentChar = Encoding.ASCII.GetChars(chArray)[0];
-                streamPosition++;
-            }
-
-            async Task ReadUntil(StringBuilder builder, char stopChar)
-            {
-                while (!currentChar.Equals(stopChar))
-                {
-                    builder.Append(currentChar);
-                    await GoNextChar().ConfigureAwait(false);
-                }
-            }
-
-            async Task ReadUntilNewLine(StringBuilder builder)
-            {
-                do
-                {
-                    if (await IsNewLine().ConfigureAwait(false))
-                    {
-                        break;
-                    }
-
-                    await ReadUntil(builder, DatadogHttpValues.CarriageReturn).ConfigureAwait(false);
-                }
-                while (true);
-            }
-
-            async Task<bool> IsNewLine()
-            {
-                if (currentChar.Equals(DatadogHttpValues.CarriageReturn))
-                {
-                    // end of headers
-                    // Next character should be a LineFeed, regardless of Linux/Windows
-                    // Skip the newline indicator
-                    await GoNextChar().ConfigureAwait(false);
-
-                    if (!currentChar.Equals(DatadogHttpValues.LineFeed))
-                    {
-                        ThrowHelper.ThrowException($"Unexpected character {currentChar} in headers: CR must be followed by LF");
-                    }
-
-                    return true;
-                }
-
-                return false;
-            }
-
-            stringBuilder.Clear();
-
             // Read POST
-            await ReadUntil(stringBuilder, stopChar: ' ').ConfigureAwait(false);
+            await helper.ReadUntil(stringBuilder, stopChar: ' ').ConfigureAwait(false);
 
             var method = stringBuilder.ToString();
             stringBuilder.Clear();
 
             // Read /path?request
-            await GoNextChar().ConfigureAwait(false);
-            await ReadUntil(stringBuilder, stopChar: ' ').ConfigureAwait(false);
+            await helper.GoNextChar().ConfigureAwait(false);
+            await helper.ReadUntil(stringBuilder, stopChar: ' ').ConfigureAwait(false);
 
             var pathAndQuery = stringBuilder.ToString().Trim();
             stringBuilder.Clear();
 
             // Skip to end of line
-            await ReadUntilNewLine(stringBuilder).ConfigureAwait(false);
+            await helper.ReadUntilNewLine(stringBuilder).ConfigureAwait(false);
             stringBuilder.Clear();
 
             // Read headers
             do
             {
-                await GoNextChar().ConfigureAwait(false);
+                await helper.GoNextChar().ConfigureAwait(false);
 
                 // Check for end of headers
-                if (await IsNewLine().ConfigureAwait(false))
+                if (await helper.IsNewLine().ConfigureAwait(false))
                 {
                     // Empty line, content starts next
                     break;
                 }
 
                 // Read key
-                await ReadUntil(stringBuilder, stopChar: ':').ConfigureAwait(false);
+                await helper.ReadUntil(stringBuilder, stopChar: ':').ConfigureAwait(false);
 
                 var name = stringBuilder.ToString().Trim();
                 stringBuilder.Clear();
 
                 // skip separator
-                await GoNextChar().ConfigureAwait(false);
+                await helper.GoNextChar().ConfigureAwait(false);
 
                 // Read value
-                await ReadUntilNewLine(stringBuilder).ConfigureAwait(false);
+                await helper.ReadUntilNewLine(stringBuilder).ConfigureAwait(false);
 
                 var value = stringBuilder.ToString().Trim();
                 stringBuilder.Clear();
@@ -181,6 +116,72 @@ namespace Datadog.Trace.TestHelpers
                     ContentLength = request.ContentLength64,
                     Body = new StreamContent(request.InputStream, request.ContentLength64),
                 };
+            }
+        }
+
+        private class StreamReaderHelper(Stream stream)
+        {
+            // https://tools.ietf.org/html/rfc2616#section-4.2
+            private const int BufferSize = 10;
+            private readonly byte[] _chArray = new byte[BufferSize];
+            private readonly Stream _stream = stream;
+
+            private char _currentChar = char.MinValue;
+            private int _streamPosition = 0;
+
+            public async Task GoNextChar()
+            {
+                var bytesRead = await _stream.ReadAsync(_chArray, offset: 0, count: 1).ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    ThrowHelper.ThrowInvalidOperationException($"Unexpected end of stream at position {_streamPosition}");
+                }
+
+                _currentChar = Encoding.ASCII.GetChars(_chArray)[0];
+                _streamPosition++;
+            }
+
+            public async Task ReadUntil(StringBuilder builder, char stopChar)
+            {
+                while (!_currentChar.Equals(stopChar))
+                {
+                    builder.Append(_currentChar);
+                    await GoNextChar().ConfigureAwait(false);
+                }
+            }
+
+            public async Task ReadUntilNewLine(StringBuilder builder)
+            {
+                do
+                {
+                    if (await IsNewLine().ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    await ReadUntil(builder, DatadogHttpValues.CarriageReturn).ConfigureAwait(false);
+                }
+                while (true);
+            }
+
+            public async Task<bool> IsNewLine()
+            {
+                if (_currentChar.Equals(DatadogHttpValues.CarriageReturn))
+                {
+                    // end of headers
+                    // Next character should be a LineFeed, regardless of Linux/Windows
+                    // Skip the newline indicator
+                    await GoNextChar().ConfigureAwait(false);
+
+                    if (!_currentChar.Equals(DatadogHttpValues.LineFeed))
+                    {
+                        ThrowHelper.ThrowException($"Unexpected character {_currentChar} in headers: CR must be followed by LF");
+                    }
+
+                    return true;
+                }
+
+                return false;
             }
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1106,6 +1106,7 @@ namespace Datadog.Trace.TestHelpers
                         catch (Exception ex)
                         {
                             Output?.WriteLine($"[HandleHttpRequests]Error processing web request to {ctx.Request.Url}: {ex}");
+                            ctx.Response.StatusCode = 500;
                             ctx.Response.Close();
                         }
                     }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -98,7 +98,7 @@ namespace Datadog.Trace.Tests.Logging
         {
             const int secondsBetweenLogs = 60;
             var rateLimiter = new LogRateLimiter(secondsBetweenLogs);
-            var logger = new DatadogSerilogLogger(_logger, rateLimiter);
+            var logger = new DatadogSerilogLogger(_logger, rateLimiter, null);
 
             var clock = new SimpleClock();
             _clockDisposable = Clock.SetForCurrentThread(clock);
@@ -120,7 +120,7 @@ namespace Datadog.Trace.Tests.Logging
         {
             const int secondsBetweenLogs = 60;
             var rateLimiter = new LogRateLimiter(secondsBetweenLogs);
-            var logger = new DatadogSerilogLogger(_logger, rateLimiter);
+            var logger = new DatadogSerilogLogger(_logger, rateLimiter, null);
 
             var clock = new SimpleClock();
             _clockDisposable = Clock.SetForCurrentThread(clock);
@@ -142,7 +142,7 @@ namespace Datadog.Trace.Tests.Logging
         {
             const int secondsBetweenLogs = 60;
             var rateLimiter = new LogRateLimiter(secondsBetweenLogs);
-            var logger = new DatadogSerilogLogger(_logger, rateLimiter);
+            var logger = new DatadogSerilogLogger(_logger, rateLimiter, null);
 
             var clock = new SimpleClock();
             _clockDisposable = Clock.SetForCurrentThread(clock);
@@ -161,7 +161,7 @@ namespace Datadog.Trace.Tests.Logging
         {
             const int secondsBetweenLogs = 60;
             var rateLimiter = new LogRateLimiter(secondsBetweenLogs);
-            var logger = new DatadogSerilogLogger(_logger, rateLimiter);
+            var logger = new DatadogSerilogLogger(_logger, rateLimiter, null);
             var clock = new SimpleClock();
             _clockDisposable = Clock.SetForCurrentThread(clock);
 
@@ -189,7 +189,7 @@ namespace Datadog.Trace.Tests.Logging
         public void ErrorsDuringRateLimiting_DontBubbleUp()
         {
             var rateLimiter = new FailingRateLimiter();
-            var logger = new DatadogSerilogLogger(_logger, rateLimiter);
+            var logger = new DatadogSerilogLogger(_logger, rateLimiter, null);
 
             // Should not throw
             logger.Warning("Warning level message");
@@ -206,7 +206,7 @@ namespace Datadog.Trace.Tests.Logging
                 .Setup(x => x.Write(It.IsAny<LogEventLevel>(), It.IsAny<Exception>(), It.IsAny<string>(), It.IsAny<object[]>()))
                 .Throws(new NotImplementedException());
 
-            var logger = new DatadogSerilogLogger(mockLogger.Object, new NullLogRateLimiter());
+            var logger = new DatadogSerilogLogger(mockLogger.Object, new NullLogRateLimiter(), null);
 
             // Should not throw
             logger.Warning("Warning level message");

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
@@ -1,0 +1,68 @@
+﻿// <copyright file="DebugLogReaderTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Logging.TracerFlare;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.TracerFlare;
+
+public class DebugLogReaderTests
+{
+    [Fact]
+    public void TryToCreateSentinelFile_CreateSentinelInExistingDirectory_Succeeds()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(directory);
+
+        var id = Guid.NewGuid().ToString();
+        var result = DebugLogReader.TryToCreateSentinelFile(directory, id);
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryToCreateSentinelFile_CreateSecondSentinelInExistingDirectory_Succeeds()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(directory);
+
+        var id1 = Guid.NewGuid().ToString();
+        var id2 = Guid.NewGuid().ToString();
+
+        var result1 = DebugLogReader.TryToCreateSentinelFile(directory, id1);
+        var result2 = DebugLogReader.TryToCreateSentinelFile(directory, id2);
+
+        result1.Should().BeTrue();
+        result2.Should().BeTrue();
+    }
+
+    [Fact]
+    public void TryToCreateSentinelFile_CreateSameSentinel_Fails()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(directory);
+
+        var id = Guid.NewGuid().ToString();
+
+        var result1 = DebugLogReader.TryToCreateSentinelFile(directory, id);
+        var result2 = DebugLogReader.TryToCreateSentinelFile(directory, id);
+
+        result1.Should().BeTrue();
+        result2.Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryToCreateSentinelFile_CreateSentinelInNonExistingDirectory_Fails()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        var id = Guid.NewGuid().ToString();
+
+        var result = DebugLogReader.TryToCreateSentinelFile(directory, id);
+
+        result.Should().BeFalse();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
@@ -5,13 +5,17 @@
 
 using System;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Logging.TracerFlare;
 using FluentAssertions;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Datadog.Trace.Tests.Logging.TracerFlare;
 
-public class DebugLogReaderTests
+public class DebugLogReaderTests(ITestOutputHelper output)
 {
     [Fact]
     public void TryToCreateSentinelFile_CreateSentinelInExistingDirectory_Succeeds()
@@ -64,5 +68,87 @@ public class DebugLogReaderTests
         var result = DebugLogReader.TryToCreateSentinelFile(directory, id);
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WriteDebugLogArchiveToStream_WithMultipleFiles_CreatesArchive()
+    {
+        // create files
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        output.WriteLine("Creating log directory " + directory);
+        Directory.CreateDirectory(directory);
+        var files = new[]
+        {
+            "dotnet-tracer-managed-dotnet-20231213.log",
+            "DD-DotNet-Profiler-Native-dotnet-16272.log",
+            "dotnet-tracer-native-dotnet-16272.log",
+            "dotnet-tracer-native-dotnet-28504.log",
+        };
+        foreach (var file in files)
+        {
+            await CreateLogFile(directory, file);
+        }
+
+        // These are chonky, going to do a lot of resizing, but meh
+        using var ms = new MemoryStream();
+
+        // zip, scrub, write to stream
+        output.WriteLine("Reading log files");
+        await DebugLogReader.WriteDebugLogArchiveToStream(ms, directory);
+
+        // write the zip file for external testing
+        var zipFile = Path.Combine(directory, "debug_logs.zip");
+        output.WriteLine("Creating zip file " + zipFile);
+        using (var fs = File.Create(zipFile))
+        {
+            ms.Seek(offset: 0, SeekOrigin.Begin);
+            await ms.CopyToAsync(fs);
+        }
+
+        ms.Seek(offset: 0, SeekOrigin.Begin);
+        using var archive = new ZipArchive(ms, ZipArchiveMode.Read);
+        archive.Entries
+               .Should()
+               .Contain(x => files.Contains(x.Name));
+
+        var extractTo = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        output.WriteLine("Extracting log directory to " + extractTo);
+
+        archive.ExtractToDirectory(extractTo);
+        // confirm all the files are identical
+        foreach (var filename in files)
+        {
+            var originalPath = Path.Combine(directory, filename);
+            var extractedPath = Path.Combine(extractTo, filename);
+
+            File.Exists(extractedPath).Should().BeTrue();
+            var originalContents = File.ReadAllText(originalPath);
+            var extractedContents = File.ReadAllText(extractedPath);
+
+            extractedContents.Should().Be(originalContents);
+        }
+
+        return;
+
+        static async Task CreateLogFile(string directory, string filename)
+        {
+            // These lines don't include anything that needs scrubbing so can be round-tripped
+            const string logLines =
+                """
+                2023-12-13 10:04:16.335 +00:00 [WRN] Error discovering available agent services  { MachineName: ".", Process: "[30856 dotnet]", AppDomain: "[1 ReSharperTestRunner]", AssemblyLoadContext: "\"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext #0", TracerVersion: "2.44.0.0" }
+                2023-12-13 18:11:55.360 +00:00 [INF] Sentinel file for config 1a6e1e13-c487-4900-bd63-65dd5c4dde0f found in C:\Users\andrew.lock\AppData\Local\Temp\99e04cab-b68c-4d1f-9586-b2c02f0f03a9  { MachineName: ".", Process: "[50524 dotnet]", AppDomain: "[1 ReSharperTestRunner]", AssemblyLoadContext: "\"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext #0", TracerVersion: "2.44.0.0" }
+                2023-12-06 11:29:18.051 +00:00 [INF] DATADOG TRACER CONFIGURATION - {"date":"2023-12-06T11:29:18.047752+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.19045.0","version":"2.43.0.0","native_tracer_version":"2.43.0","platform":"x64","lang":".NET","lang_version":"8.0.0","env":"andrew","enabled":true,"service":"BlazorWebApp","agent_url":"http://127.0.0.1:8126/","agent_transport":"Default","debug":true,"health_checks_enabled":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":false,"disabled_integrations":["OpenTelemetry"],"routetemplate_resourcenames_enabled":true,"routetemplate_expansion_enabled":false,"querystring_reporting_enabled":true,"obfuscation_querystring_regex_timout":200.0,"obfuscation_querystring_size":5000,"partialflush_enabled":false,"partialflush_minspans":500,"runtime_id":"b3eef1ac-546a-408a-994c-fdc69456c36c","agent_reachable":true,"agent_error":"","appsec_enabled":false,"appsec_trace_rate_limit":100,"appsec_rules_file_path":"(default)","appsec_libddwaf_version":"(none)","iast_enabled":false,"iast_deduplication_enabled":true,"iast_weak_hash_algorithms":"HMACMD5,MD5,HMACSHA1,SHA1","iast_weak_cipher_algorithms":"DES,TRIPLEDES,RC2","direct_logs_submission_enabled_integrations":[],"direct_logs_submission_enabled":false,"direct_logs_submission_error":"","exporter_settings_warning":["No transport configuration found, using default values"],"dd_trace_methods":"","activity_listener_enabled":false,"profiler_enabled":false,"code_hotspots_enabled":false,"wcf_obfuscation_enabled":true,"data_streams_enabled":false,"span_sampling_rules":null,"stats_computation_enabled":false,"dbm_propagation_mode":"Disabled","header_tags":[],"service_mapping":[]}  { MachineName: ".", Process: "[35160 dotnet]", AppDomain: "[1 BlazorWebApp]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.43.0.0" }
+                """;
+
+            using var writer = File.CreateText(Path.Combine(directory, filename));
+            // Creates files ~10MB (max file size we expect)
+            const int repeats = 4000;
+            foreach (var line in Enumerable.Repeat(logLines, repeats))
+            {
+                await writer.WriteLineAsync(line);
+            }
+
+            await writer.FlushAsync();
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
@@ -4,9 +4,11 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Logging.TracerFlare;
@@ -216,7 +218,76 @@ public class DebugLogReaderTests(ITestOutputHelper output)
         }
     }
 
-    private static async Task CreateLogFileWithContent(string directory, string filename)
+    [Theory]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    public async Task WriteDebugLogArchiveToStream_OnlyIncludesMostRecentLogsWhenOverSizeLimit(int filesToWrite)
+    {
+        // create files
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        output.WriteLine("Creating log directory " + directory);
+        Directory.CreateDirectory(directory);
+
+        // These files are very repetitive, so each one compresses down massively
+        const int totalFiles = 4;
+        var skippedFileCount = totalFiles - filesToWrite;
+        var allFiles = new List<string>();
+        for (var i = 0; i < totalFiles; i++)
+        {
+            var filename = $"dotnet-tracer-managed-dotnet-202312{i}.log";
+            await CreateLogFileWithContent(directory, filename);
+            allFiles.Add(filename);
+        }
+
+        // make sure we flag as being "oversized" when we have more than two of them
+        // We only write the _last_
+        var includedFiles = allFiles.Skip(skippedFileCount).ToArray();
+        var filesWritten = 0;
+        var extractTo = await CreateAndExtractZipFile(
+                            directory,
+                            includedFiles,
+                            streamHasCapacityFunc: (_, _) => Interlocked.Increment(ref filesWritten) <= filesToWrite);
+
+        // confirm we only have the files we expected and not the remaining
+        foreach (var filename in includedFiles)
+        {
+            var originalPath = Path.Combine(directory, filename);
+            var extractedPath = Path.Combine(extractTo, filename);
+
+            File.Exists(extractedPath).Should().BeTrue();
+            var originalContents = File.ReadAllText(originalPath);
+            var extractedContents = File.ReadAllText(extractedPath);
+
+            extractedContents.Should().Be(originalContents);
+        }
+
+        foreach (var filename in allFiles.Take(skippedFileCount))
+        {
+            var extractedPath = Path.Combine(extractTo, filename);
+            File.Exists(extractedPath).Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task StreamHasCapacity_EstimatesCapacityCorrectly()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        output.WriteLine("Creating log directory " + directory);
+        Directory.CreateDirectory(directory);
+        var file = await CreateLogFileWithContent(directory, "somefile.log");
+
+        // Plenty of capacity
+        DebugLogReader.StreamHasCapacity(file, remainingCapacity: file.Length * 2).Should().BeTrue();
+        // just enough capacity
+        DebugLogReader.StreamHasCapacity(file, remainingCapacity: file.Length / 10).Should().BeTrue();
+        // just too little capacity
+        DebugLogReader.StreamHasCapacity(file, remainingCapacity: (file.Length / 10) - 1).Should().BeFalse();
+        // No capacity
+        DebugLogReader.StreamHasCapacity(file, remainingCapacity: 0).Should().BeFalse();
+    }
+
+    private static async Task<FileInfo> CreateLogFileWithContent(string directory, string filename)
     {
         // These lines don't include anything that needs scrubbing so can be round-tripped
         const string logLines =
@@ -226,22 +297,36 @@ public class DebugLogReaderTests(ITestOutputHelper output)
             2023-12-06 11:29:18.051 +00:00 [INF] DATADOG TRACER CONFIGURATION - {"date":"2023-12-06T11:29:18.047752+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.19045.0","version":"2.43.0.0","native_tracer_version":"2.43.0","platform":"x64","lang":".NET","lang_version":"8.0.0","env":"andrew","enabled":true,"service":"BlazorWebApp","agent_url":"http://127.0.0.1:8126/","agent_transport":"Default","debug":true,"health_checks_enabled":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":false,"disabled_integrations":["OpenTelemetry"],"routetemplate_resourcenames_enabled":true,"routetemplate_expansion_enabled":false,"querystring_reporting_enabled":true,"obfuscation_querystring_regex_timout":200.0,"obfuscation_querystring_size":5000,"partialflush_enabled":false,"partialflush_minspans":500,"runtime_id":"b3eef1ac-546a-408a-994c-fdc69456c36c","agent_reachable":true,"agent_error":"","appsec_enabled":false,"appsec_trace_rate_limit":100,"appsec_rules_file_path":"(default)","appsec_libddwaf_version":"(none)","iast_enabled":false,"iast_deduplication_enabled":true,"iast_weak_hash_algorithms":"HMACMD5,MD5,HMACSHA1,SHA1","iast_weak_cipher_algorithms":"DES,TRIPLEDES,RC2","direct_logs_submission_enabled_integrations":[],"direct_logs_submission_enabled":false,"direct_logs_submission_error":"","exporter_settings_warning":["No transport configuration found, using default values"],"dd_trace_methods":"","activity_listener_enabled":false,"profiler_enabled":false,"code_hotspots_enabled":false,"wcf_obfuscation_enabled":true,"data_streams_enabled":false,"span_sampling_rules":null,"stats_computation_enabled":false,"dbm_propagation_mode":"Disabled","header_tags":[],"service_mapping":[]}  { MachineName: ".", Process: "[35160 dotnet]", AppDomain: "[1 BlazorWebApp]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.43.0.0" }
             """;
 
-        using var writer = File.CreateText(Path.Combine(directory, filename));
-        // Creates files ~10MB (max file size we expect)
-        const int repeats = 4000;
-        foreach (var line in Enumerable.Repeat(logLines, repeats))
+        var filepath = Path.Combine(directory, filename);
+        using var writer = File.CreateText(filepath);
         {
-            await writer.WriteLineAsync(line);
+            // Creates files ~10MB (max file size we expect)
+            const int repeats = 4000;
+            // write the name of the file in the top to ensure each file is unique
+            await writer.WriteLineAsync(filename);
+            foreach (var line in Enumerable.Repeat(logLines, repeats))
+            {
+                await writer.WriteLineAsync(line);
+            }
+
+            await writer.FlushAsync();
         }
 
-        await writer.FlushAsync();
+        return new FileInfo(filepath);
     }
 
-    private async Task<string> CreateAndExtractZipFile(string directory, string[] files)
+    private async Task<string> CreateAndExtractZipFile(string directory, string[] files, Func<FileInfo, long, bool> streamHasCapacityFunc = null)
     {
         using var ms = new MemoryStream();
         output.WriteLine("Reading log files");
-        await DebugLogReader.WriteDebugLogArchiveToStream(ms, directory);
+        if (streamHasCapacityFunc is not null)
+        {
+            await DebugLogReader.WriteDebugLogArchiveToStream(ms, directory, streamHasCapacityFunc);
+        }
+        else
+        {
+            await DebugLogReader.WriteDebugLogArchiveToStream(ms, directory);
+        }
 
         // write the zip file for external testing
         var zipFile = Path.Combine(directory, "debug_logs.zip");

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/DebugLogReaderTests.cs
@@ -71,6 +71,91 @@ public class DebugLogReaderTests(ITestOutputHelper output)
     }
 
     [Fact]
+    public async Task WriteDebugLogArchiveToStream_WithEmptyDirectory_CreatesArchive()
+    {
+        // create directory
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        output.WriteLine("Creating log directory " + directory);
+        Directory.CreateDirectory(directory);
+
+        var extractTo = await CreateAndExtractZipFile(directory, files: Array.Empty<string>());
+
+        Directory.GetFiles(extractTo, "*.*", SearchOption.AllDirectories)
+                 .Should()
+                 .BeEmpty();
+    }
+
+    [Fact]
+    public async Task WriteDebugLogArchiveToStream_WithZeroLengthFiles_CreatesArchive()
+    {
+        // create directory
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        output.WriteLine("Creating log directory " + directory);
+        Directory.CreateDirectory(directory);
+        var files = new[]
+        {
+            "dotnet-tracer-managed-dotnet-20231213.log",
+            "DD-DotNet-Profiler-Native-dotnet-16272.log",
+            "dotnet-tracer-native-dotnet-16272.log",
+            "dotnet-tracer-native-dotnet-28504.log",
+        };
+        foreach (var file in files)
+        {
+            using var fs = File.Create(Path.Combine(directory, file));
+        }
+
+        var extractTo = await CreateAndExtractZipFile(directory, files);
+
+        foreach (var filename in files)
+        {
+            var extractedPath = Path.Combine(extractTo, filename);
+
+            File.Exists(extractedPath).Should().BeTrue();
+            File.ReadAllText(extractedPath).Should().BeNullOrEmpty();
+        }
+    }
+
+    [Fact]
+    public async Task WriteDebugLogArchiveToStream_ExcludesSentinelFiles_CreatesArchive()
+    {
+        // create directory
+        var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        output.WriteLine("Creating log directory " + directory);
+        Directory.CreateDirectory(directory);
+        var files = new[]
+        {
+            "dotnet-tracer-managed-dotnet-20231213.log",
+            "DD-DotNet-Profiler-Native-dotnet-16272.log",
+            "dotnet-tracer-native-dotnet-16272.log",
+            "dotnet-tracer-native-dotnet-28504.log",
+        };
+
+        foreach (var file in files)
+        {
+            using var fs = File.Create(Path.Combine(directory, file));
+        }
+
+        // Create a sentinel file in the logs directory
+        // It shouldn't be included in the archive
+        var result = DebugLogReader.TryToCreateSentinelFile(directory, Guid.NewGuid().ToString());
+        result.Should().BeTrue();
+
+        var extractTo = await CreateAndExtractZipFile(directory, files);
+
+        foreach (var filename in files)
+        {
+            var extractedPath = Path.Combine(extractTo, filename);
+
+            File.Exists(extractedPath).Should().BeTrue();
+            File.ReadAllText(extractedPath).Should().BeNullOrEmpty();
+        }
+
+        Directory.GetFiles(extractTo, "*sentinel*.*", SearchOption.AllDirectories)
+                 .Should()
+                 .BeEmpty();
+    }
+
+    [Fact]
     public async Task WriteDebugLogArchiveToStream_WithMultipleFiles_CreatesArchive()
     {
         // create files
@@ -86,13 +171,49 @@ public class DebugLogReaderTests(ITestOutputHelper output)
         };
         foreach (var file in files)
         {
-            await CreateLogFile(directory, file);
+            await CreateLogFileWithContent(directory, file);
         }
 
-        // These are chonky, going to do a lot of resizing, but meh
-        using var ms = new MemoryStream();
+        var extractTo = await CreateAndExtractZipFile(directory, files);
 
-        // zip, scrub, write to stream
+        // confirm all the files are identical
+        foreach (var filename in files)
+        {
+            var originalPath = Path.Combine(directory, filename);
+            var extractedPath = Path.Combine(extractTo, filename);
+
+            File.Exists(extractedPath).Should().BeTrue();
+            var originalContents = File.ReadAllText(originalPath);
+            var extractedContents = File.ReadAllText(extractedPath);
+
+            extractedContents.Should().Be(originalContents);
+        }
+    }
+
+    private static async Task CreateLogFileWithContent(string directory, string filename)
+    {
+        // These lines don't include anything that needs scrubbing so can be round-tripped
+        const string logLines =
+            """
+            2023-12-13 10:04:16.335 +00:00 [WRN] Error discovering available agent services  { MachineName: ".", Process: "[30856 dotnet]", AppDomain: "[1 ReSharperTestRunner]", AssemblyLoadContext: "\"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext #0", TracerVersion: "2.44.0.0" }
+            2023-12-13 18:11:55.360 +00:00 [INF] Sentinel file for config 1a6e1e13-c487-4900-bd63-65dd5c4dde0f found in C:\Users\andrew.lock\AppData\Local\Temp\99e04cab-b68c-4d1f-9586-b2c02f0f03a9  { MachineName: ".", Process: "[50524 dotnet]", AppDomain: "[1 ReSharperTestRunner]", AssemblyLoadContext: "\"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext #0", TracerVersion: "2.44.0.0" }
+            2023-12-06 11:29:18.051 +00:00 [INF] DATADOG TRACER CONFIGURATION - {"date":"2023-12-06T11:29:18.047752+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.19045.0","version":"2.43.0.0","native_tracer_version":"2.43.0","platform":"x64","lang":".NET","lang_version":"8.0.0","env":"andrew","enabled":true,"service":"BlazorWebApp","agent_url":"http://127.0.0.1:8126/","agent_transport":"Default","debug":true,"health_checks_enabled":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":false,"disabled_integrations":["OpenTelemetry"],"routetemplate_resourcenames_enabled":true,"routetemplate_expansion_enabled":false,"querystring_reporting_enabled":true,"obfuscation_querystring_regex_timout":200.0,"obfuscation_querystring_size":5000,"partialflush_enabled":false,"partialflush_minspans":500,"runtime_id":"b3eef1ac-546a-408a-994c-fdc69456c36c","agent_reachable":true,"agent_error":"","appsec_enabled":false,"appsec_trace_rate_limit":100,"appsec_rules_file_path":"(default)","appsec_libddwaf_version":"(none)","iast_enabled":false,"iast_deduplication_enabled":true,"iast_weak_hash_algorithms":"HMACMD5,MD5,HMACSHA1,SHA1","iast_weak_cipher_algorithms":"DES,TRIPLEDES,RC2","direct_logs_submission_enabled_integrations":[],"direct_logs_submission_enabled":false,"direct_logs_submission_error":"","exporter_settings_warning":["No transport configuration found, using default values"],"dd_trace_methods":"","activity_listener_enabled":false,"profiler_enabled":false,"code_hotspots_enabled":false,"wcf_obfuscation_enabled":true,"data_streams_enabled":false,"span_sampling_rules":null,"stats_computation_enabled":false,"dbm_propagation_mode":"Disabled","header_tags":[],"service_mapping":[]}  { MachineName: ".", Process: "[35160 dotnet]", AppDomain: "[1 BlazorWebApp]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.43.0.0" }
+            """;
+
+        using var writer = File.CreateText(Path.Combine(directory, filename));
+        // Creates files ~10MB (max file size we expect)
+        const int repeats = 4000;
+        foreach (var line in Enumerable.Repeat(logLines, repeats))
+        {
+            await writer.WriteLineAsync(line);
+        }
+
+        await writer.FlushAsync();
+    }
+
+    private async Task<string> CreateAndExtractZipFile(string directory, string[] files)
+    {
+        using var ms = new MemoryStream();
         output.WriteLine("Reading log files");
         await DebugLogReader.WriteDebugLogArchiveToStream(ms, directory);
 
@@ -107,48 +228,24 @@ public class DebugLogReaderTests(ITestOutputHelper output)
 
         ms.Seek(offset: 0, SeekOrigin.Begin);
         using var archive = new ZipArchive(ms, ZipArchiveMode.Read);
-        archive.Entries
-               .Should()
-               .Contain(x => files.Contains(x.Name));
+        if (files.Length > 0)
+        {
+            archive.Entries
+                   .Should()
+                   .Contain(x => files.Contains(x.Name));
+        }
+        else
+        {
+            archive.Entries
+                   .Should()
+                   .BeEmpty();
+        }
 
         var extractTo = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
         output.WriteLine("Extracting log directory to " + extractTo);
 
+        Directory.CreateDirectory(extractTo);
         archive.ExtractToDirectory(extractTo);
-        // confirm all the files are identical
-        foreach (var filename in files)
-        {
-            var originalPath = Path.Combine(directory, filename);
-            var extractedPath = Path.Combine(extractTo, filename);
-
-            File.Exists(extractedPath).Should().BeTrue();
-            var originalContents = File.ReadAllText(originalPath);
-            var extractedContents = File.ReadAllText(extractedPath);
-
-            extractedContents.Should().Be(originalContents);
-        }
-
-        return;
-
-        static async Task CreateLogFile(string directory, string filename)
-        {
-            // These lines don't include anything that needs scrubbing so can be round-tripped
-            const string logLines =
-                """
-                2023-12-13 10:04:16.335 +00:00 [WRN] Error discovering available agent services  { MachineName: ".", Process: "[30856 dotnet]", AppDomain: "[1 ReSharperTestRunner]", AssemblyLoadContext: "\"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext #0", TracerVersion: "2.44.0.0" }
-                2023-12-13 18:11:55.360 +00:00 [INF] Sentinel file for config 1a6e1e13-c487-4900-bd63-65dd5c4dde0f found in C:\Users\andrew.lock\AppData\Local\Temp\99e04cab-b68c-4d1f-9586-b2c02f0f03a9  { MachineName: ".", Process: "[50524 dotnet]", AppDomain: "[1 ReSharperTestRunner]", AssemblyLoadContext: "\"Default\" System.Runtime.Loader.DefaultAssemblyLoadContext #0", TracerVersion: "2.44.0.0" }
-                2023-12-06 11:29:18.051 +00:00 [INF] DATADOG TRACER CONFIGURATION - {"date":"2023-12-06T11:29:18.047752+00:00","os_name":"Windows","os_version":"Microsoft Windows NT 10.0.19045.0","version":"2.43.0.0","native_tracer_version":"2.43.0","platform":"x64","lang":".NET","lang_version":"8.0.0","env":"andrew","enabled":true,"service":"BlazorWebApp","agent_url":"http://127.0.0.1:8126/","agent_transport":"Default","debug":true,"health_checks_enabled":false,"analytics_enabled":false,"sample_rate":null,"sampling_rules":null,"tags":[],"log_injection_enabled":false,"runtime_metrics_enabled":false,"disabled_integrations":["OpenTelemetry"],"routetemplate_resourcenames_enabled":true,"routetemplate_expansion_enabled":false,"querystring_reporting_enabled":true,"obfuscation_querystring_regex_timout":200.0,"obfuscation_querystring_size":5000,"partialflush_enabled":false,"partialflush_minspans":500,"runtime_id":"b3eef1ac-546a-408a-994c-fdc69456c36c","agent_reachable":true,"agent_error":"","appsec_enabled":false,"appsec_trace_rate_limit":100,"appsec_rules_file_path":"(default)","appsec_libddwaf_version":"(none)","iast_enabled":false,"iast_deduplication_enabled":true,"iast_weak_hash_algorithms":"HMACMD5,MD5,HMACSHA1,SHA1","iast_weak_cipher_algorithms":"DES,TRIPLEDES,RC2","direct_logs_submission_enabled_integrations":[],"direct_logs_submission_enabled":false,"direct_logs_submission_error":"","exporter_settings_warning":["No transport configuration found, using default values"],"dd_trace_methods":"","activity_listener_enabled":false,"profiler_enabled":false,"code_hotspots_enabled":false,"wcf_obfuscation_enabled":true,"data_streams_enabled":false,"span_sampling_rules":null,"stats_computation_enabled":false,"dbm_propagation_mode":"Disabled","header_tags":[],"service_mapping":[]}  { MachineName: ".", Process: "[35160 dotnet]", AppDomain: "[1 BlazorWebApp]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.43.0.0" }
-                """;
-
-            using var writer = File.CreateText(Path.Combine(directory, filename));
-            // Creates files ~10MB (max file size we expect)
-            const int repeats = 4000;
-            foreach (var line in Enumerable.Repeat(logLines, repeats))
-            {
-                await writer.WriteLineAsync(line);
-            }
-
-            await writer.FlushAsync();
-        }
+        return extractTo;
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.net461.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.net461.verified.txt
@@ -3,6 +3,7 @@ System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
 System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
 System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
+System.IO.Compression, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
 System.Numerics, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
 System.Runtime.Serialization, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
 System.Web, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
@@ -75,6 +75,11 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             MockCIVisibilityTestModule testSession = null;
             agent.EventPlatformProxyPayloadReceived += (sender, args) =>
             {
+                if (args.Value.Headers["Content-Type"] != "application/msgpack")
+                {
+                    return;
+                }
+
                 var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(args.Value.BodyInJson);
                 if (payload.Events?.Length > 0)
                 {


### PR DESCRIPTION
## Summary of changes

- Don't return a `200 OK` if an error occurs parsing a request
- Extract HTTP stream-reading helpers into separate class
- Don't include the `\0` in the parsed HTTP method
- Ensure MockTracerAgent handles different types of `evp_proxy` requests correctly

## Reason for change

Ran into these issues when working on the tracer flare.

## Implementation details

Easiest to review the commits individually - the "extract" commit is a very simple cut and paste

## Test coverage

All covered by existing (or don't care enough to create tests for it 😅)

## Other details

Prerequisite for other stacked PRs
- https://github.com/DataDog/dd-trace-dotnet/pull/4989
- https://github.com/DataDog/dd-trace-dotnet/pull/4990
- https://github.com/DataDog/dd-trace-dotnet/pull/4991
- https://github.com/DataDog/dd-trace-dotnet/pull/4997

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/4987
- https://github.com/DataDog/dd-trace-dotnet/pull/4994

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
