### PR TITLE
Add nullable annotations to the datadog logging files

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -433,12 +433,6 @@ src/Datadog.Trace/IAST/Analyzers/UserStringInterop.cs
 src/Datadog.Trace/IAST/Aspects/DebugAspects.cs
 src/Datadog.Trace/IAST/Dataflow/AspectFilter.cs
 src/Datadog.Trace/IAST/Dataflow/AspectType.cs
-src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
-src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
-src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
-src/Datadog.Trace/Logging/Internal/ILogRateLimiter.cs
-src/Datadog.Trace/Logging/Internal/LogRateLimiter.cs
-src/Datadog.Trace/Logging/Internal/NullLogRateLimiter.cs
 src/Datadog.Trace/PDBs/dnlibAdditions/DssSymbolReaderImpl.Additions.cs
 src/Datadog.Trace/PDBs/dnlibAdditions/PdbReader.Additions.cs
 src/Datadog.Trace/PDBs/dnlibAdditions/PortablePdbReader.Additions.cs

--- a/tracer/src/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.csproj
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Datadog.Trace.SourceGenerators.csproj
@@ -6,6 +6,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <!--  Using the root namespace so generators are all in the root + we can control how they're written to disk  -->
     <RootNamespace></RootNamespace>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
+    <NoWarn>RS2008</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
@@ -257,8 +259,8 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\Datadog.Trace\Vendors\MessagePack\Formatters\ForceSizePrimitiveFormatter.tt">

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/Datadog.Trace.Tools.Analyzers.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/Datadog.Trace.Tools.Analyzers.csproj
@@ -3,12 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
+    <NoWarn>RS2008</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
-	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
+	  <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/LogAnalyzer/Diagnostics.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/LogAnalyzer/Diagnostics.cs
@@ -65,7 +65,7 @@ public class Diagnostics
         "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Exceptions should be passed in the Exception Parameter");
