### PR TITLE
Add support for writing managed logs to stdout

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -679,6 +679,7 @@
       <type fullname="System.PlatformNotSupportedException" />
       <type fullname="System.Predicate`1" />
       <type fullname="System.Random" />
+      <type fullname="System.ReadOnlyMemory`1" />
       <type fullname="System.ReadOnlySpan`1" />
       <type fullname="System.Reflection.AmbiguousMatchException" />
       <type fullname="System.Reflection.Assembly" />
@@ -822,6 +823,7 @@
       <type fullname="System.Text.Encoding" />
       <type fullname="System.Text.StringBuilder" />
       <type fullname="System.Text.StringBuilder/AppendInterpolatedStringHandler" />
+      <type fullname="System.Text.StringBuilder/ChunkEnumerator" />
       <type fullname="System.Threading.CancellationToken" />
       <type fullname="System.Threading.CancellationTokenRegistration" />
       <type fullname="System.Threading.CancellationTokenSource" />

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/ConsoleLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/ConsoleLoggingConfiguration.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="ConsoleLoggingConfiguration.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Logging.Internal.Configuration;
+
+internal readonly struct ConsoleLoggingConfiguration
+{
+    public readonly string MessageTemplate;
+    public readonly int BufferSize;
+
+    public ConsoleLoggingConfiguration(string formatString, int bufferSize)
+    {
+        MessageTemplate = formatString;
+        BufferSize = bufferSize;
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/ConsoleLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/ConsoleLoggingConfiguration.cs
@@ -11,13 +11,11 @@ namespace Datadog.Trace.Logging.Internal.Configuration;
 
 internal readonly struct ConsoleLoggingConfiguration
 {
-    public readonly string MessageTemplate;
     public readonly int BufferSize;
-    public readonly TextWriter? TextWriter;
+    public readonly TextWriter TextWriter;
 
-    public ConsoleLoggingConfiguration(string formatString, int bufferSize, TextWriter? textWriter)
+    public ConsoleLoggingConfiguration(int bufferSize, TextWriter textWriter)
     {
-        MessageTemplate = formatString;
         BufferSize = bufferSize;
         TextWriter = textWriter;
     }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/ConsoleLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/ConsoleLoggingConfiguration.cs
@@ -5,16 +5,20 @@
 
 #nullable enable
 
+using System.IO;
+
 namespace Datadog.Trace.Logging.Internal.Configuration;
 
 internal readonly struct ConsoleLoggingConfiguration
 {
     public readonly string MessageTemplate;
     public readonly int BufferSize;
+    public readonly TextWriter? TextWriter;
 
-    public ConsoleLoggingConfiguration(string formatString, int bufferSize)
+    public ConsoleLoggingConfiguration(string formatString, int bufferSize, TextWriter? textWriter)
     {
         MessageTemplate = formatString;
         BufferSize = bufferSize;
+        TextWriter = textWriter;
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
@@ -11,11 +11,13 @@ internal readonly struct DatadogLoggingConfiguration
     public readonly int RateLimit;
     public readonly FileLoggingConfiguration? File;
     public readonly RedactedErrorLoggingConfiguration? ErrorLogging;
+    public readonly ConsoleLoggingConfiguration? Console;
 
-    public DatadogLoggingConfiguration(int rateLimit, FileLoggingConfiguration? file, RedactedErrorLoggingConfiguration? errorLogging)
+    public DatadogLoggingConfiguration(int rateLimit, FileLoggingConfiguration? file, RedactedErrorLoggingConfiguration? errorLogging, ConsoleLoggingConfiguration? console)
     {
         RateLimit = rateLimit;
         File = file;
         ErrorLogging = errorLogging;
+        Console = console;
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/DatadogLoggingConfiguration.cs
@@ -13,11 +13,15 @@ internal readonly struct DatadogLoggingConfiguration
     public readonly RedactedErrorLoggingConfiguration? ErrorLogging;
     public readonly ConsoleLoggingConfiguration? Console;
 
-    public DatadogLoggingConfiguration(int rateLimit, FileLoggingConfiguration? file, RedactedErrorLoggingConfiguration? errorLogging, ConsoleLoggingConfiguration? console)
+    public DatadogLoggingConfiguration(
+        int rateLimit,
+        RedactedErrorLoggingConfiguration? errorLogging,
+        FileLoggingConfiguration? file,
+        ConsoleLoggingConfiguration? console)
     {
         RateLimit = rateLimit;
-        File = file;
         ErrorLogging = errorLogging;
+        File = file;
         Console = console;
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
@@ -10,4 +10,5 @@ namespace Datadog.Trace.Logging.Internal.Configuration;
 internal static class LogSinkOptions
 {
     public const string File = "file";
+    public const string Console = "console";
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
@@ -21,7 +21,7 @@ internal static class LogSinkOptions
     /// The console log sink.
     /// </summary>
     /// <remarks>
-    /// The console log sink is experimental and unsupported.
+    /// The console log sink is experimental and unsupported. It may be removed or replaced at any time.
     /// </remarks>
     public const string Console = "console-experimental";
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Configuration/LogSinkOptions.cs
@@ -7,8 +7,21 @@
 
 namespace Datadog.Trace.Logging.Internal.Configuration;
 
+/// <summary>
+/// Available log sinks for the Datadog logging system.
+/// </summary>
 internal static class LogSinkOptions
 {
+    /// <summary>
+    /// The file log sink.
+    /// </summary>
     public const string File = "file";
-    public const string Console = "console";
+
+    /// <summary>
+    /// The console log sink.
+    /// </summary>
+    /// <remarks>
+    /// The console log sink is experimental and unsupported.
+    /// </remarks>
+    public const string Console = "console-experimental";
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -79,7 +79,6 @@ internal static class DatadogLoggingFactory
 
     private static ConsoleLoggingConfiguration GetConsoleLoggingConfiguration(IConfigurationSource? source)
     {
-        // TODO: allow users to set the message template? Use Json? Different/better message template?
         return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, DefaultConsoleQueueLimit);
     }
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -8,13 +8,11 @@
 using System;
 using System.Globalization;
 using System.IO;
-using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging.Internal;
 using Datadog.Trace.Logging.Internal.Configuration;
-using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -141,7 +141,7 @@ internal static class DatadogLoggingFactory
                .WriteTo.Logger(
                    lc => lc
                          .Enrich.With(new RemovePropertyEnricher(LogEventLevel.Error, DatadogSerilogLogger.SkipTelemetryProperty))
-                         .WriteTo.Sink(new ConsoleSink(consoleConfig.MessageTemplate, consoleConfig.BufferSize));
+                         .WriteTo.Sink(new ConsoleSink(consoleConfig.MessageTemplate, consoleConfig.BufferSize)));
         }
 
         try

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -30,7 +30,7 @@ internal static class DatadogLoggingFactory
     private const int DefaultMaxLogFileSize = 10 * 1024 * 1024;
 
     internal const string DefaultConsoleMessageTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception}{NewLine}";
-    internal const int DefaultConsoleMaxBufferSize = 1024;
+    internal const int DefaultConsoleQueueLimit = 1024;
 
     public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
@@ -87,7 +87,7 @@ internal static class DatadogLoggingFactory
     private static ConsoleLoggingConfiguration GetConsoleLoggingConfiguration(IConfigurationSource? source)
     {
         // TODO: allow users to set the message template? Use Json? Different/better message template?
-        return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, DefaultConsoleMaxBufferSize);
+        return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, DefaultConsoleQueueLimit);
     }
 
     public static IDatadogLogger? CreateFromConfiguration(

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -138,7 +138,10 @@ internal static class DatadogLoggingFactory
         if (config.Console is { } consoleConfig)
         {
             loggerConfiguration
-               .WriteTo.Sink(new ConsoleSink(consoleConfig.MessageTemplate, consoleConfig.BufferSize));
+               .WriteTo.Logger(
+                   lc => lc
+                         .Enrich.With(new RemovePropertyEnricher(LogEventLevel.Error, DatadogSerilogLogger.SkipTelemetryProperty))
+                         .WriteTo.Sink(new ConsoleSink(consoleConfig.MessageTemplate, consoleConfig.BufferSize));
         }
 
         try

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -13,6 +13,7 @@ using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging.Internal;
 using Datadog.Trace.Logging.Internal.Configuration;
+using Datadog.Trace.Logging.Internal.Sinks;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog;

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -29,6 +29,7 @@ internal static class DatadogLoggingFactory
     // By default, we don't rate limit log messages;
     private const int DefaultRateLimit = 0;
     private const int DefaultMaxLogFileSize = 10 * 1024 * 1024;
+    internal const string DefaultConsoleMessageTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception}{NewLine}";
 
     public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
@@ -43,6 +44,12 @@ internal static class DatadogLoggingFactory
             fileConfig = GetFileLoggingConfiguration(source, telemetry);
         }
 
+        ConsoleLoggingConfiguration? consoleConfig = null;
+        if (Contains(logSinkOptions, LogSinkOptions.Console))
+        {
+            consoleConfig = GetConsoleLoggingConfiguration(source);
+        }
+
         var redactedErrorLogsConfig = GetRedactedErrorTelemetryConfiguration(source, telemetry);
 
         var rateLimit = new ConfigurationBuilder(source, telemetry)
@@ -50,7 +57,7 @@ internal static class DatadogLoggingFactory
                        .AsInt32(DefaultRateLimit, x => x >= 0)
                        .Value;
 
-        return new DatadogLoggingConfiguration(rateLimit, fileConfig, redactedErrorLogsConfig);
+        return new DatadogLoggingConfiguration(rateLimit, fileConfig, redactedErrorLogsConfig, consoleConfig);
 
         static bool Contains(string?[]? array, string toMatch)
         {
@@ -76,11 +83,20 @@ internal static class DatadogLoggingFactory
         }
     }
 
+    private static ConsoleLoggingConfiguration GetConsoleLoggingConfiguration(IConfigurationSource? source)
+    {
+        // TODO: allow users to set the message template? Use Json? Different/better message template?
+        // Yes, I chose this arbitrarily
+        var maxBufferSize = 1000;
+
+        return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, maxBufferSize);
+    }
+
     public static IDatadogLogger? CreateFromConfiguration(
         in DatadogLoggingConfiguration config,
         DomainMetadata domainMetadata)
     {
-        if (config is { File: null, ErrorLogging: null })
+        if (config is { File: null, ErrorLogging: null, Console: null })
         {
             // no enabled sinks
             return null;
@@ -117,6 +133,12 @@ internal static class DatadogLoggingFactory
                                rollOnFileSizeLimit: true,
                                fileSizeLimitBytes: fileConfig.MaxLogFileSizeBytes,
                                shared: true));
+        }
+
+        if (config.Console is { } consoleConfig)
+        {
+            loggerConfiguration
+               .WriteTo.Sink(new ConsoleSink(consoleConfig.MessageTemplate, consoleConfig.BufferSize));
         }
 
         try

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -36,7 +36,7 @@ internal static class DatadogLoggingFactory
         var logSinkOptions = new ConfigurationBuilder(source, telemetry)
                             .WithKeys(ConfigurationKeys.LogSinks)
                             .AsString()
-                           ?.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                           ?.Split([','], StringSplitOptions.RemoveEmptyEntries);
 
         FileLoggingConfiguration? fileConfig = null;
         if (logSinkOptions is null || Contains(logSinkOptions, LogSinkOptions.File))

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -60,23 +60,16 @@ internal static class DatadogLoggingFactory
 
         return new DatadogLoggingConfiguration(rateLimit, fileConfig, redactedErrorLogsConfig, consoleConfig);
 
-        static bool Contains(string?[]? array, string toMatch)
+        static bool Contains(string?[]? items, string value)
         {
-            if (array is null)
+            if (items is not null)
             {
-                return false;
-            }
-
-            foreach (var value in array)
-            {
-                if (string.IsNullOrWhiteSpace(value))
+                foreach (var item in items)
                 {
-                    continue;
-                }
-
-                if (string.Equals(value!.Trim(), toMatch))
-                {
-                    return true;
+                    if (string.Equals(item?.Trim(), value, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -58,7 +58,7 @@ internal static class DatadogLoggingFactory
                        .AsInt32(DefaultRateLimit, x => x >= 0)
                        .Value;
 
-        return new DatadogLoggingConfiguration(rateLimit, fileConfig, redactedErrorLogsConfig, consoleConfig);
+        return new DatadogLoggingConfiguration(rateLimit, redactedErrorLogsConfig, fileConfig, consoleConfig);
 
         static bool Contains(string?[]? items, string value)
         {

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -29,7 +29,7 @@ internal static class DatadogLoggingFactory
     private const int DefaultRateLimit = 0;
     private const int DefaultMaxLogFileSize = 10 * 1024 * 1024;
 
-    internal const string DefaultConsoleMessageTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception}{NewLine}";
+    internal const string DefaultConsoleMessageTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} dd-trace-dotnet {Level:u3}] {Message:lj}{NewLine}{Exception}";
     internal const int DefaultConsoleQueueLimit = 1024;
 
     public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource source, IConfigurationTelemetry telemetry)

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -79,7 +79,8 @@ internal static class DatadogLoggingFactory
 
     private static ConsoleLoggingConfiguration GetConsoleLoggingConfiguration(IConfigurationSource? source)
     {
-        return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, DefaultConsoleQueueLimit);
+        // textWriter: null defaults to Console.Out
+        return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, DefaultConsoleQueueLimit, textWriter: null);
     }
 
     public static IDatadogLogger? CreateFromConfiguration(

--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogLoggingFactory.cs
@@ -29,7 +29,9 @@ internal static class DatadogLoggingFactory
     // By default, we don't rate limit log messages;
     private const int DefaultRateLimit = 0;
     private const int DefaultMaxLogFileSize = 10 * 1024 * 1024;
+
     internal const string DefaultConsoleMessageTemplate = "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj} {Exception}{NewLine}";
+    internal const int DefaultConsoleMaxBufferSize = 1024;
 
     public static DatadogLoggingConfiguration GetConfiguration(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
@@ -86,10 +88,7 @@ internal static class DatadogLoggingFactory
     private static ConsoleLoggingConfiguration GetConsoleLoggingConfiguration(IConfigurationSource? source)
     {
         // TODO: allow users to set the message template? Use Json? Different/better message template?
-        // Yes, I chose this arbitrarily
-        var maxBufferSize = 1000;
-
-        return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, maxBufferSize);
+        return new ConsoleLoggingConfiguration(DefaultConsoleMessageTemplate, DefaultConsoleMaxBufferSize);
     }
 
     public static IDatadogLogger? CreateFromConfiguration(

--- a/tracer/src/Datadog.Trace/Logging/Internal/Enrichers/SingleLineExceptionEnricher.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Enrichers/SingleLineExceptionEnricher.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="SingleLineExceptionEnricher.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+
+namespace Datadog.Trace.Logging.Internal.Enrichers;
+
+internal class SingleLineExceptionEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        if (logEvent.Exception != null)
+        {
+            var singleLine = logEvent.Exception
+                                     .ToString()
+                                     .Replace(Environment.NewLine, "\\n");
+
+            logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("SingleLineException", singleLine));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/Enrichers/UtcTimestampEnricher.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Enrichers/UtcTimestampEnricher.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="UtcTimestampEnricher.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+
+namespace Datadog.Trace.Logging.Internal.Enrichers;
+
+internal class UtcTimestampEnricher : ILogEventEnricher
+{
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+        var utcTimestamp = logEvent.Timestamp.ToUniversalTime();
+        logEvent.AddPropertyIfAbsent(propertyFactory.CreateProperty("UtcTimestamp", utcTimestamp));
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -1,0 +1,136 @@
+﻿// <copyright file="ConsoleSink.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+using Datadog.Trace.Vendors.Serilog.Formatting.Display;
+
+/// <summary>
+/// Loosely based on https://github.com/manigandham/serilog-sinks-fastconsole
+/// </summary>
+internal class ConsoleSink : ILogEventSink, IDisposable
+{
+    private readonly StringWriter _bufferWriter = new();
+    private readonly TextWriter _consoleWriter;
+    private readonly BoundedConcurrentQueue<LogEvent?> _writeQueue;
+    private readonly Task _writeTask;
+
+    private readonly MessageTemplateTextFormatter _textFormatter;
+    private readonly ManualResetEventSlim _serializationMutex = new(initialState: false);
+    private readonly TaskCompletionSource<bool> _processExit = new();
+
+    public ConsoleSink(string messageTemplate, int queueLimit, TextWriter? consoleWriter = null)
+    {
+        _consoleWriter = consoleWriter ?? new StreamWriter(Console.OpenStandardOutput(), Console.OutputEncoding) { AutoFlush = true };
+        _textFormatter = new MessageTemplateTextFormatter(messageTemplate);
+        _writeQueue = new BoundedConcurrentQueue<LogEvent?>(queueLimit);
+        _writeTask = Task.Run(WriteToConsoleStream);
+    }
+
+    // logs are immediately queued to channel
+    public void Emit(LogEvent? logEvent)
+    {
+        // TODO: metrics about dropped logs?
+        if (_processExit.Task.IsCompleted)
+        {
+            return;
+        }
+
+        if (_writeQueue.TryEnqueue(logEvent))
+        {
+            if (!_serializationMutex.IsSet)
+            {
+                _serializationMutex.Set();
+            }
+        }
+    }
+
+    private async Task WriteToConsoleStream()
+    {
+        // cache reference to stringbuilder inside writer
+        var sb = _bufferWriter.GetStringBuilder();
+        var isFinalFlush = false;
+
+        while (true)
+        {
+            try
+            {
+                while (_writeQueue.TryDequeue(out var logEvent))
+                {
+                    // console output is an IO stream
+                    // format and write event to in-memory buffer and then flush to console async
+                    // do not use the locking textwriter from console.out used by console.writeline
+                    _textFormatter.Format(logEvent, _bufferWriter);
+
+#if NET5_0_OR_GREATER
+                    // use StringBuilder internal buffers directly without allocating a new string
+                    foreach (var chunk in sb.GetChunks())
+                    {
+                        await _consoleWriter.WriteAsync(chunk).ConfigureAwait(false);
+                    }
+#else
+                    // fallback to creating string output
+                    await _consoleWriter.WriteAsync(sb.ToString()).ConfigureAwait(false);
+#endif
+
+                    sb.Clear();
+                }
+            }
+            catch (Exception)
+            {
+                // Nowhere to log safely so just swallow!
+            }
+
+            await _consoleWriter.FlushAsync().ConfigureAwait(false);
+
+            if (_processExit.Task.IsCompleted)
+            {
+                if (isFinalFlush)
+                {
+                    return;
+                }
+
+                // do one more loop to make sure everything is flushed
+                if (!_serializationMutex.IsSet)
+                {
+                    _serializationMutex.Set();
+                }
+
+                isFinalFlush = true;
+                continue;
+            }
+
+            _serializationMutex.Wait();
+            _serializationMutex.Reset();
+        }
+    }
+
+    public void Dispose() => Dispose(true);
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_processExit.TrySetResult(true))
+        {
+            return;
+        }
+
+        if (disposing)
+        {
+            // Close write queue and wait until items are drained
+            // then wait for all console output to be flushed.
+            _writeTask.GetAwaiter().GetResult();
+
+            _bufferWriter.Dispose();
+            _consoleWriter.Dispose();
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -40,7 +40,8 @@ internal sealed class ConsoleSink : ILogEventSink, IDisposable
 
         // Since we are writing from a background thread, we can use the synchronized Console.Out
         // instead of Console.OpenStandardOutput() without blocking the main thread. By using Console.Out we honor
-        // any previous call to Console.SetOut() and we don't have to worry about writing the UTF-8 BOM to the output stream.
+        // any previous call to Console.SetOut() and we don't have to worry about writing the UTF-8 BOM to the output stream
+        // or mangling the output by writing to the console from multiple threads.
         _consoleWriter = consoleWriter ?? Console.Out;
 
         _writeTask = Task.Factory.StartNew(

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -6,133 +6,117 @@
 #nullable enable
 
 using System;
+using System.Collections.Concurrent;
+using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Events;
 using Datadog.Trace.Vendors.Serilog.Formatting.Display;
 
 namespace Datadog.Trace.Logging.Internal.Sinks;
 
-/// <summary>
-/// Loosely based on https://github.com/manigandham/serilog-sinks-fastconsole
-/// </summary>
-internal class ConsoleSink : ILogEventSink, IDisposable
+internal sealed class ConsoleSink : ILogEventSink, IDisposable
 {
-    private readonly StringWriter _bufferWriter = new();
-    private readonly TextWriter _consoleWriter;
-    private readonly BoundedConcurrentQueue<LogEvent?> _writeQueue;
-    private readonly Task _writeTask;
+    // these are only used from the background thread
+    private readonly StringBuilder _bufferBuilder;
+    private readonly StringWriter _bufferWriter;
 
     private readonly MessageTemplateTextFormatter _textFormatter;
-    private readonly ManualResetEventSlim _serializationMutex = new(initialState: false);
-    private readonly TaskCompletionSource<bool> _processExit = new();
+    private readonly BlockingCollection<LogEvent> _writeQueue;
+    private readonly TextWriter _consoleWriter;
+    private readonly Task _writeTask;
 
     public ConsoleSink(string messageTemplate, int queueLimit, TextWriter? consoleWriter = null)
     {
-        _consoleWriter = consoleWriter ?? new StreamWriter(Console.OpenStandardOutput(), Console.OutputEncoding) { AutoFlush = true };
-        _textFormatter = new MessageTemplateTextFormatter(messageTemplate);
-        _writeQueue = new BoundedConcurrentQueue<LogEvent?>(queueLimit);
-        _writeTask = Task.Run(WriteToConsoleStream);
+        // these are only used from the background thread
+        _bufferBuilder = new StringBuilder(capacity: 512);
+        _bufferWriter = new StringWriter(_bufferBuilder);
+
+        _textFormatter = new MessageTemplateTextFormatter(messageTemplate, CultureInfo.InvariantCulture);
+        _writeQueue = new BlockingCollection<LogEvent>(queueLimit);
+
+        // do not use the locking textwriter from console.out used by console.writeline
+        _consoleWriter = consoleWriter ??
+                         new StreamWriter(Console.OpenStandardOutput(), Console.OutputEncoding) { AutoFlush = false };
+
+        _writeTask = Task.Factory.StartNew(
+            WriteToConsoleStream,
+            CancellationToken.None,
+            TaskCreationOptions.LongRunning | TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default);
     }
 
-    // logs are immediately queued to channel
     public void Emit(LogEvent? logEvent)
     {
         // TODO: metrics about dropped logs?
-        if (_processExit.Task.IsCompleted)
+
+        if (logEvent is null || _writeQueue.IsAddingCompleted || _writeTask.IsCompleted)
         {
+            // if log event is null, or
+            // if we are no longer writing to the console,
+            // so don't accept any more log events
             return;
         }
 
-        if (_writeQueue.TryEnqueue(logEvent))
+        try
         {
-            if (!_serializationMutex.IsSet)
-            {
-                _serializationMutex.Set();
-            }
+            // try to add the log event to the queue
+            _writeQueue.TryAdd(logEvent);
+        }
+        catch (InvalidOperationException)
+        {
+            // queue is marked as complete, drop log event
         }
     }
 
-    private async Task WriteToConsoleStream()
+    private void WriteToConsoleStream()
     {
-        // cache reference to stringbuilder inside writer
-        var sb = _bufferWriter.GetStringBuilder();
-        var isFinalFlush = false;
-
-        while (true)
+        try
         {
-            try
+            foreach (var logEvent in _writeQueue.GetConsumingEnumerable())
             {
-                while (_writeQueue.TryDequeue(out var logEvent))
-                {
-                    // console output is an IO stream
-                    // format and write event to in-memory buffer and then flush to console async
-                    // do not use the locking textwriter from console.out used by console.writeline
-                    _textFormatter.Format(logEvent, _bufferWriter);
+                _bufferBuilder.Clear();
+
+                // format event into in-memory buffer and then flush to console
+                _textFormatter.Format(logEvent, _bufferWriter);
 
 #if NET5_0_OR_GREATER
-                    // use StringBuilder internal buffers directly without allocating a new string
-                    foreach (var chunk in sb.GetChunks())
-                    {
-                        await _consoleWriter.WriteAsync(chunk).ConfigureAwait(false);
-                    }
+                // use StringBuilder internal buffers directly without allocating a new string
+                foreach (var chunk in _bufferBuilder.GetChunks())
+                {
+                    _consoleWriter.Write(chunk.Span);
+                }
 #else
-                    // fallback to creating string output
-                    await _consoleWriter.WriteAsync(sb.ToString()).ConfigureAwait(false);
+                // fallback to creating string output
+                _consoleWriter.Write(_bufferBuilder.ToString());
 #endif
 
-                    sb.Clear();
-                }
+                _consoleWriter.Flush();
             }
-            catch (Exception)
-            {
-                // Nowhere to log safely so just swallow!
-            }
-
-            await _consoleWriter.FlushAsync().ConfigureAwait(false);
-
-            if (_processExit.Task.IsCompleted)
-            {
-                if (isFinalFlush)
-                {
-                    return;
-                }
-
-                // do one more loop to make sure everything is flushed
-                if (!_serializationMutex.IsSet)
-                {
-                    _serializationMutex.Set();
-                }
-
-                isFinalFlush = true;
-                continue;
-            }
-
-            _serializationMutex.Wait();
-            _serializationMutex.Reset();
+        }
+        catch (Exception)
+        {
+            // Nowhere to log safely so just swallow!
+        }
+        finally
+        {
+            _consoleWriter.Flush();
         }
     }
 
-    public void Dispose() => Dispose(true);
-
-    protected virtual void Dispose(bool disposing)
+    public async Task FlushAsync()
     {
-        if (!_processExit.TrySetResult(true))
-        {
-            return;
-        }
+        _writeQueue.CompleteAdding();
+        await _writeTask.ConfigureAwait(false);
+    }
 
-        if (disposing)
-        {
-            // Close write queue and wait until items are drained
-            // then wait for all console output to be flushed.
-            _writeTask.GetAwaiter().GetResult();
-
-            _bufferWriter.Dispose();
-            _consoleWriter.Dispose();
-        }
+    public void Dispose()
+    {
+        FlushAsync().GetAwaiter().GetResult();
+        _bufferWriter.Dispose();
+        _consoleWriter.Dispose();
     }
 }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -40,7 +40,13 @@ internal sealed class ConsoleSink : ILogEventSink, IDisposable
 
         // do not use the locking textwriter from console.out used by console.writeline
         _consoleWriter = consoleWriter ??
-                         new StreamWriter(Console.OpenStandardOutput(), Console.OutputEncoding) { AutoFlush = false };
+                         new StreamWriter(
+                                 Console.OpenStandardOutput(),
+                                 Console.OutputEncoding,
+                                 leaveOpen: true) // do not close the underlying stream or the app may crash when it tries to write to the console again
+                             {
+                                 AutoFlush = false // don't flush after every Write(char), we will flush manually after writing each log event
+                             };
 
         _writeTask = Task.Factory.StartNew(
             WriteToConsoleStream,

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Logging.Internal.Sinks;
 
 internal sealed class ConsoleSink : ILogEventSink, IDisposable
 {
-    // these are only used from the background thread
+    // in-memory buffer used only from the background thread
     private readonly StringBuilder _bufferBuilder;
     private readonly StringWriter _bufferWriter;
 
@@ -31,7 +31,7 @@ internal sealed class ConsoleSink : ILogEventSink, IDisposable
 
     public ConsoleSink(string messageTemplate, int queueLimit, TextWriter? consoleWriter = null)
     {
-        // these are only used from the background thread
+        // in-memory buffer used only from the background thread
         _bufferBuilder = new StringBuilder(capacity: 512);
         _bufferWriter = new StringWriter(_bufferBuilder);
 

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -84,21 +84,12 @@ internal sealed class ConsoleSink : ILogEventSink, IDisposable
             // The foreach loop will exit when the collection is marked as complete.
             foreach (var logEvent in _writeQueue.GetConsumingEnumerable())
             {
+                // clear in-memory buffer and format event into buffer
                 _bufferBuilder.Clear();
-
-                // format event into in-memory buffer and then flush to console
                 _textFormatter.Format(logEvent, _bufferWriter);
 
-#if NET5_0_OR_GREATER
-                // use StringBuilder internal buffers directly without allocating a new string
-                foreach (var chunk in _bufferBuilder.GetChunks())
-                {
-                    _consoleWriter.Write(chunk.Span);
-                }
-#else
-                _consoleWriter.Write(_bufferBuilder.ToString());
-#endif
-
+                // write the formatted log event to the console and flush
+                _consoleWriter.Write(_bufferBuilder);
                 _consoleWriter.Flush();
             }
         }

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -106,10 +106,6 @@ internal sealed class ConsoleSink : ILogEventSink, IDisposable
         {
             // Nowhere to log safely so just swallow!
         }
-        finally
-        {
-            _consoleWriter.Flush();
-        }
     }
 
     public async Task FlushAsync()

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -14,6 +14,8 @@ using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Events;
 using Datadog.Trace.Vendors.Serilog.Formatting.Display;
 
+namespace Datadog.Trace.Logging.Internal.Sinks;
+
 /// <summary>
 /// Loosely based on https://github.com/manigandham/serilog-sinks-fastconsole
 /// </summary>

--- a/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/Sinks/ConsoleSink.cs
@@ -7,42 +7,41 @@
 
 using System;
 using System.Collections.Concurrent;
-using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Vendors.Serilog.Core;
 using Datadog.Trace.Vendors.Serilog.Events;
-using Datadog.Trace.Vendors.Serilog.Formatting.Display;
+using Datadog.Trace.Vendors.Serilog.Formatting;
 
 namespace Datadog.Trace.Logging.Internal.Sinks;
 
+/// <summary>
+/// A buffered sink that writes log events to a <see cref="TextWriter"/> using a background thread.
+/// Used to write log events to the console without blocking.
+/// </summary>
 internal sealed class ConsoleSink : ILogEventSink, IDisposable
 {
     // in-memory buffer used only from the background thread
     private readonly StringBuilder _bufferBuilder;
     private readonly StringWriter _bufferWriter;
 
-    private readonly MessageTemplateTextFormatter _textFormatter;
+    private readonly ITextFormatter _textFormatter;
     private readonly BlockingCollection<LogEvent> _writeQueue;
     private readonly TextWriter _consoleWriter;
     private readonly Task _writeTask;
 
-    public ConsoleSink(string messageTemplate, int queueLimit, TextWriter? consoleWriter = null)
+    public ConsoleSink(ITextFormatter formatter, TextWriter consoleWriter, int queueLimit)
     {
         // in-memory buffer used only from the background thread
         _bufferBuilder = new StringBuilder(capacity: 512);
         _bufferWriter = new StringWriter(_bufferBuilder);
 
-        _textFormatter = new MessageTemplateTextFormatter(messageTemplate, CultureInfo.InvariantCulture);
+        // _textFormatter = new MessageTemplateTextFormatter(messageTemplate, CultureInfo.InvariantCulture);
+        _textFormatter = formatter;
         _writeQueue = new BlockingCollection<LogEvent>(queueLimit);
-
-        // Since we are writing from a background thread, we can use the synchronized Console.Out
-        // instead of Console.OpenStandardOutput() without blocking the main thread. By using Console.Out we honor
-        // any previous call to Console.SetOut() and we don't have to worry about writing the UTF-8 BOM to the output stream
-        // or mangling the output by writing to the console from multiple threads.
-        _consoleWriter = consoleWriter ?? Console.Out;
+        _consoleWriter = consoleWriter;
 
         _writeTask = Task.Factory.StartNew(
             WriteToConsoleStream,

--- a/tracer/src/Datadog.Trace/Logging/Internal/TextFormatters/SimpleTextFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/TextFormatters/SimpleTextFormatter.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="SimpleTextFormatter.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.Serilog.Events;
+using Datadog.Trace.Vendors.Serilog.Formatting;
+using Datadog.Trace.Vendors.Serilog.Formatting.Display;
+
+namespace Datadog.Trace.Logging.Internal.TextFormatters;
+
+internal class SimpleTextFormatter : ITextFormatter
+{
+    public void Format(LogEvent logEvent, TextWriter output)
+    {
+        if (logEvent is null)
+        {
+            return;
+        }
+
+        // buffer the log event before writing it to the output
+        var sb = StringBuilderCache.Acquire();
+        var writer = new StringWriter(sb, output.FormatProvider);
+
+        var utcTimestamp = logEvent.Timestamp.ToUniversalTime();
+        var logLevel = LevelOutputFormat.GetLevelMoniker(logEvent.Level, "u3");
+        writer.Write($"[{utcTimestamp:yyyy-MM-dd HH:mm:ss.fff zzz} | DD_TRACE_DOTNET | {logLevel}] ");
+
+        // render the message using the template and properties
+        logEvent.MessageTemplate.Render(logEvent.Properties, writer);
+
+        if (logEvent.Exception != null)
+        {
+            writer.Write($" | {logEvent.Exception}");
+        }
+
+        // replace any newlines
+        sb.Replace(Environment.NewLine, "\\n");
+        output.WriteLine(sb);
+
+        StringBuilderCache.Release(sb);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="ConsoleSinkTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Serilog;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging;
+
+public class ConsoleSinkTests
+{
+    [Fact]
+    public void CanWriteToConsoleSink()
+    {
+        var sw = new StringWriter();
+        var consoleSink = new ConsoleSink(DatadogLoggingFactory.DefaultConsoleMessageTemplate, queueLimit: 1000, sw);
+
+        var logger = new LoggerConfiguration()
+                    .MinimumLevel.Debug()
+                    .WriteTo.Sink(consoleSink)
+                    .CreateLogger();
+
+        for (var i = 0; i < 100; i++)
+        {
+            logger.Information("This is log number {LogNumber}", i);
+        }
+
+        logger.Dispose();
+
+        var strings = sw.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+        strings.Should()
+               .HaveCount(100)
+               .And.OnlyHaveUniqueItems()
+               .And.OnlyContain(x => x.Contains("This is log number"));
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
@@ -8,6 +8,7 @@ using System.IO;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.Internal.Sinks;
 using Datadog.Trace.Vendors.Serilog;
+using Datadog.Trace.Vendors.Serilog.Formatting.Display;
 using FluentAssertions;
 using Xunit;
 
@@ -21,14 +22,14 @@ public class ConsoleSinkTests
         var sw = new StringWriter();
 
         var consoleSink = new ConsoleSink(
-            messageTemplate: DatadogLoggingFactory.DefaultConsoleMessageTemplate,
-            queueLimit: DatadogLoggingFactory.DefaultConsoleQueueLimit,
-            sw);
+            formatter: new MessageTemplateTextFormatter("{Message}{NewLine}"), // output the message only
+            consoleWriter: sw,
+            queueLimit: DatadogLoggingFactory.DefaultConsoleQueueLimit);
 
         var logger = new LoggerConfiguration()
-                    .MinimumLevel.Debug()
-                    .WriteTo.Sink(consoleSink)
-                    .CreateLogger();
+                     .MinimumLevel.Debug()
+                     .WriteTo.Sink(consoleSink)
+                     .CreateLogger();
 
         for (var i = 0; i < 100; i++)
         {

--- a/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.IO;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Logging.Internal.Sinks;
 using Datadog.Trace.Vendors.Serilog;
 using FluentAssertions;
 using Xunit;

--- a/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
@@ -32,7 +32,8 @@ public class ConsoleSinkTests
 
         logger.Dispose();
 
-        var strings = sw.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+        var strings = sw.ToString().Split([Environment.NewLine], StringSplitOptions.RemoveEmptyEntries);
+
         strings.Should()
                .HaveCount(100)
                .And.OnlyHaveUniqueItems()

--- a/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ConsoleSinkTests.cs
@@ -19,7 +19,11 @@ public class ConsoleSinkTests
     public void CanWriteToConsoleSink()
     {
         var sw = new StringWriter();
-        var consoleSink = new ConsoleSink(DatadogLoggingFactory.DefaultConsoleMessageTemplate, queueLimit: 1000, sw);
+
+        var consoleSink = new ConsoleSink(
+            messageTemplate: DatadogLoggingFactory.DefaultConsoleMessageTemplate,
+            queueLimit: DatadogLoggingFactory.DefaultConsoleQueueLimit,
+            sw);
 
         var logger = new LoggerConfiguration()
                     .MinimumLevel.Debug()

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -171,5 +171,18 @@ public class DatadogLoggingFactoryTests
             var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.File.Should().BeNull();
         }
+
+        [Theory]
+        [InlineData("console")]
+        [InlineData("file,console")]
+        [InlineData("console, file")]
+        [InlineData("unknown,console")]
+        public void WhenConsoleSinkIsIncluded_UsesConsoleSink(string sinks)
+        {
+            var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source);
+            config.Console.HasValue.Should().BeTrue();
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -181,7 +181,7 @@ public class DatadogLoggingFactoryTests
         {
             var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });
 
-            var config = DatadogLoggingFactory.GetConfiguration(source);
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.Console.HasValue.Should().BeTrue();
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -173,10 +173,10 @@ public class DatadogLoggingFactoryTests
         }
 
         [Theory]
-        [InlineData("console")]
-        [InlineData("file,console")]
-        [InlineData("console, file")]
-        [InlineData("unknown,console")]
+        [InlineData("console-experimental")]
+        [InlineData("file,console-experimental")]
+        [InlineData("console-experimental, file")]
+        [InlineData("unknown,console-experimental")]
         public void WhenConsoleSinkIsIncluded_UsesConsoleSink(string sinks)
         {
             var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -184,5 +184,18 @@ public class DatadogLoggingFactoryTests
             var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
             config.Console.HasValue.Should().BeTrue();
         }
+
+        [Theory]
+        [InlineData("file")]
+        [InlineData("datadog")]
+        [InlineData("datadog,file")]
+        [InlineData("unknown")]
+        public void WhenConsoleSinkIsNotIncluded_DoesNotUseConsoleSink(string sinks)
+        {
+            var source = new NameValueConfigurationSource(new() { { ConfigurationKeys.LogSinks, sinks } });
+
+            var config = DatadogLoggingFactory.GetConfiguration(source, NullConfigurationTelemetry.Instance);
+            config.Console.HasValue.Should().BeFalse();
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingFactoryTests.cs
@@ -8,7 +8,6 @@ using System.IO;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
-using Datadog.Trace.Logging.Internal.Configuration;
 using FluentAssertions;
 using Xunit;
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -359,7 +359,8 @@ namespace Datadog.Trace.Tests.Logging
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
                 file: null,
-                errorLogging: new RedactedErrorLoggingConfiguration(collector));
+                errorLogging: new RedactedErrorLoggingConfiguration(collector),
+                console: null);
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance);
 
@@ -428,7 +429,8 @@ namespace Datadog.Trace.Tests.Logging
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
                 file: null,
-                errorLogging: new RedactedErrorLoggingConfiguration(collector));
+                errorLogging: new RedactedErrorLoggingConfiguration(collector),
+                console: null);
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance);
 
@@ -461,7 +463,8 @@ namespace Datadog.Trace.Tests.Logging
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
                 file: new FileLoggingConfiguration(10 * 1024 * 1024, tempLogsDir, 1),
-                errorLogging: new RedactedErrorLoggingConfiguration(collector));
+                errorLogging: new RedactedErrorLoggingConfiguration(collector),
+                console: null);
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance);
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -358,8 +358,8 @@ namespace Datadog.Trace.Tests.Logging
 
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
-                file: null,
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
+                file: null,
                 console: null);
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance);
@@ -428,8 +428,8 @@ namespace Datadog.Trace.Tests.Logging
 
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
-                file: null,
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
+                file: null,
                 console: null);
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
@@ -462,8 +462,8 @@ namespace Datadog.Trace.Tests.Logging
 
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
-                file: new FileLoggingConfiguration(10 * 1024 * 1024, tempLogsDir, 1),
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
+                file: new FileLoggingConfiguration(10 * 1024 * 1024, tempLogsDir, 1),
                 console: null);
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
@@ -501,9 +501,11 @@ namespace Datadog.Trace.Tests.Logging
 
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
-                file: null,
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
-                console: new ConsoleLoggingConfiguration(DatadogLoggingFactory.DefaultConsoleMessageTemplate, DatadogLoggingFactory.DefaultConsoleQueueLimit));
+                file: null,
+                console: new ConsoleLoggingConfiguration(
+                    DatadogLoggingFactory.DefaultConsoleMessageTemplate,
+                    DatadogLoggingFactory.DefaultConsoleQueueLimit));
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
 
