### PR TITLE
Try to fix the RedirectInput test

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/RunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/RunCommandTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -79,6 +80,8 @@ public class RunCommandTests : ConsoleTestHelper
 
         // dd-env is an argument for the target application and therefore shouldn't set the DD_ENV variable
         var commandLine = $"run -- {startInfo.Executable} {startInfo.Args} echo";
+
+        System.Console.InputEncoding = Encoding.ASCII;
 
         var process = RunToolInteractive(commandLine);
 


### PR DESCRIPTION
## Summary of changes

The RunCommandTests.RedirectInput test is failing randomly with a weird encoding error. I don't know where it comes from, but I don't think it's caused by dd-dotnet. Forcing the encoding in the test _seems_ to fix it.

## Reason for change

Flaky test.

## Implementation details

When starting a new process, its `StandardInput` stream uses the current value of `Console.InputEncoding`.

## Test coverage

Ran the RedirectInput test a bunch of times and it didn't fail. It doesn't necessarily mean that it will fix the issue, but it's worth trying.