### PR TITLE
Add `PushStream` support to `IApiRequest` and support chunked-encoding

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -318,6 +318,8 @@
    </assembly>
    <assembly fullname="System.Memory">
       <type fullname="System.Buffers.Binary.BinaryPrimitives" />
+      <type fullname="System.Buffers.StandardFormat" />
+      <type fullname="System.Buffers.Text.Utf8Formatter" />
       <type fullname="System.MemoryExtensions" />
       <type fullname="System.Runtime.InteropServices.MemoryMarshal" />
    </assembly>
@@ -329,6 +331,7 @@
       <type fullname="System.Net.Http.Headers.HttpRequestHeaders" />
       <type fullname="System.Net.Http.Headers.HttpResponseHeaders" />
       <type fullname="System.Net.Http.Headers.MediaTypeHeaderValue" />
+      <type fullname="System.Net.Http.Headers.NameValueHeaderValue" />
       <type fullname="System.Net.Http.HttpClient" />
       <type fullname="System.Net.Http.HttpClientHandler" />
       <type fullname="System.Net.Http.HttpContent" />

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -359,6 +359,7 @@
       <type fullname="System.Net.Sockets.AddressFamily" />
       <type fullname="System.Net.Sockets.SocketError" />
       <type fullname="System.Net.Sockets.SocketException" />
+      <type fullname="System.Net.TransportContext" />
    </assembly>
    <assembly fullname="System.Net.Requests">
       <type fullname="System.Net.HttpWebRequest" />

--- a/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiRequest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.IO;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.Agent
@@ -17,5 +18,7 @@ namespace Datadog.Trace.Agent
         Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType);
 
         Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding);
+
+        Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.IO;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
@@ -34,21 +35,11 @@ namespace Datadog.Trace.Agent.Transports
             _request.Headers.Add(name, value);
         }
 
-        public async Task<IApiResponse> GetAsync()
+        public Task<IApiResponse> GetAsync()
         {
             ResetRequest(method: "GET", contentType: null, contentEncoding: null);
 
-            try
-            {
-                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
-                return new ApiWebResponse(httpWebResponse);
-            }
-            catch (WebException exception)
-                when (exception.Status == WebExceptionStatus.ProtocolError && exception.Response != null)
-            {
-                // If the exception is caused by an error status code, swallow the exception and let the caller handle the result
-                return new ApiWebResponse((HttpWebResponse)exception.Response);
-            }
+            return FinishAndGetResponse();
         }
 
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
@@ -63,17 +54,19 @@ namespace Datadog.Trace.Agent.Transports
                 await requestStream.WriteAsync(bytes.Array, bytes.Offset, bytes.Count).ConfigureAwait(false);
             }
 
-            try
+            return await FinishAndGetResponse().ConfigureAwait(false);
+        }
+
+        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+        {
+            ResetRequest(method: "POST", ContentTypeHelper.GetContentType(contentType, multipartBoundary), contentEncoding);
+
+            using (var requestStream = await _request.GetRequestStreamAsync().ConfigureAwait(false))
             {
-                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
-                return new ApiWebResponse(httpWebResponse);
+                await writeToRequestStream(requestStream).ConfigureAwait(false);
             }
-            catch (WebException exception)
-                when (exception.Status == WebExceptionStatus.ProtocolError && exception.Response != null)
-            {
-                // If the exception is caused by an error status code, ignore it and let the caller handle the result
-                return new ApiWebResponse((HttpWebResponse)exception.Response);
-            }
+
+            return await FinishAndGetResponse().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -167,17 +160,7 @@ namespace Datadog.Trace.Agent.Transports
                 }
             }
 
-            try
-            {
-                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
-                return new ApiWebResponse(httpWebResponse);
-            }
-            catch (WebException exception)
-                when (exception.Status == WebExceptionStatus.ProtocolError && exception.Response != null)
-            {
-                // If the exception is caused by an error status code, ignore it and let the caller handle the result
-                return new ApiWebResponse((HttpWebResponse)exception.Response);
-            }
+            return await FinishAndGetResponse().ConfigureAwait(false);
         }
 
         private void ResetRequest(string method, string contentType, string contentEncoding)
@@ -191,6 +174,21 @@ namespace Datadog.Trace.Agent.Transports
             else
             {
                 _request.Headers.Set(HttpRequestHeader.ContentEncoding, contentEncoding);
+            }
+        }
+
+        private async Task<IApiResponse> FinishAndGetResponse()
+        {
+            try
+            {
+                var httpWebResponse = (HttpWebResponse)await _request.GetResponseAsync().ConfigureAwait(false);
+                return new ApiWebResponse(httpWebResponse);
+            }
+            catch (WebException exception)
+                when (exception.Status == WebExceptionStatus.ProtocolError && exception.Response != null)
+            {
+                // If the exception is caused by an error status code, ignore it and let the caller handle the result
+                return new ApiWebResponse((HttpWebResponse)exception.Response);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ContentTypeHelper.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ContentTypeHelper.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="ContentTypeHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Agent.Transports;
+
+internal static class ContentTypeHelper
+{
+    public static string GetContentType(string contentType, string? multipartBoundary)
+        => string.IsNullOrEmpty(multipartBoundary)
+               ? contentType
+               : $"{contentType}; boundary={multipartBoundary}";
+}

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -33,18 +33,18 @@ namespace Datadog.Trace.Agent.Transports
         }
 
         public async Task<IApiResponse> GetAsync()
-            => (await SendAsync(WebRequestMethods.Http.Get, null, null, null).ConfigureAwait(false)).Item1;
+            => (await SendAsync(WebRequestMethods.Http.Get, null, null, null, chunkedEncoding: false).ConfigureAwait(false)).Item1;
 
         public Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType)
             => PostAsync(bytes, contentType, contentEncoding: null);
 
         public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