@@ -527,7 +529,7 @@ namespace Datadog.Trace.Tests.Logging
 
         private class CollectionSink : ILogEventSink
         {
-            public List<LogEvent> Events { get; } = new List<LogEvent>();
+            public List<LogEvent> Events { get; } = [];
 
             public void Emit(LogEvent le)
             {

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -499,10 +499,6 @@ namespace Datadog.Trace.Tests.Logging
         {
             var collector = new RedactedErrorLogCollector();
 
-            var tempLogsDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-            _output.WriteLine($"Using temporary logs directory: {tempLogsDir}");
-            Directory.CreateDirectory(tempLogsDir);
-
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
                 file: null,
@@ -524,15 +520,6 @@ namespace Datadog.Trace.Tests.Logging
             }
 
             collector.GetLogs().Should().BeNull();
-
-            try
-            {
-                Directory.Delete(tempLogsDir, true);
-            }
-            catch
-            {
-                // cleanup isn't required, just avoiding clutter when the test passes
-            }
         }
 
         private void WriteRateLimitedLogMessage(IDatadogLogger logger, string message)

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -498,6 +498,7 @@ namespace Datadog.Trace.Tests.Logging
         public void RedactedErrorLogs_ExcludesIfSkipTelemetryIsSet_WithConsoleSink(bool withException)
         {
             var collector = new RedactedErrorLogCollector();
+            var logsWriter = TextWriter.Null; // don't write logs to console (or anywhere else)
 
             var config = new DatadogLoggingConfiguration(
                 rateLimit: 0,
@@ -505,7 +506,8 @@ namespace Datadog.Trace.Tests.Logging
                 file: null,
                 console: new ConsoleLoggingConfiguration(
                     DatadogLoggingFactory.DefaultConsoleMessageTemplate,
-                    DatadogLoggingFactory.DefaultConsoleQueueLimit));
+                    DatadogLoggingFactory.DefaultConsoleQueueLimit,
+                    logsWriter));
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -466,7 +466,7 @@ namespace Datadog.Trace.Tests.Logging
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
                 console: null);
 
