### PR TITLE
Making RCM async

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -936,6 +936,7 @@
       <type fullname="System.Threading.Monitor" />
       <type fullname="System.Threading.Mutex" />
       <type fullname="System.Threading.ReaderWriterLockSlim" />
+      <type fullname="System.Threading.SemaphoreSlim" />
       <type fullname="System.Threading.SpinWait" />
       <type fullname="System.Threading.SynchronizationContext" />
       <type fullname="System.Threading.ThreadLocal`1" />

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using Datadog.Trace.Configuration.ConfigurationSources;
@@ -110,16 +109,16 @@ namespace Datadog.Trace.Configuration
             Tracer.ConfigureInternal(newSettings);
         }
 
-        private IEnumerable<ApplyDetails> ConfigurationUpdated(Dictionary<string, List<RemoteConfiguration>> configByProduct, Dictionary<string, List<RemoteConfigurationPath>>? removedConfigByProduct)
+        private ApplyDetails[] ConfigurationUpdated(Dictionary<string, List<RemoteConfiguration>> configByProduct, Dictionary<string, List<RemoteConfigurationPath>>? removedConfigByProduct)
         {
             if (!configByProduct.TryGetValue(ProductName, out var apmLibrary))
             {
-                return Enumerable.Empty<ApplyDetails>();
+                return Array.Empty<ApplyDetails>();
             }
 
             if (apmLibrary.Count == 0)
             {
-                return Enumerable.Empty<ApplyDetails>();
+                return Array.Empty<ApplyDetails>();
             }
 
             var result = new ApplyDetails[apmLibrary.Count];

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -73,7 +73,7 @@ namespace Datadog.Trace.Debugger
                 {
                     AcceptAddedConfiguration(updates.Values.SelectMany(u => u).Select(i => new NamedRawFile(i.Path, i.Contents)));
                     AcceptRemovedConfiguration(removals.Values.SelectMany(u => u));
-                    return Enumerable.Empty<ApplyDetails>();
+                    return Array.Empty<ApplyDetails>();
                 },
                 RcmProducts.LiveDebugging);
             discoveryService?.SubscribeToChanges(DiscoveryCallback);

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
@@ -27,7 +28,5 @@ internal interface IRcmSubscriptionManager
 
     byte[] GetCapabilities();
 
-    GetRcmRequest BuildRequest(RcmClientTracer rcmTracer, string? lastPollError);
-
-    Task ProcessResponse(GetRcmResponse response);
+    Task SendRequest(RcmClientTracer rcmTracer, Func<GetRcmRequest, Task<GetRcmResponse>> callback);
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/IRcmSubscriptionManager.cs
@@ -6,6 +6,7 @@
 #nullable enable
 using System.Collections.Generic;
 using System.Numerics;
+using System.Threading.Tasks;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 
 namespace Datadog.Trace.RemoteConfigurationManagement;
@@ -22,13 +23,11 @@ internal interface IRcmSubscriptionManager
 
     void Unsubscribe(ISubscription subscription);
 
-    List<ApplyDetails> Update(Dictionary<string, List<RemoteConfiguration>> configByProducts, Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct);
-
     void SetCapability(BigInteger index, bool available);
 
     byte[] GetCapabilities();
 
     GetRcmRequest BuildRequest(RcmClientTracer rcmTracer, string? lastPollError);
 
