### PR TITLE
[Build] adds a notification on build end

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -23,7 +23,7 @@ using Logger = Serilog.Log;
 // #pragma warning disable SA1400
 // #pragma warning disable SA1401
 
-[ShutdownDotNetAfterServerBuild, WindowsBuildFinishedNotification]
+[ShutdownDotNetAfterServerBuild, BuildFinishedNotification]
 partial class Build : NukeBuild
 {
     /// Support plugins are available for:

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -2,8 +2,10 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Colorful;
 using Nuke.Common;
 using Nuke.Common.CI;
+using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
@@ -21,7 +23,7 @@ using Logger = Serilog.Log;
 // #pragma warning disable SA1400
 // #pragma warning disable SA1401
 
-[ShutdownDotNetAfterServerBuild]
+[ShutdownDotNetAfterServerBuild, WindowsBuildFinishedNotification]
 partial class Build : NukeBuild
 {
     /// Support plugins are available for:
@@ -150,17 +152,17 @@ partial class Build : NukeBuild
           });
 
     Target BuildNativeTracerHome => _ => _
-        .Unlisted()   
+        .Unlisted()
         .Description("Builds the native src ")
         .After(Clean, CompileManagedLoader)
         .DependsOn(CreateRequiredDirectories)
         .DependsOn(CompileNativeSrc)
         .DependsOn(BuildNativeLoader)
         .DependsOn(PublishNativeTracer);
-                                         
+
 
     Target BuildManagedTracerHome => _ => _
-        .Unlisted()   
+        .Unlisted()
         .Description("Builds the native and managed src, and publishes the tracer home directory")
         .After(Clean, BuildNativeTracerHome)
         .DependsOn(CreateRequiredDirectories)
@@ -366,7 +368,7 @@ partial class Build : NukeBuild
         .Unlisted()
         .Executes(() =>
         {
-            var framework = Framework ?? TargetFramework.NET8_0; 
+            var framework = Framework ?? TargetFramework.NET8_0;
             DotNetBuild(x => x
                 .SetProjectFile(Solution.GetProject(Projects.DdDotnet))
                 .SetConfiguration(BuildConfiguration)

--- a/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
+++ b/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
@@ -1,4 +1,5 @@
 ﻿
+#if IS_WINDOWS
 #nullable enable
 
 using System;
@@ -7,15 +8,13 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
-#if IS_WINDOWS
 using Microsoft.Toolkit.Uwp.Notifications;
-#endif
 using NuGet.Packaging;
 using Nuke.Common;
 using Nuke.Common.Execution;
 using Logger = Serilog.Log;
 
-public class WindowsBuildFinishedNotificationAttribute : BuildExtensionAttributeBase, IOnBuildFinished
+public partial class BuildFinishedNotificationAttribute
 {
     private static readonly bool Enabled = false;
 
@@ -25,9 +24,8 @@ public class WindowsBuildFinishedNotificationAttribute : BuildExtensionAttribute
 
     private static bool resourcesAvailable = false;
 
-    static WindowsBuildFinishedNotificationAttribute()
+    static BuildFinishedNotificationAttribute()
     {
-#if IS_WINDOWS
         try
         {
             if (bool.TryParse(Environment.GetEnvironmentVariable("NUKE_NOTIFY"), out var notify))
@@ -114,7 +112,6 @@ public class WindowsBuildFinishedNotificationAttribute : BuildExtensionAttribute
         builder
             .AddText(message)
             .Show();
-#endif
     }
 
 
@@ -129,3 +126,4 @@ public class WindowsBuildFinishedNotificationAttribute : BuildExtensionAttribute
     }
 }
 
+#endif

--- a/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
+++ b/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
@@ -125,5 +125,8 @@ public partial class BuildFinishedNotificationAttribute
         }
     }
 }
-
+#else
+public partial class BuildFinishedNotificationAttribute
+{
+}
 #endif

--- a/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
+++ b/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
@@ -78,12 +78,10 @@ public partial class BuildFinishedNotificationAttribute
             Enabled = false;
             Logger.Error("Failed to initialize notifications");
         }
-#endif
     }
 
     public void OnBuildFinished(NukeBuild build)
     {
-#if IS_WINDOWS
         if (!Enabled)
         {
             return;
@@ -124,9 +122,5 @@ public partial class BuildFinishedNotificationAttribute
             stream.CopyToFile(target.LocalPath);
         }
     }
-}
-#else
-public partial class BuildFinishedNotificationAttribute
-{
 }
 #endif

--- a/tracer/build/_build/BuildFinishedNotificationAttribute.cs
+++ b/tracer/build/_build/BuildFinishedNotificationAttribute.cs
@@ -1,0 +1,11 @@
+using Nuke.Common;
+using Nuke.Common.Execution;
+
+public partial class BuildFinishedNotificationAttribute : BuildExtensionAttributeBase, IOnBuildFinished
+{
+#if !IS_WINDOWS
+    public void OnBuildFinished(NukeBuild build)
+    {}
+#endif
+}
+

--- a/tracer/build/_build/WindowsBuildFinishedNotificationAttribute.cs
+++ b/tracer/build/_build/WindowsBuildFinishedNotificationAttribute.cs
@@ -4,7 +4,9 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+#if IS_WINDOWS
 using Microsoft.Toolkit.Uwp.Notifications;