-            var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance);
+            var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
 
             logger.Should().NotBeNull();
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -432,7 +432,7 @@ namespace Datadog.Trace.Tests.Logging
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
                 console: null);
 
-            var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance);
+            var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
 
             logger.Should().NotBeNull();
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -422,7 +422,7 @@ namespace Datadog.Trace.Tests.Logging
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void RedactedErrorLogs_ExcludesIfSkipTelemetryIsSet_WithoutFile(bool withException)
+        public void RedactedErrorLogs_ExcludesIfSkipTelemetryIsSet_WithoutSinks(bool withException)
         {
             var collector = new RedactedErrorLogCollector();
 
@@ -452,7 +452,7 @@ namespace Datadog.Trace.Tests.Logging
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void RedactedErrorLogs_ExcludesIfSkipTelemetryIsSet_WithFile(bool withException)
+        public void RedactedErrorLogs_ExcludesIfSkipTelemetryIsSet_WithFileSink(bool withException)
         {
             var collector = new RedactedErrorLogCollector();
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -507,7 +507,7 @@ namespace Datadog.Trace.Tests.Logging
                 rateLimit: 0,
                 file: null,
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
-                console: new ConsoleLoggingConfiguration(DatadogLoggingFactory.DefaultConsoleMessageTemplate, DatadogLoggingFactory.DefaultConsoleMaxBufferSize));
+                console: new ConsoleLoggingConfiguration(DatadogLoggingFactory.DefaultConsoleMessageTemplate, DatadogLoggingFactory.DefaultConsoleQueueLimit));
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DatadogLoggingTests.cs
@@ -12,7 +12,6 @@ using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.Internal.Configuration;
-using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Collectors;
 using Datadog.Trace.Util;