-    void ProcessResponse(GetRcmResponse response);
+    Task ProcessResponse(GetRcmResponse response);
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/ISubscription.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/ISubscription.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
@@ -14,6 +15,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
     {
         public IReadOnlyCollection<string> ProductKeys { get; }
 
-        Func<Dictionary<string, List<RemoteConfiguration>>, Dictionary<string, List<RemoteConfigurationPath>>?, IEnumerable<ApplyDetails>> Invoke { get; }
+        Func<Dictionary<string, List<RemoteConfiguration>>, Dictionary<string, List<RemoteConfigurationPath>>?, Task<ApplyDetails[]>> Invoke { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #nullable enable
+#pragma warning disable SA1010 // Opening square brackets should be spaced correctly
 
 using System;
 using System.Collections.Generic;
@@ -35,7 +36,8 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
 
     private readonly string _id;
 
-    private IReadOnlyList<ISubscription> _subscriptions = new List<ISubscription>();
+    // Ideally this would be an ImmutableArray but that's not available in net461
+    private IReadOnlyList<ISubscription> _subscriptions = [];
 
     private string? _backendClientState;
     private int _targetsVersion;
@@ -50,7 +52,7 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
     public bool HasAnySubscription => _subscriptions.Count > 0;
 
     // this list shouldn't be recalculated everytime we access it as it is used by RemoteConfigurationManager to build an rcm request every x seconds
-    public ICollection<string> ProductKeys { get; private set; } = new List<string>();
+    public ICollection<string> ProductKeys { get; private set; } = [];
 
     public void SubscribeToChanges(ISubscription subscription)
     {
@@ -58,7 +60,7 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
         {
             if (!_subscriptions.Contains(subscription))
             {
-                _subscriptions = new List<ISubscription>(_subscriptions) { subscription };
+                _subscriptions = [.. _subscriptions, subscription];
             }
 
             RefreshProductKeys();

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -220,8 +220,6 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
         }
 
         var configByProducts = new Dictionary<string, List<RemoteConfiguration>>();
-        var removedConfigsByProduct = new Dictionary<string, List<RemoteConfigurationPath>>();
-
         var receivedPaths = new List<string>();
 
         // handle new configurations
@@ -268,6 +266,8 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
 
             configByProducts[remoteConfigurationPath.Product].Add(remoteConfiguration);
         }
+
+        Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct = new();
 
         // handle removed configurations
         foreach (var appliedConfiguration in _appliedConfigurations)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -163,7 +163,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
                 if (response?.Targets?.Signed != null)
                 {
-                    _subscriptionManager.ProcessResponse(response);
+                    await _subscriptionManager.ProcessResponse(response).ConfigureAwait(false);
                 }
             }
             catch (Exception e)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RemoteConfigurationManager.cs
@@ -33,7 +33,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         private readonly CancellationTokenSource _cancellationSource;
 
-        private string? _lastPollError;
         private int _isPollingStarted;
         private bool _isRcmEnabled;
         private bool _gitMetadataAddedToRequestTags;
@@ -52,7 +51,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             _pollInterval = pollInterval;
             _gitMetadataTagsProvider = gitMetadataTagsProvider;
 
-            _lastPollError = null;
             _subscriptionManager = subscriptionManager;
             _cancellationSource = new CancellationTokenSource();
             discoveryService.SubscribeToChanges(SetRcmEnabled);
@@ -135,8 +133,16 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
                 if (isRcmEnabled && _subscriptionManager.HasAnySubscription)
                 {
-                    await Poll().ConfigureAwait(false);
-                    _lastPollError = null;
+                    try
+                    {
+                        await Poll().ConfigureAwait(false);
+                    }
+                    catch (Exception ex)
+                    {
+                        // It shouldn't happen because the RcmSubscriptionManager swallows exceptions.
+                        // But hey, we all know what's going to happen sooner or later.
+                        Log.Error(ex, "Error while polling remote configuration management service");
+                    }
                 }
 
                 try
@@ -150,26 +156,15 @@ namespace Datadog.Trace.RemoteConfigurationManagement
             }
         }
 
