### PR TITLE
Add remote-configuration + manager support for tracer flare

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -17,6 +17,7 @@ internal record AgentConfiguration
         string? dataStreamsMonitoringEndpoint,
         string? eventPlatformProxyEndpoint,
         string? telemetryProxyEndpoint,
+        string? tracerFlareEndpoint,
         bool clientDropP0)
     {
         ConfigurationEndpoint = configurationEndpoint;
@@ -26,6 +27,7 @@ internal record AgentConfiguration
         DataStreamsMonitoringEndpoint = dataStreamsMonitoringEndpoint;
         EventPlatformProxyEndpoint = eventPlatformProxyEndpoint;
         TelemetryProxyEndpoint = telemetryProxyEndpoint;
+        TracerFlareEndpoint = tracerFlareEndpoint;
         ClientDropP0s = clientDropP0;
     }
 
@@ -42,6 +44,8 @@ internal record AgentConfiguration
     public string? EventPlatformProxyEndpoint { get; }
 
     public string? TelemetryProxyEndpoint { get; }
+
+    public string? TracerFlareEndpoint { get; }
 
     public bool ClientDropP0s { get; }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -25,6 +25,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
         private const string SupportedDataStreamsEndpoint = "v0.1/pipeline_stats";
         private const string SupportedEventPlatformProxyEndpoint = "evp_proxy/v2";
         private const string SupportedTelemetryProxyEndpoint = "telemetry/proxy";
+        private const string SupportedTracerFlareEndpoint = "tracer_flare/v1";
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DiscoveryService>();
         private readonly IApiRequestFactory _apiRequestFactory;
@@ -66,7 +67,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 SupportedStatsEndpoint,
                 SupportedDataStreamsEndpoint,
                 SupportedEventPlatformProxyEndpoint,
-                SupportedTelemetryProxyEndpoint
+                SupportedTelemetryProxyEndpoint,
+                SupportedTracerFlareEndpoint,
             };
 
         public static DiscoveryService Create(ImmutableExporterSettings exporterSettings)
@@ -217,6 +219,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
             string? dataStreamsMonitoringEndpoint = null;
             string? eventPlatformProxyEndpoint = null;
             string? telemetryProxyEndpoint = null;
+            string? tracerFlareEndpoint = null;
 
             if (discoveredEndpoints is { Length: > 0 })
             {
@@ -253,6 +256,10 @@ namespace Datadog.Trace.Agent.DiscoveryService
                     {
                         telemetryProxyEndpoint = endpoint;
                     }
+                    else if (endpoint.Equals(SupportedTracerFlareEndpoint, StringComparison.OrdinalIgnoreCase))
+                    {
+                        tracerFlareEndpoint = endpoint;
+                    }
                 }
             }
 
@@ -266,6 +273,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 dataStreamsMonitoringEndpoint: dataStreamsMonitoringEndpoint,
                 eventPlatformProxyEndpoint: eventPlatformProxyEndpoint,
                 telemetryProxyEndpoint: telemetryProxyEndpoint,
+                tracerFlareEndpoint: tracerFlareEndpoint,
                 clientDropP0: clientDropP0);
 
             // AgentConfiguration is a record, so this compares by value

--- a/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManager.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.TracerFlare;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
@@ -40,7 +41,8 @@ namespace Datadog.Trace.Ci
             ITraceSampler traceSampler,
             ISpanSampler spanSampler,
             IRemoteConfigurationManager remoteConfigurationManager,
-            IDynamicConfigurationManager dynamicConfigurationManager)
+            IDynamicConfigurationManager dynamicConfigurationManager,
+            ITracerFlareManager tracerFlareManager)
             : base(
                 settings,
                 agentWriter,
@@ -57,6 +59,7 @@ namespace Datadog.Trace.Ci
                 spanSampler,
                 remoteConfigurationManager,
                 dynamicConfigurationManager,
+                tracerFlareManager,
                 GetProcessors(settings.ExporterInternal.PartialFlushEnabledInternal, agentWriter is CIVisibilityProtocolWriter))
         {
         }
@@ -141,7 +144,8 @@ namespace Datadog.Trace.Ci
                 ITraceSampler traceSampler,
                 ISpanSampler spanSampler,
                 IRemoteConfigurationManager remoteConfigurationManager,
-                IDynamicConfigurationManager dynamicConfigurationManager)
+                IDynamicConfigurationManager dynamicConfigurationManager,
+                ITracerFlareManager tracerFlareManager)
             : base(
                 settings,
                 agentWriter,
@@ -157,7 +161,8 @@ namespace Datadog.Trace.Ci
                 traceSampler,
                 spanSampler,
                 remoteConfigurationManager,
-                dynamicConfigurationManager)
+                dynamicConfigurationManager,
+                tracerFlareManager)
             {
             }
         }

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Ci.Sampling;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.TracerFlare;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
@@ -51,15 +52,16 @@ namespace Datadog.Trace.Ci
             ITraceSampler traceSampler,
             ISpanSampler spanSampler,
             IRemoteConfigurationManager remoteConfigurationManager,