@@ -504,10 +503,7 @@ namespace Datadog.Trace.Tests.Logging
                 rateLimit: 0,
                 errorLogging: new RedactedErrorLoggingConfiguration(collector),
                 file: null,
-                console: new ConsoleLoggingConfiguration(
-                    DatadogLoggingFactory.DefaultConsoleMessageTemplate,
-                    DatadogLoggingFactory.DefaultConsoleQueueLimit,
-                    logsWriter));
+                console: new ConsoleLoggingConfiguration(DatadogLoggingFactory.DefaultConsoleQueueLimit, logsWriter));
 
             var logger = DatadogLoggingFactory.CreateFromConfiguration(in config, DomainMetadata.Instance)!;
 

--- a/tracer/test/Datadog.Trace.Tests/Logging/Enrichers/SingleLineExceptionEnricherTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/Enrichers/SingleLineExceptionEnricherTests.cs
@@ -1,0 +1,51 @@
+﻿// <copyright file="SingleLineExceptionEnricherTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Logging.Internal.Enrichers;
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.Enrichers;
+
+public class SingleLineExceptionEnricherTests
+{
+    [Fact]
+    public void SingleLineExceptionEnricher_AddProperty()
+    {
+        Exception exception;
+
+        try
+        {
+            throw new Exception("Exception message.");
+        }
+        catch (Exception e)
+        {
+            exception = e;
+        }
+
+        var properties = Array.Empty<EventProperty>();
+        var logEvent = new LogEvent(DateTimeOffset.Now, LogEventLevel.Information, exception, MessageTemplate.Empty, properties);
+
+        // enrich the log event
+        new SingleLineExceptionEnricher().Enrich(logEvent, new PropertyFactory());
+
+        // assert that the SingleLineException property is present and has the expected value
+        logEvent.Properties.Should().ContainKey("SingleLineException")
+                .WhoseValue.Should().BeOfType<ScalarValue>()
+                .Which.Value.Should().BeOfType<string>()
+                .Which.Should().NotContain(Environment.NewLine);
+    }
+
+    private class PropertyFactory : ILogEventPropertyFactory
+    {
+        public LogEventProperty CreateProperty(string name, object value, bool destructureObjects = false)
+        {
+            return new LogEventProperty(name, new ScalarValue(value));
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/Enrichers/UtcTimestampEnricherTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/Enrichers/UtcTimestampEnricherTests.cs
@@ -1,0 +1,43 @@
+﻿// <copyright file="UtcTimestampEnricherTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Logging.Internal.Enrichers;
+using Datadog.Trace.Vendors.Serilog.Core;
+using Datadog.Trace.Vendors.Serilog.Events;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.Enrichers;
+
+public class UtcTimestampEnricherTests
+{
+    [Fact]
+    public void UtcTimestampEnricher_AddProperty()
+    {
+        // intentionally using a non-UTC timestamp to ensure the enricher converts it to UTC
+        var timestamp = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.FromHours(-4));
+
+        var properties = Array.Empty<EventProperty>();
+        var logEvent = new LogEvent(timestamp, LogEventLevel.Information, exception: null, MessageTemplate.Empty, properties);
+
+        // enrich the log event
+        new UtcTimestampEnricher().Enrich(logEvent, new PropertyFactory());
+
+        // assert that the UtcTimestamp property is present and has the expected value
+        logEvent.Properties.Should().ContainKey("UtcTimestamp")
+                .WhoseValue.Should().BeOfType<ScalarValue>()
+                .Which.Value.Should().BeOfType<DateTimeOffset>()
+                .Which.Should().Be(timestamp.ToUniversalTime());
+    }
+
+    private class PropertyFactory : ILogEventPropertyFactory
+    {
+        public LogEventProperty CreateProperty(string name, object value, bool destructureObjects = false)
+        {
+            return new LogEventProperty(name, new ScalarValue(value));
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/TextFormatters/SimpleTextFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TextFormatters/SimpleTextFormatterTests.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="SimpleTextFormatterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace.Logging.Internal.TextFormatters;
+using Datadog.Trace.Vendors.Serilog.Events;
+using Datadog.Trace.Vendors.Serilog.Parsing;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Logging.TextFormatters;
+
+public class SimpleTextFormatterTests
+{
+    [Fact]
+    public void Format()
+    {
+        // intentionally using a non-UTC timestamp to ensure the formatter writes UTC timestamps
+        var timestamp = new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.FromHours(-4));
+        Exception exception;
+
+        try
+        {
+            throw new Exception("Exception message.");
+        }
+        catch (Exception e)
+        {
+            exception = e;
+        }
+
+        var messageTemplate = new MessageTemplateParser().Parse("This is log number {LogNumber}");
+        var properties = new[] { new LogEventProperty("LogNumber", new ScalarValue(1)) };
+        var logEvent = new LogEvent(timestamp, LogEventLevel.Information, exception, messageTemplate, properties);
+        var sw = new StringWriter();
+
+        new SimpleTextFormatter().Format(logEvent, sw);
+
+        // assert that SimpleTextFormatter uses UTC timestamps and emits a single line. trim to ignore trailing newlines.
+        sw.ToString().TrimEnd()
+          .Should().StartWith("[2000-01-01 04:00:00.000 +00:00 | DD_TRACE_DOTNET | INF] This is log number 1 | System.Exception: Exception message.\\n")
+          .And.NotContain(Environment.NewLine);
+    }
+}


### PR DESCRIPTION
## Summary of changes

Adds ~support~ experimental setting for writing managed logs to stdout/console

## Reason for change

For testing in particular, this simplifies various things

## Implementation details

Added a new sink

## Test coverage

Basic coverage

## Other details

Currently writes logs in the same format as the file logs. This means it likely isn't massively useful for customers (who will generally want JSON/custom templates) etc, but that isn't the target for now

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->

APMSVLS-57 (@lucaspimentel)