-        private async Task Poll()
+        private Task Poll()
         {
-            try
+            return _subscriptionManager.SendRequest(_rcmTracer, request =>
             {
-                var request = _subscriptionManager.BuildRequest(_rcmTracer, _lastPollError);
-
                 EnrichTagsWithGitMetadata(request.Client.ClientTracer.Tags);
                 request.Client.ClientTracer.ExtraServices = ExtraServicesProvider.Instance.GetExtraServices();
 
-                var response = await _remoteConfigurationApi.GetConfigs(request).ConfigureAwait(false);
-
-                if (response?.Targets?.Signed != null)
-                {
-                    await _subscriptionManager.ProcessResponse(response).ConfigureAwait(false);
-                }
-            }
-            catch (Exception e)
-            {
-                _lastPollError = e.Message;
-            }
+                return _remoteConfigurationApi.GetConfigs(request);
+            });
         }
 
         private void EnrichTagsWithGitMetadata(List<string> tags)

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Subscription.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Subscription.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Datadog.Trace.RemoteConfigurationManagement
 {
@@ -14,7 +15,13 @@ namespace Datadog.Trace.RemoteConfigurationManagement
     {
         private readonly HashSet<string> _productKeys;
 
-        public Subscription(Func<Dictionary<string, List<RemoteConfiguration>>, Dictionary<string, List<RemoteConfigurationPath>>?, IEnumerable<ApplyDetails>> callback, params string[] productKeys)
+        public Subscription(Func<Dictionary<string, List<RemoteConfiguration>>, Dictionary<string, List<RemoteConfigurationPath>>?, ApplyDetails[]> callback, params string[] productKeys)
+        {
+            _productKeys = new HashSet<string>(productKeys);
+            Invoke = (configsByProduct, removedConfigsByProduct) => Task.FromResult(callback(configsByProduct, removedConfigsByProduct));
+        }
+
+        public Subscription(Func<Dictionary<string, List<RemoteConfiguration>>, Dictionary<string, List<RemoteConfigurationPath>>?, Task<ApplyDetails[]>> callback, params string[] productKeys)
         {
             _productKeys = new HashSet<string>(productKeys);
             Invoke = callback;
@@ -22,6 +29,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public IReadOnlyCollection<string> ProductKeys => _productKeys;
 
-        public Func<Dictionary<string, List<RemoteConfiguration>>, Dictionary<string, List<RemoteConfigurationPath>>?, IEnumerable<ApplyDetails>> Invoke { get; }
+        public Func<Dictionary<string, List<RemoteConfiguration>>, Dictionary<string, List<RemoteConfigurationPath>>?, Task<ApplyDetails[]>> Invoke { get; }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -142,12 +142,7 @@ public class LiveDebuggerTests
             throw new NotImplementedException();
         }
 
-        public GetRcmRequest BuildRequest(RcmClientTracer rcmTracer, string lastPollError)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task ProcessResponse(GetRcmResponse response)
+        public Task SendRequest(RcmClientTracer rcmTracer, Func<GetRcmRequest, Task<GetRcmResponse>> callback)
         {
             throw new NotImplementedException();
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -132,11 +132,6 @@ public class LiveDebuggerTests
             }
         }
 
-        public List<ApplyDetails> Update(Dictionary<string, List<RemoteConfiguration>> configByProducts, Dictionary<string, List<RemoteConfigurationPath>> removedConfigsByProduct)
-        {
-            throw new NotImplementedException();
-        }
-
         public void SetCapability(BigInteger index, bool available)
         {
             throw new NotImplementedException();
@@ -152,7 +147,7 @@ public class LiveDebuggerTests
             throw new NotImplementedException();
         }
 
-        public void ProcessResponse(GetRcmResponse response)
+        public Task ProcessResponse(GetRcmResponse response)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
## Summary of changes

Making the RCM ISubscription callback async.

## Reason for change

Avoiding sync-over-async in the tracer flare implementation.

## Implementation details

 - To keep changes to a minimum, I added a constructor to Subscription that creates an async callback from a synchronous one
 - Tried to make RCM as thread safe as possible, but I'm having a hard time reasoning about what can actually be executed simultaneously
 - `_subscriptions` is now a read-only list so it can be accessed outside of a lock
 - Introduced a `BackendState` struct to keep the value of `TargetsVersion` and `OpaqueBackendState` in sync (I don't know what will happen if they get out of sync, so let's not find out)
 - Turned `_appliedConfigurations` to a concurrent dictionary for concurrent access

Not gonna lie, I'm unclear if `_appliedConfigurations` needs to be kept in sync with the backend state.

## Test coverage

Relying on the existing tests.