### PR TITLE
speedup CI step verify_files_without_nullability

### DIFF
--- a/.github/workflows/verify_files_without_nullability.yml
+++ b/.github/workflows/verify_files_without_nullability.yml
@@ -23,7 +23,7 @@ jobs:
         run: Get-ChildItem –Path ".\tracer\missing-nullability-files.csv" | Remove-Item
 
       - name: "Regenerating missing-nullability-files.csv"
-        run: .\tracer\build.ps1 BuildTracerHome CreateMissingNullabilityFile
+        run: .\tracer\build.ps1 Restore CreateMissingNullabilityFile
 
       - name: "Verify no changes in missing-nullability-files.csv"
         run: |

--- a/.github/workflows/verify_files_without_nullability.yml
+++ b/.github/workflows/verify_files_without_nullability.yml
@@ -23,7 +23,7 @@ jobs:
         run: Get-ChildItem –Path ".\tracer\missing-nullability-files.csv" | Remove-Item
 
       - name: "Regenerating missing-nullability-files.csv"
-        run: .\tracer\build.ps1 Restore CreateMissingNullabilityFile
+        run: .\tracer\build.ps1 CreateMissingNullabilityFile
 
       - name: "Verify no changes in missing-nullability-files.csv"
         run: |


### PR DESCRIPTION
I'm pretty sure building the whole project is not necessary when we just want to check that the nullability csv is built properly.
We can skip directly to regenerating the file, which reduces the time this step takes from ~14 min to a couple seconds