### PR TITLE
Explicitly sort files before generating missing nullability csv

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2187,12 +2187,19 @@ partial class Build
                 return d;
             }
 
+            string NormalizedPath(AbsolutePath ap)
+            {
+                // paths are not printed the same way in windows vs unix-based, which affects the ordering.
+                // to get a stable order, we use / everywhere, which is what's written in the csv in the end.
+                return ap.ToString().Replace(oldChar: '\\', newChar: '/');
+            }
+
             var sourceFiles = include.Except(exclude).ToList();
             // sort by depth, then alphabetical.
             sourceFiles.Sort((a, b) =>
             {
                 var depthDiff = ComputeDepth(a) - ComputeDepth(b);
-                return depthDiff != 0 ? depthDiff : string.Compare(a.ToString(), b.ToString(), StringComparison.OrdinalIgnoreCase);
+                return depthDiff != 0 ? depthDiff : string.Compare(NormalizedPath(a), NormalizedPath(b), StringComparison.OrdinalIgnoreCase);
             });
 
             var sb = new StringBuilder();

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2217,7 +2217,7 @@ partial class Build
 
             var csvFilePath = TracerDirectory / "missing-nullability-files.csv";
             File.WriteAllText(csvFilePath, sb.ToString());
-            Serilog.Log.Information("File saved: {File}", csvFilePath);
+            Serilog.Log.Information("File ordered and saved: {File}", csvFilePath);
         });
 
     Target CreateRootDescriptorsFile => _ => _

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2176,7 +2176,24 @@ partial class Build
                 "src/Datadog.Trace/Vendors/**"
             );
 
-            var sourceFiles = include.Except(exclude);
+            int ComputeDepth(AbsolutePath ap)
+            {
+                var d = 0;
+                while ((ap = ap.Parent) != null)
+                {
+                    d++;
+                }
+
+                return d;
+            }
+
+            var sourceFiles = include.Except(exclude).ToList();
+            // sort by depth, then alphabetical.
+            sourceFiles.Sort((a, b) =>
+            {
+                var depthDiff = ComputeDepth(a) - ComputeDepth(b);
+                return depthDiff != 0 ? depthDiff : string.Compare(a.ToString(), b.ToString(), StringComparison.OrdinalIgnoreCase);
+            });
 
             var sb = new StringBuilder();
             foreach (var file in sourceFiles)

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -681,10 +681,10 @@ src/Datadog.Trace/Debugger/Sink/Models/ProbeException.cs
 src/Datadog.Trace/Debugger/Sink/Models/ProbeStatus.cs
 src/Datadog.Trace/Debugger/Sink/Models/Status.cs
 src/Datadog.Trace/Debugger/Sink/Models/TimedMessage.cs
-src/Datadog.Trace/IAST/Aspects/System/StringAspects.cs
 src/Datadog.Trace/IAST/Aspects/System.DirectoryServices/SearchRequestAspect.cs
 src/Datadog.Trace/IAST/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
 src/Datadog.Trace/IAST/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
+src/Datadog.Trace/IAST/Aspects/System/StringAspects.cs
 src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Signed.cs
 src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/Target.cs
 src/Datadog.Trace/RemoteConfigurationManagement/Protocol/Tuf/TargetCustom.cs


### PR DESCRIPTION
## Reason for change

The file list was not ordered by the code before being written to the `missing-nullability-files.csv`. This causes trouble, because the way files are coming out of the `GlobFiles` method varies from one OS to the next, for instance between Mac OS and Windows.
Having it written in code ensures consistency for all users.

## Implementation details

I chose an implementation that'd be close to the current order. 
For the sake of simplicity, I just order by the full path's alphabetical order, which differs for one single line in the existing file.
The fix would be to iterate over the elements of the path to compare them one by one, but I judged that the aded complexity was not worth it.

## Test coverage

No tests on the build steps AFAIK

## Other details

discussed in https://dd.slack.com/archives/GPTD8CS4C/p1703252172664199