+#endif
 using NuGet.Packaging;
 using Nuke.Common;
 using Nuke.Common.Execution;

--- a/tracer/build/_build/WindowsBuildFinishedNotificationAttribute.cs
+++ b/tracer/build/_build/WindowsBuildFinishedNotificationAttribute.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Toolkit.Uwp.Notifications;
+using NuGet.Packaging;
+using Nuke.Common;
+using Nuke.Common.Execution;
+
+public class WindowsBuildFinishedNotificationAttribute : BuildExtensionAttributeBase, IOnBuildFinished
+{
+    private static readonly string AppData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+    private static readonly string BuildImages = Path.Combine(AppData, "build-images");
+    private static readonly string SucceedImage = Path.Combine(BuildImages, "build-succeed.jpg");
+    private static readonly string FailedImage = Path.Combine(BuildImages, "build-failed.jpg");
+    private static readonly string LogoImage = Path.Combine(BuildImages, "dd_logo.png");
+
+    public void OnBuildFinished(NukeBuild build)
+    {
+#if IS_WINDOWS
+        if (!(bool.TryParse(Environment.GetEnvironmentVariable("NUKE_NOTIFY"), out var notify)
+            && notify))
+        {
+            return;
+        }
+
+        CreateLocalImages();
+
+        var message =
+            build.IsSuccessful
+                ? $"Build succeeded on {DateTime.Now.ToString(CultureInfo.CurrentCulture)}. ＼（＾ᴗ＾）／"
+                : $"Build failed on {DateTime.Now.ToString(CultureInfo.CurrentCulture)}. (╯°□°）╯︵ ┻━┻";
+
+        var image =
+            build.IsSuccessful
+                ? SucceedImage
+                : FailedImage;
+
+        new ToastContentBuilder()
+            .AddInlineImage(new Uri($"file:///{image}"))
+            .AddAppLogoOverride(new Uri($"file:///{LogoImage}"), ToastGenericAppLogoCrop.Circle)
+            .AddText(message)
+            .Show();
+#endif
+    }
+
+    private static void CreateLocalImages()
+    {
+        if (!Directory.Exists(BuildImages))
+        {
+            Directory.CreateDirectory(BuildImages);
+        }
+
+        var urlBase = "https://github.com/robertpi/build-images/blob/main/";
+        var tasks = new []
+        {
+            DownloadAndCache(urlBase + "build-succeed.jpg?raw=true", SucceedImage),
+            DownloadAndCache(urlBase + "build-failed.jpg?raw=true", FailedImage),
+            DownloadAndCache(urlBase + "dd_logo.jpg?raw=true", LogoImage),
+        };
+
+        Task.WhenAll(tasks).Wait();
+    }
+
+    static async Task DownloadAndCache(string url, string target)
+    {
+        if (!File.Exists(target))
+        {
+            var wc = new HttpClient();
+            await using var stream = await wc.GetStreamAsync(url);
+            stream.CopyToFile(target);
+        }
+    }
+}
+

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework Condition="$(OS.StartsWith('Windows'))">$(TargetFramework)-windows10.0.17763</TargetFramework>
+    <DefineConstants>IS_WINDOWS</DefineConstants>
     <RollForward>LatestMajor</RollForward>
     <RootNamespace></RootNamespace>
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
@@ -38,6 +40,11 @@
     <PackageReference Include="ByteSize" Version="2.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- on it's own, since windows only and just used for notifications -->
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" Condition="$(OS.StartsWith('Windows'))" />
+  </ItemGroup>
+  
   <ItemGroup>
     <Content Include="..\..\..\.azure-pipelines\steps\*" Link="ci\steps\%(Filename)%(Extension)" />
     <Content Include="..\..\..\.azure-pipelines\ultimate-pipeline.yml" Link="ci\ultimate-pipeline.yml" />

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <TargetFramework Condition="$(OS.StartsWith('Windows'))">$(TargetFramework)-windows10.0.17763</TargetFramework>
-    <DefineConstants>IS_WINDOWS</DefineConstants>
+    <DefineConstants Condition="$(OS.StartsWith('Windows'))">IS_WINDOWS</DefineConstants>
     <RollForward>LatestMajor</RollForward>
     <RootNamespace></RootNamespace>
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->


### PR DESCRIPTION
## Summary of changes

Adds a notification to the end of a nuke build. That way you don't need to be looking at the terminal to see that it's finished.

Opt-in:

`$env:NUKE_NOTIFY = "true"`

To enable images:

`$env:NUKE_NOTIFY_RESOURCES = "https://github.com/robertpi/build-images/blob/main/"`

(The url maybe any local or http[s] url that that has three images:

* build-succeed.jpg
* build-failed.jpg
* dd_logo.jpg

The images must be under 20kb)

This is what it looks like.

![Screenshot 2023-12-27 163417](https://github.com/DataDog/dd-trace-dotnet/assets/51381/4e13254b-b7e7-472d-ac61-5ab2e66ff126)

## Reason for change

It's nice to know when your build it done.

## Implementation details

Uses toast, so Windows only. Sadly (or happily) toasts sound apis don't work unless the app is packaged.

## Test coverage

Ugh.