### PR TITLE
Remove SA1010 exclusions

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
+++ b/tracer/src/Datadog.Trace/Logging/Internal/DatadogSerilogLogger.cs
@@ -165,7 +165,6 @@ namespace Datadog.Trace.Logging
             (logger as IDisposable)?.Dispose();
         }
 
-#pragma warning disable SA1010 // Opening square bracket should not be preceded by a space
         private void Write<T>(LogEventLevel level, Exception? exception, string messageTemplate, T property, int sourceLine, string sourceFile)
         {
             if (_logger.IsEnabled(level))
@@ -201,7 +200,6 @@ namespace Datadog.Trace.Logging
                 WriteIfNotRateLimited(level, exception, messageTemplate, [property0, property1, property2, property3], sourceLine, sourceFile);
             }
         }
-#pragma warning restore SA1010
 
         private void Write(LogEventLevel level, Exception? exception, string messageTemplate, object?[] args, int sourceLine, string sourceFile)
         {

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 #nullable enable
-#pragma warning disable SA1010 // Opening square brackets should be spaced correctly
 
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
## Summary of changes

- Remove `#pragma warning disable SA1010`

## Reason for change

This was required because stylecop didn't support c#12. The latest version does, so we can remove this.

## Implementation details

Delete the `#pragma` I _thought_ there was one somewhere else, but I can't find it now 🤔 

## Test coverage

If it builds, we're good (it works locally)

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
