### PR TITLE
Add `TracerFlareApi` implementation for sending requests to endpoint

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/MimeTypes.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/MimeTypes.cs
@@ -9,5 +9,6 @@ namespace Datadog.Trace.Agent.Transports
     {
         public const string MsgPack = "application/msgpack";
         public const string Json = "application/json";
+        public const string MultipartFormData = "multipart/form-data";
     }
 }

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -28,7 +28,6 @@
     from a source generator as opposed to something that is coming from some other tool. -->
     <Compile Remove="$(GeneratedFolder)/*/**/*.cs" />
     <Compile Update="Configuration\ConfigurationKeys.*.cs" DependentUpon="ConfigurationKeys.cs" />
-    <Compile Remove="Util\Streams\ChunkedEncodingWriteStream.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareApi.cs
@@ -45,7 +45,7 @@ internal class TracerFlareApi
         return new TracerFlareApi(requestFactory);
     }
 
-    public async Task<KeyValuePair<bool, string?>> SendTracerFlare(Func<Stream, Task> writeFlareToStreamFunc, string caseId)
+    public async Task<KeyValuePair<bool, string?>> SendTracerFlare(Func<Stream, Task> writeFlareToStreamFunc, string caseId, string hostname, string email)
     {
         try
         {
@@ -53,7 +53,7 @@ internal class TracerFlareApi
 
             var request = _requestFactory.Create(_endpoint);
             using var response = await request.PostAsync(
-                                                   stream => TracerFlareRequestFactory.WriteRequestBody(stream, writeFlareToStreamFunc, caseId),
+                                                   stream => TracerFlareRequestFactory.WriteRequestBody(stream, writeFlareToStreamFunc, caseId, hostname: hostname, email: email),
                                                    MimeTypes.MultipartFormData,
                                                    contentEncoding: null,
                                                    multipartBoundary: TracerFlareRequestFactory.Boundary)

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareApi.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareApi.cs
@@ -1,0 +1,69 @@
+﻿// <copyright file="TracerFlareApi.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.HttpOverStreams;
+
+namespace Datadog.Trace.Logging.TracerFlare;
+
+internal class TracerFlareApi
+{
+    internal const string TracerFlareSentLog = "Tracer flare sent successfully";
+    private const string TracerFlareEndpoint = "tracer_flare/v1";
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerFlareApi>();
+
+    private readonly IApiRequestFactory _requestFactory;
+    private readonly Uri _endpoint;
+
+    public TracerFlareApi(IApiRequestFactory requestFactory)
+    {
+        _requestFactory = requestFactory;
+        _endpoint = _requestFactory.GetEndpoint(TracerFlareEndpoint);
+    }
+
+    public static TracerFlareApi Create(ImmutableExporterSettings exporterSettings)
+    {
+        var requestFactory = AgentTransportStrategy.Get(
+            exporterSettings,
+            productName: "tracer_flare",
+            tcpTimeout: TimeSpan.FromSeconds(30),
+            AgentHttpHeaderNames.MinimalHeaders,
+            () => new MinimalAgentHeaderHelper(),
+            uri => uri);
+
+        return new TracerFlareApi(requestFactory);
+    }
+
+    public async Task SendTracerFlare(ArraySegment<byte> flare, string caseId)
+    {
+        try
+        {
+            Log.Debug("Sending {FlareSize} byte tracer flare to {Endpoint}", flare.Count, _endpoint);
+
+            // TODO: Stream this instead
+            var buffer = TracerFlareRequestFactory.GetRequestBody(flare, caseId);
+
+            var request = _requestFactory.Create(_endpoint);
+            using var response = await request.PostAsync(buffer, MimeTypes.MultipartFormData).ConfigureAwait(false);
+            if (response.StatusCode is >= 200 and < 300)
+            {
+                Log.Debug("Tracer flare sent successfully");
+                return;
+            }
+
+            Log.Warning<string, int>("Error sending tracer flare to '{Endpoint}' {StatusCode} ", _requestFactory.Info(_endpoint), response.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            Log.Information(ex, "Error sending tracer flare to '{Endpoint}'", _requestFactory.Info(_endpoint));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareRequestFactory.cs
@@ -16,57 +16,14 @@ internal class TracerFlareRequestFactory
 {
     internal const string Boundary = "83CAD6AA-8A24-462C-8B3D-FF9CC683B51B";
     private const string Separator = "--" + Boundary;
+    private const string CrLf = "\r\n";
 
-    private const string RequestBodyCaseId =
-        $$"""
-          {{Separator}}
-          Content-Disposition: form-data; name="source"
-
-          tracer_dotnet
-          {{Separator}}
-          Content-Disposition: form-data; name="case_id"
-
-
-          """;
-
-    private const string RequestBodyHostname =
-        $$"""
-
-          {{Separator}}
-          Content-Disposition: form-data; name="hostname"
-
-
-          """;
-
-    private const string RequestBodyEmail =
-        $$"""
-
-          {{Separator}}
-          Content-Disposition: form-data; name="email"
-
-
-          """;
-
-    private const string RequestBodyFlareFile1 =
-        $$"""
-
-          {{Separator}}
-          Content-Disposition: form-data; name="flare_file"; filename="tracer-dotnet-
-          """;
-
-    private const string RequestBodyFlareFile2 =
-        """
-          -debug.zip"
-          Content-Type: application/octet-stream
-
-
-          """;
-
-    private const string RequestBodySuffix =
-        $$"""
-
-          {{Separator}}--
-          """;
+    private const string RequestBodyCaseId = $"""{Separator}{CrLf}Content-Disposition: form-data; name="source"{CrLf}{CrLf}tracer_dotnet{CrLf}{Separator}{CrLf}Content-Disposition: form-data; name="case_id"{CrLf}{CrLf}""";
+    private const string RequestBodyHostname = $"""{CrLf}{Separator}{CrLf}Content-Disposition: form-data; name="hostname"{CrLf}{CrLf}""";
+    private const string RequestBodyEmail = $"""{CrLf}{Separator}{CrLf}Content-Disposition: form-data; name="email"{CrLf}{CrLf}""";
+    private const string RequestBodyFlareFile1 = $"""{CrLf}{Separator}{CrLf}Content-Disposition: form-data; name="flare_file"; filename="tracer-dotnet-""";
+    private const string RequestBodyFlareFile2 = $"""-debug.zip"{CrLf}Content-Type: application/octet-stream{CrLf}{CrLf}""";
+    private const string RequestBodySuffix = $"""{CrLf}{Separator}--{CrLf}""";
 
     public static Task WriteRequestBody(
         Stream destination,

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareRequestFactory.cs
@@ -1,0 +1,82 @@
+﻿// <copyright file="TracerFlareRequestFactory.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Datadog.Trace.Util;
+
+namespace Datadog.Trace.Logging.TracerFlare;
+
+internal class TracerFlareRequestFactory
+{
+    internal const string Boundary = "--83CAD6AA-8A24-462C-8B3D-FF9CC683B51B";
+
+    private const string RequestBodyPrefix =
+        $$"""
+          {{Boundary}}
+          Content-Disposition: form-data; name="source"
+
+          tracer_dotnet
+          {{Boundary}}
+          Content-Disposition: form-data; name="case_id"
+
+
+          """;
+
+    private const string RequestBodyMiddle =
+        $$"""
+
+          {{Boundary}}
+          Content-Disposition: form-data; name="flare_file"; filename="debug_logs.zip"
+          Content-Type: application/octet-stream
+
+
+          """;
+
+    private const string RequestBodySuffix =
+        $$"""
+
+          {{Boundary}}--
+          """;
+
+    public static async Task WriteRequestBody(Stream destination, Func<Stream, Task> writeFlareBytes, string caseId)
+    {
+        // Need to create a body that looks something like this:
+
+        // --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+        // Content-Disposition: form-data; name="source"
+        //
+        // tracer_dotnet
+        // --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+        // Content-Disposition: form-data; name="case_id"
+        //
+        // 1234567
+        // --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+        // Content-Disposition: form-data; name="flare_file"; filename="debug_logs.zip"
+        // Content-Type: application/octet-stream
+        //
+        // <binary data>
+        //
+        // --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B--
+
+        // Use the default buffer size, and the UTF8NoBOM encoding for the stream writer
+        // In .NET Core 3+, if you pass null for the encoding you get UTF8NoBOM, but
+        // using it everywhere here for consistency
+        using var sw = new StreamWriter(destination, encoding: EncodingHelpers.Utf8NoBom, bufferSize: 1024, leaveOpen: true);
+        await sw.WriteAsync(RequestBodyPrefix).ConfigureAwait(false);
+        await sw.WriteAsync(caseId).ConfigureAwait(false);
+        await sw.WriteAsync(RequestBodyMiddle).ConfigureAwait(false);
+        await sw.FlushAsync().ConfigureAwait(false);
+
+        await writeFlareBytes(destination).ConfigureAwait(false);
+
+        await sw.WriteAsync(RequestBodySuffix).ConfigureAwait(false);
+        // explicitly flush to avoid any potential sync-over-async from the disposal
+        await sw.FlushAsync().ConfigureAwait(false);
+    }
+}

--- a/tracer/src/Datadog.Trace/Util/EncodingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/EncodingHelpers.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="EncodingHelpers.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Text;
+
+namespace Datadog.Trace.Util;
+
+internal static class EncodingHelpers
+{
+    internal static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+}

--- a/tracer/test/Datadog.Trace.IntegrationTests/Logging/TracerFlare/TracerFlareApiTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Logging/TracerFlare/TracerFlareApiTests.cs
@@ -1,0 +1,126 @@
+﻿// <copyright file="TracerFlareApiTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.TracerFlare;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using HttpMultipartParser;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.IntegrationTests.Logging.TracerFlare;
+
+public class TracerFlareApiTests(ITestOutputHelper output)
+{
+    private readonly byte[] _flareFile = Enumerable.Repeat<byte>(43, 50).ToArray(); // repeat '+' 50 times
+
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    public async Task CanSendToAgent_Tcp()
+    {
+        const string caseId = "abc123";
+        using var agent = MockTracerAgent.Create(output);
+        var agentPath = new Uri($"http://localhost:{agent.Port}");
+        var settings = new ImmutableExporterSettings(new ExporterSettings { AgentUri = agentPath });
+
+        await RunTest(settings, caseId, agent);
+    }
+
+#if NETCOREAPP3_1_OR_GREATER
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    public async Task CanSendToAgent_UDS()
+    {
+        const string caseId = "abc123";
+        using var agent = MockTracerAgent.Create(output, new UnixDomainSocketConfig(Path.Combine(Path.GetTempPath(), Path.GetRandomFileName()), null));
+        var agentPath = agent.TracesUdsPath;
+        var settings = new ImmutableExporterSettings(
+            new ExporterSettings(
+                new NameValueConfigurationSource(new() { { "DD_APM_RECEIVER_SOCKET", agentPath } })));
+
+        await RunTest(settings, caseId, agent);
+    }
+#endif
+
+    [SkippableFact]
+    [Trait("Category", "EndToEnd")]
+    [Trait("RunOnWindows", "True")]
+    public async Task CanSendToAgent_NamedPipes()
+    {
+        if (!EnvironmentTools.IsWindows())
+        {
+            throw new SkipException("Can't use WindowsNamedPipes on non-Windows");
+        }
+
+        // named pipes is notoriously flaky
+        var attemptsRemaining = 3;
+        while (true)
+        {
+            try
+            {
+                attemptsRemaining--;
+                await RunNamedPipesTest();
+                return;
+            }
+            catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
+            {
+            }
+        }
+
+        async Task RunNamedPipesTest()
+        {
+            const string caseId = "abc123";
+            using var agent = MockTracerAgent.Create(output, new WindowsPipesConfig($"trace-{Guid.NewGuid()}", null));
+            var pipeName = agent.TracesWindowsPipeName;
+            var settings = new ImmutableExporterSettings(
+                new ExporterSettings(
+                    new NameValueConfigurationSource(new() { { "DD_TRACE_PIPE_NAME", pipeName } })));
+
+            await RunTest(settings, caseId, agent);
+        }
+    }
+
+    private async Task RunTest(ImmutableExporterSettings settings, string caseId, MockTracerAgent agent)
+    {
+        var api = TracerFlareApi.Create(settings);
+
+        var result = await api.SendTracerFlare(WriteFlareToStreamFunc, caseId);
+
+        var tracerFlares = agent.TracerFlareRequests;
+        var (headers, form) = tracerFlares.Should().ContainSingle().Subject;
+
+        result.Should().BeTrue();
+        headers.Should()
+               .ContainKey("Content-Type")
+               .WhoseValue
+               .Split(';')
+               .Should()
+               .Contain("multipart/form-data")
+               .And.ContainSingle(x => x.Trim().StartsWith("boundary="));
+        form.GetParameterValue("source").Should().Be("tracer_dotnet");
+        form.GetParameterValue("case_id").Should().Be(caseId);
+        var file = form.Files.Should().ContainSingle().Subject;
+        file.FileName.Should().StartWith($"tracer-dotnet-{caseId}-").And.EndWith("-debug.zip");
+        file.Name.Should().Be("flare_file");
+        file.ContentType.Should().Be("application/octet-stream");
+        file.Data.Length.Should().Be(_flareFile.Length);
+        // read the data
+        using var ms = new MemoryStream(_flareFile.Length);
+        await file.Data.CopyToAsync(ms);
+        ms.GetBuffer().Should().Equal(_flareFile);
+    }
+
+    private Task WriteFlareToStreamFunc(Stream stream)
+    {
+        return stream.WriteAsync(_flareFile, offset: 0, count: _flareFile.Length);
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+++ b/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="Bogus" Version="34.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
+    <PackageReference Include="HttpMultipartParser" Version="5.1.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
     <PackageReference Include="DiffPlex" Version="1.7.1" />
   </ItemGroup>

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -27,6 +27,7 @@ using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using FluentAssertions;
+using HttpMultipartParser;
 using MessagePack; // use nuget MessagePack to deserialize
 using Xunit.Abstractions;
 
@@ -76,6 +77,8 @@ namespace Datadog.Trace.TestHelpers
         public IImmutableList<MockDataStreamsPayload> DataStreams { get; private set; } = ImmutableList<MockDataStreamsPayload>.Empty;
 
         public IImmutableList<NameValueCollection> TraceRequestHeaders { get; private set; } = ImmutableList<NameValueCollection>.Empty;
+
+        public IImmutableList<(Dictionary<string, string> Headers, MultipartFormDataParser Form)> TracerFlareRequests { get; private set; } = ImmutableList<(Dictionary<string, string> Headers, MultipartFormDataParser Form)>.Empty;
 
         public IImmutableList<string> Snapshots { get; private set; } = ImmutableList<string>.Empty;
 
@@ -508,6 +511,11 @@ namespace Datadog.Trace.TestHelpers
                 HandleEvpProxyPayload(request);
                 responseType = MockTracerResponseType.EvpProxy;
             }
+            else if (request.PathAndQuery.StartsWith("/tracer_flare/v1"))
+            {
+                HandleTracerFlarePayload(request);
+                responseType = MockTracerResponseType.TracerFlare;
+            }
             else
             {
                 HandlePotentialTraces(request);
@@ -756,6 +764,38 @@ namespace Datadog.Trace.TestHelpers
                     };
 
                     EventPlatformProxyPayloadReceived?.Invoke(this, new EventArgs<EvpProxyPayload>(new EvpProxyPayload(request.PathAndQuery, headerCollection, bodyAsJson)));
+                }
+                catch (Exception ex)
+                {
+                    var message = ex.Message.ToLowerInvariant();
+
+                    if (message.Contains("beyond the end of the stream"))
+                    {
+                        // Accept call is likely interrupted by a dispose
+                        // Swallow the exception and let the test finish
+                        return;
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        private void HandleTracerFlarePayload(MockHttpParser.MockHttpRequest request)
+        {
+            // we don't send content length header in the request, so just deserialize into bytes
+            if (ShouldDeserializeTraces)
+            {
+                try
+                {
+                    var formData = MultipartFormDataParser.Parse(request.Body.Stream);
+                    var headerCollection = new Dictionary<string, string>();
+                    foreach (var header in request.Headers)
+                    {
+                        headerCollection.Add(header.Name, header.Value);
+                    }
+
+                    TracerFlareRequests = TracerFlareRequests.Add((headerCollection, formData));
                 }
                 catch (Exception ex)
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerResponseType.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerResponseType.cs
@@ -51,4 +51,9 @@ public enum MockTracerResponseType
     /// The CI Visibility EVP proxy endpoint
     /// </summary>
     EvpProxy,
+
+    /// <summary>
+    /// The Tracer flare endpoint
+    /// </summary>
+    TracerFlare,
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareRequestFactoryTests.cs
@@ -28,8 +28,9 @@ public class TracerFlareRequestFactoryTests
         using var requestStream = new MemoryStream();
 
         var caseId = "12345";
+        var timestamp = 1703093253;
 
-        await TracerFlareRequestFactory.WriteRequestBody(requestStream, stream => flare.CopyToAsync(stream), caseId);
+        await TracerFlareRequestFactory.WriteRequestBody(requestStream, stream => flare.CopyToAsync(stream), caseId, timestamp);
 
         var deserializedBytes = Encoding.UTF8.GetString(requestStream.ToArray());
 
@@ -43,7 +44,7 @@ public class TracerFlareRequestFactoryTests
 
                                       12345
                                       --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
-                                      Content-Disposition: form-data; name="flare_file"; filename="debug_logs.zip"
+                                      Content-Disposition: form-data; name="flare_file"; filename="tracer-dotnet-12345-1703093253-debug.zip"
                                       Content-Type: application/octet-stream
 
                                       ++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareRequestFactoryTests.cs
@@ -1,0 +1,53 @@
+﻿// <copyright file="TracerFlareRequestFactoryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Logging.TracerFlare;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.TracerFlare;
+
+public class TracerFlareRequestFactoryTests
+{
+    [Fact]
+    public async Task GetRequestBody_GeneratesExpectedRequest()
+    {
+        var flareBytes = new byte[50];
+        for (var i = 0; i < flareBytes.Length; i++)
+        {
+            flareBytes[i] = 43;
+        }
+
+        using var flare = new MemoryStream(flareBytes);
+
+        using var requestStream = new MemoryStream();
+
+        var caseId = "12345";
+
+        await TracerFlareRequestFactory.WriteRequestBody(requestStream, stream => flare.CopyToAsync(stream), caseId);
+
+        var deserializedBytes = Encoding.UTF8.GetString(requestStream.ToArray());
+
+        deserializedBytes.Should().Be("""
+                                      --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+                                      Content-Disposition: form-data; name="source"
+
+                                      tracer_dotnet
+                                      --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+                                      Content-Disposition: form-data; name="case_id"
+
+                                      12345
+                                      --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+                                      Content-Disposition: form-data; name="flare_file"; filename="debug_logs.zip"
+                                      Content-Type: application/octet-stream
+
+                                      ++++++++++++++++++++++++++++++++++++++++++++++++++
+                                      --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B--
+                                      """);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareRequestFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareRequestFactoryTests.cs
@@ -28,9 +28,17 @@ public class TracerFlareRequestFactoryTests
         using var requestStream = new MemoryStream();
 
         var caseId = "12345";
+        var hostname = "my.hostname";
+        var email = "some.person@datadoghq.com";
         var timestamp = 1703093253;
 
-        await TracerFlareRequestFactory.WriteRequestBody(requestStream, stream => flare.CopyToAsync(stream), caseId, timestamp);
+        await TracerFlareRequestFactory.WriteRequestBody(
+            requestStream,
+            stream => flare.CopyToAsync(stream),
+            caseId: caseId,
+            hostname: hostname,
+            email: email,
+            timestamp);
 
         var deserializedBytes = Encoding.UTF8.GetString(requestStream.ToArray());
 
@@ -43,6 +51,14 @@ public class TracerFlareRequestFactoryTests
                                       Content-Disposition: form-data; name="case_id"
 
                                       12345
+                                      --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+                                      Content-Disposition: form-data; name="hostname"
+                                      
+                                      my.hostname
+                                      --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
+                                      Content-Disposition: form-data; name="email"
+                                      
+                                      some.person@datadoghq.com
                                       --83CAD6AA-8A24-462C-8B3D-FF9CC683B51B
                                       Content-Disposition: form-data; name="flare_file"; filename="tracer-dotnet-12345-1703093253-debug.zip"
                                       Content-Type: application/octet-stream


### PR DESCRIPTION
## Summary of changes

- Adds the `TracerFlareApi` implementation which makes HTTP requests to the agent flare endpoint
- Sends the debug logs to the agent endpoint

## Reason for change

This is the meat of the tracer flare - it zips up the debug logs and streams them to the endpoint

## Implementation details

Pretty standard. Uses the new `PushStreamContent` and transfer-encoding features introduced in https://github.com/DataDog/dd-trace-dotnet/pull/4989

## Test coverage

Unit/integration-ish tests for the API sending, which end-to-end tests the various Http changes in previous stacked PRs

## Other details

Prerequisite for other stacked PRs
- https://github.com/DataDog/dd-trace-dotnet/pull/4991

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/4994
- https://github.com/DataDog/dd-trace-dotnet/pull/4987
- https://github.com/DataDog/dd-trace-dotnet/pull/4988
- https://github.com/DataDog/dd-trace-dotnet/pull/4989
- https://github.com/DataDog/dd-trace-dotnet/pull/4997


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
