### PR TITLE
Make sure OsX ITests don't require dd_dotnet stuff

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -168,13 +168,10 @@ partial class Build
         Solution.GetProject(Projects.OpenTracingIntegrationTests),
     };
 
-    Project[] ClrProfilerIntegrationTests => new[]
-    {
-        Solution.GetProject(Projects.ClrProfilerIntegrationTests),
-        Solution.GetProject(Projects.AppSecIntegrationTests),
-        Solution.GetProject(Projects.DdTraceIntegrationTests),
-        Solution.GetProject(Projects.DdDotnetIntegrationTests)
-    };
+    Project[] ClrProfilerIntegrationTests
+        => IsOsx
+               ? new[] { Solution.GetProject(Projects.ClrProfilerIntegrationTests), Solution.GetProject(Projects.AppSecIntegrationTests), Solution.GetProject(Projects.DdTraceIntegrationTests) }
+               : new[] { Solution.GetProject(Projects.ClrProfilerIntegrationTests), Solution.GetProject(Projects.AppSecIntegrationTests), Solution.GetProject(Projects.DdTraceIntegrationTests), Solution.GetProject(Projects.DdDotnetIntegrationTests) };
 
     TargetFramework[] TestingFrameworks =>
     IncludeAllTestFrameworks || HaveIntegrationsChanged


### PR DESCRIPTION
## Summary of changes

remove the project DdDotnetIntegrationTests from the list of ClrProfilerIntegrationTests that are used when running integration tests on OSX

## Reason for change

dd dotnet is not available on osx