### PR TITLE
Make custom sampling rules case-insensitive

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Sampling
                     ? null
                     : new(
                         WrapWithLineCharacters(serviceNameRegex),
-                        RegexOptions.Compiled,
+                        RegexOptions.Compiled | RegexOptions.IgnoreCase,
                         RegexTimeout);
             }
             catch (ArgumentException e)
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Sampling
                                       ? null
                                       : new(
                                           WrapWithLineCharacters(operationNameRegex),
-                                          RegexOptions.Compiled,
+                                          RegexOptions.Compiled | RegexOptions.IgnoreCase,
                                           RegexTimeout);
             }
             catch (ArgumentException e)

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
@@ -103,7 +103,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void RuleShouldBeCaseInsensitive()
         {
-            var config = "[{\"sample_rate\":0.5, \"service\":\"SHOPPING-cart-service\"}]";
+            var config = "[{\"sample_rate\":0.5, \"service\":\"SHOPPING-cart-service\", \"name\":\"CHECKOUT\"}]";
             var rule = CustomSamplingRule.BuildFromConfigurationString(config).Single();
             VerifySingleRule(rule, CartCheckoutSpan, true);
         }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
@@ -100,6 +100,14 @@ namespace Datadog.Trace.Tests.Sampling
             VerifySingleRule(fallbackRule, RequestShippingSpan, true);
         }
 
+        [Fact]
+        public void RuleShouldBeCaseInsensitive()
+        {
+            var config = "[{\"sample_rate\":0.5, \"service\":\"SHOPPING-cart-service\"}]";
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config).Single();
+            VerifySingleRule(rule, CartCheckoutSpan, true);
+        }
+
         [Theory]
         [InlineData("\"rate:0.5, \"name\":\"auth.*\"}]")]
         [InlineData("[{\"name\":\"wat\"}]")]


### PR DESCRIPTION
## Summary of changes

Make custom sampling rules case-insensitive.

## Reason for change

The service name/operation name are normalized and changed to lower-case in the backend, but they still have their capitalization in the tracer. This can lead to confusing situations where a user create a sampling rule from the name seen in the Datadog UI, but it doesn't match because the service name is not lower-case in the tracer.

## Implementation details

Just added the IgnoreCase option on the regex.

## Test coverage

Added a test-case with a capitalized service name and operation name.


## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