-            IDynamicConfigurationManager dynamicConfigurationManager)
+            IDynamicConfigurationManager dynamicConfigurationManager,
+            ITracerFlareManager tracerFlareManager)
         {
             if (_useLockedManager)
             {
-                return new CITracerManager.LockedManager(settings, agentWriter, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, traceSampler, spanSampler, remoteConfigurationManager, dynamicConfigurationManager);
+                return new CITracerManager.LockedManager(settings, agentWriter, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, traceSampler, spanSampler, remoteConfigurationManager, dynamicConfigurationManager, tracerFlareManager);
             }
             else
             {
-                return new CITracerManager(settings, agentWriter, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, traceSampler, spanSampler, remoteConfigurationManager, dynamicConfigurationManager);
+                return new CITracerManager(settings, agentWriter, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, traceSampler, spanSampler, remoteConfigurationManager, dynamicConfigurationManager, tracerFlareManager);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/ITracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/ITracerFlareManager.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="ITracerFlareManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Logging.TracerFlare;
+
+internal interface ITracerFlareManager
+{
+    public void Start();
+
+    public void Dispose();
+}

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareController.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareController.cs
@@ -1,0 +1,153 @@
+﻿// <copyright file="TracerFlareController.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.RemoteConfigurationManagement;
+
+namespace Datadog.Trace.Logging.TracerFlare;
+
+internal class TracerFlareController
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerFlareController>();
+
+    private readonly IDiscoveryService _discoveryService;
+    private readonly IRcmSubscriptionManager _subscriptionManager;
+    private ISubscription? _subscription;
+
+    public TracerFlareController(
+        IDiscoveryService discoveryService,
+        IRcmSubscriptionManager subscriptionManager)
+    {
+        _subscriptionManager = subscriptionManager;
+        _discoveryService = discoveryService;
+    }
+
+    public bool? CanSendTracerFlare { get; private set; } = null;
+
+    public void Start()
+    {
+        if (Interlocked.Exchange(ref _subscription, new Subscription(RcmProductReceived, RcmProducts.TracerFlareInitiated, RcmProducts.TracerFlareRequested)) == null)
+        {
+            // TODO: do we need to set capabilities?
+            _subscriptionManager.SubscribeToChanges(_subscription!);
+        }
+    }
+
+    public Task DisposeAsync()
+    {
+        _discoveryService.RemoveSubscription(HandleConfigUpdate);
+
+        if (_subscription is { } subscription)
+        {
+            _subscriptionManager.Unsubscribe(subscription);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static ApplyDetails[] HandleTracerFlareInitiated(List<RemoteConfiguration> config)
+    {
+        try
+        {
+            // This product means "prepare for sending a tracer flare."
+            // We may consider doing more than just enabling debug mode in the future
+            // The timer is a fallback, in case we never receive a "send flare" product
+            GlobalSettings.SetDebugEnabledInternal(true);
+            Log.Debug("Enabling debug mode due to tracer flare initialization");
+
+            var result = new ApplyDetails[config.Count];
+            for (var i = 0; i < config.Count; i++)
+            {
+                result[i] = ApplyDetails.FromOk(config[i].Path.Path);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error handling tracer flare initialization");
+
+            var result = new ApplyDetails[config.Count];
+            for (var i = 0; i < config.Count; i++)
+            {
+                result[i] = ApplyDetails.FromError(config[i].Path.Path, ex.ToString());
+            }
+
+            return result;
+        }
+
+        throw new NotImplementedException();
+    }
+
+    private static ApplyDetails[] HandleTracerFlareRequested(List<RemoteConfiguration> config)
+    {
+        try
+        {
+            // This product means "send the flare to the endpoint."
+            // We may consider doing more than just enabling debug mode in the future
+            // The timer is a fallback, in case we never receive a "send flare" product
+            GlobalSettings.SetDebugEnabledInternal(true);
+            Log.Debug("Enabling debug mode due to tracer flare initialization");
+
+            var result = new ApplyDetails[config.Count];
+            for (var i = 0; i < config.Count; i++)
+            {
+                result[i] = ApplyDetails.FromOk(config[i].Path.Path);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error handling tracer flare initialization");
+
+            var result = new ApplyDetails[config.Count];
+            for (var i = 0; i < config.Count; i++)
+            {
+                result[i] = ApplyDetails.FromError(config[i].Path.Path, ex.ToString());
+            }
+
+            return result;
+        }
+
+        throw new NotImplementedException();
+    }
+
+    private IEnumerable<ApplyDetails> RcmProductReceived(Dictionary<string, List<RemoteConfiguration>> configByProduct, Dictionary<string, List<RemoteConfigurationPath>>? removedConfigByProduct)
+    {
+        if (configByProduct.TryGetValue(RcmProducts.TracerFlareInitiated, out var initiatedConfig)
+            && initiatedConfig.Count > 0)
+        {
+            return HandleTracerFlareInitiated(initiatedConfig);
+        }
+
+        if (configByProduct.TryGetValue(RcmProducts.TracerFlareRequested, out var requestedConfig)
+            && requestedConfig.Count > 0)
+        {
+            return HandleTracerFlareRequested(requestedConfig);
+        }
+
+        return Enumerable.Empty<ApplyDetails>();
+    }
+
+    private void HandleConfigUpdate(AgentConfiguration config)
+    {
+        CanSendTracerFlare = !string.IsNullOrWhiteSpace(config.TracerFlareEndpoint);
+
+        if (CanSendTracerFlare.Value)
+        {
+            Log.Debug("Tracer flare endpoint available");
+        }
+        else
+        {
+            Log.Debug("Tracer flare endpoint is not available");
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareController.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareController.cs
@@ -7,23 +7,27 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
 namespace Datadog.Trace.Logging.TracerFlare;
 
 internal class TracerFlareController
 {
+    private const int RevertGlobalDebugMinutes = 20;
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerFlareController>();
 
     private readonly IDiscoveryService _discoveryService;
     private readonly IRcmSubscriptionManager _subscriptionManager;
     private ISubscription? _subscription;
+    private Timer? _resetTimer = null;
 
     public TracerFlareController(
         IDiscoveryService discoveryService,
@@ -46,6 +50,14 @@ internal class TracerFlareController
 
     public Task DisposeAsync()
     {
+        if (_resetTimer is not null)
+        {
+            // If we have a timer, we should reset debugging now
+            // otherwise we'll be permanently in debug mode
+            ResetDebugging();
+            _resetTimer.Dispose();
+        }
+
         _discoveryService.RemoveSubscription(HandleConfigUpdate);
 
         if (_subscription is { } subscription)
@@ -56,85 +68,145 @@ internal class TracerFlareController
         return Task.CompletedTask;
     }
 
-    private static ApplyDetails[] HandleTracerFlareInitiated(List<RemoteConfiguration> config)
-    {
-        try
-        {
-            // This product means "prepare for sending a tracer flare."
-            // We may consider doing more than just enabling debug mode in the future
-            // The timer is a fallback, in case we never receive a "send flare" product
-            GlobalSettings.SetDebugEnabledInternal(true);
-            Log.Debug("Enabling debug mode due to tracer flare initialization");
-
-            var result = new ApplyDetails[config.Count];
-            for (var i = 0; i < config.Count; i++)
-            {
-                result[i] = ApplyDetails.FromOk(config[i].Path.Path);
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Error handling tracer flare initialization");
-
-            var result = new ApplyDetails[config.Count];
-            for (var i = 0; i < config.Count; i++)
-            {
-                result[i] = ApplyDetails.FromError(config[i].Path.Path, ex.ToString());
-            }
-
-            return result;
-        }
-
-        throw new NotImplementedException();
-    }
-
-    private static ApplyDetails[] HandleTracerFlareRequested(List<RemoteConfiguration> config)
-    {
-        try
-        {
-            // This product means "send the flare to the endpoint."
-            // We may consider doing more than just enabling debug mode in the future
-            // The timer is a fallback, in case we never receive a "send flare" product
-            GlobalSettings.SetDebugEnabledInternal(true);
-            Log.Debug("Enabling debug mode due to tracer flare initialization");
-
-            var result = new ApplyDetails[config.Count];
-            for (var i = 0; i < config.Count; i++)
-            {
-                result[i] = ApplyDetails.FromOk(config[i].Path.Path);
-            }
-        }
-        catch (Exception ex)
-        {
-            Log.Error(ex, "Error handling tracer flare initialization");
-
-            var result = new ApplyDetails[config.Count];
-            for (var i = 0; i < config.Count; i++)
-            {
-                result[i] = ApplyDetails.FromError(config[i].Path.Path, ex.ToString());
-            }
-
-            return result;
-        }
-
-        throw new NotImplementedException();
-    }
+    private static void ResetDebugging() => GlobalSettings.SetDebugEnabledInternal(false);
 
     private IEnumerable<ApplyDetails> RcmProductReceived(Dictionary<string, List<RemoteConfiguration>> configByProduct, Dictionary<string, List<RemoteConfigurationPath>>? removedConfigByProduct)
     {
         if (configByProduct.TryGetValue(RcmProducts.TracerFlareInitiated, out var initiatedConfig)
-            && initiatedConfig.Count > 0)
+         && initiatedConfig.Count > 0)
         {
             return HandleTracerFlareInitiated(initiatedConfig);
         }
 
         if (configByProduct.TryGetValue(RcmProducts.TracerFlareRequested, out var requestedConfig)
-            && requestedConfig.Count > 0)
+         && requestedConfig.Count > 0)
         {
             return HandleTracerFlareRequested(requestedConfig);
         }
 
         return Enumerable.Empty<ApplyDetails>();
+    }
+
+    private ApplyDetails[] HandleTracerFlareInitiated(List<RemoteConfiguration> config)
+    {
+        try
+        {
+            // This product means "prepare for sending a tracer flare."
+            // We may consider doing more than just enabling debug mode in the future
+            GlobalSettings.SetDebugEnabledInternal(true);
+
+            // The timer is a fallback, in case we never receive a "send flare" product
+            var timer = new Timer(
+                _ => ResetDebugging(),
+                state: null,
+                dueTime: TimeSpan.FromMinutes(RevertGlobalDebugMinutes),
+                period: Timeout.InfiniteTimeSpan);
+
+            var previous = Interlocked.Exchange(ref _resetTimer, timer);
+            previous?.Dispose();
+
+            Log.Debug("Enabling debug mode due to tracer flare initialization");
+
+            return AcknowledgeAll(config);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error handling tracer flare initialization");
+
+            return ErrorAll(config, ex);
+        }
+    }
+
+    private ApplyDetails[] HandleTracerFlareRequested(List<RemoteConfiguration> config)
+    {
+        try
+        {
+            // This product means "send the flare to the endpoint."
+            // We may consider doing more than just enabling debug mode in the future
+            Log.Debug("Received tracer flare request");
+
+            if (CanSendTracerFlare != true)
+            {
+                Log.Debug("Ignoring tracer flare request - tracer flare endpoint is not available");
+                return AcknowledgeAll(config);
+            }
+
+            if (Log.FileLogDirectory is not { } fileLogDirectory)
+            {
+                Log.Debug("Ignoring tracer flare request - file logging is disabled");
+                return AcknowledgeAll(config);
+            }
+
+            return AcknowledgeAll(config);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error handling tracer flare request");
+
+            return ErrorAll(config, ex);
+        }
+    }
+
+    private void ShouldSendDebugLogs(List<RemoteConfiguration> configs)
+    {
+        // // We can't
+        // // We could have multiple configs here with the same config_ids, so need to account for all of them
+        // Dictionary<string, List<RemoteConfiguration>>? results
+        //
+        //
+        // // try with each of the configs until we find one that works
+        // foreach (var config in configs)
+        // {
+        //     // TODO: I have no idea what I'm doing here. This almost certainly isn't correct
+        //     // TODO: Look for the "task_type": "tracer_flare" key, reject config if it doesn't have that
+        //     // TODO: Look for the "args" { "case_id": "12345"} key (I think?)
+        //     var jobject = TryDeserialize(config);
+        //     if (jobject is null
+        //         || !jobject.TryGetValue("task_type", StringComparison.Ordinal, out var taskTypeToken)
+        //         || taskTypeToken.Type != JTokenType.String
+        //         || !string.Equals(taskTypeToken.Value<string>(), "tracer_flare", StringComparison.Ordinal))
+        //     {
+        //         // not the right sort of task
+        //         continue;
+        //     }
+        //
+        //     if (!jobject.TryGetValue("args", StringComparison.Ordinal, out var args)
+        //      || args is not JObject argsObject
+        //      || argsObject.TryGetValue("case_id", out var caseIdToken)
+        //      || caseIdToken?.Type != JTokenType.String
+        //      || caseIdToken.Value<string>() is not { Length: > 0 } caseId)
+        //     {
+        //         // missing case_id
+        //         continue;
+        //     }
+        //
+        //     if (DebugLogReader.TryToCreateSentinelFile(fileLogDirectory, fileLogDirectory))
+        //     {
+        //         return true;
+        //     }
+        // }
+    }
+
+    private ApplyDetails[] AcknowledgeAll(List<RemoteConfiguration> config)
+    {
+        var result = new ApplyDetails[config.Count];
+        for (var i = 0; i < config.Count; i++)
+        {
+            result[i] = ApplyDetails.FromOk(config[i].Path.Path);
+        }
+
+        return result;
+    }
+
+    private ApplyDetails[] ErrorAll(List<RemoteConfiguration> config, Exception ex)
+    {
+        var result = new ApplyDetails[config.Count];
+        for (var i = 0; i < config.Count; i++)
+        {
+            result[i] = ApplyDetails.FromError(config[i].Path.Path, ex.ToString());
+        }
+
+        return result;
     }
 
     private void HandleConfigUpdate(AgentConfiguration config)
@@ -149,5 +221,30 @@ internal class TracerFlareController
         {
             Log.Debug("Tracer flare endpoint is not available");
         }
+    }
+
+    private JObject? TryDeserialize(RemoteConfiguration config)
+    {
+        try
+        {
+            using var stream = new MemoryStream(config.Contents);
+            using var streamReader = new StreamReader(stream);
+            using var jsonReader = new JsonTextReader(streamReader);
+            return JObject.Load(jsonReader);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error parsing remote configuration response");
+            return null;
+        }
+    }
+
+    private class TracerFlareRequest
+    {
+        [JsonProperty("tracer_type")]
+        public string? TracerType { get; set; }
+
+        [JsonProperty("args")]
+        public Dictionary<string, object>? Args { get; set; }
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -19,7 +19,7 @@ using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
 namespace Datadog.Trace.Logging.TracerFlare;
 
-internal class TracerFlareManager
+internal class TracerFlareManager : ITracerFlareManager
 {
     internal const string TracerFlareInitializationLog = "Enabling debug mode due to tracer flare initialization";
     internal const string TracerFlareCompleteLog = "Disabled debug mode due to tracer flare complete";

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -47,9 +47,9 @@ internal class TracerFlareManager : ITracerFlareManager
 
     public void Start()
     {
-        _discoveryService.SubscribeToChanges(HandleConfigUpdate);
         if (Interlocked.Exchange(ref _subscription, new Subscription(RcmProductReceived, RcmProducts.TracerFlareInitiated, RcmProducts.TracerFlareRequested)) == null)
         {
+            _discoveryService.SubscribeToChanges(HandleConfigUpdate);
             // Don't need to set any capabilities for tracer flare
             _subscriptionManager.SubscribeToChanges(_subscription!);
         }

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -54,7 +54,7 @@ internal class TracerFlareManager
         }
     }
 
-    public Task DisposeAsync()
+    public void Dispose()
     {
         if (_resetTimer is not null)
         {
@@ -70,8 +70,6 @@ internal class TracerFlareManager
         {
             _subscriptionManager.Unsubscribe(subscription);
         }
-
-        return Task.CompletedTask;
     }
 
     private static void ResetDebugging() => GlobalSettings.SetDebugEnabledInternal(false);

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmProducts.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmProducts.cs
@@ -8,8 +8,12 @@ namespace Datadog.Trace.RemoteConfigurationManagement;
 internal static class RcmProducts
 {
     public const string LiveDebugging = "LIVE_DEBUGGING";
+
     public const string Asm = "ASM";
     public const string AsmFeatures = "ASM_FEATURES";
     public const string AsmDd = "ASM_DD";
     public const string AsmData = "ASM_DATA";
+
+    public const string TracerFlareInitiated = "AGENT_CONFIG";
+    public const string TracerFlareRequested = "AGENT_TASK";
 }

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -11,6 +11,7 @@ using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.TracerFlare;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Tagging;
@@ -88,7 +89,7 @@ namespace Datadog.Trace
         /// The <see cref="TracerManager"/> created will be scoped specifically to this instance.
         /// </summary>
         internal Tracer(TracerSettings settings, IAgentWriter agentWriter, ITraceSampler sampler, IScopeManager scopeManager, IDogStatsd statsd, ITelemetryController telemetry = null, IDiscoveryService discoveryService = null)
-            : this(TracerManagerFactory.Instance.CreateTracerManager(settings is null ? null : new ImmutableTracerSettings(settings, true), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance, dataStreamsManager: null, remoteConfigurationManager: null, dynamicConfigurationManager: null))
+            : this(TracerManagerFactory.Instance.CreateTracerManager(settings is null ? null : new ImmutableTracerSettings(settings, true), agentWriter, sampler, scopeManager, statsd, runtimeMetrics: null, logSubmissionManager: null, telemetry: telemetry ?? NullTelemetryController.Instance, discoveryService ?? NullDiscoveryService.Instance, dataStreamsManager: null, remoteConfigurationManager: null, dynamicConfigurationManager: null, tracerFlareManager: null))
         {
         }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -18,6 +18,7 @@ using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.TracerFlare;
 using Datadog.Trace.Processors;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.RemoteConfigurationManagement;
@@ -61,7 +62,8 @@ namespace Datadog.Trace
                 discoveryService: null,
                 dataStreamsManager: null,
                 remoteConfigurationManager: null,
-                dynamicConfigurationManager: null);
+                dynamicConfigurationManager: null,
+                tracerFlareManager: null);
 
             try
             {
@@ -97,7 +99,8 @@ namespace Datadog.Trace
             IDiscoveryService discoveryService,
             DataStreamsManager dataStreamsManager,
             IRemoteConfigurationManager remoteConfigurationManager,
-            IDynamicConfigurationManager dynamicConfigurationManager)
+            IDynamicConfigurationManager dynamicConfigurationManager,
+            ITracerFlareManager tracerFlareManager)
         {
             settings ??= new ImmutableTracerSettings(TracerSettings.FromDefaultSourcesInternal(), true);
 
@@ -177,6 +180,7 @@ namespace Datadog.Trace
             }
 
             dynamicConfigurationManager ??= new DynamicConfigurationManager(RcmSubscriptionManager.Instance);
+            tracerFlareManager ??= new TracerFlareManager(discoveryService, RcmSubscriptionManager.Instance, TracerFlareApi.Create(settings.ExporterInternal));
 
             return CreateTracerManagerFrom(
                 settings,
@@ -193,7 +197,8 @@ namespace Datadog.Trace
                 sampler,
                 GetSpanSampler(settings),
                 remoteConfigurationManager,
-                dynamicConfigurationManager);
+                dynamicConfigurationManager,
+                tracerFlareManager);
         }
 
         protected virtual ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService)
@@ -224,8 +229,9 @@ namespace Datadog.Trace
             ITraceSampler traceSampler,
             ISpanSampler spanSampler,
             IRemoteConfigurationManager remoteConfigurationManager,
-            IDynamicConfigurationManager dynamicConfigurationManager)
-            => new TracerManager(settings, agentWriter, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, traceSampler, spanSampler, remoteConfigurationManager, dynamicConfigurationManager);
+            IDynamicConfigurationManager dynamicConfigurationManager,
+            ITracerFlareManager tracerFlareManager)
+            => new TracerManager(settings, agentWriter, scopeManager, statsd, runtimeMetrics, logSubmissionManager, telemetry, discoveryService, dataStreamsManager, defaultServiceName, gitMetadataTagsProvider, traceSampler, spanSampler, remoteConfigurationManager, dynamicConfigurationManager, tracerFlareManager);
 
         protected virtual ITraceSampler GetSampler(ImmutableTracerSettings settings)
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -22,8 +22,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 [Collection(nameof(DynamicConfigurationTests))]
 public class TracerFlareTests : TestHelper
 {
+    private const string CaseId = "abc123";
+
     private const string LogFileNamePrefix = "dotnet-tracer-managed-";
     private const string DiagnosticLog = "DATADOG TRACER CONFIGURATION";
+    private const string Email = "test_user";
+    private const string Hostname = "integration_tests";
 
     public TracerFlareTests(ITestOutputHelper output)
         : base("Console", output)
@@ -35,7 +39,6 @@ public class TracerFlareTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task SendTracerFlare()
     {
-        const string caseId = "abc123";
         using var agent = EnvironmentHelper.GetMockAgent();
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
         using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
@@ -46,7 +49,7 @@ public class TracerFlareTests : TestHelper
             _ = await logEntryWatcher.WaitForLogEntry(DiagnosticLog);
 
             await InitializeFlare(agent, logEntryWatcher);
-            await TriggerFlareCollection(agent, logEntryWatcher, caseId: caseId);
+            await TriggerFlareCollection(agent, logEntryWatcher);
         }
         finally
         {
@@ -57,7 +60,9 @@ public class TracerFlareTests : TestHelper
         }
 
         var (_, flare) = agent.TracerFlareRequests.Should().ContainSingle().Subject;
-        flare.GetParameterValue("case_id").Should().Be(caseId);
+        flare.GetParameterValue("case_id").Should().Be(CaseId);
+        flare.GetParameterValue("email").Should().Be(Email);
+        flare.GetParameterValue("hostname").Should().Be(Hostname);
         var flareFile = flare.Files.Should().ContainSingle().Subject;
         flareFile.Name.Should().Be("flare_file");
         flareFile.ContentType.Should().Be("application/octet-stream");
@@ -80,16 +85,16 @@ public class TracerFlareTests : TestHelper
         logs.Should().Contain(x => x.Contains(TracerFlareManager.TracerFlareInitializationLog));
     }
 
-    private async Task TriggerFlareCollection(MockTracerAgent agent, LogEntryWatcher logEntryWatcher, string caseId)
+    private async Task TriggerFlareCollection(MockTracerAgent agent, LogEntryWatcher logEntryWatcher)
     {
         object config = new
         {
             task_type = "tracer_flare",
             args = new
             {
-                case_id = caseId,
-                user_handle = "test_user",
-                hostname = "integration_tests",
+                case_id = CaseId,
+                user_handle = Email,
+                hostname = Hostname,
             }
         };
         var fileId = Guid.NewGuid().ToString();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -1,0 +1,108 @@
+﻿// <copyright file="TracerFlareTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.TracerFlare;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using HttpMultipartParser;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests;
+
+[CollectionDefinition(nameof(DynamicConfigurationTests), DisableParallelization = true)]
+[Collection(nameof(DynamicConfigurationTests))]
+public class TracerFlareTests : TestHelper
+{
+    private const string LogFileNamePrefix = "dotnet-tracer-managed-";
+    private const string DiagnosticLog = "DATADOG TRACER CONFIGURATION";
+
+    public TracerFlareTests(ITestOutputHelper output)
+        : base("Console", output)
+    {
+        SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "5");
+    }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task SendTracerFlare()
+    {
+        const string caseId = "abc123";
+        using var agent = EnvironmentHelper.GetMockAgent();
+        var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
+        using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
+        using var sample = StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
+
+        try
+        {
+            _ = await logEntryWatcher.WaitForLogEntry(DiagnosticLog);
+
+            await InitializeFlare(agent, logEntryWatcher);
+            await TriggerFlareCollection(agent, logEntryWatcher, caseId: caseId);
+        }
+        finally
+        {
+            if (!sample.HasExited)
+            {
+                sample.Kill();
+            }
+        }
+
+        var (_, flare) = agent.TracerFlareRequests.Should().ContainSingle().Subject;
+        flare.GetParameterValue("case_id").Should().Be(caseId);
+        var flareFile = flare.Files.Should().ContainSingle().Subject;
+        flareFile.Name.Should().Be("flare_file");
+        flareFile.ContentType.Should().Be("application/octet-stream");
+
+        var zip = new ZipArchive(flareFile.Data, ZipArchiveMode.Read);
+        zip.Entries.Should().NotBeNullOrEmpty();
+    }
+
+    private async Task InitializeFlare(MockTracerAgent agent, LogEntryWatcher logEntryWatcher)
+    {
+        var fileId = Guid.NewGuid().ToString();
+
+        var request = await agent.SetupRcmAndWait(Output, new[] { ((object)new { }, RcmProducts.TracerFlareInitiated, fileId) });
+
+        request.Should().NotBeNull();
+        request.Client.State.ConfigStates.Should().ContainSingle(f => f.Id == fileId)
+               .Subject.ApplyState.Should().Be(ApplyStates.ACKNOWLEDGED);
+
+        var logs = await logEntryWatcher.WaitForLogEntries(new[] { TracerFlareManager.TracerFlareInitializationLog });
+        logs.Should().Contain(x => x.Contains(TracerFlareManager.TracerFlareInitializationLog));
+    }
+
+    private async Task TriggerFlareCollection(MockTracerAgent agent, LogEntryWatcher logEntryWatcher, string caseId)
+    {
+        object config = new
+        {
+            task_type = "tracer_flare",
+            args = new
+            {
+                case_id = caseId,
+                user_handle = "test_user",
+                hostname = "integration_tests",
+            }
+        };
+        var fileId = Guid.NewGuid().ToString();
+
+        // This will also remove the AGENT_CONF log at the same time
+        var request = await agent.SetupRcmAndWait(Output, new[] { (config, RcmProducts.TracerFlareRequested, fileId) });
+
+        request.Client.State.ConfigStates.Should()
+               .OnlyContain(f => f.Id == fileId)
+               .And.OnlyContain(x => x.ApplyState == ApplyStates.ACKNOWLEDGED);
+
+        var logs = await logEntryWatcher.WaitForLogEntries(new[] { TracerFlareApi.TracerFlareSentLog, TracerFlareManager.TracerFlareCompleteLog });
+        logs.Should().Contain(x => x.Contains(TracerFlareManager.TracerFlareCompleteLog));
+        logs.Should().Contain(x => x.Contains(TracerFlareApi.TracerFlareSentLog));
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmToggle.cs
@@ -77,8 +77,16 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
                 if (EnableSecurity != null)
                 {
                     associatedRcmRequest.CachedTargetFiles.Should().BeEmpty();
-                    // Expected: APM_PRODUCT + the 3 ASM products
-                    associatedRcmRequest.Client.Products.Should().HaveCount(EnableSecurity == false ? 1 : 4);
+                    // Other products may be included, but none of the ASM ones should be
+                    var asmProducts = new[] { RcmProducts.Asm, RcmProducts.AsmData, RcmProducts.AsmDd };
+                    if (EnableSecurity == false)
+                    {
+                        associatedRcmRequest.Client.Products.Should().NotContain(asmProducts);
+                    }
+                    else
+                    {
+                        associatedRcmRequest.Client.Products.Should().Contain(asmProducts);
+                    }
                 }
                 else
                 {

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
@@ -22,6 +22,7 @@ internal class DiscoveryServiceMock : IDiscoveryService
         string dataStreamsMonitoringEndpoint = "dataStreamsMonitoringEndpoint",
         string eventPlatformProxyEndpoint = "eventPlatformProxyEndpoint",
         string telemetryProxyEndpoint = "telemetryProxyEndpoint",
+        string tracerFlareEndpoint = "tracerFlareEndpoint",
         bool clientDropP0 = true)
         => TriggerChange(
             new AgentConfiguration(
@@ -32,6 +33,7 @@ internal class DiscoveryServiceMock : IDiscoveryService
                 dataStreamsMonitoringEndpoint: dataStreamsMonitoringEndpoint,
                 eventPlatformProxyEndpoint: eventPlatformProxyEndpoint,
                 telemetryProxyEndpoint: telemetryProxyEndpoint,
+                tracerFlareEndpoint: tracerFlareEndpoint,
                 clientDropP0: clientDropP0));
 
     public void TriggerChange(AgentConfiguration config)

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -256,6 +256,7 @@ public class DiscoveryServiceTests
             dataStreamsMonitoringEndpoint: "DataStreamsMonitoringEndpoint",
             eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
             telemetryProxyEndpoint: "telemetryProxyEndpoint",
+            tracerFlareEndpoint: "tracerFlareEndpoint",
             clientDropP0: false);
 
         // same config
@@ -267,6 +268,7 @@ public class DiscoveryServiceTests
             dataStreamsMonitoringEndpoint: "DataStreamsMonitoringEndpoint",
             eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
             telemetryProxyEndpoint: "telemetryProxyEndpoint",
+            tracerFlareEndpoint: "tracerFlareEndpoint",
             clientDropP0: false);
 
         // different
@@ -278,6 +280,7 @@ public class DiscoveryServiceTests
             dataStreamsMonitoringEndpoint: "DataStreamsMonitoringEndpoint",
             eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
             telemetryProxyEndpoint: "telemetryProxyEndpoint",
+            tracerFlareEndpoint: "tracerFlareEndpoint",
             clientDropP0: false);
 
         config1.Equals(config2).Should().BeTrue();

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -452,6 +452,7 @@ namespace Datadog.Trace.Tests.Agent
                              dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
                              eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
                              telemetryProxyEndpoint: "telemetryProxyEndpoint",
+                             tracerFlareEndpoint: "tracerFlareEndpoint",
                              clientDropP0: true));
             }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ServiceNameTests.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Tests.Configuration
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager(TracerSettings tracerSettings)
-                : base(new ImmutableTracerSettings(tracerSettings), null, Mock.Of<IScopeManager>(), null, null, null, null, null, null, null, null, null, null, null, null)
+                : base(new ImmutableTracerSettings(tracerSettings), null, Mock.Of<IScopeManager>(), null, null, null, null, null, null, null, null, null, null, null, null, null)
             {
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -87,6 +87,7 @@ public class LiveDebuggerTests
                     dataStreamsMonitoringEndpoint: "dataStreamsMonitoringEndpoint",
                     eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
                     telemetryProxyEndpoint: "telemetryProxyEndpoint",
+                    tracerFlareEndpoint: "tracerFlareEndpoint",
                     clientDropP0: false));
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
@@ -1,0 +1,153 @@
+﻿// <copyright file="TracerFlareManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Text;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Logging.TracerFlare;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using Datadog.Trace.Tests.Agent;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.TracerFlare;
+
+public class TracerFlareManagerTests
+{
+    private const string ConfigPath = "/some/path";
+    private readonly string _requestId = Guid.NewGuid().ToString();
+    private readonly string _logsDir;
+    private readonly byte[] _validConfigBytes = """{ "task_type": "tracer_flare", "args": { "case_id": "abc123" } }"""u8.ToArray();
+
+    public TracerFlareManagerTests()
+    {
+        // Ensure we have a valid log directory
+        _logsDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_logsDir);
+    }
+
+    [Fact]
+    public void CanSendFlare_AfterDiscovery_IsTrue()
+    {
+        var discoveryService = new DiscoveryServiceMock();
+        var manager = new TracerFlareManager(
+            discoveryService,
+            Mock.Of<IRcmSubscriptionManager>(),
+            new TracerFlareApi(Mock.Of<IApiRequestFactory>()));
+
+        manager.Start();
+
+        manager.CanSendTracerFlare.Should().BeNull();
+        discoveryService.TriggerChange();
+
+        manager.CanSendTracerFlare.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanSendFlare_AfterDiscoveryFails_IsFalse()
+    {
+        var discoveryService = new DiscoveryServiceMock();
+        var manager = new TracerFlareManager(
+            discoveryService,
+            Mock.Of<IRcmSubscriptionManager>(),
+            new TracerFlareApi(Mock.Of<IApiRequestFactory>()));
+
+        manager.Start();
+
+        manager.CanSendTracerFlare.Should().BeNull();
+        discoveryService.TriggerChange(tracerFlareEndpoint: null);
+
+        manager.CanSendTracerFlare.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("{")]
+    [InlineData("""{ "task_type": "tracer_flare"}""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": {} }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": null} }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": 123} }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "" } }""")]
+    public void InvalidConfig_DoesNotSend_ReturnsError(string config)
+    {
+        var requestMock = new Mock<IApiRequestFactory>();
+        var manager = new TracerFlareManager(
+            new DiscoveryServiceMock(),
+            Mock.Of<IRcmSubscriptionManager>(),
+            new TracerFlareApi(requestMock.Object));
+
+        var result = manager.TrySendDebugLogs(ConfigPath, Encoding.UTF8.GetBytes(config), _requestId, _logsDir);
+
+        result.Filename.Should().Be(ConfigPath);
+        result.ApplyState.Should().Be(ApplyStates.ERROR);
+        result.Error.Should().NotBeNull();
+        requestMock.Verify(x => x.Create(It.IsAny<Uri>()), Times.Never);
+    }
+
+    [Theory]
+    [InlineData("{}")]
+    [InlineData("""{ "task_type": "agent_flare"}""")]
+    [InlineData("""{ "something": "else"}""")]
+    public void ValidNonApplicableConfig_DoesNotSend_ReturnsSuccess(string config)
+    {
+        var requestMock = new Mock<IApiRequestFactory>();
+        var manager = new TracerFlareManager(
+            new DiscoveryServiceMock(),
+            Mock.Of<IRcmSubscriptionManager>(),
+            new TracerFlareApi(requestMock.Object));
+
+        var result = manager.TrySendDebugLogs(ConfigPath, Encoding.UTF8.GetBytes(config), _requestId, _logsDir);
+
+        result.Filename.Should().Be(ConfigPath);
+        result.ApplyState.Should().Be(ApplyStates.ACKNOWLEDGED);
+        result.Error.Should().BeNull();
+        requestMock.Verify(x => x.Create(It.IsAny<Uri>()), Times.Never);
+    }
+
+    [Fact]
+    public void WhenSentinelIsAlreadySet_DoesNotSend_ReturnsSuccess()
+    {
+        var requestMock = new Mock<IApiRequestFactory>();
+        var manager = new TracerFlareManager(
+            new DiscoveryServiceMock(),
+            Mock.Of<IRcmSubscriptionManager>(),
+            new TracerFlareApi(requestMock.Object));
+
+        // pre-create the sentinel, to simulate another tracer catching it
+        var configId = Guid.NewGuid().ToString();
+        DebugLogReader.TryToCreateSentinelFile(_logsDir, configId);
+
+        var result = manager.TrySendDebugLogs(ConfigPath, _validConfigBytes, configId, _logsDir);
+
+        result.Filename.Should().Be(ConfigPath);
+        result.ApplyState.Should().Be(ApplyStates.ACKNOWLEDGED);
+        result.Error.Should().BeNull();
+        requestMock.Verify(x => x.Create(It.IsAny<Uri>()), Times.Never);
+    }
+
+    [Fact]
+    public void WhenShouldShip_SendsRequest_ReturnsSuccess()
+    {
+        var requestFactory = new TestRequestFactory();
+        var manager = new TracerFlareManager(
+            new DiscoveryServiceMock(),
+            Mock.Of<IRcmSubscriptionManager>(),
+            new TracerFlareApi(requestFactory));
+
+        // Create a new sentinel to make sure there's no flake
+        var configId = Guid.NewGuid().ToString();
+
+        var result = manager.TrySendDebugLogs(ConfigPath, _validConfigBytes, configId, _logsDir);
+
+        result.Filename.Should().Be(ConfigPath);
+        result.ApplyState.Should().Be(ApplyStates.ACKNOWLEDGED);
+        result.Error.Should().BeNull();
+
+        requestFactory.RequestsSent.Should().ContainSingle();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
@@ -22,7 +22,7 @@ public class TracerFlareManagerTests
     private const string ConfigPath = "/some/path";
     private readonly string _requestId = Guid.NewGuid().ToString();
     private readonly string _logsDir;
-    private readonly byte[] _validConfigBytes = """{ "task_type": "tracer_flare", "args": { "case_id": "abc123" } }"""u8.ToArray();
+    private readonly byte[] _validConfigBytes = """{ "task_type": "tracer_flare", "args": { "case_id": "abc123","hostname": "my.hostname", "user_handle": "its.me@datadoghq.com" } }"""u8.ToArray();
 
     public TracerFlareManagerTests()
     {
@@ -73,6 +73,14 @@ public class TracerFlareManagerTests
     [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": null} }""")]
     [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": 123} }""")]
     [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "" } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123", "hostname": null } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123", "hostname": "" } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123", "hostname": 123 } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123", "hostname": "my.host", "user_handle": null } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123", "hostname": "my.host", "user_handle": "" } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123", "hostname": "my.host", "user_handle": 123 } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": "abc123", "hostname": null, "user_handle": "test@datadog.com" } }""")]