+        description: "Exceptions should be passed in the Exception Parameter.");
 
     internal static readonly DiagnosticDescriptor TemplateRule = new(
         TemplateDiagnosticId,
@@ -74,7 +74,7 @@ public class Diagnostics
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Checks for errors in the MessageTemplate");
+        description: "Checks for errors in the MessageTemplate.");
 
     internal static readonly DiagnosticDescriptor PropertyBindingRule = new(
         PropertyBindingDiagnosticId,
@@ -83,7 +83,7 @@ public class Diagnostics
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Checks whether properties and arguments match up");
+        description: "Checks whether properties and arguments match up.");
 
     internal static readonly DiagnosticDescriptor ConstantMessageTemplateRule = new(
         ConstantMessageTemplateDiagnosticId,
@@ -92,7 +92,7 @@ public class Diagnostics
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "MessageTemplate must be a constant value to ensure caching and avoid interpolation issues");
+        description: "MessageTemplate must be a constant value to ensure caching and avoid interpolation issues.");
 
     internal static readonly DiagnosticDescriptor UniquePropertyNameRule = new(
         UniquePropertyNameDiagnosticId,
@@ -101,7 +101,7 @@ public class Diagnostics
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "All property names in a MessageTemplate must be unique");
+        description: "All property names in a MessageTemplate must be unique.");
 
     internal static readonly DiagnosticDescriptor PascalPropertyNameRule = new(
         PascalPropertyNameDiagnosticId,
@@ -110,7 +110,7 @@ public class Diagnostics
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Property names in a MessageTemplates should be Pascal Case for consistency");
+        description: "Property names in a MessageTemplates should be Pascal Case for consistency.");
 
     internal static readonly DiagnosticDescriptor DestructureAnonymousObjectsRule = new(
         DestructureAnonymousObjectsDiagnosticId,
@@ -119,7 +119,7 @@ public class Diagnostics
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Anonymous objects should use the '@' hint to ensure they are destructed");
+        description: "Anonymous objects should use the '@' hint to ensure they are destructed.");
 
     internal static readonly DiagnosticDescriptor UseCorrectContextualLoggerRule = new(
         UseCorrectContextualLoggerDiagnosticId,
@@ -128,14 +128,14 @@ public class Diagnostics
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "Logger instances should use the current class for context");
+        description: "Logger instances should use the current class for context.");
 
     internal static readonly DiagnosticDescriptor UseDatadogLoggerRule = new(
         UseDatadogLoggerDiagnosticId,
         title: "Incorrect logger type",
-        messageFormat: "Incorrect use of Serilog ILogger. Use IDatadogLogger instead",
+        messageFormat: "Incorrect use of Serilog ILogger. Use IDatadogLogger instead.",
         category: "CodeQuality",
         defaultSeverity: DiagnosticSeverity.Warning,
         isEnabledByDefault: true,
-        description: "You should use the IDatadogLogger wrapper for logging");
+        description: "You should use the IDatadogLogger wrapper for logging.");
 }

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/LogAnalyzer/LogAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/LogAnalyzer/LogAnalyzer.cs
@@ -155,7 +155,8 @@ public class LogAnalyzer : DiagnosticAnalyzer
                 var nextParameterIndex = messageTemplateArgumentIndex + 1;
                 if ((invocationArguments.Count == nextParameterIndex + 1)
                     && method.Parameters.Length > nextParameterIndex
-                    && method.Parameters[nextParameterIndex].Type.ToString() == "object[]")
+                    && (method.Parameters[nextParameterIndex].Type.ToString() == "object[]"
+                        || method.Parameters[nextParameterIndex].Type.ToString() == "object?[]"))
                 {
                     // we're in the object[] version of the log message,
                     if (invocationArguments[nextParameterIndex].Expression is ArrayCreationExpressionSyntax { Initializer: { } initializer })

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLogging.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -45,22 +47,22 @@ namespace Datadog.Trace.Logging
         public void Debug<T0, T1, T2, T3>(string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception: null, messageTemplate, property0, property1, property2, property3, sourceLine, sourceFile);
 
-        public void Debug(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Debug(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception: null, messageTemplate, args, sourceLine, sourceFile);
 
-        public void Debug(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Debug(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception, messageTemplate, NoPropertyValues, sourceLine, sourceFile);
 
-        public void Debug<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Debug<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception, messageTemplate, property, sourceLine, sourceFile);
 
-        public void Debug<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Debug<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception, messageTemplate, property0, property1, sourceLine, sourceFile);
 
-        public void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Debug<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
-        public void Debug(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Debug(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Debug, exception, messageTemplate, args, sourceLine, sourceFile);
 
         public void Information(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
@@ -75,22 +77,22 @@ namespace Datadog.Trace.Logging
         public void Information<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Information, exception: null, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
-        public void Information(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Information(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Information, exception: null, messageTemplate, args, sourceLine, sourceFile);
 
-        public void Information(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Information(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Information, exception, messageTemplate, NoPropertyValues, sourceLine, sourceFile);
 
-        public void Information<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Information<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Information, exception, messageTemplate, property, sourceLine, sourceFile);
 
-        public void Information<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Information<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Information, exception, messageTemplate, property0, property1, sourceLine, sourceFile);
 
-        public void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Information<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Information, exception, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
-        public void Information(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Information(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Information, exception, messageTemplate, args, sourceLine, sourceFile);
 
         public void Warning(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
@@ -105,22 +107,22 @@ namespace Datadog.Trace.Logging
         public void Warning<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Warning, exception: null, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
-        public void Warning(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Warning(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Warning, exception: null, messageTemplate, args, sourceLine, sourceFile);
 
-        public void Warning(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Warning(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Warning, exception, messageTemplate, NoPropertyValues, sourceLine, sourceFile);
 
-        public void Warning<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Warning<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Warning, exception, messageTemplate, property, sourceLine, sourceFile);
 
-        public void Warning<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Warning<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Warning, exception, messageTemplate, property0, property1, sourceLine, sourceFile);
 
-        public void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Warning<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Warning, exception, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
-        public void Warning(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Warning(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Warning, exception, messageTemplate, args, sourceLine, sourceFile);
 
         public void Error(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
@@ -135,22 +137,22 @@ namespace Datadog.Trace.Logging
         public void Error<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Error, exception: null, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
-        public void Error(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Error(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Error, exception: null, messageTemplate, args, sourceLine, sourceFile);
 
-        public void Error(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Error(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Error, exception, messageTemplate, NoPropertyValues, sourceLine, sourceFile);
 
-        public void Error<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Error<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Error, exception, messageTemplate, property, sourceLine, sourceFile);
 
-        public void Error<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Error<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Error, exception, messageTemplate, property0, property1, sourceLine, sourceFile);
 
-        public void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Error<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Error, exception, messageTemplate, property0, property1, property2, sourceLine, sourceFile);
 
-        public void Error(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
+        public void Error(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "")
             => Write(LogEventLevel.Error, exception, messageTemplate, args, sourceLine, sourceFile);
 
         public void CloseAndFlush()
@@ -160,43 +162,45 @@ namespace Datadog.Trace.Logging
             (logger as IDisposable)?.Dispose();
         }
 
-        private void Write<T>(LogEventLevel level, Exception exception, string messageTemplate, T property, int sourceLine, string sourceFile)
+#pragma warning disable SA1010 // Opening square bracket should not be preceded by a space
+        private void Write<T>(LogEventLevel level, Exception? exception, string messageTemplate, T property, int sourceLine, string sourceFile)
         {
             if (_logger.IsEnabled(level))
             {
                 // Avoid boxing + array allocation if disabled
-                WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property }, sourceLine, sourceFile);
+                WriteIfNotRateLimited(level, exception, messageTemplate, [property], sourceLine, sourceFile);
             }
         }
 
-        private void Write<T0, T1>(LogEventLevel level, Exception exception, string messageTemplate, T0 property0, T1 property1, int sourceLine, string sourceFile)
+        private void Write<T0, T1>(LogEventLevel level, Exception? exception, string messageTemplate, T0 property0, T1 property1, int sourceLine, string sourceFile)
         {
             if (_logger.IsEnabled(level))
             {
                 // Avoid boxing + array allocation if disabled
-                WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property0, property1 }, sourceLine, sourceFile);
+                WriteIfNotRateLimited(level, exception, messageTemplate, [property0, property1], sourceLine, sourceFile);
             }
         }
 
-        private void Write<T0, T1, T2>(LogEventLevel level, Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine, string sourceFile)
+        private void Write<T0, T1, T2>(LogEventLevel level, Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine, string sourceFile)
         {
             if (_logger.IsEnabled(level))
             {
                 // Avoid boxing + array allocation if disabled
-                WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property0, property1, property2 }, sourceLine, sourceFile);
+                WriteIfNotRateLimited(level, exception, messageTemplate, [property0, property1, property2], sourceLine, sourceFile);
             }
         }
 