-            => (await SendAsync(WebRequestMethods.Http.Post, contentType, new BufferContent(bytes), contentEncoding).ConfigureAwait(false)).Item1;
+            => (await SendAsync(WebRequestMethods.Http.Post, contentType, new BufferContent(bytes), contentEncoding, chunkedEncoding: false).ConfigureAwait(false)).Item1;
 
-        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding)
-            => (await SendAsync(WebRequestMethods.Http.Post, contentType, new HttpOverStreams.HttpContent.PushStreamContent(writeToRequestStream), contentEncoding).ConfigureAwait(false)).Item1;
+        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+            => (await SendAsync(WebRequestMethods.Http.Post, contentType, new HttpOverStreams.HttpContent.PushStreamContent(writeToRequestStream), contentEncoding, chunkedEncoding: true, multipartBoundary).ConfigureAwait(false)).Item1;
 
-        private async Task<Tuple<IApiResponse, HttpRequest>> SendAsync(string verb, string contentType, IHttpContent content, string contentEncoding)
+        private async Task<Tuple<IApiResponse, HttpRequest>> SendAsync(string verb, string contentType, IHttpContent content, string contentEncoding, bool chunkedEncoding, string multipartBoundary = null)
         {
             using (var bidirectionalStream = _streamFactory.GetBidirectionalStream())
             {
@@ -56,6 +56,11 @@ namespace Datadog.Trace.Agent.Transports
                 if (!string.IsNullOrEmpty(contentEncoding))
                 {
                     _headers.Add("Content-Encoding", contentEncoding);
+                }
+
+                if (chunkedEncoding)
+                {
+                    _headers.Add("Transfer-Encoding", "chunked");
                 }
 
                 var request = new HttpRequest(verb, _uri.Host, _uri.PathAndQuery, _headers, content);

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
@@ -41,13 +41,16 @@ namespace Datadog.Trace.Agent.Transports
         public async Task<IApiResponse> PostAsync(ArraySegment<byte> bytes, string contentType, string contentEncoding)
             => (await SendAsync(WebRequestMethods.Http.Post, contentType, new BufferContent(bytes), contentEncoding).ConfigureAwait(false)).Item1;
 
+        public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding)
+            => (await SendAsync(WebRequestMethods.Http.Post, contentType, new HttpOverStreams.HttpContent.PushStreamContent(writeToRequestStream), contentEncoding).ConfigureAwait(false)).Item1;
+
         private async Task<Tuple<IApiResponse, HttpRequest>> SendAsync(string verb, string contentType, IHttpContent content, string contentEncoding)
         {
             using (var bidirectionalStream = _streamFactory.GetBidirectionalStream())
             {
                 if (contentType != null)
                 {
-                    _headers.Add("Content-Type", contentType);
+                    _headers.Add("Content-Type", ContentTypeHelper.GetContentType(contentType, multipartBoundary));
                 }
 
                 if (!string.IsNullOrEmpty(contentEncoding))

--- a/tracer/src/Datadog.Trace/Agent/Transports/PushStreamContent.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/PushStreamContent.cs
@@ -1,0 +1,256 @@
+﻿// <copyright file="PushStreamContent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// Based on code from https://github.com/aspnet/AspNetWebStack/blob/1231b77d79956152831b75ad7f094f844251b97f/src/System.Net.Http.Formatting/PushStreamContent.cs
+// and https://github.com/aspnet/AspNetWebStack/blob/1231b77d79956152831b75ad7f094f844251b97f/src/System.Net.Http.Formatting/Internal/DelegatingStream.cs
+// which is licensed as:
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#nullable enable
+
+#if NETCOREAPP
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Agent.Transports;
+
+/// <summary>
+/// Provides an <see cref="HttpContent"/> implementation that exposes an output <see cref="Stream"/>
+/// which can be written to directly. The ability to push data to the output stream differs from the
+/// <see cref="StreamContent"/> where data is pulled and not pushed.
+/// </summary>
+internal class PushStreamContent : HttpContent
+{
+    private readonly Func<Stream, Task> _onStreamAvailable;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PushStreamContent"/> class with the given <see cref="MediaTypeHeaderValue"/>.
+    /// </summary>
+    /// <param name="onStreamAvailable">The action to call when an output stream is available. When the
+    /// output stream is closed or disposed, it will signal to the content that it has completed and the
+    /// HTTP request or response will be completed.</param>
+    public PushStreamContent(Func<Stream, Task> onStreamAvailable)
+    {
+        _onStreamAvailable = onStreamAvailable;
+    }
+
+    /// <summary>
+    /// When this method is called, it calls the action provided in the constructor with the output
+    /// stream to write to. Once the action has completed its work it closes the stream which will
+    /// close this content instance and complete the HTTP request or response.
+    /// </summary>
+    /// <param name="stream">The <see cref="Stream"/> to which to write.</param>
+    /// <param name="context">The associated <see cref="TransportContext"/>.</param>
+    /// <returns>A <see cref="Task"/> instance that is asynchronously serializing the object's content.</returns>
+    [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exception is passed as task result.")]
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        var serializeToStreamTask = new TaskCompletionSource<bool>();
+
+        var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
+        await _onStreamAvailable(wrappedStream).ConfigureAwait(false);
+
+        // wait for wrappedStream.Close/Dispose to get called.
+        await serializeToStreamTask.Task.ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Computes the length of the stream if possible.
+    /// </summary>
+    /// <param name="length">The computed length of the stream.</param>
+    /// <returns><c>true</c> if the length has been computed; otherwise <c>false</c>.</returns>
+    protected override bool TryComputeLength(out long length)
+    {
+        // We can't know the length of the content being pushed to the output stream.
+        length = -1;
+        return false;
+    }
+
+    private class CompleteTaskOnCloseStream : DelegatingStream
+    {
+        private readonly TaskCompletionSource<bool> _serializeToStreamTask;
+
+        public CompleteTaskOnCloseStream(Stream innerStream, TaskCompletionSource<bool> serializeToStreamTask)
+            : base(innerStream)
+        {
+            Contract.Assert(serializeToStreamTask != null);
+            _serializeToStreamTask = serializeToStreamTask;
+        }
+
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2215:Dispose methods should call base class dispose",
+            Justification = "See comments, this is intentional.")]
+        protected override void Dispose(bool disposing)
+        {
+            // We don't dispose the underlying stream because we don't own it. Dispose in this case just signifies
+            // that the user's action is finished.
+            _serializeToStreamTask.TrySetResult(true);
+        }
+
+        public override void Close()
+        {
+            // We don't Close the underlying stream because we don't own it. Dispose in this case just signifies
+            // that the user's action is finished.
+            _serializeToStreamTask.TrySetResult(true);
+        }
+    }
+
+    /// <summary>
+    /// Stream that delegates to inner stream.
+    /// This is taken from System.Net.Http
+    /// </summary>
+    private abstract class DelegatingStream : Stream
+    {
+        private readonly Stream _innerStream;
+
+        protected DelegatingStream(Stream innerStream)
+        {
+            _innerStream = innerStream;
+        }
+
+        protected Stream InnerStream
+        {
+            get { return _innerStream; }
+        }
+
+        public override bool CanRead
+        {
+            get { return _innerStream.CanRead; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return _innerStream.CanSeek; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return _innerStream.CanWrite; }
+        }
+
+        public override long Length
+        {
+            get { return _innerStream.Length; }
+        }
+
+        public override long Position
+        {
+            get { return _innerStream.Position; }
+            set { _innerStream.Position = value; }
+        }
+
+        public override int ReadTimeout
+        {
+            get { return _innerStream.ReadTimeout; }
+            set { _innerStream.ReadTimeout = value; }
+        }
+
+        public override bool CanTimeout
+        {
+            get { return _innerStream.CanTimeout; }
+        }
+
+        public override int WriteTimeout
+        {
+            get { return _innerStream.WriteTimeout; }
+            set { _innerStream.WriteTimeout = value; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _innerStream.Seek(offset, origin);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _innerStream.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+#if !NETSTANDARD1_3 // BeginX and EndX not supported on Streams in netstandard1.3
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            return _innerStream.BeginRead(buffer, offset, count, callback!, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return _innerStream.EndRead(asyncResult);
+        }
+#endif
+
+        public override int ReadByte()
+        {
+            return _innerStream.ReadByte();
+        }
+
+        public override void Flush()
+        {
+            _innerStream.Flush();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _innerStream.FlushAsync(cancellationToken);
+        }
+
+        public override void SetLength(long value)
+        {
+            _innerStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _innerStream.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+#if !NETSTANDARD1_3 // BeginX and EndX not supported on Streams in netstandard1.3
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            return _innerStream.BeginWrite(buffer, offset, count, callback!, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            _innerStream.EndWrite(asyncResult);
+        }
+#endif
+
+        public override void WriteByte(byte value)
+        {
+            _innerStream.WriteByte(value);
+        }
+    }
+}
+#endif

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -28,6 +28,7 @@
     from a source generator as opposed to something that is coming from some other tool. -->
     <Compile Remove="$(GeneratedFolder)/*/**/*.cs" />
     <Compile Update="Configuration\ConfigurationKeys.*.cs" DependentUpon="ConfigurationKeys.cs" />
+    <Compile Remove="Util\Streams\ChunkedEncodingWriteStream.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingWriteStream.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingWriteStream.cs
@@ -1,0 +1,100 @@
+﻿// <copyright file="ChunkedEncodingWriteStream.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Util.Streams;
+
+namespace Datadog.Trace.HttpOverStreams;
+
+internal class ChunkedEncodingWriteStream(Stream innerStream) : LeaveOpenDelegatingStream(innerStream)
+{
+    private static readonly byte[] CrLfBytes = { 0x0D, 0x0A }; // UTF-8 for \r\n
+    private static readonly byte[] FinalChunkBytes = { 0x30, 0x0D, 0x0A, 0x0D, 0x0A, }; // UTF-8 for 0\r\n\r\n
+
+    private readonly Stream _innerStream = innerStream;
+    private readonly byte[] _chunkSizeBuffer = new byte[8]; // max length of Int32 as UTF-8 hex
+
+    public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        // don't want to ever send a zero-length terminator unless we're at the end
+        if (count == 0)
+        {
+            // Don't write if nothing was given, especially since we don't want to accidentally send a 0 chunk,
+            // which would indicate end of body.  Instead, just ensure no content is stuck in the buffer.
+            await _innerStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        // write the chunked encoding header
+        var bytesWritten = WriteChunkedEncodingHeaderToBuffer(_chunkSizeBuffer, count);
+        await _innerStream.WriteAsync(_chunkSizeBuffer, 0, bytesWritten, cancellationToken).ConfigureAwait(false);
+
+        // add the new line
+        await _innerStream.WriteAsync(CrLfBytes, offset: 0, count: 2, cancellationToken).ConfigureAwait(false);
+
+        // add the content
+        await _innerStream.WriteAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+
+        // add the extra new line
+        await _innerStream.WriteAsync(CrLfBytes, offset: 0, count: 2, cancellationToken).ConfigureAwait(false);
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        // don't want to ever send a zero-length terminator unless we're at the end
+        if (count == 0)
+        {
+            // Don't write if nothing was given, especially since we don't want to accidentally send a 0 chunk,
+            // which would indicate end of body.  Instead, just ensure no content is stuck in the buffer.
+            _innerStream.Flush();
+            return;
+        }
+
+        // write the chunked encoding header
+        var bytesWritten = WriteChunkedEncodingHeaderToBuffer(_chunkSizeBuffer, count);
+        _innerStream.Write(_chunkSizeBuffer, 0, bytesWritten);
+
+        // add the new line
+        _innerStream.Write(CrLfBytes, offset: 0, count: 2);
+
+        // flush the content
+        _innerStream.Write(buffer, offset, count);
+
+        // add the extra new line
+        _innerStream.Write(CrLfBytes, offset: 0, count: 2);
+    }
+
+    public Task FinishAsync()
+    {
+        // Send 0 byte chunk to indicate end, then final CrLf
+        return _innerStream.WriteAsync(FinalChunkBytes, 0, FinalChunkBytes.Length);
+    }
+
+    internal static int WriteChunkedEncodingHeaderToBuffer(byte[] outputBuffer, int count)
+    {
+#if NET6_0_OR_GREATER
+        // Try to format into our output buffer directly.
+        if (System.Buffers.Text.Utf8Formatter.TryFormat(count, outputBuffer, out var bytesWritten, 'X'))
+        {
+            return bytesWritten;
+        }
+#endif
+
+        var hexEncoded = count.ToString("X", CultureInfo.InvariantCulture);
+        // Assuming there's enough space in the buffer
+        // As this is ascii, the `char`s can be directly converted to bytes and it's valid UTF-8
+        for (var i = 0; i < hexEncoded.Length; i++)
+        {
+            outputBuffer[i] = (byte)hexEncoded[i];
+        }
+
+        return hexEncoded.Length;
+    }
+}

--- a/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/PushStreamContent.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/PushStreamContent.cs
@@ -1,0 +1,232 @@
+﻿// <copyright file="PushStreamContent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.HttpOverStreams.HttpContent;
+
+/// <summary>
+/// Provides an <see cref="HttpContent"/> implementation that exposes an output <see cref="Stream"/>
+/// which can be written to directly. The ability to push data to the output stream differs from the
+/// StreamContent where data is pulled and not pushed.
+/// </summary>
+internal class PushStreamContent : IHttpContent
+{
+    private readonly Func<Stream, Task> _onStreamAvailable;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PushStreamContent"/> class.
+    /// </summary>
+    /// <param name="onStreamAvailable">The action to call when an output stream is available. When the
+    /// output stream is closed or disposed, it will signal to the content that it has completed and the
+    /// HTTP request or response will be completed.</param>
+    public PushStreamContent(Func<Stream, Task> onStreamAvailable)
+    {
+        _onStreamAvailable = onStreamAvailable;
+    }
+
+    public long? Length => 0;
+
+    public async Task CopyToAsync(Stream destination)
+    {
+        var serializeToStreamTask = new TaskCompletionSource<bool>();
+
+        var wrappedStream = new CompleteTaskOnCloseStream(destination, serializeToStreamTask);
+        await _onStreamAvailable(wrappedStream).ConfigureAwait(false);
+
+        // wait for wrappedStream.Close/Dispose to get called.
+        await serializeToStreamTask.Task.ConfigureAwait(false);
+    }
+
+    public Task CopyToAsync(byte[] buffer)
+    {
+        // This CopyToAsync overload is only used to read responses
+        // And we never use PushStreamContent for that
+        throw new NotImplementedException();
+    }
+
+    private class CompleteTaskOnCloseStream : DelegatingStream
+    {
+        private readonly TaskCompletionSource<bool> _serializeToStreamTask;
+
+        public CompleteTaskOnCloseStream(Stream innerStream, TaskCompletionSource<bool> serializeToStreamTask)
+            : base(innerStream)
+        {
+            Contract.Assert(serializeToStreamTask != null);
+            _serializeToStreamTask = serializeToStreamTask!;
+        }
+
+        [SuppressMessage(
+            "Microsoft.Usage",
+            "CA2215:Dispose methods should call base class dispose",
+            Justification = "See comments, this is intentional.")]
+        protected override void Dispose(bool disposing)
+        {
+            // We don't dispose the underlying stream because we don't own it. Dispose in this case just signifies
+            // that the user's action is finished.
+            _serializeToStreamTask.TrySetResult(true);
+        }
+
+        public override void Close()
+        {
+            // We don't Close the underlying stream because we don't own it. Dispose in this case just signifies
+            // that the user's action is finished.
+            _serializeToStreamTask.TrySetResult(true);
+        }
+    }
+
+    /// <summary>
+    /// Stream that delegates to inner stream.
+    /// This is taken from System.Net.Http
+    /// </summary>
+    private abstract class DelegatingStream : Stream
+    {
+        private readonly Stream _innerStream;
+
+        protected DelegatingStream(Stream innerStream)
+        {
+            _innerStream = innerStream;
+        }
+
+        protected Stream InnerStream
+        {
+            get { return _innerStream; }
+        }
+
+        public override bool CanRead
+        {
+            get { return _innerStream.CanRead; }
+        }
+
+        public override bool CanSeek
+        {
+            get { return _innerStream.CanSeek; }
+        }
+
+        public override bool CanWrite
+        {
+            get { return _innerStream.CanWrite; }
+        }
+
+        public override long Length
+        {
+            get { return _innerStream.Length; }
+        }
+
+        public override long Position
+        {
+            get { return _innerStream.Position; }
+            set { _innerStream.Position = value; }
+        }
+
+        public override int ReadTimeout
+        {
+            get { return _innerStream.ReadTimeout; }
+            set { _innerStream.ReadTimeout = value; }
+        }
+
+        public override bool CanTimeout
+        {
+            get { return _innerStream.CanTimeout; }
+        }
+
+        public override int WriteTimeout
+        {
+            get { return _innerStream.WriteTimeout; }
+            set { _innerStream.WriteTimeout = value; }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _innerStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _innerStream.Seek(offset, origin);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _innerStream.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+#if !NETSTANDARD1_3 // BeginX and EndX not supported on Streams in netstandard1.3
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            return _innerStream.BeginRead(buffer, offset, count, callback!, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return _innerStream.EndRead(asyncResult);
+        }
+#endif
+
+        public override int ReadByte()
+        {
+            return _innerStream.ReadByte();
+        }
+
+        public override void Flush()
+        {
+            _innerStream.Flush();
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _innerStream.FlushAsync(cancellationToken);
+        }
+
+        public override void SetLength(long value)
+        {
+            _innerStream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _innerStream.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+#if !NETSTANDARD1_3 // BeginX and EndX not supported on Streams in netstandard1.3
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
+        {
+            return _innerStream.BeginWrite(buffer, offset, count, callback!, state);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            _innerStream.EndWrite(asyncResult);
+        }
+#endif
+
+        public override void WriteByte(byte value)
+        {
+            _innerStream.WriteByte(value);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/PushStreamContent.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/PushStreamContent.cs
@@ -6,10 +6,7 @@
 #nullable enable
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Diagnostics.Contracts;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Datadog.Trace.HttpOverStreams.HttpContent;
@@ -36,15 +33,12 @@ internal class PushStreamContent : IHttpContent
 
     public long? Length => 0;
 
-    public async Task CopyToAsync(Stream destination)
+    public Task CopyToAsync(Stream destination)
     {
-        var serializeToStreamTask = new TaskCompletionSource<bool>();
-
-        var wrappedStream = new CompleteTaskOnCloseStream(destination, serializeToStreamTask);
-        await _onStreamAvailable(wrappedStream).ConfigureAwait(false);
-
-        // wait for wrappedStream.Close/Dispose to get called.
-        await serializeToStreamTask.Task.ConfigureAwait(false);
+        // Note the callee must not close or dispose the stream because they don't own it
+        // We _could_ use a wrapper stream to enforce that, but then it _requires_ the
+        // callee to call close/dispose which seems weird
+        return _onStreamAvailable(destination);
     }
 
     public Task CopyToAsync(byte[] buffer)
@@ -52,181 +46,5 @@ internal class PushStreamContent : IHttpContent
         // This CopyToAsync overload is only used to read responses
         // And we never use PushStreamContent for that
         throw new NotImplementedException();
-    }
-
-    private class CompleteTaskOnCloseStream : DelegatingStream
-    {
-        private readonly TaskCompletionSource<bool> _serializeToStreamTask;
-
-        public CompleteTaskOnCloseStream(Stream innerStream, TaskCompletionSource<bool> serializeToStreamTask)
-            : base(innerStream)
-        {
-            Contract.Assert(serializeToStreamTask != null);
-            _serializeToStreamTask = serializeToStreamTask!;
-        }
-
-        [SuppressMessage(
-            "Microsoft.Usage",
-            "CA2215:Dispose methods should call base class dispose",
-            Justification = "See comments, this is intentional.")]
-        protected override void Dispose(bool disposing)
-        {
-            // We don't dispose the underlying stream because we don't own it. Dispose in this case just signifies
-            // that the user's action is finished.
-            _serializeToStreamTask.TrySetResult(true);
-        }
-
-        public override void Close()
-        {
-            // We don't Close the underlying stream because we don't own it. Dispose in this case just signifies
-            // that the user's action is finished.
-            _serializeToStreamTask.TrySetResult(true);
-        }
-    }
-
-    /// <summary>
-    /// Stream that delegates to inner stream.
-    /// This is taken from System.Net.Http
-    /// </summary>
-    private abstract class DelegatingStream : Stream
-    {
-        private readonly Stream _innerStream;
-
-        protected DelegatingStream(Stream innerStream)
-        {
-            _innerStream = innerStream;
-        }
-
-        protected Stream InnerStream
-        {
-            get { return _innerStream; }
-        }
-
-        public override bool CanRead
-        {
-            get { return _innerStream.CanRead; }
-        }
-
-        public override bool CanSeek
-        {
-            get { return _innerStream.CanSeek; }
-        }
-
-        public override bool CanWrite
-        {
-            get { return _innerStream.CanWrite; }
-        }
-
-        public override long Length
-        {
-            get { return _innerStream.Length; }
-        }
-
-        public override long Position
-        {
-            get { return _innerStream.Position; }
-            set { _innerStream.Position = value; }
-        }
-
-        public override int ReadTimeout
-        {
-            get { return _innerStream.ReadTimeout; }
-            set { _innerStream.ReadTimeout = value; }
-        }
-
-        public override bool CanTimeout
-        {
-            get { return _innerStream.CanTimeout; }
-        }
-
-        public override int WriteTimeout
-        {
-            get { return _innerStream.WriteTimeout; }
-            set { _innerStream.WriteTimeout = value; }
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                _innerStream.Dispose();
-            }
-
-            base.Dispose(disposing);
-        }
-
-        public override long Seek(long offset, SeekOrigin origin)
-        {
-            return _innerStream.Seek(offset, origin);
-        }
-
-        public override int Read(byte[] buffer, int offset, int count)
-        {
-            return _innerStream.Read(buffer, offset, count);
-        }
-
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return _innerStream.ReadAsync(buffer, offset, count, cancellationToken);
-        }
-
-#if !NETSTANDARD1_3 // BeginX and EndX not supported on Streams in netstandard1.3
-        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
-        {
-            return _innerStream.BeginRead(buffer, offset, count, callback!, state);
-        }
-
-        public override int EndRead(IAsyncResult asyncResult)
-        {
-            return _innerStream.EndRead(asyncResult);
-        }
-#endif
-
-        public override int ReadByte()
-        {
-            return _innerStream.ReadByte();
-        }
-
-        public override void Flush()
-        {
-            _innerStream.Flush();
-        }
-
-        public override Task FlushAsync(CancellationToken cancellationToken)
-        {
-            return _innerStream.FlushAsync(cancellationToken);
-        }
-
-        public override void SetLength(long value)
-        {
-            _innerStream.SetLength(value);
-        }
-
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            _innerStream.Write(buffer, offset, count);
-        }
-
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-        {
-            return _innerStream.WriteAsync(buffer, offset, count, cancellationToken);
-        }
-
-#if !NETSTANDARD1_3 // BeginX and EndX not supported on Streams in netstandard1.3
-        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback? callback, object? state)
-        {
-            return _innerStream.BeginWrite(buffer, offset, count, callback!, state);
-        }
-
-        public override void EndWrite(IAsyncResult asyncResult)
-        {
-            _innerStream.EndWrite(asyncResult);
-        }
-#endif
-
-        public override void WriteByte(byte value)
-        {
-            _innerStream.WriteByte(value);
-        }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
@@ -3,13 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.IO;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.HttpOverStreams.HttpContent;
 using Datadog.Trace.Util;
+using Datadog.Trace.Util.Streams;
 
 namespace Datadog.Trace.TestHelpers
 {
@@ -74,6 +77,9 @@ namespace Datadog.Trace.TestHelpers
             while (true);
 
             var length = long.TryParse(headers.GetValue(ContentLengthHeaderKey), out var headerValue) ? headerValue : (long?)null;
+            var body = headers.GetValue("Transfer-Encoding") is "chunked"
+                           ? new ChunkedEncodingReadContent(stream)
+                           : new StreamContent(stream, length);
 
             return new MockHttpRequest()
             {
@@ -81,7 +87,7 @@ namespace Datadog.Trace.TestHelpers
                 Method = method,
                 PathAndQuery = pathAndQuery,
                 ContentLength = length,
-                Body = new StreamContent(stream, length)
+                Body = body
             };
         }
 
@@ -183,6 +189,89 @@ namespace Datadog.Trace.TestHelpers
                 }
 
                 return false;
+            }
+        }
+
+        private class ChunkedEncodingReadContent(Stream stream)
+            : StreamContent(new ChunkedEncodingReadStream(stream), length: null);
+
+        private class ChunkedEncodingReadStream(Stream innerStream) : DelegatingStream(innerStream)
+        {
+            private readonly Stream _innerStream = innerStream;
+            private readonly StreamReaderHelper _helper = new(innerStream);
+            private readonly StringBuilder _sb = new();
+            private int _bytesRemainingInChunk = 0;
+            private State _state = State.AwaitingChunkHeader;
+
+            private enum State
+            {
+                AwaitingChunkHeader,
+                ReadingChunk,
+                ChunkFinished,
+                Complete,
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                // YOLO
+                return ReadAsync(buffer, offset, count).GetAwaiter().GetResult();
+            }
+
+            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            {
+                // This is very crude and doesn't handle edge cases etc, but hopefully it's good enough for tests
+                while (true)
+                {
+                    switch (_state)
+                    {
+                        case State.AwaitingChunkHeader:
+                            // Read the chunk size
+                            _sb.Clear();
+                            await _helper.ReadUntilNewLine(_sb).ConfigureAwait(false);
+                            // annoying, but this is always prepended with an invalid char due to
+                            // the way we parse the response. Just hacking around it for simplicity
+                            var hexString = _sb.ToString(startIndex: 1, _sb.Length - 1);
+                            _bytesRemainingInChunk = int.Parse(hexString, System.Globalization.NumberStyles.HexNumber);
+                            _state = State.ReadingChunk;
+                            if (_bytesRemainingInChunk == 0)
+                            {
+                                // we're done
+                                _state = State.Complete;
+                                // The final chunk has a double newline at the end
+                                await _helper.ReadUntilNewLine(_sb);
+                                return 0;
+                            }
+
+                            break;
+                        case State.ReadingChunk:
+                            // Read and return the chunk bytes
+                            // We might not have enough for the whole chunk, so just read what we can
+                            var bytesToRead = Math.Min(count, _bytesRemainingInChunk);
+                            var bytesReadFromStream = await _innerStream.ReadAsync(buffer, offset, bytesToRead, cancellationToken).ConfigureAwait(false);
+
+                            // we might not have read the whole chunk, so just return what we have for now
+                            _bytesRemainingInChunk -= bytesReadFromStream;
+                            if (_bytesRemainingInChunk <= 0)
+                            {
+                                _state = State.ChunkFinished;
+                            }
+
+                            return bytesReadFromStream;
+                        case State.ChunkFinished:
+                            // Should have a CRLF after the chunk is finished
+                            await _helper.GoNextChar();
+                            if (!await _helper.IsNewLine())
+                            {
+                                throw new Exception("Did not receive expected line feed");
+                            }
+
+                            // chunk is finished, wait for the next one
+                            _state = State.AwaitingChunkHeader;
+                            break;
+                        case State.Complete:
+                            return 0;
+                    }
+                }
             }
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiRequest.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiRequest.cs
@@ -5,8 +5,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
 
 namespace Datadog.Trace.TestHelpers.TransportHelpers;
 
@@ -56,5 +58,14 @@ internal class TestApiRequest : IApiRequest
         Responses.Add(response);
 
         return Task.FromResult((IApiResponse)response);
+    }
+
+    public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+    {
+        using (var ms = new MemoryStream())
+        {
+            await writeToRequestStream(ms);
+            return await PostAsync(new ArraySegment<byte>(ms.ToArray()), ContentTypeHelper.GetContentType(contentType, multipartBoundary), contentEncoding);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/ChunkedEncodingWriteStreamTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/ChunkedEncodingWriteStreamTests.cs
@@ -3,9 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
-using Datadog.Trace.HttpOverStreams.ChunkedEncoding;
+using System.Threading.Tasks;
+using Datadog.Trace.HttpOverStreams;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
@@ -28,5 +33,135 @@ public class ChunkedEncodingWriteStreamTests
         using var x = new AssertionScope();
         bytesWritten.Should().Be(bytes);
         result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task HttpStreamIsWrittenCorrectly()
+    {
+        const int chunks = 5;
+        const int bytesPerChunk = 30; // 1E in hex
+        var data = Enumerable.Repeat((byte)43, bytesPerChunk).ToArray();
+
+        using var ms = new MemoryStream();
+
+        // need to make sure we always use CRLF, and get the line breaks etc all correct
+        var headers =
+            """
+            POST / HTTP/1.1
+            Host: localhost:8000
+            Accept: text/html
+            Content-Type: application/octet-stream
+            Transfer-Encoding: chunked
+            """.Trim();
+
+        headers += $"{Environment.NewLine}{Environment.NewLine}";
+
+        if (Environment.NewLine.Length == 1)
+        {
+            headers = headers.Replace(Environment.NewLine, "\r\n");
+        }
+
+        // this part isn't chunked
+        var bytes = Encoding.ASCII.GetBytes(headers);
+        await ms.WriteAsync(bytes, 0, bytes.Length);
+
+        // this part should be
+        using var chunked = new ChunkedEncodingWriteStream(ms);
+        for (var i = 0; i < chunks; i++)
+        {
+            await chunked.WriteAsync(data, 0, data.Length);
+        }
+
+        await chunked.FinishAsync();
+
+        // Now check what we got
+        ms.Position = 0;
+        var sr = new StreamReader(ms);
+        var result = await sr.ReadToEndAsync();
+
+        var expected =
+            """
+                POST / HTTP/1.1
+                Host: localhost:8000
+                Accept: text/html
+                Content-Type: application/octet-stream
+                Transfer-Encoding: chunked
+
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                0
+                """.Trim() + Environment.NewLine + Environment.NewLine;
+
+        // fix the expected line breaks in response
+        if (Environment.NewLine.Length == 1)
+        {
+            expected = expected.Replace(Environment.NewLine, "\r\n");
+        }
+
+        result.Should().Be(expected);
+    }
+
+    [Fact]
+    public async Task ChunkedEncodingIsReadCorrectly()
+    {
+        var input =
+            """
+                POST /test HTTP/1.1
+                Host: localhost:8000
+                Accept: text/html
+                Content-Type: application/octet-stream
+                Transfer-Encoding: chunked
+
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                1E
+                ++++++++++++++++++++++++++++++
+                0
+                """.Trim() + Environment.NewLine + Environment.NewLine;
+
+        // fix the expected line breaks in response
+        if (Environment.NewLine.Length == 1)
+        {
+            input = input.Replace(Environment.NewLine, "\r\n");
+        }
+
+        using var ms = new MemoryStream();
+        using var sw = new StreamWriter(ms, new UTF8Encoding(false), bufferSize: 100, leaveOpen: true);
+        await sw.WriteAsync(input);
+        await sw.FlushAsync();
+
+        ms.Position = 0;
+        var request = await MockHttpParser.ReadRequest(ms);
+
+        request.Method.Should().Be("POST");
+        request.PathAndQuery.Should().Be("/test");
+        request.Headers
+               .Select(x => new KeyValuePair<string, string>(x.Name, x.Value))
+               .Should()
+               .Equal(new Dictionary<string, string>
+                {
+                    { "Host", "localhost:8000" },
+                    { "Accept", "text/html" },
+                    { "Content-Type", "application/octet-stream" },
+                    { "Transfer-Encoding", "chunked" },
+                });
+
+        using var sr = new StreamReader(request.Body.Stream);
+        var output = await sr.ReadToEndAsync();
+        output.Should().Be("++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/ChunkedEncodingWriteStreamTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/ChunkedEncodingWriteStreamTests.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="ChunkedEncodingWriteStreamTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+using System.Text;
+using Datadog.Trace.HttpOverStreams.ChunkedEncoding;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace Datadog.Trace.Tests.HttpOverStreams;
+
+public class ChunkedEncodingWriteStreamTests
+{
+    [Theory]
+    [InlineData(0, 1, "0")]
+    [InlineData(15, 1, "F")]
+    [InlineData(12345, 4, "3039")]
+    [InlineData(int.MaxValue, 8, "7FFFFFFF")]
+    public void WriteChunkedEncodingHeaderToBuffer_GivesCorrectOutput(int count, int bytes, string expected)
+    {
+        var buffer = new byte[8];
+        var bytesWritten = ChunkedEncodingWriteStream.WriteChunkedEncodingHeaderToBuffer(buffer, count);
+        var result = Encoding.UTF8.GetString(buffer, index: 0, count: bytesWritten);
+
+        using var x = new AssertionScope();
+        bytesWritten.Should().Be(bytes);
+        result.Should().Be(expected);
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -123,6 +123,15 @@ namespace Benchmarks.Trace
                 return new FakeApiResponse();
             }
 
+            public async Task<IApiResponse> PostAsync(Func<Stream, Task> writeToRequestStream, string contentType, string contentEncoding, string multipartBoundary)
+            {
+                using (var requestStream = Stream.Null)
+                {
+                    await writeToRequestStream(requestStream).ConfigureAwait(false);
+                }
+
+                return new FakeApiResponse();
+            }
         }
 
         private class FakeApiResponse : IApiResponse


### PR DESCRIPTION
## Summary of changes

- Adds `PushStream` support to `IApiRequest` (in contrast to "pull" `Stream` support)
- Add support for writing `Transfer-Encoding: chunked` with the `DatadogHttpClient` (UDS <.NET 6/Named Pipes)
- Add support for reading chunked encoding in the `MockTracerAgent` (named pipes/UDS)

## Reason for change

We don't want to buffer the whole debug log stream in memory as it _could_ be quite large. Unfortunately, our `IApiRequest` implementations (and even `HttpClient` itself AFAICT) don't currently support writing to the request stream directly - they all allow _reading_ (pulling) from a Stream, but not _pushing_ to the request stream.

As soon as we enable streaming like that, we need to stop sending content-length (because we don't know it up-front) and use [`Transfer-Encoding: chunked`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding) to send the body of the request.

With chunked encoding, you send the number of bytes in the chunk (encoded as hex), followed by `\r\n`, then the chunk itself, and finally `\r\n`. You signify the end of the body by sending a 0-length chunk, e.g.

```
1E
++++++++++++++++++++++++++++++
1E
++++++++++++++++++++++++++++++
1E
++++++++++++++++++++++++++++++
0

```

## Implementation details

Started by vendoring in [`PushStreamContent`](https://github.com/aspnet/AspNetWebStack/blob/1231b77d79956152831b75ad7f094f844251b97f/src/System.Net.Http.Formatting/PushStreamContent.cs) which basically does what we want, and then simplified it by cutting out all the extra cruft and use-cases we don't need. Created something similar for our custom `HttpClient`

For the chunked encoding writer I based it on [the .NET 8 HttpClient implementation](https://github.com/dotnet/runtime/blob/c282395b63c1757d4f4c1dc2e236680cfe2e7f96/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpConnection.cs#L35) with some workarounds for missing APIs. 

For the chunked reader I just rolled with something new because it's only used in tests, so if it works for us, that's probably good enough.

## Test coverage

Added some unit tests for the chunked reader and writer, but the new APIs are actually tested properly in subsequent stacked PRs.

## Other details

Note that tranfer-encoding: chunked isn't supported in HTTP/2.0. I can't see that causing issues for us at this point, just wanted to flag it.

Prerequisite for other stacked PRs
- https://github.com/DataDog/dd-trace-dotnet/pull/4990
- https://github.com/DataDog/dd-trace-dotnet/pull/4991
- https://github.com/DataDog/dd-trace-dotnet/pull/4997

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/4987
- https://github.com/DataDog/dd-trace-dotnet/pull/4988
- https://github.com/DataDog/dd-trace-dotnet/pull/4994

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