+    [InlineData("""{ "task_type": "tracer_flare", "args": { "case_id": null, "hostname": "my.host", "user_handle": "test@datadog.com" } }""")]
     public void InvalidConfig_DoesNotSend_ReturnsError(string config)
     {
         var requestMock = new Mock<IApiRequestFactory>();

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Logging.TracerFlare;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -121,7 +122,7 @@ namespace Datadog.Trace.Tests
         private class LockedTracerManager : TracerManager, ILockedTracer
         {
             public LockedTracerManager()
-                : base(new ImmutableTracerSettings(new TracerSettings()), null, null, null, null, null, null, null, null, null, null, null, null, Mock.Of<IRemoteConfigurationManager>(), Mock.Of<IDynamicConfigurationManager>())
+                : base(new ImmutableTracerSettings(new TracerSettings()), null, null, null, null, null, null, null, null, null, null, null, null, Mock.Of<IRemoteConfigurationManager>(), Mock.Of<IDynamicConfigurationManager>(), Mock.Of<ITracerFlareManager>())
             {
             }
         }


### PR DESCRIPTION
## Summary of changes

- Subscribe to the `AGENT_CONF` and `AGENT_TASK` remote configuration products
- Implement the tracer flare flow

## Reason for change

We want to implement the tracer flare as described in [the RFC](https://docs.google.com/document/d/1U9aaYM401mJPTM8YMVvym1zaBxFtS4TjbdpZxhX3c3E/edit)

## Implementation details

- When we receive the `AGENT_CONF` task, we enable debug-logging
- 10 mins later, when we receive the `AGENT_TASK` with `task_type=tracer_flare` we send the tracer logs
- When the `AGENT_CONF` task is removed, we revert the debug logging (or after 20 mins, no matter what)

I have some significant concerns about the sync-over-async forced by the remote config infrastructure. The RC infra currently is sync by design, _and_ it uses `lock`, so switching it to `async` is not easy. But we have in here probably isn't safe? (even though it works in the tests)

## Test coverage

Added integration test for the end-to-end flow (based on the dynamic config tests)

## Other details

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/4994
- https://github.com/DataDog/dd-trace-dotnet/pull/4987
- https://github.com/DataDog/dd-trace-dotnet/pull/4988
- https://github.com/DataDog/dd-trace-dotnet/pull/4997
- https://github.com/DataDog/dd-trace-dotnet/pull/4989
- https://github.com/DataDog/dd-trace-dotnet/pull/4990



<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
