### PR TITLE
Add install signature to app-started telemetry event

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/AppStartedPayload.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/AppStartedPayload.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AppStartedPayload.cs" company="Datadog">
+// <copyright file="AppStartedPayload.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -16,5 +16,16 @@ internal class AppStartedPayload : IPayload
 
     public ErrorData? Error { get; set; }
 
+    public InstallSignaturePayload? InstallSignature { get; set; }
+
     public ICollection<TelemetryValue>? AdditionalPayload { get; set; }
+
+    internal class InstallSignaturePayload
+    {
+        public string? InstallId { get; set; }
+
+        public string? InstallType { get; set; }
+
+        public string? InstallTime { get; set; }
+    }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilder.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryDataBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryDataBuilder.cs" company="Datadog">
+// <copyright file="TelemetryDataBuilder.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Telemetry.DTOs;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Telemetry;
 
@@ -36,6 +37,7 @@ internal class TelemetryDataBuilder
                 {
                     Configuration = input.Configuration,
                     Products = input.Products,
+                    InstallSignature = GetInstallSignature()
                 })
             };
         }
@@ -161,6 +163,25 @@ internal class TelemetryDataBuilder
                 Integrations = integrations
             },
             namingSchemeVersion);
+
+    private static AppStartedPayload.InstallSignaturePayload? GetInstallSignature()
+    {
+        var installId = EnvironmentHelpers.GetEnvironmentVariable("DD_INSTRUMENTATION_INSTALL_ID");
+        var installType = EnvironmentHelpers.GetEnvironmentVariable("DD_INSTRUMENTATION_INSTALL_TYPE");
+        var installTime = EnvironmentHelpers.GetEnvironmentVariable("DD_INSTRUMENTATION_INSTALL_TIME");
+
+        if (string.IsNullOrEmpty(installId) && string.IsNullOrEmpty(installType) && string.IsNullOrEmpty(installTime))
+        {
+            return null;
+        }
+
+        return new AppStartedPayload.InstallSignaturePayload
+        {
+            InstallId = installId,
+            InstallType = installType,
+            InstallTime = installTime
+        };
+    }
 
     private TelemetryData GetRequest(
         ApplicationTelemetryData application,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -351,9 +351,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedInstallType = "install type";
             var expectedInstallTime = "install time";
 
-            EnvironmentHelper.CustomEnvironmentVariables["DD_INSTRUMENTATION_INSTALL_ID"] = expectedInstallId;
-            EnvironmentHelper.CustomEnvironmentVariables["DD_INSTRUMENTATION_INSTALL_TYPE"] = expectedInstallType;
-            EnvironmentHelper.CustomEnvironmentVariables["DD_INSTRUMENTATION_INSTALL_TIME"] = expectedInstallTime;
+            SetEnvironmentVariable("DD_INSTRUMENTATION_INSTALL_ID", expectedInstallId);
+            SetEnvironmentVariable("DD_INSTRUMENTATION_INSTALL_TYPE", expectedInstallType);
+            SetEnvironmentVariable("DD_INSTRUMENTATION_INSTALL_TIME", expectedInstallTime);
 
             using var agent = MockTracerAgent.Create(Output, useTelemetry: true);
             using var telemetry = new MockTelemetryAgent();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ConfigurationTests.cs" company="Datadog">
+// <copyright file="ConfigurationTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -46,6 +46,9 @@ public class ConfigurationTests
         // Internal env vars that we only ever read from environment
         "DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH",
         "DD_DOTNET_TRACER_HOME",
+        "DD_INSTRUMENTATION_INSTALL_ID",
+        "DD_INSTRUMENTATION_INSTALL_TYPE",
+        "DD_INSTRUMENTATION_INSTALL_TIME"
     };
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="JsonTelemetryTransportTests.cs" company="Datadog">
+// <copyright file="JsonTelemetryTransportTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -59,7 +59,13 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                     {
                         Appsec = new ProductData(false, null),
                         Profiler = new ProductData(true, new ErrorData((TelemetryErrorCode)1, "Some error"))
-                    }
+                    },
+                    InstallSignature = new AppStartedPayload.InstallSignaturePayload
+                    {
+                        InstallId = "68e75c48-57ca-4a12-adfc-575c4b05fcbe",
+                        InstallTime = "1703188212",
+                        InstallType = "k8s_single_step"
+                    },
                 })
             {
                 NamingSchemaVersion = "1"

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started.json
@@ -66,6 +66,11 @@
           "message": "Invalid value"
         }
       }
-    ]
+    ],
+    "install_signature": {
+      "install_id": "68e75c48-57ca-4a12-adfc-575c4b05fcbe",
+      "install_type": "k8s_single_step",
+      "install_time": "1703188212"
+    }
   }
 }


### PR DESCRIPTION
## Summary of changes

Add the install signature to app-started telemetry event.

Jira: AIT-9191

## Reason for change

Compute "time to value" metric.

## Implementation details

For now the install signature logic is implemented directly in the `TelemetryDataBuilder`. If in the future we want to use that data elsewhere, we should probably extract it into its own class.

## Test coverage

- Updated the `JsonTelemetryTransportTests.SerializedAppStartedShouldProduceJsonWithExpectedFormat` unit test to validate the serialization
- Added the `TelemetryTests.Telemetry_CollectsInstallSignature` integration test to validate that the information is pulled from environment variables