-        private void Write<T0, T1, T2, T3>(LogEventLevel level, Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, int sourceLine, string sourceFile)
+        private void Write<T0, T1, T2, T3>(LogEventLevel level, Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, int sourceLine, string sourceFile)
         {
             if (_logger.IsEnabled(level))
             {
                 // Avoid boxing + array allocation if disabled
-                WriteIfNotRateLimited(level, exception, messageTemplate, new object[] { property0, property1, property2, property3 }, sourceLine, sourceFile);
+                WriteIfNotRateLimited(level, exception, messageTemplate, [property0, property1, property2, property3], sourceLine, sourceFile);
             }
         }
+#pragma warning restore SA1010
 
-        private void Write(LogEventLevel level, Exception exception, string messageTemplate, object[] args, int sourceLine, string sourceFile)
+        private void Write(LogEventLevel level, Exception? exception, string messageTemplate, object?[] args, int sourceLine, string sourceFile)
         {
             if (_logger.IsEnabled(level))
             {
@@ -205,7 +209,7 @@ namespace Datadog.Trace.Logging
             }
         }
 
-        private void WriteIfNotRateLimited(LogEventLevel level, Exception exception, string messageTemplate, object[] args, int sourceLine, string sourceFile)
+        private void WriteIfNotRateLimited(LogEventLevel level, Exception? exception, string messageTemplate, object?[] args, int sourceLine, string sourceFile)
         {
             try
             {

--- a/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/IDatadogLogger.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 using Datadog.Trace.Vendors.Serilog.Events;
@@ -23,17 +25,17 @@ namespace Datadog.Trace.Logging
 
         void Debug<T0, T1, T2, T3>(string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Debug(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Debug(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Debug(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Debug(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Debug<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Debug<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Debug<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Debug<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Debug<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Debug(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Debug(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
         void Information(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
@@ -43,17 +45,17 @@ namespace Datadog.Trace.Logging
 
         void Information<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Information(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Information(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Information(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Information(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Information<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Information<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Information<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Information<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Information<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Information(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Information(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
         void Warning(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
@@ -63,17 +65,17 @@ namespace Datadog.Trace.Logging
 
         void Warning<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Warning(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Warning(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Warning(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Warning(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Warning<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Warning<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Warning<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Warning<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Warning<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Warning(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Warning(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
         void Error(string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
@@ -83,17 +85,17 @@ namespace Datadog.Trace.Logging
 
         void Error<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Error(string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Error(string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Error(Exception exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Error(Exception? exception, string messageTemplate, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Error<T>(Exception exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Error<T>(Exception? exception, string messageTemplate, T property, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Error<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Error<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Error<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
-        void Error(Exception exception, string messageTemplate, object[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
+        void Error(Exception? exception, string messageTemplate, object?[] args, [CallerLineNumber] int sourceLine = 0, [CallerFilePath] string sourceFile = "");
 
         void CloseAndFlush();
     }

--- a/tracer/src/Datadog.Trace/Logging/Internal/ILogRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/ILogRateLimiter.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.Logging
 {
     internal interface ILogRateLimiter

--- a/tracer/src/Datadog.Trace/Logging/Internal/LogRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/LogRateLimiter.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 
@@ -13,8 +15,7 @@ namespace Datadog.Trace.Logging
     internal class LogRateLimiter : ILogRateLimiter
     {
         private readonly int _secondsBetweenLogs;
-        private readonly ConcurrentDictionary<LogRateBucketKey, LogRateBucketInfo> _buckets
-            = new ConcurrentDictionary<LogRateBucketKey, LogRateBucketInfo>();
+        private readonly ConcurrentDictionary<LogRateBucketKey, LogRateBucketInfo> _buckets = new();
 
         public LogRateLimiter(int secondsBetweenLogs)
         {
@@ -49,7 +50,7 @@ namespace Datadog.Trace.Logging
             var newLogInfo = _buckets.AddOrUpdate(
                 key,
                 new LogRateBucketInfo(currentTimeBucket, skipCount: 0, 0),
-                (key, prev) => GetUpdatedLimitInfo(prev, currentTimeBucket));
+                (_, prev) => GetUpdatedLimitInfo(prev, currentTimeBucket));
 
             skipCount = newLogInfo.PreviousSkipCount;
             return newLogInfo.SkipCount == 0;
@@ -90,7 +91,7 @@ namespace Datadog.Trace.Logging
                 LineNo = lineNo;
             }
 
-            public override bool Equals(object obj)
+            public override bool Equals(object? obj)
             {
                 return obj is LogRateBucketKey key &&
                        FilePath == key.FilePath &&

--- a/tracer/src/Datadog.Trace/Logging/Internal/NullLogRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/NullLogRateLimiter.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.Logging
 {
     internal class NullLogRateLimiter : ILogRateLimiter

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/Datadog.Trace.SourceGenerators.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/Datadog.Trace.Tools.Analyzers.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeRefactoring.Testing.XUnit" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/CorrectLoggingAbstractionDiagnostic.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/CorrectLoggingAbstractionDiagnostic.cs
@@ -81,7 +81,7 @@ public class CorrectLoggingAbstractionDiagnostic
 
         var expected = new DiagnosticResult(DiagnosticId, Severity)
                       .WithLocation(0)
-                      .WithMessage("Incorrect use of Serilog ILogger. Use IDatadogLogger instead");
+                      .WithMessage("Incorrect use of Serilog ILogger. Use IDatadogLogger instead.");
         await Verifier.VerifyAnalyzerAsync(src, expected);
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/Helpers.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/Helpers.cs
@@ -19,6 +19,8 @@ public static class Helpers
 
     public static string LoggerDefinitions { get; } =
         """
+        #nullable enable
+
         namespace Datadog.Trace.Logging
         {
             using System;
@@ -38,42 +40,42 @@ public static class Helpers
                 void Debug<T0, T1>(string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
                 void Debug<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
                 void Debug<T0, T1, T2, T3>(string messageTemplate, T0 property0, T1 property1, T2 property2, T3 property3, int sourceLine = 0, string sourceFile = "");
-                void Debug(string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
-                void Debug(Exception exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
-                void Debug<T>(Exception exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
-                void Debug<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
-                void Debug<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
-                void Debug(Exception exception, string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
+                void Debug(string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
+                void Debug(Exception? exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
+                void Debug<T>(Exception? exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
+                void Debug<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
+                void Debug<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
+                void Debug(Exception? exception, string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
                 void Information(string messageTemplate, int sourceLine = 0, string sourceFile = "");
                 void Information<T>(string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
                 void Information<T0, T1>(string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
                 void Information<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
-                void Information(string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
-                void Information(Exception exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
-                void Information<T>(Exception exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
-                void Information<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
-                void Information<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
-                void Information(Exception exception, string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
+                void Information(string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
+                void Information(Exception? exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
+                void Information<T>(Exception? exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
+                void Information<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
+                void Information<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
+                void Information(Exception? exception, string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
                 void Warning(string messageTemplate, int sourceLine = 0, string sourceFile = "");
                 void Warning<T>(string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
                 void Warning<T0, T1>(string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
                 void Warning<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
-                void Warning(string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
-                void Warning(Exception exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
-                void Warning<T>(Exception exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
-                void Warning<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
-                void Warning<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
-                void Warning(Exception exception, string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
+                void Warning(string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
+                void Warning(Exception? exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
+                void Warning<T>(Exception? exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
+                void Warning<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
+                void Warning<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
+                void Warning(Exception? exception, string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
                 void Error(string messageTemplate, int sourceLine = 0, string sourceFile = "");
                 void Error<T>(string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
                 void Error<T0, T1>(string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
                 void Error<T0, T1, T2>(string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
-                void Error(string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
-                void Error(Exception exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
-                void Error<T>(Exception exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
-                void Error<T0, T1>(Exception exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
-                void Error<T0, T1, T2>(Exception exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
-                void Error(Exception exception, string messageTemplate, object[] args, int sourceLine = 0, string sourceFile = "");
+                void Error(string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
+                void Error(Exception? exception, string messageTemplate, int sourceLine = 0, string sourceFile = "");
+                void Error<T>(Exception? exception, string messageTemplate, T property, int sourceLine = 0, string sourceFile = "");
+                void Error<T0, T1>(Exception? exception, string messageTemplate, T0 property0, T1 property1, int sourceLine = 0, string sourceFile = "");
+                void Error<T0, T1, T2>(Exception? exception, string messageTemplate, T0 property0, T1 property1, T2 property2, int sourceLine = 0, string sourceFile = "");
+                void Error(Exception? exception, string messageTemplate, object?[] args, int sourceLine = 0, string sourceFile = "");
                 void CloseAndFlush();
             }
         }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/PropertyDiagnosticTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/LogAnalyzer/PropertyDiagnosticTests.cs
@@ -68,6 +68,52 @@ public class PropertyDiagnosticTests
 
     [Theory]
     [MemberData(nameof(Helpers.LogMethods), MemberType = typeof(Helpers))]
+    public async Task ShouldNotFlag_MatchingPropertiesAndArgsWhenUsingNullableArray(string logMethod)
+    {
+        var src = $$"""
+        #nullable enable
+        using Datadog.Trace.Logging;
+
+        {{Helpers.LoggerDefinitions}}
+
+        class TypeName
+        {
+            private static IDatadogLogger Log = null;
+            public static void Test()
+            {
+                Log.{{logMethod}}("Hello {Tester1} {Tester2}", new object?[] {"tester1", "tester2"});
+            }
+        }
+        """;
+
+        await Verifier.VerifyAnalyzerAsync(src);
+    }
+
+    [Theory]
+    [MemberData(nameof(Helpers.LogMethods), MemberType = typeof(Helpers))]
+    public async Task ShouldNotFlag_MatchingPropertiesAndArgsWhenUsingCollectionInitializer(string logMethod)
+    {
+        var src = $$"""
+        #nullable enable
+        using Datadog.Trace.Logging;
+
+        {{Helpers.LoggerDefinitions}}
+
+        class TypeName
+        {
+            private static IDatadogLogger Log = null;
+            public static void Test()
+            {
+                Log.{{logMethod}}("Hello {Tester1} {Tester2}", ["tester1", "tester2"]);
+            }
+        }
+        """;
+
+        await Verifier.VerifyAnalyzerAsync(src);
+    }
+
+    [Theory]
+    [MemberData(nameof(Helpers.LogMethods), MemberType = typeof(Helpers))]
     public async Task ShouldNotFlag_MatchingPositionalPropertiesAndArgs(string logMethod)
     {
         var src = $$"""


### PR DESCRIPTION
## Summary of changes

- Add `#nullable enable` to all the internal logging files that are missing them
- Update the analyzer packages to support c#12
- Update the log analyzer to support the new APIs

## Reason for change

Request in PR review in https://github.com/DataDog/dd-trace-dotnet/pull/4987

## Implementation details

Mostly obvious. The only controversial part is that I used c#12 collection literals in some places, as they're basically recommended as the way to do things now, as they give the chance for the compiler to (potentially) do some magic to speed things up.

Unfortunately, stylecop doesn't like them yet (though [it's already fixed in an unreleased version](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3745)) so added a pragma for now. I can revert to the normal/old style if people prefer, otherwise will remove the pragma once it does.

Unfortunately, when I tested these changes, it broke all the log analyzers we use, so had to update them. While I was at it, I updated the code analysis packages to the latest to support c#12 etc

## Test coverage

Added another test for collection initializers, but otherwise updated the existing tests

## Other details
Will likely stack the tracer flare PRs on top of this

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
