### PR TITLE
[ASM][IAST] Fix macOS build for IAST Instrumented tests

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -106,6 +106,7 @@ static const WSTRING _fixedMethodExcludeFilters[] = {
     WStr("System.ServiceModel*"),
     WStr("System.Web.Http*"),
     WStr("MongoDB.*"),
+    WStr("JetBrains*"),
     LastEntry, // Can't have an empty array. This must be the last element
 };
 static const WSTRING _fixedMethodAttributeExcludeFilters[] = {

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/generaterunsettings.sh
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/generaterunsettings.sh
@@ -4,6 +4,8 @@ MONITORING_HOME_FOLDER="${SOLUTIONFOLDER}/shared/bin/monitoring-home"
 FILE="${PROJECT_FOLDER}/iast.runsettings"
 DISTRIBUTION="$(cat /etc/*-release)"
 ARCH=$(uname -m)
+FILE_EXTENSION="so"
+
 echo DISTRIBUTION $DISTRIBUTION
 echo ARCH $ARCH
 echo PROJECT_FOLDER $PROJECT_FOLDER
@@ -20,13 +22,21 @@ if [[ "$ARCH" == *"aarch64"* ]]; then
 	  esac 
 fi
 
+# Check for macos
+# if $DISTRIBUTION is empty and uname -s is Darwin then it's macos
+if [[ -z "$DISTRIBUTION" && "$(uname -s)" == "Darwin" ]]; then
+  echo "Detected macOS"
+  BIN_FOLDER="osx"
+  FILE_EXTENSION="dylib"
+fi
+
 echo BIN_FOLDER $BIN_FOLDER
 
 echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>" > $FILE
 echo "<RunSettings><RunConfiguration><EnvironmentVariables>" >> $FILE
 echo "<CORECLR_ENABLE_PROFILING>1</CORECLR_ENABLE_PROFILING>" >> $FILE
 echo "<CORECLR_PROFILER>{846F5F1C-F9AE-4B07-969E-05C26BC060D8}</CORECLR_PROFILER>" >> $FILE
-echo "<CORECLR_PROFILER_PATH>${MONITORING_HOME_FOLDER}/${BIN_FOLDER}/Datadog.Trace.ClrProfiler.Native.so</CORECLR_PROFILER_PATH>" >> $FILE
+echo "<CORECLR_PROFILER_PATH>${MONITORING_HOME_FOLDER}/${BIN_FOLDER}/Datadog.Trace.ClrProfiler.Native.${FILE_EXTENSION}</CORECLR_PROFILER_PATH>" >> $FILE
 echo "<DD_DOTNET_TRACER_HOME>${MONITORING_HOME_FOLDER}</DD_DOTNET_TRACER_HOME>" >> $FILE
 echo "<DD_VERSION>1.0.0</DD_VERSION>" >> $FILE
 echo "<DD_TRACE_DEBUG>1</DD_TRACE_DEBUG>" >> $FILE


### PR DESCRIPTION
## Summary of changes

- Add JetBrain to the exclusion list.
- Add support for macOS to the script that generate environment vars for the IAST instrumented tests 

## Reason for change

Difficulty to run the IAST Instrumented tests on macOS (+ in Rider).

