### PR TITLE
[ASM] Adapt ASM benchmarks

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -529,6 +529,8 @@ partial class Build : NukeBuild
                     CopyDirectoryRecursively(resultsDirectory, BuildDataDirectory / "benchmarks",
                                              DirectoryExistsPolicy.Merge, FileExistsPolicy.Overwrite);
                 }
+
+                CopyDumpsToBuildData();
             }
         });
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="AppSecBenchmarkUtils.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using Datadog.Trace;
+using Datadog.Trace.AppSec.Waf.NativeBindings;
+
+namespace Benchmarks.Trace.Asm;
+
+internal class AppSecBenchmarkUtils
+{
+    internal static WafLibraryInvoker CreateWafLibraryInvoker()
+    {
+        var fDesc = FrameworkDescription.Instance;
+        var rid = (fDesc.ProcessArchitecture, fDesc.OSPlatform) switch
+        {
+            ("x64", "Windows") => "win-x64",
+            ("x86", "Windows") => "win-x86",
+            ("x64", "Linux") => "linux-x64",
+            ("arm64", "Linux") => "linux-arm64",
+            _ => throw new Exception($"RID not detected or supported: {fDesc.OSPlatform} / {fDesc.ProcessArchitecture}")
+        };
+
+        var folder = new DirectoryInfo(Environment.CurrentDirectory);
+        var path = Environment.CurrentDirectory;
+        while (folder.Exists)
+        {
+            path = Path.Combine(folder.FullName, "./shared/bin/monitoring-home");
+            if (Directory.Exists(path))
+            {
+                break;
+            }
+
+            if (folder == folder.Parent)
+            {
+                break;
+            }
+
+            folder = folder.Parent;
+        }
+
+        path = Path.Combine(path, $"./{rid}/");
+        if (!Directory.Exists(path))
+        {
+            throw new DirectoryNotFoundException($"The Path: '{path}' doesn't exist.");
+        }
+
+        Environment.SetEnvironmentVariable("DD_TRACE_LOGGING_RATE", "60");
+        Environment.SetEnvironmentVariable("DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH", path);
+        var libInitResult = WafLibraryInvoker.Initialize();
+        if (!libInitResult.Success)
+        {
+            throw new ArgumentException("Waf could not load");
+        }
+
+        return libInitResult.WafLibraryInvoker!;
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
@@ -1,0 +1,116 @@
+﻿// <copyright file="AppSecEncoderBenchmark.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Datadog.Trace;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.AppSec.Waf.NativeBindings;
+using Datadog.Trace.AppSec.WafEncoding;
+
+namespace Benchmarks.Trace.Asm;
+
+[MemoryDiagnoser]
+[BenchmarkAgent7]
+public class AppSecEncoderBenchmark
+{
+    private static readonly Encoder _encoder;
+    private static readonly EncoderLegacy _encoderLegacy;
+    private static readonly NestedMap _args;
+
+    static AppSecEncoderBenchmark()
+    {
+        _encoder = new Encoder();
+
+        var wafLibraryInvoker = AppSecBenchmarkUtils.CreateWafLibraryInvoker();
+        _encoderLegacy = new EncoderLegacy(wafLibraryInvoker);
+
+        _args = MakeNestedMap(20);
+    }
+
+    /// <summary>
+    /// Generates dummy arguments for the waf
+    /// </summary>
+    /// <param name="nestingDepth">Encoder.cs respects WafConstants.cs limits to process arguments with a max depth of 20 so above depth 20, there shouldn't be much difference of performances.</param>
+    /// <param name="withAttack">an attack present in arguments can slow down waf's run</param>
+    /// <returns></returns>
+    private static NestedMap MakeNestedMap(int nestingDepth, bool withAttack = false)
+    {
+        var root = new Dictionary<string, object>();
+        var map = root;
+        if (withAttack)
+        {
+            map.Add(
+                AddressesConstants.RequestHeaderNoCookies,
+                new Dictionary<string, string> { { "user-agent", "Arachni/v1" } }
+            );
+        }
+        else
+        {
+            map.Add(
+                "toto",
+                new Dictionary<string, string> { { "user-agent", "tata" } }
+            );
+        }
+
+        for (var i = 0; i < nestingDepth; i++)
+        {
+            if (i % 2 == 0)
+            {
+                var nextList = new List<object>
+                {
+                    true,
+                    false,
+                    false,
+                    false,
+                    true,
+                    123,
+                    "lorem",
+                    "ipsum",
+                    "dolor",
+                    AddressesConstants.RequestCookies,
+                    new Dictionary<string, string> { { "something", ".htaccess" }, { "something2", ";shutdown--" } }
+                };
+                map.Add("list", nextList);
+            }
+
+            var nextMap = new Dictionary<string, object>
+            {
+                { "lorem", "ipsum" },
+                { "dolor", "sit" },
+                { "amet", "amet" },
+                { "lorem2", "dolor2" },
+                { "sit2", true },
+                { "amet3", 4356 }
+            };
+            map.Add("item", nextMap);
+            map = nextMap;
+        }
+
+        return new NestedMap(root, nestingDepth, withAttack);
+    }
+
+
+    [Benchmark]
+    public void EncodeArgs()
+    {
+        using var pwArgs = _encoder.Encode(_args.Map, applySafetyLimits: true);
+    }
+
+    [Benchmark]
+    public void EncodeLegacyArgs()
+    {
+        using var pwArgs = _encoderLegacy.Encode(_args.Map, applySafetyLimits: true);
+    }
+
+    public record NestedMap(Dictionary<string, object> Map, int NestingDepth, bool IsAttack = false)
+    {
+        public override string ToString() => IsAttack ? $"NestedMap ({NestingDepth}, attack)" : $"NestedMap ({NestingDepth})";
+    }
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -23,165 +23,113 @@ public class AppSecWafBenchmark
 
     private static readonly Waf Waf;
 
-    private static readonly Dictionary<string, object> SecondRunArg = new Dictionary<string, object>() { { "address", new Dictionary<string, object>() { {"route", "path"} } } };
+    private static readonly Dictionary<string, object> stage1 = MakeRealisticNestedMapStage1(false);
+    private static readonly Dictionary<string, object> stage1Attack = MakeRealisticNestedMapStage1(true);
+    private static readonly Dictionary<string, object> stage2 = MakeRealisticNestedMapStage2();
+    private static readonly Dictionary<string, object> stage3 = MakeRealisticNestedMapStage3();
 
     static AppSecWafBenchmark()
     {
-        var fDesc = FrameworkDescription.Instance;
-        var rid = (fDesc.ProcessArchitecture, fDesc.OSPlatform) switch
-        {
-            ("x64", "Windows") => "win-x64",
-            ("x86", "Windows") => "win-x86",
-            ("x64", "Linux") => "linux-x64",
-            ("arm64", "Linux") => "linux-arm64",
-            _ => throw new Exception($"RID not detected or supported: {fDesc.OSPlatform} / {fDesc.ProcessArchitecture}")
-        };
+        var wafLibraryInvoker = AppSecBenchmarkUtils.CreateWafLibraryInvoker();
 
-        var folder = new DirectoryInfo(Environment.CurrentDirectory);
-        var path = Environment.CurrentDirectory;
-        while (folder.Exists)
-        {
-            path = Path.Combine(folder.FullName, "./shared/bin/monitoring-home");
-            if (Directory.Exists(path))
-            {
-                break;
-            }
-
-            if (folder == folder.Parent)
-            {
-                break;
-            }
-
-            folder = folder.Parent;
-        }
-
-        path = Path.Combine(path, $"./{rid}/");
-        if (!Directory.Exists(path))
-        {
-            throw new DirectoryNotFoundException($"The Path: '{path}' doesn't exist.");
-        }
-
-        Environment.SetEnvironmentVariable("DD_TRACE_LOGGING_RATE", "60");
-        Environment.SetEnvironmentVariable("DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH", path);
-        var libInitResult = WafLibraryInvoker.Initialize();
-        if (!libInitResult.Success)
-        {
-            throw new ArgumentException("Waf could not load");
-        }
-
-        var wafLibraryInvoker = libInitResult.WafLibraryInvoker!;
-        var initResult = Waf.Create(wafLibraryInvoker, string.Empty, string.Empty, embeddedRulesetPath: Path.Combine(Directory.GetCurrentDirectory(), "Asm", "rule-set.1.7.2.json"));
-
+        var rulesPath = Path.Combine(Directory.GetCurrentDirectory(), "Asm", "rule-set.1.10.0.json");
+        var initResult = Waf.Create(wafLibraryInvoker, string.Empty, string.Empty, embeddedRulesetPath:rulesPath);
         if (!initResult.Success || initResult.HasErrors)
         {
             throw new ArgumentException($"Waf could not initialize, error message is: {initResult.ErrorMessage}");
         }
-
         Waf = initResult.Waf;
     }
 
-    public IEnumerable<NestedMap> Source()
+    private static Dictionary<string, object> MakeRealisticNestedMapStage1(bool withAttack)
     {
-        yield return MakeNestedMap(10);
-        yield return MakeNestedMap(20);
-        yield return MakeNestedMap(100);
-    }
+        var headersDict = new Dictionary<string, string[]>
+        {
+            { "header1", new [] { "value1", "value2", "value3", } },
+            { "header2", new [] { "value1", "value2", "value3", } },
+            { "header3", new [] { "value1", "value2", "value3", } },
+        };
+        var cookiesDic = new Dictionary<string, List<string>>
+        {
+            { "cookie1", new List<string> { "value1", "value2", "value3", } },
+        };
 
-    public IEnumerable<NestedMap> SourceWithAttack()
-    {
-        yield return MakeNestedMap(10, true);
-        yield return MakeNestedMap(20, true);
-        yield return MakeNestedMap(100, true);
-    }
-
-    /// <summary>
-    /// Generates dummy arguments for the waf
-    /// </summary>
-    /// <param name="nestingDepth">Encoder.cs respects WafConstants.cs limits to process arguments with a max depth of 20 so above depth 20, there shouldn't be much difference of performances.</param>
-    /// <param name="withAttack">an attack present in arguments can slow down waf's run</param>
-    /// <returns></returns>
-    private static NestedMap MakeNestedMap(int nestingDepth, bool withAttack = false)
-    {
-        var root = new Dictionary<string, object>();
-        var map = root;
         if (withAttack)
         {
-            map.Add(
-                AddressesConstants.RequestHeaderNoCookies,
-                new Dictionary<string, string> { { "user-agent", "Arachni/v1" } }
-            );
+            cookiesDic.Add("user-agent", new List<string>() { "Arachni/v1" } );
         }
-        else
+
+        var queryStringDic = new Dictionary<string, List<string>>
         {
-            map.Add(
-                "toto",
-                new Dictionary<string, string> { { "user-agent", "tata" } }
-            );
-        }
+            { "key1", new List<string> { "value1", "value2", "value3", } },
+        };
 
-        for (var i = 0; i < nestingDepth; i++)
+        var addressesDictionary = new Dictionary<string, object>
         {
-            if (i % 2 == 0)
-            {
-                var nextList = new List<object>
-                {
-                    true,
-                    false,
-                    false,
-                    false,
-                    true,
-                    123,
-                    "lorem",
-                    "ipsum",
-                    "dolor",
-                    AddressesConstants.RequestCookies,
-                    new Dictionary<string, string> { { "something", ".htaccess" }, { "something2", ";shutdown--" } }
-                };
-                map.Add("list", nextList);
-            }
+            { AddressesConstants.RequestMethod, "GET" },
+            { AddressesConstants.ResponseStatus, "200" },
+            { AddressesConstants.RequestUriRaw, "/short/url" },
+            { AddressesConstants.RequestClientIp, "10.20.30.40" }
+        };
 
-            var nextMap = new Dictionary<string, object>
-            {
-                { "lorem", "ipsum" },
-                { "dolor", "sit" },
-                { "amet", "amet" },
-                { "lorem2", "dolor2" },
-                { "sit2", true },
-                { "amet3", 4356 }
-            };
-            map.Add("item", nextMap);
-            map = nextMap;
-        }
+        addressesDictionary.Add(AddressesConstants.RequestQuery, queryStringDic);
+        addressesDictionary.Add(AddressesConstants.RequestHeaderNoCookies, headersDict);
+        addressesDictionary.Add(AddressesConstants.RequestCookies, cookiesDic);
 
-        return new NestedMap(root, nestingDepth, withAttack);
+        return addressesDictionary;
+    }
+
+    private static Dictionary<string, object> MakeRealisticNestedMapStage2()
+    {
+        IDictionary<string, object> pathParams = new Dictionary<string, object>()
+        {
+            { "id", "22" }
+        };
+
+        var args = new Dictionary<string, object>
+        {
+            { AddressesConstants.RequestPathParams, pathParams }
+        };
+
+        return args;
+    }
+
+    private static Dictionary<string, object> MakeRealisticNestedMapStage3()
+    {
+        var headersDict = new Dictionary<string, string[]>()
+        {
+            { "header1", new [] { "value1", "value2", "value3", } },
+            { "header2", new [] { "value1", "value2", "value3", } },
+            { "header3", new [] { "value1", "value2", "value3", } },
+        };
+
+        var args = new Dictionary<string, object>
+        {
+            {
+                AddressesConstants.ResponseHeaderNoCookies,
+                headersDict
+            },
+            { AddressesConstants.ResponseStatus, "200" },
+        };
+
+        return args;
     }
 
     [Benchmark]
-    [ArgumentsSource(nameof(Source))]
-    public void RunWaf(NestedMap args) => RunWafBenchmark(args, false);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(Source))]
-    public void RunWafTwice(NestedMap args) => RunWafBenchmark(args, true);
-
-    [Benchmark]
-    [ArgumentsSource(nameof(SourceWithAttack))]
-    public void RunWafWithAttack(NestedMap args) => RunWafBenchmark(args, false);
-
-    private void RunWafBenchmark(NestedMap args, bool secondRun)
+    public void RunWafRealisticBenchmark()
     {
         var context = Waf.CreateContext();
-        context!.Run(args.Map, TimeoutMicroSeconds);
-        if (secondRun)
-        {
-            context!.Run(SecondRunArg, TimeoutMicroSeconds);
-        }
-
+        context!.Run(stage1, TimeoutMicroSeconds);
+        context!.Run(stage2, TimeoutMicroSeconds);
+        context!.Run(stage3, TimeoutMicroSeconds);
         context.Dispose();
     }
 
-    public record NestedMap(Dictionary<string, object> Map, int NestingDepth, bool IsAttack = false)
+    [Benchmark]
+    public void RunWafRealisticBenchmarkWithAttack()
     {
-        public override string ToString() => IsAttack ? $"NestedMap ({NestingDepth}, attack)" : $"NestedMap ({NestingDepth})";
+        var context = Waf.CreateContext();
+        context!.Run(stage1Attack, TimeoutMicroSeconds);
+        context.Dispose();
     }
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/rule-set.1.10.0.json
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/rule-set.1.10.0.json
@@ -1,7 +1,7 @@
 {
   "version": "2.2",
   "metadata": {
-    "rules_version": "1.7.2"
+    "rules_version": "1.10.0"
   },
   "rules": [
     {
@@ -62,6 +62,8 @@
         "crs_id": "913110",
         "category": "attack_attempt",
         "tool_name": "Acunetix",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "0"
       },
       "conditions": [
@@ -94,6 +96,8 @@
         "type": "security_scanner",
         "crs_id": "913120",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -108,6 +112,15 @@
               },
               {
                 "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "list": [
@@ -144,6 +157,8 @@
         "type": "http_protocol_violation",
         "crs_id": "920260",
         "category": "attack_attempt",
+        "cwe": "176",
+        "capec": "1000/255/153/267/71",
         "confidence": "0"
       },
       "conditions": [
@@ -171,7 +186,9 @@
       "tags": {
         "type": "http_protocol_violation",
         "crs_id": "921110",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "444",
+        "capec": "1000/210/272/220/33"
       },
       "conditions": [
         {
@@ -206,7 +223,9 @@
       "tags": {
         "type": "http_protocol_violation",
         "crs_id": "921160",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "113",
+        "capec": "1000/210/272/220/105"
       },
       "conditions": [
         {
@@ -239,6 +258,8 @@
         "type": "lfi",
         "crs_id": "930100",
         "category": "attack_attempt",
+        "cwe": "22",
+        "capec": "1000/255/153/126",
         "confidence": "1"
       },
       "conditions": [
@@ -271,6 +292,8 @@
         "type": "lfi",
         "crs_id": "930110",
         "category": "attack_attempt",
+        "cwe": "22",
+        "capec": "1000/255/153/126",
         "confidence": "1"
       },
       "conditions": [
@@ -304,6 +327,8 @@
         "type": "lfi",
         "crs_id": "930120",
         "category": "attack_attempt",
+        "cwe": "22",
+        "capec": "1000/255/153/126",
         "confidence": "1"
       },
       "conditions": [
@@ -321,6 +346,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "list": [
@@ -1764,6 +1795,8 @@
         "type": "rfi",
         "crs_id": "931110",
         "category": "attack_attempt",
+        "cwe": "98",
+        "capec": "1000/152/175/253/193",
         "confidence": "1"
       },
       "conditions": [
@@ -1790,7 +1823,9 @@
       "tags": {
         "type": "rfi",
         "crs_id": "931120",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "98",
+        "capec": "1000/152/175/253/193"
       },
       "conditions": [
         {
@@ -1804,6 +1839,15 @@
               },
               {
                 "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "^(?i:file|ftps?)://.*?\\?+$",
@@ -1824,6 +1868,8 @@
         "type": "command_injection",
         "crs_id": "932160",
         "category": "attack_attempt",
+        "cwe": "77",
+        "capec": "1000/152/248/88",
         "confidence": "1"
       },
       "conditions": [
@@ -1841,6 +1887,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "list": [
@@ -2326,6 +2378,8 @@
         "type": "command_injection",
         "crs_id": "932171",
         "category": "attack_attempt",
+        "cwe": "77",
+        "capec": "1000/152/248/88",
         "confidence": "1"
       },
       "conditions": [
@@ -2346,6 +2400,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "^\\(\\s*\\)\\s+{",
@@ -2366,6 +2426,8 @@
         "type": "command_injection",
         "crs_id": "932180",
         "category": "attack_attempt",
+        "cwe": "706",
+        "capec": "1000/225/122/17/177",
         "confidence": "1"
       },
       "conditions": [
@@ -2425,6 +2487,8 @@
         "type": "unrestricted_file_upload",
         "crs_id": "933111",
         "category": "attack_attempt",
+        "cwe": "434",
+        "capec": "1000/225/122/17/650",
         "confidence": "1"
       },
       "conditions": [
@@ -2476,6 +2540,8 @@
         "type": "php_code_injection",
         "crs_id": "933130",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/225/122/17/650",
         "confidence": "1"
       },
       "conditions": [
@@ -2493,6 +2559,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "list": [
@@ -2532,7 +2604,9 @@
       "tags": {
         "type": "php_code_injection",
         "crs_id": "933131",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/225/122/17/650"
       },
       "conditions": [
         {
@@ -2549,6 +2623,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:HTTP_(?:ACCEPT(?:_(?:ENCODING|LANGUAGE|CHARSET))?|(?:X_FORWARDED_FO|REFERE)R|(?:USER_AGEN|HOS)T|CONNECTION|KEEP_ALIVE)|PATH_(?:TRANSLATED|INFO)|ORIG_PATH_INFO|QUERY_STRING|REQUEST_URI|AUTH_TYPE)",
@@ -2569,6 +2649,8 @@
         "type": "php_code_injection",
         "crs_id": "933140",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/225/122/17/650",
         "confidence": "1"
       },
       "conditions": [
@@ -2586,6 +2668,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "php://(?:std(?:in|out|err)|(?:in|out)put|fd|memory|temp|filter)",
@@ -2605,6 +2693,8 @@
         "type": "php_code_injection",
         "crs_id": "933150",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/225/122/17/650",
         "confidence": "1"
       },
       "conditions": [
@@ -2622,6 +2712,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "list": [
@@ -2684,7 +2780,9 @@
       "tags": {
         "type": "php_code_injection",
         "crs_id": "933160",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/225/122/17/650"
       },
       "conditions": [
         {
@@ -2701,6 +2799,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\b(?:s(?:e(?:t(?:_(?:e(?:xception|rror)_handler|magic_quotes_runtime|include_path)|defaultstub)|ssion_s(?:et_save_handler|tart))|qlite_(?:(?:(?:unbuffered|single|array)_)?query|create_(?:aggregate|function)|p?open|exec)|tr(?:eam_(?:context_create|socket_client)|ipc?slashes|rev)|implexml_load_(?:string|file)|ocket_c(?:onnect|reate)|h(?:ow_sourc|a1_fil)e|pl_autoload_register|ystem)|p(?:r(?:eg_(?:replace(?:_callback(?:_array)?)?|match(?:_all)?|split)|oc_(?:(?:terminat|clos|nic)e|get_status|open)|int_r)|o(?:six_(?:get(?:(?:e[gu]|g)id|login|pwnam)|mk(?:fifo|nod)|ttyname|kill)|pen)|hp(?:_(?:strip_whitespac|unam)e|version|info)|g_(?:(?:execut|prepar)e|connect|query)|a(?:rse_(?:ini_file|str)|ssthru)|utenv)|r(?:unkit_(?:function_(?:re(?:defin|nam)e|copy|add)|method_(?:re(?:defin|nam)e|copy|add)|constant_(?:redefine|add))|e(?:(?:gister_(?:shutdown|tick)|name)_function|ad(?:(?:gz)?file|_exif_data|dir))|awurl(?:de|en)code)|i(?:mage(?:createfrom(?:(?:jpe|pn)g|x[bp]m|wbmp|gif)|(?:jpe|pn)g|g(?:d2?|if)|2?wbmp|xbm)|s_(?:(?:(?:execut|write?|read)ab|fi)le|dir)|ni_(?:get(?:_all)?|set)|terator_apply|ptcembed)|g(?:et(?:_(?:c(?:urrent_use|fg_va)r|meta_tags)|my(?:[gpu]id|inode)|(?:lastmo|cw)d|imagesize|env)|z(?:(?:(?:defla|wri)t|encod|fil)e|compress|open|read)|lob)|a(?:rray_(?:u(?:intersect(?:_u?assoc)?|diff(?:_u?assoc)?)|intersect_u(?:assoc|key)|diff_u(?:assoc|key)|filter|reduce|map)|ssert(?:_options)?|tob)|h(?:tml(?:specialchars(?:_decode)?|_entity_decode|entities)|(?:ash(?:_(?:update|hmac))?|ighlight)_file|e(?:ader_register_callback|x2bin))|f(?:i(?:le(?:(?:[acm]tim|inod)e|(?:_exist|perm)s|group)?|nfo_open)|tp_(?:nb_(?:ge|pu)|connec|ge|pu)t|(?:unction_exis|pu)ts|write|open)|o(?:b_(?:get_(?:c(?:ontents|lean)|flush)|end_(?:clean|flush)|clean|flush|start)|dbc_(?:result(?:_all)?|exec(?:ute)?|connect)|pendir)|m(?:b_(?:ereg(?:_(?:replace(?:_callback)?|match)|i(?:_replace)?)?|parse_str)|(?:ove_uploaded|d5)_file|ethod_exists|ysql_query|kdir)|e(?:x(?:if_(?:t(?:humbnail|agname)|imagetype|read_data)|ec)|scapeshell(?:arg|cmd)|rror_reporting|val)|c(?:url_(?:file_create|exec|init)|onvert_uuencode|reate_function|hr)|u(?:n(?:serialize|pack)|rl(?:de|en)code|[ak]?sort)|b(?:(?:son_(?:de|en)|ase64_en)code|zopen|toa)|(?:json_(?:de|en)cod|debug_backtrac|tmpfil)e|var_dump)(?:\\s|/\\*.*\\*/|//.*|#.*|\\\"|')*\\((?:(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:\\$\\w+|[A-Z\\d]\\w*|\\w+\\(.*\\)|\\\\?\"(?:[^\"]|\\\\\"|\"\"|\"\\+\")*\\\\?\"|\\\\?'(?:[^']|''|'\\+')*\\\\?')(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:(?:::|\\.|->)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\w+(?:\\(.*\\))?)?,)*(?:(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:\\$\\w+|[A-Z\\d]\\w*|\\w+\\(.*\\)|\\\\?\"(?:[^\"]|\\\\\"|\"\"|\"\\+\")*\\\\?\"|\\\\?'(?:[^']|''|'\\+')*\\\\?')(?:\\s|/\\*.*\\*/|//.*|#.*)*(?:(?:::|\\.|->)(?:\\s|/\\*.*\\*/|//.*|#.*)*\\w+(?:\\(.*\\))?)?)?\\)",
@@ -2721,6 +2825,8 @@
         "type": "php_code_injection",
         "crs_id": "933170",
         "category": "attack_attempt",
+        "cwe": "502",
+        "capec": "1000/152/586",
         "confidence": "1"
       },
       "conditions": [
@@ -2741,6 +2847,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "[oOcC]:\\d+:\\\".+?\\\":\\d+:{[\\W\\w]*}",
@@ -2760,7 +2872,9 @@
       "tags": {
         "type": "php_code_injection",
         "crs_id": "933200",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "502",
+        "capec": "1000/152/586"
       },
       "conditions": [
         {
@@ -2777,6 +2891,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:(?:bzip|ssh)2|z(?:lib|ip)|(?:ph|r)ar|expect|glob|ogg)://",
@@ -2798,7 +2918,9 @@
       "tags": {
         "type": "js_code_injection",
         "crs_id": "934100",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242"
       },
       "conditions": [
         {
@@ -2815,6 +2937,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\b(?:(?:l(?:(?:utimes|chmod)(?:Sync)?|(?:stat|ink)Sync)|w(?:rite(?:(?:File|v)(?:Sync)?|Sync)|atchFile)|u(?:n(?:watchFile|linkSync)|times(?:Sync)?)|s(?:(?:ymlink|tat)Sync|pawn(?:File|Sync))|ex(?:ec(?:File(?:Sync)?|Sync)|istsSync)|a(?:ppendFile|ccess)(?:Sync)?|(?:Caveat|Inode)s|open(?:dir)?Sync|new\\s+Function|Availability|\\beval)\\s*\\(|m(?:ain(?:Module\\s*(?:\\W*\\s*(?:constructor|require)|\\[)|\\s*(?:\\W*\\s*(?:constructor|require)|\\[))|kd(?:temp(?:Sync)?|irSync)\\s*\\(|odule\\.exports\\s*=)|c(?:(?:(?:h(?:mod|own)|lose)Sync|reate(?:Write|Read)Stream|p(?:Sync)?)\\s*\\(|o(?:nstructor\\s*(?:\\W*\\s*_load|\\[)|pyFile(?:Sync)?\\s*\\())|f(?:(?:(?:s(?:(?:yncS)?|tatS)|datas(?:yncS)?)ync|ch(?:mod|own)(?:Sync)?)\\s*\\(|u(?:nction\\s*\\(\\s*\\)\\s*{|times(?:Sync)?\\s*\\())|r(?:e(?:(?:ad(?:(?:File|link|dir)?Sync|v(?:Sync)?)|nameSync)\\s*\\(|quire\\s*(?:\\W*\\s*main|\\[))|m(?:Sync)?\\s*\\()|process\\s*(?:\\W*\\s*(?:mainModule|binding)|\\[)|t(?:his\\.constructor|runcateSync\\s*\\()|_(?:\\$\\$ND_FUNC\\$\\$_|_js_function)|global\\s*(?:\\W*\\s*process|\\[)|String\\s*\\.\\s*fromCharCode|binding\\s*\\[)",
@@ -2835,7 +2963,9 @@
         "type": "js_code_injection",
         "crs_id": "934101",
         "category": "attack_attempt",
-        "confidence": "1"
+        "confidence": "1",
+        "cwe": "94",
+        "capec": "1000/152/242"
       },
       "conditions": [
         {
@@ -2852,6 +2982,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\b(?:w(?:atch|rite)|(?:spaw|ope)n|exists|close|fork|read)\\s*\\(",
@@ -2872,6 +3008,8 @@
         "type": "xss",
         "crs_id": "941110",
         "category": "attack_attempt",
+        "cwe": "80",
+        "capec": "1000/152/242/63/591",
         "confidence": "1"
       },
       "conditions": [
@@ -2901,10 +3039,17 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "<script[^>]*>[\\s\\S]*?",
             "options": {
+              "case_sensitive": false,
               "min_length": 8
             }
           },
@@ -2923,6 +3068,8 @@
         "type": "xss",
         "crs_id": "941120",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -2952,6 +3099,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\bon(?:d(?:r(?:ag(?:en(?:ter|d)|leave|start|over)?|op)|urationchange|blclick)|s(?:e(?:ek(?:ing|ed)|arch|lect)|u(?:spend|bmit)|talled|croll|how)|m(?:ouse(?:(?:lea|mo)ve|o(?:ver|ut)|enter|down|up)|essage)|p(?:a(?:ge(?:hide|show)|(?:st|us)e)|lay(?:ing)?|rogress|aste|ointer(?:cancel|down|enter|leave|move|out|over|rawupdate|up))|c(?:anplay(?:through)?|o(?:ntextmenu|py)|hange|lick|ut)|a(?:nimation(?:iteration|start|end)|(?:fterprin|bor)t|uxclick|fterscriptexecute)|t(?:o(?:uch(?:cancel|start|move|end)|ggle)|imeupdate)|f(?:ullscreen(?:change|error)|ocus(?:out|in)?|inish)|(?:(?:volume|hash)chang|o(?:ff|n)lin)e|b(?:efore(?:unload|print)|lur)|load(?:ed(?:meta)?data|start|end)?|r(?:es(?:ize|et)|atechange)|key(?:press|down|up)|w(?:aiting|heel)|in(?:valid|put)|e(?:nded|rror)|unload)[\\s\\x0B\\x09\\x0C\\x3B\\x2C\\x28\\x3B]*?=[^=]",
@@ -2974,6 +3127,8 @@
         "type": "xss",
         "crs_id": "941140",
         "category": "attack_attempt",
+        "cwe": "84",
+        "capec": "1000/152/242/63/591/244",
         "confidence": "1"
       },
       "conditions": [
@@ -3003,6 +3158,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "[a-z]+=(?:[^:=]+:.+;)*?[^:=]+:url\\(javascript",
@@ -3025,6 +3186,8 @@
         "type": "xss",
         "crs_id": "941170",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -3051,6 +3214,15 @@
               },
               {
                 "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:\\W|^)(?:javascript:(?:[\\s\\S]+[=\\x5c\\(\\[\\.<]|[\\s\\S]*?(?:\\bname\\b|\\x5c[ux]\\d)))|@\\W*?i\\W*?m\\W*?p\\W*?o\\W*?r\\W*?t\\W*?(?:/\\*[\\s\\S]*?)?(?:[\\\"']|\\W*?u\\W*?r\\W*?l[\\s\\S]*?\\()|[^-]*?-\\W*?m\\W*?o\\W*?z\\W*?-\\W*?b\\W*?i\\W*?n\\W*?d\\W*?i\\W*?n\\W*?g[^:]*?:\\W*?u\\W*?r\\W*?l[\\s\\S]*?\\(",
@@ -3072,7 +3244,9 @@
       "tags": {
         "type": "xss",
         "crs_id": "941180",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "79",
+        "capec": "1000/152/242/63/591"
       },
       "conditions": [
         {
@@ -3089,6 +3263,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "list": [
@@ -3115,6 +3295,8 @@
         "type": "xss",
         "crs_id": "941200",
         "category": "attack_attempt",
+        "cwe": "80",
+        "capec": "1000/152/242/63/591",
         "confidence": "1"
       },
       "conditions": [
@@ -3132,6 +3314,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:<.*[:]?vmlframe.*?[\\s/+]*?src[\\s/+]*=)",
@@ -3154,6 +3342,8 @@
         "type": "xss",
         "crs_id": "941210",
         "category": "attack_attempt",
+        "cwe": "80",
+        "capec": "1000/152/242/63/591",
         "confidence": "1"
       },
       "conditions": [
@@ -3171,6 +3361,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:(?:j|&#x?0*(?:74|4A|106|6A);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:a|&#x?0*(?:65|41|97|61);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|\\n|\\r|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
@@ -3193,6 +3389,8 @@
         "type": "xss",
         "crs_id": "941220",
         "category": "attack_attempt",
+        "cwe": "80",
+        "capec": "1000/152/242/63/591",
         "confidence": "1"
       },
       "conditions": [
@@ -3210,6 +3408,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:(?:v|&#x?0*(?:86|56|118|76);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:b|&#x?0*(?:66|42|98|62);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:s|&#x?0*(?:83|53|115|73);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:c|&#x?0*(?:67|43|99|63);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:r|&#x?0*(?:82|52|114|72);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:i|&#x?0*(?:73|49|105|69);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:p|&#x?0*(?:80|50|112|70);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?:t|&#x?0*(?:84|54|116|74);?)(?:\\t|&(?:#x?0*(?:9|13|10|A|D);?|tab;|newline;))*(?::|&(?:#x?0*(?:58|3A);?|colon;)).)",
@@ -3232,6 +3436,8 @@
         "type": "xss",
         "crs_id": "941230",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -3249,6 +3455,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "<EMBED[\\s/+].*?(?:src|type).*?=",
@@ -3270,6 +3482,8 @@
         "type": "xss",
         "crs_id": "941240",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -3287,6 +3501,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "<[?]?import[\\s/+\\S]*?implementation[\\s/+]*?=",
@@ -3309,7 +3529,9 @@
       "tags": {
         "type": "xss",
         "crs_id": "941270",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243"
       },
       "conditions": [
         {
@@ -3326,6 +3548,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "<LINK[\\s/+].*?href[\\s/+]*=",
@@ -3347,6 +3575,8 @@
         "type": "xss",
         "crs_id": "941280",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -3364,6 +3594,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "<BASE[\\s/+].*?href[\\s/+]*=",
@@ -3385,6 +3621,8 @@
         "type": "xss",
         "crs_id": "941290",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -3402,6 +3640,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "<APPLET[\\s/+>]",
@@ -3423,6 +3667,8 @@
         "type": "xss",
         "crs_id": "941300",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -3440,6 +3686,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "<OBJECT[\\s/+].*?(?:type|codetype|classid|code|data)[\\s/+]*=",
@@ -3461,6 +3713,8 @@
         "type": "xss",
         "crs_id": "941350",
         "category": "attack_attempt",
+        "cwe": "87",
+        "capec": "1000/152/242/63/591/199",
         "confidence": "1"
       },
       "conditions": [
@@ -3478,6 +3732,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\+ADw-.*(?:\\+AD4-|>)|<.*\\+AD4-",
@@ -3497,7 +3757,9 @@
       "tags": {
         "type": "xss",
         "crs_id": "941360",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "87",
+        "capec": "1000/152/242/63/591/199"
       },
       "conditions": [
         {
@@ -3514,6 +3776,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "![!+ ]\\[\\]",
@@ -3534,7 +3802,9 @@
         "type": "xss",
         "crs_id": "941390",
         "category": "attack_attempt",
-        "confidence": "1"
+        "confidence": "1",
+        "cwe": "79",
+        "capec": "1000/152/242/63/591"
       },
       "conditions": [
         {
@@ -3551,6 +3821,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\b(?i:eval|settimeout|setinterval|new\\s+Function|alert|prompt)[\\s+]*\\([^\\)]",
@@ -3570,7 +3846,9 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942100",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66"
       },
       "conditions": [
         {
@@ -3587,6 +3865,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ]
           },
@@ -3604,6 +3888,8 @@
         "type": "sql_injection",
         "crs_id": "942160",
         "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66/7",
         "confidence": "1"
       },
       "conditions": [
@@ -3621,6 +3907,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:sleep\\(\\s*?\\d*?\\s*?\\)|benchmark\\(.*?\\,.*?\\))",
@@ -3641,6 +3933,8 @@
         "type": "sql_injection",
         "crs_id": "942240",
         "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66/7",
         "confidence": "1"
       },
       "conditions": [
@@ -3658,6 +3952,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:[\\\"'`](?:;*?\\s*?waitfor\\s+(?:delay|time)\\s+[\\\"'`]|;.*?:\\s*?goto)|alter\\s*?\\w+.*?cha(?:racte)?r\\s+set\\s+\\w+)",
@@ -3676,7 +3976,9 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942250",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66"
       },
       "conditions": [
         {
@@ -3693,6 +3995,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:merge.*?using\\s*?\\(|execute\\s*?immediate\\s*?[\\\"'`]|match\\s*?[\\w(?:),+-]+\\s*?against\\s*?\\()",
@@ -3712,7 +4020,9 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942270",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66"
       },
       "conditions": [
         {
@@ -3729,6 +4039,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "union.*?select.*?from",
@@ -3748,6 +4064,8 @@
         "type": "sql_injection",
         "crs_id": "942280",
         "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66/7",
         "confidence": "1"
       },
       "conditions": [
@@ -3765,6 +4083,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:;\\s*?shutdown\\s*?(?:[#;{]|\\/\\*|--)|waitfor\\s*?delay\\s?[\\\"'`]+\\s?\\d|select\\s*?pg_sleep)",
@@ -3783,7 +4107,9 @@
       "tags": {
         "type": "nosql_injection",
         "crs_id": "942290",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "943",
+        "capec": "1000/152/248/676"
       },
       "conditions": [
         {
@@ -3800,6 +4126,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:(?:\\[?\\$(?:(?:s(?:lic|iz)|wher)e|e(?:lemMatch|xists|q)|n(?:o[rt]|in?|e)|l(?:ike|te?)|t(?:ext|ype)|a(?:ll|nd)|jsonSchema|between|regex|x?or|div|mod)\\]?)\\b)",
@@ -3821,7 +4153,9 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942360",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66/470"
       },
       "conditions": [
         {
@@ -3838,6 +4172,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:^[\\W\\d]+\\s*?(?:alter\\s*(?:a(?:(?:pplication\\s*rol|ggregat)e|s(?:ymmetric\\s*ke|sembl)y|u(?:thorization|dit)|vailability\\s*group)|c(?:r(?:yptographic\\s*provider|edential)|o(?:l(?:latio|um)|nversio)n|ertificate|luster)|s(?:e(?:rv(?:ice|er)|curity|quence|ssion|arch)|y(?:mmetric\\s*key|nonym)|togroup|chema)|m(?:a(?:s(?:ter\\s*key|k)|terialized)|e(?:ssage\\s*type|thod)|odule)|l(?:o(?:g(?:file\\s*group|in)|ckdown)|a(?:ngua|r)ge|ibrary)|t(?:(?:abl(?:espac)?|yp)e|r(?:igger|usted)|hreshold|ext)|p(?:a(?:rtition|ckage)|ro(?:cedur|fil)e|ermission)|d(?:i(?:mension|skgroup)|atabase|efault|omain)|r(?:o(?:l(?:lback|e)|ute)|e(?:sourc|mot)e)|f(?:u(?:lltext|nction)|lashback|oreign)|e(?:xte(?:nsion|rnal)|(?:ndpoi|ve)nt)|in(?:dex(?:type)?|memory|stance)|b(?:roker\\s*priority|ufferpool)|x(?:ml\\s*schema|srobject)|w(?:ork(?:load)?|rapper)|hi(?:erarchy|stogram)|o(?:perator|utline)|(?:nicknam|queu)e|us(?:age|er)|group|java|view)|union\\s*(?:(?:distin|sele)ct|all))\\b|\\b(?:(?:(?:trunc|cre|upd)at|renam)e|(?:inser|selec)t|de(?:lete|sc)|alter|load)\\s+(?:group_concat|load_file|char)\\b\\s*\\(?|[\\s(]load_file\\s*?\\(|[\\\"'`]\\s+regexp\\W)",
@@ -3856,7 +4196,9 @@
       "tags": {
         "type": "sql_injection",
         "crs_id": "942500",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "89",
+        "capec": "1000/152/248/66"
       },
       "conditions": [
         {
@@ -3873,6 +4215,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:/\\*[!+](?:[\\w\\s=_\\-(?:)]+)?\\*/)",
@@ -3893,6 +4241,8 @@
         "type": "http_protocol_violation",
         "crs_id": "943100",
         "category": "attack_attempt",
+        "cwe": "384",
+        "capec": "1000/225/21/593/61",
         "confidence": "1"
       },
       "conditions": [
@@ -3907,6 +4257,15 @@
               },
               {
                 "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i:\\.cookie\\b.*?;\\W*?(?:expires|domain)\\W*?=|\\bhttp-equiv\\W+set-cookie\\b)",
@@ -3927,6 +4286,8 @@
         "type": "java_code_injection",
         "crs_id": "944100",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242",
         "confidence": "1"
       },
       "conditions": [
@@ -3947,6 +4308,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "java\\.lang\\.(?:runtime|processbuilder)",
@@ -3967,8 +4334,9 @@
       "name": "Remote Command Execution: Java process spawn (CVE-2017-9805)",
       "tags": {
         "type": "java_code_injection",
-        "crs_id": "944110",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242"
       },
       "conditions": [
         {
@@ -3988,47 +4356,24 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "(?:runtime|processbuilder)",
+            "regex": "(?:unmarshaller|base64data|java\\.).*(?:runtime|processbuilder)",
             "options": {
-              "case_sensitive": true,
-              "min_length": 7
-            }
-          },
-          "operator": "match_regex"
-        },
-        {
-          "parameters": {
-            "inputs": [
-              {
-                "address": "server.request.query"
-              },
-              {
-                "address": "server.request.body"
-              },
-              {
-                "address": "server.request.path_params"
-              },
-              {
-                "address": "server.request.headers.no_cookies"
-              },
-              {
-                "address": "grpc.server.request.message"
-              }
-            ],
-            "regex": "(?:unmarshaller|base64data|java\\.)",
-            "options": {
-              "case_sensitive": true,
-              "min_length": 5
+              "case_sensitive": false,
+              "min_length": 13
             }
           },
           "operator": "match_regex"
         }
       ],
-      "transformers": [
-        "lowercase"
-      ]
+      "transformers": []
     },
     {
       "id": "crs-944-130",
@@ -4036,7 +4381,9 @@
       "tags": {
         "type": "java_code_injection",
         "crs_id": "944130",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242"
       },
       "conditions": [
         {
@@ -4056,6 +4403,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "list": [
@@ -4091,6 +4444,7 @@
               "java.lang.object",
               "java.lang.process",
               "java.lang.reflect",
+              "java.lang.runtime",
               "java.lang.string",
               "java.lang.stringbuilder",
               "java.lang.system",
@@ -4116,6 +4470,8 @@
         "type": "java_code_injection",
         "crs_id": "944260",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242",
         "confidence": "1"
       },
       "conditions": [
@@ -4136,6 +4492,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:class\\.module\\.classLoader\\.resources\\.context\\.parent\\.pipeline|springframework\\.context\\.support\\.FileSystemXmlApplicationContext)",
@@ -4154,7 +4516,9 @@
       "name": "Look for Cassandra injections",
       "tags": {
         "type": "nosql_injection",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "943",
+        "capec": "1000/152/248/676"
       },
       "conditions": [
         {
@@ -4168,6 +4532,15 @@
               },
               {
                 "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               },
               {
                 "address": "server.request.headers.no_cookies"
@@ -4187,7 +4560,9 @@
       "name": "OGNL - Look for formatting injection patterns",
       "tags": {
         "type": "java_code_injection",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242"
       },
       "conditions": [
         {
@@ -4208,6 +4583,15 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
               }
             ],
             "regex": "[#%$]{(?:[^}]+[^\\w\\s}\\-_][^}]+|\\d+-\\d+)}",
@@ -4225,6 +4609,8 @@
       "tags": {
         "type": "java_code_injection",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242",
         "confidence": "1"
       },
       "conditions": [
@@ -4246,6 +4632,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "[@#]ognl",
@@ -4263,6 +4655,8 @@
       "tags": {
         "type": "exploit_detection",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242",
         "confidence": "1"
       },
       "conditions": [
@@ -4291,6 +4685,8 @@
       "tags": {
         "type": "js_code_injection",
         "category": "attack_attempt",
+        "cwe": "1321",
+        "capec": "1000/152/242",
         "confidence": "1"
       },
       "conditions": [
@@ -4319,6 +4715,8 @@
       "tags": {
         "type": "js_code_injection",
         "category": "attack_attempt",
+        "cwe": "1321",
+        "capec": "1000/152/242",
         "confidence": "1"
       },
       "conditions": [
@@ -4361,6 +4759,8 @@
       "tags": {
         "type": "java_code_injection",
         "category": "attack_attempt",
+        "cwe": "1336",
+        "capec": "1000/152/242/19",
         "confidence": "1"
       },
       "conditions": [
@@ -4381,6 +4781,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "#(?:set|foreach|macro|parse|if)\\(.*\\)|<#assign.*>"
@@ -4397,6 +4803,8 @@
         "type": "attack_tool",
         "category": "attack_attempt",
         "tool_name": "BurpCollaborator",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -4417,6 +4825,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\b(?:burpcollaborator\\.net|oastify\\.com)\\b"
@@ -4433,6 +4847,8 @@
         "type": "commercial_scanner",
         "category": "attack_attempt",
         "tool_name": "Qualys",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "0"
       },
       "conditions": [
@@ -4453,9 +4869,15 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "\\bqualysperiscope\\.com\\b"
+            "regex": "\\bqualysperiscope\\.com\\b|\\.oscomm\\."
           },
           "operator": "match_regex"
         }
@@ -4469,6 +4891,8 @@
         "type": "commercial_scanner",
         "category": "attack_attempt",
         "tool_name": "Probely",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "0"
       },
       "conditions": [
@@ -4489,6 +4913,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\bprbly\\.win\\b"
@@ -4504,6 +4934,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -4524,9 +4956,15 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "\\b(?:webhook\\.site|\\.canarytokens\\.com|vii\\.one|act1on3\\.ru|gdsburp\\.com)\\b"
+            "regex": "\\b(?:webhook\\.site|\\.canarytokens\\.com|vii\\.one|act1on3\\.ru|gdsburp\\.com|arcticwolf\\.net|oob\\.li|htbiw\\.com|h4\\.vc|mochan\\.cloud|imshopping\\.com|bootstrapnodejs\\.com|mooo-ng\\.com|securitytrails\\.com|canyouhackit\\.io|7bae\\.xyz)\\b"
           },
           "operator": "match_regex"
         }
@@ -4539,6 +4977,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "0"
       },
       "conditions": [
@@ -4559,6 +4999,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\b(?:\\.ngrok\\.io|requestbin\\.com|requestbin\\.net)\\b"
@@ -4575,6 +5021,8 @@
         "type": "commercial_scanner",
         "category": "attack_attempt",
         "tool_name": "Rapid7",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "0"
       },
       "conditions": [
@@ -4595,6 +5043,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\bappspidered\\.rapid7\\."
@@ -4611,6 +5065,8 @@
         "type": "attack_tool",
         "category": "attack_attempt",
         "tool_name": "interact.sh",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -4631,9 +5087,15 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "\\b(?:interact\\.sh|oast\\.(?:pro|live|site|online|fun|me))\\b"
+            "regex": "\\b(?:interact\\.sh|oast\\.(?:pro|live|site|online|fun|me)|indusfacefinder\\.in|where\\.land|syhunt\\.net|tssrt\\.de|boardofcyber\\.io|assetnote-callback\\.com|praetorianlabs\\.dev|netspi\\.sh)\\b"
           },
           "operator": "match_regex"
         }
@@ -4647,6 +5109,8 @@
         "type": "commercial_scanner",
         "category": "attack_attempt",
         "tool_name": "Netsparker",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "0"
       },
       "conditions": [
@@ -4667,9 +5131,207 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "\\b(?:\\.|(?:\\\\|&#)(?:0*46|x0*2e);)r87(?:\\.|(?:\\\\|&#)(?:0*46|x0*2e);)(?:me|com)\\b",
+            "regex": "\\b(?:\\.|(?:\\\\|&#)(?:0*46|x0*2e);)?r87(?:\\.|(?:\\\\|&#)(?:0*46|x0*2e);)(?:me|com)\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 7
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-913-009",
+      "name": "WhiteHat Security OOB domain",
+      "tags": {
+        "type": "commercial_scanner",
+        "category": "attack_attempt",
+        "tool_name": "WhiteHatSecurity",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "confidence": "0"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "regex": "\\bwhsec(?:\\.|(?:\\\\|&#)(?:0*46|x0*2e);)us\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 8
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-913-010",
+      "name": "Nessus OOB domain",
+      "tags": {
+        "type": "commercial_scanner",
+        "category": "attack_attempt",
+        "tool_name": "Nessus",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "confidence": "0"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "regex": "\\b\\.nessus\\.org\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 8
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-913-011",
+      "name": "Watchtowr OOB domain",
+      "tags": {
+        "type": "commercial_scanner",
+        "category": "attack_attempt",
+        "tool_name": "Watchtowr",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "confidence": "0"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "regex": "\\bwatchtowr\\.com\\b",
+            "options": {
+              "case_sensitive": false,
+              "min_length": 8
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "dog-913-012",
+      "name": "AppCheck NG OOB domain",
+      "tags": {
+        "type": "commercial_scanner",
+        "category": "attack_attempt",
+        "tool_name": "AppCheckNG",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "confidence": "0"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "regex": "\\bptst\\.io\\b",
             "options": {
               "case_sensitive": false,
               "min_length": 7
@@ -4686,6 +5348,8 @@
       "tags": {
         "type": "rfi",
         "category": "attack_attempt",
+        "cwe": "98",
+        "capec": "1000/152/175/253/193",
         "confidence": "1"
       },
       "conditions": [
@@ -4700,6 +5364,15 @@
               },
               {
                 "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "^(?i:file|ftps?|https?).*/rfiinc\\.txt\\?+$",
@@ -4714,12 +5387,61 @@
       "transformers": []
     },
     {
+      "id": "dog-932-100",
+      "name": "Shell spawn executing network command",
+      "tags": {
+        "type": "command_injection",
+        "category": "attack_attempt",
+        "cwe": "77",
+        "capec": "1000/152/248/88",
+        "confidence": "0"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "server.request.headers.no_cookies"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "regex": "(?:(?:['\"\\x60({|;&]|(?:^|['\"\\x60({|;&])(?:cmd(?:\\.exe)?\\s+(?:/\\w(?::\\w+)?\\s+)*))(?:ping|curl|wget|telnet)|\\bnslookup)[\\s,]",
+            "options": {
+              "case_sensitive": true,
+              "min_length": 5
+            }
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
       "id": "dog-934-001",
       "name": "XXE - XML file loads external entity",
       "tags": {
         "type": "xxe",
         "category": "attack_attempt",
-        "confidence": "0"
+        "cwe": "91",
+        "capec": "1000/152/248/250",
+        "confidence": "1"
       },
       "conditions": [
         {
@@ -4730,6 +5452,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?:<\\?xml[^>]*>.*)<!ENTITY[^>]+SYSTEM\\s+[^>]+>",
@@ -4749,7 +5477,9 @@
       "tags": {
         "type": "xss",
         "category": "attack_attempt",
-        "confidence": "0"
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
+        "confidence": "1"
       },
       "conditions": [
         {
@@ -4778,9 +5508,15 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "<(?:iframe|esi:include)(?:(?:\\s|/)*\\w+=[\"'\\w]+)*(?:\\s|/)*src(?:doc)?=[\"']?(?:data:|javascript:|http:|//)[^\\s'\"]+['\"]?",
+            "regex": "<(?:iframe|esi:include)(?:(?:\\s|/)*\\w+=[\"'\\w]+)*(?:\\s|/)*src(?:doc)?=[\"']?(?:data:|javascript:|http:|dns:|//)[^\\s'\"]+['\"]?",
             "options": {
               "min_length": 14
             }
@@ -4799,6 +5535,8 @@
       "tags": {
         "type": "xss",
         "category": "attack_attempt",
+        "cwe": "83",
+        "capec": "1000/152/242/63/591/243",
         "confidence": "1"
       },
       "conditions": [
@@ -4819,9 +5557,15 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "https?:\\/\\/(?:.*\\.)?(?:bxss\\.in|xss\\.ht|js\\.rip)",
+            "regex": "https?:\\/\\/(?:.*\\.)?(?:bxss\\.(?:in|me)|xss\\.ht|js\\.rip)",
             "options": {
               "case_sensitive": false
             }
@@ -4837,6 +5581,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5072,6 +5818,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5112,6 +5860,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5152,6 +5902,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5192,6 +5944,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5232,6 +5986,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5272,6 +6028,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5312,6 +6070,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5352,6 +6112,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -5387,11 +6149,55 @@
       "transformers": []
     },
     {
+      "id": "nfd-000-010",
+      "name": "Detect failed attempts to find API documentation",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "confidence": "0"
+      },
+      "conditions": [
+        {
+          "operator": "match_regex",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.response.status"
+              }
+            ],
+            "regex": "^404$",
+            "options": {
+              "case_sensitive": true
+            }
+          }
+        },
+        {
+          "operator": "match_regex",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.uri.raw"
+              }
+            ],
+            "regex": "(?:/swagger\\b|/api[-/]docs?\\b)",
+            "options": {
+              "case_sensitive": false
+            }
+          }
+        }
+      ],
+      "transformers": []
+    },
+    {
       "id": "sqr-000-001",
       "name": "SSRF: Try to access the credential manager of the main cloud services",
       "tags": {
         "type": "ssrf",
         "category": "attack_attempt",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
         "confidence": "1"
       },
       "conditions": [
@@ -5409,6 +6215,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i)^\\W*((http|ftp)s?://)?\\W*((::f{4}:)?(169|(0x)?0*a9|0+251)\\.?(254|(0x)?0*fe|0+376)[0-9a-fx\\.:]+|metadata\\.google\\.internal|metadata\\.goog)\\W*/",
@@ -5428,7 +6240,9 @@
       "name": "Server-side Javascript injection: Try to detect obvious JS injection",
       "tags": {
         "type": "js_code_injection",
-        "category": "attack_attempt"
+        "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242"
       },
       "conditions": [
         {
@@ -5445,6 +6259,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "require\\(['\"][\\w\\.]+['\"]\\)|process\\.\\w+\\([\\w\\.]*\\)|\\.toString\\(\\)",
@@ -5465,6 +6285,8 @@
       "tags": {
         "type": "command_injection",
         "category": "attack_attempt",
+        "cwe": "78",
+        "capec": "1000/152/248/88",
         "confidence": "1"
       },
       "conditions": [
@@ -5485,6 +6307,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i)[&|]\\s*type\\s+%\\w+%\\\\+\\w+\\.ini\\s*[&|]"
@@ -5500,6 +6328,8 @@
       "tags": {
         "type": "command_injection",
         "category": "attack_attempt",
+        "cwe": "78",
+        "capec": "1000/152/248/88",
         "confidence": "1"
       },
       "conditions": [
@@ -5520,6 +6350,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i)[&|]\\s*cat\\s*\\/etc\\/[\\w\\.\\/]*passwd\\s*[&|]"
@@ -5537,6 +6373,8 @@
       "tags": {
         "type": "command_injection",
         "category": "attack_attempt",
+        "cwe": "78",
+        "capec": "1000/152/248/88",
         "confidence": "1"
       },
       "conditions": [
@@ -5557,6 +6395,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "(?i)[&|]\\s*timeout\\s+/t\\s+\\d+\\s*[&|]"
@@ -5572,6 +6416,8 @@
       "tags": {
         "type": "ssrf",
         "category": "attack_attempt",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
         "confidence": "1"
       },
       "conditions": [
@@ -5589,6 +6435,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "http(s?):\\/\\/([A-Za-z0-9\\.\\-\\_]+|\\[[A-Fa-f0-9\\:]+\\]|):5986\\/wsman",
@@ -5607,6 +6459,8 @@
       "tags": {
         "type": "ssrf",
         "category": "attack_attempt",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
         "confidence": "0"
       },
       "conditions": [
@@ -5624,6 +6478,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "^(jar:)?(http|https):\\/\\/([0-9oq]{1,5}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}|[0-9]{1,10})(:[0-9]{1,5})?(\\/[^:@]*)?$"
@@ -5641,6 +6501,8 @@
       "tags": {
         "type": "ssrf",
         "category": "attack_attempt",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
         "confidence": "0"
       },
       "conditions": [
@@ -5658,6 +6520,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "^(jar:)?(http|https):\\/\\/((\\[)?[:0-9a-f\\.x]{2,}(\\])?)(:[0-9]{1,5})?(\\/[^:@]*)?$"
@@ -5675,6 +6543,8 @@
       "tags": {
         "type": "ssrf",
         "category": "attack_attempt",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
         "confidence": "1"
       },
       "conditions": [
@@ -5695,9 +6565,15 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
-            "regex": "(http|https):\\/\\/(?:.*\\.)?(?:burpcollaborator\\.net|localtest\\.me|mail\\.ebc\\.apple\\.com|bugbounty\\.dod\\.network|.*\\.[nx]ip\\.io|oastify\\.com|oast\\.(?:pro|live|site|online|fun|me)|sslip\\.io|requestbin\\.com|requestbin\\.net|hookbin\\.com|webhook\\.site|canarytokens\\.com|interact\\.sh|ngrok\\.io|bugbounty\\.click|prbly\\.win|qualysperiscope\\.com|vii.one|act1on3.ru)"
+            "regex": "(http|https):\\/\\/(?:.*\\.)?(?:burpcollaborator\\.net|localtest\\.me|mail\\.ebc\\.apple\\.com|bugbounty\\.dod\\.network|.*\\.[nx]ip\\.io|oastify\\.com|oast\\.(?:pro|live|site|online|fun|me)|sslip\\.io|requestbin\\.com|requestbin\\.net|hookbin\\.com|webhook\\.site|canarytokens\\.com|interact\\.sh|ngrok\\.io|bugbounty\\.click|prbly\\.win|qualysperiscope\\.com|vii\\.one|act1on3\\.ru)"
           },
           "operator": "match_regex"
         }
@@ -5710,6 +6586,8 @@
       "tags": {
         "type": "ssrf",
         "category": "attack_attempt",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
         "confidence": "0"
       },
       "conditions": [
@@ -5730,6 +6608,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "^(jar:)?((file|netdoc):\\/\\/[\\\\\\/]+|(dict|gopher|ldap|sftp|tftp):\\/\\/.*:[0-9]{1,5})"
@@ -5747,6 +6631,8 @@
       "tags": {
         "type": "exploit_detection",
         "category": "attack_attempt",
+        "cwe": "94",
+        "capec": "1000/152/242",
         "confidence": "1"
       },
       "conditions": [
@@ -5770,6 +6656,12 @@
               },
               {
                 "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
               }
             ],
             "regex": "\\${[^j]*j[^n]*n[^d]*d[^i]*i[^:]*:[^}]*}"
@@ -5787,6 +6679,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Joomla exploitation tool",
         "confidence": "1"
       },
@@ -5814,6 +6708,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Nessus",
         "confidence": "1"
       },
@@ -5841,6 +6737,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Arachni",
         "confidence": "1"
       },
@@ -5868,6 +6766,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Jorgee",
         "confidence": "1"
       },
@@ -5895,6 +6795,8 @@
       "tags": {
         "type": "commercial_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Probely",
         "confidence": "0"
       },
@@ -5922,6 +6824,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Metis",
         "confidence": "1"
       },
@@ -5949,6 +6853,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "SQLPowerInjector",
         "confidence": "1"
       },
@@ -5976,6 +6882,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "N-Stealth",
         "confidence": "1"
       },
@@ -6003,6 +6911,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Brutus",
         "confidence": "1"
       },
@@ -6030,6 +6940,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "confidence": "1"
       },
       "conditions": [
@@ -6056,6 +6968,8 @@
       "tags": {
         "type": "commercial_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Netsparker",
         "confidence": "0"
       },
@@ -6083,6 +6997,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "JAASCois",
         "confidence": "1"
       },
@@ -6110,6 +7026,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Nsauditor",
         "confidence": "1"
       },
@@ -6137,6 +7055,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Paros",
         "confidence": "1"
       },
@@ -6164,6 +7084,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "DirBuster",
         "confidence": "1"
       },
@@ -6191,6 +7113,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Pangolin",
         "confidence": "1"
       },
@@ -6218,6 +7142,8 @@
       "tags": {
         "type": "commercial_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Qualys",
         "confidence": "0"
       },
@@ -6245,6 +7171,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "SQLNinja",
         "confidence": "1"
       },
@@ -6272,6 +7200,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Nikto",
         "confidence": "1"
       },
@@ -6299,6 +7229,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "BlackWidow",
         "confidence": "1"
       },
@@ -6326,6 +7258,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Grendel-Scan",
         "confidence": "1"
       },
@@ -6353,6 +7287,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Havij",
         "confidence": "1"
       },
@@ -6380,6 +7316,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "w3af",
         "confidence": "1"
       },
@@ -6407,6 +7345,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Nmap",
         "confidence": "1"
       },
@@ -6434,6 +7374,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Nessus",
         "confidence": "1"
       },
@@ -6461,6 +7403,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "EvilScanner",
         "confidence": "1"
       },
@@ -6488,6 +7432,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "WebFuck",
         "confidence": "1"
       },
@@ -6515,6 +7461,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "OpenVAS",
         "confidence": "1"
       },
@@ -6542,6 +7490,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Spider-Pig",
         "confidence": "1"
       },
@@ -6569,6 +7519,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Zgrab",
         "confidence": "1"
       },
@@ -6596,6 +7548,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Zmeu",
         "confidence": "1"
       },
@@ -6623,6 +7577,8 @@
       "tags": {
         "type": "commercial_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "GoogleSecurityScanner",
         "confidence": "0"
       },
@@ -6650,6 +7606,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Commix",
         "confidence": "1"
       },
@@ -6677,6 +7635,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Gobuster",
         "confidence": "1"
       },
@@ -6704,6 +7664,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "CGIchk",
         "confidence": "1"
       },
@@ -6731,6 +7693,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "FFUF",
         "confidence": "1"
       },
@@ -6758,6 +7722,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Nuclei",
         "confidence": "1"
       },
@@ -6785,6 +7751,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Tsunami",
         "confidence": "1"
       },
@@ -6812,6 +7780,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Nimbostratus",
         "confidence": "1"
       },
@@ -6839,6 +7809,8 @@
       "tags": {
         "type": "security_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Datadog Canary Test",
         "confidence": "1"
       },
@@ -6872,6 +7844,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Datadog Canary Test",
         "confidence": "1"
       },
@@ -6908,6 +7882,8 @@
       "tags": {
         "type": "commercial_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "AlertLogic",
         "confidence": "0"
       },
@@ -6935,6 +7911,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "wfuzz",
         "confidence": "1"
       },
@@ -6962,6 +7940,8 @@
       "tags": {
         "type": "commercial_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Detectify",
         "confidence": "0"
       },
@@ -6989,6 +7969,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "BSQLBF",
         "confidence": "1"
       },
@@ -7016,6 +7998,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "masscan",
         "confidence": "1"
       },
@@ -7043,6 +8027,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "WPScan",
         "confidence": "1"
       },
@@ -7070,6 +8056,8 @@
       "tags": {
         "type": "commercial_scanner",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Aon",
         "confidence": "0"
       },
@@ -7092,11 +8080,14 @@
       "transformers": []
     },
     {
-      "id": "ua0-600-6xx",
-      "name": "Stealthy scanner",
+      "id": "ua0-600-63x",
+      "name": "FeroxBuster",
       "tags": {
-        "type": "security_scanner",
+        "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "tool_name": "feroxbuster",
         "confidence": "1"
       },
       "conditions": [
@@ -7110,7 +8101,35 @@
                 ]
               }
             ],
-            "regex": "mozilla/4\\.0 \\(compatible(; msie (?:6\\.0; win32|4\\.0; Windows NT))?\\)",
+            "regex": "^feroxbuster/"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
+    },
+    {
+      "id": "ua0-600-6xx",
+      "name": "Stealthy scanner",
+      "tags": {
+        "type": "security_scanner",
+        "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "confidence": "1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "mozilla/4\\.0 \\(compatible(; msie (?:6\\.0; (?:win32|Windows NT 5\\.0)|4\\.0; Windows NT))?\\)",
             "options": {
               "case_sensitive": false
             }
@@ -7126,6 +8145,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "SQLmap",
         "confidence": "1"
       },
@@ -7153,6 +8174,8 @@
       "tags": {
         "type": "attack_tool",
         "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
         "tool_name": "Skipfish",
         "confidence": "1"
       },
@@ -7173,6 +8196,1125 @@
         }
       ],
       "transformers": []
+    }
+  ],
+  "processors": [
+    {
+      "id": "extract-content",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.body"
+              }
+            ],
+            "output": "_dd.appsec.s.req.body"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.cookies"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "output": "_dd.appsec.s.req.query"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.request.path_params"
+              }
+            ],
+            "output": "_dd.appsec.s.req.params"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.body"
+              }
+            ],
+            "output": "_dd.appsec.s.res.body"
+          },
+          {
+            "inputs": [
+              {
+                "address": "graphql.server.all_resolvers"
+              }
+            ],
+            "output": "_dd.appsec.s.graphql.all_resolvers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "graphql.server.resolver"
+              }
+            ],
+            "output": "_dd.appsec.s.graphql.resolver"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "payment"
+            }
+          },
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    },
+    {
+      "id": "extract-headers",
+      "generator": "extract_schema",
+      "conditions": [
+        {
+          "operator": "equals",
+          "parameters": {
+            "inputs": [
+              {
+                "address": "waf.context.processor",
+                "key_path": [
+                  "extract-schema"
+                ]
+              }
+            ],
+            "type": "boolean",
+            "value": true
+          }
+        }
+      ],
+      "parameters": {
+        "mappings": [
+          {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.req.headers"
+          },
+          {
+            "inputs": [
+              {
+                "address": "server.response.headers.no_cookies"
+              }
+            ],
+            "output": "_dd.appsec.s.res.headers"
+          }
+        ],
+        "scanners": [
+          {
+            "tags": {
+              "category": "credentials"
+            }
+          },
+          {
+            "tags": {
+              "category": "pii"
+            }
+          }
+        ]
+      },
+      "evaluate": false,
+      "output": true
+    }
+  ],
+  "scanners": [
+    {
+      "id": "JU1sRk3mSzqSUJn6GrVn7g",
+      "name": "American Express Card Scanner (4+4+4+3 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{2}(?:(?:\\s\\d{4}\\s\\d{4}\\s\\d{3})|(?:\\,\\d{4}\\,\\d{4}\\,\\d{3})|(?:-\\d{4}-\\d{4}-\\d{3})|(?:\\.\\d{4}\\.\\d{4}\\.\\d{3}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "edmH513UTQWcRiQ9UnzHlw-mod",
+      "name": "American Express Card Scanner (4+6|5+5|6 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{2}(?:(?:\\s\\d{5,6}\\s\\d{5,6})|(?:\\.\\d{5,6}\\.\\d{5,6})|(?:-\\d{5,6}-\\d{5,6})|(?:,\\d{5,6},\\d{5,6}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "e6K4h_7qTLaMiAbaNXoSZA",
+      "name": "American Express Card Scanner (8+7 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{6}(?:(?:\\s\\d{7})|(?:\\,\\d{7})|(?:-\\d{7})|(?:\\.\\d{7}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "K2rZflWzRhGM9HiTc6whyQ",
+      "name": "American Express Card Scanner (1x15 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b3[47]\\d{13}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 15
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "amex",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9d7756e343cefa22a5c098e1092590f806eb5446",
+      "name": "Basic Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^basic\\s+[A-Za-z0-9+/=]+",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 7
+          }
+        }
+      },
+      "tags": {
+        "type": "basic_auth",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "mZy8XjZLReC9smpERXWnnw",
+      "name": "Bearer Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^bearer\\s+[-a-z0-9._~+/]{4,}",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "bearer_token",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "450239afc250a19799b6c03dc0e16fd6a4b2a1af",
+      "name": "Canadian Social Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:social[\\s_]?(?:insurance(?:\\s+number)?)?|SIN|Canadian[\\s_]?(?:social[\\s_]?(?:insurance)?|insurance[\\s_]?number)?)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}-\\d{3}-\\d{3}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "canadian_sin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "87a879ff33693b46c8a614d8211f5a2c289beca0",
+      "name": "Digest Authentication Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bauthorization\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^digest\\s+",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 7
+          }
+        }
+      },
+      "tags": {
+        "type": "digest_auth",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "qWumeP1GQUa_E4ffAnT-Yg",
+      "name": "American Express Card Scanner (1x14 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "(?:30[0-59]\\d|3[689]\\d{2})(?:\\d{10})",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 14
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "NlTWWM5LS6W0GSqBLuvtRw",
+      "name": "Diners Card Scanner (4+4+4+2 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d|3[689]\\d{2})(?:(?:\\s\\d{4}\\s\\d{4}\\s\\d{2})|(?:\\,\\d{4}\\,\\d{4}\\,\\d{2})|(?:-\\d{4}-\\d{4}-\\d{2})|(?:\\.\\d{4}\\.\\d{4}\\.\\d{2}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "Xr5VdbQSTXitYGGiTfxBpw",
+      "name": "Diners Card Scanner (4+6+4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d|3[689]\\d{2})(?:(?:\\s\\d{6}\\s\\d{4})|(?:\\.\\d{6}\\.\\d{4})|(?:-\\d{6}-\\d{4})|(?:,\\d{6},\\d{4}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "gAbunN_WQNytxu54DjcbAA-mod",
+      "name": "Diners Card Scanner (8+6 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:30[0-59]\\d{5}|3[689]\\d{6})\\s?(?:(?:\\s\\d{6})|(?:\\,\\d{6})|(?:-\\d{6})|(?:\\.\\d{6}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 14
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "diners",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9cs4qCfEQBeX17U7AepOvQ",
+      "name": "MasterCard Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:6221(?:2[6-9]|[3-9][0-9])\\d{2}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8})|6229(?:[01][0-9]|2[0-5])\\d{2}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8})|(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])\\d{4}(?:,\\d{8}|\\s\\d{8}|-\\d{8}|\\.\\d{8}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "YBIDWJIvQWW_TFOyU0CGJg",
+      "name": "Discover Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:(?:6221(?:2[6-9]|[3-9][0-9])\\d{2}(?:,\\d{4}){2})|(?:6221\\s(?:2[6-9]|[3-9][0-9])\\d{2}(?:\\s\\d{4}){2})|(?:6221\\.(?:2[6-9]|[3-9][0-9])\\d{2}(?:\\.\\d{4}){2})|(?:6221-(?:2[6-9]|[3-9][0-9])\\d{2}(?:-\\d{4}){2}))|(?:(?:6229(?:[01][0-9]|2[0-5])\\d{2}(?:,\\d{4}){2})|(?:6229\\s(?:[01][0-9]|2[0-5])\\d{2}(?:\\s\\d{4}){2})|(?:6229\\.(?:[01][0-9]|2[0-5])\\d{2}(?:\\.\\d{4}){2})|(?:6229-(?:[01][0-9]|2[0-5])\\d{2}(?:-\\d{4}){2}))|(?:(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "12cpbjtVTMaMutFhh9sojQ",
+      "name": "Discover Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:6221(?:2[6-9]|[3-9][0-9])\\d{10}|6229(?:[01][0-9]|2[0-5])\\d{10}|(?:6011|65\\d{2}|64[4-9]\\d|622[2-8])\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "discover",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "PuXiVTCkTHOtj0Yad1ppsw",
+      "name": "Standard E-mail Address",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:e[-\\s]?)?mail|address|sender|\\bto\\b|from|recipient)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 2
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[\\w!#$%&'*+/=?`{|}~^-]+(?:\\.[\\w!#$%&'*+/=?`{|}~^-]+)*(%40|@)(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,6}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 5
+          }
+        }
+      },
+      "tags": {
+        "type": "email",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "8VS2RKxzR8a_95L5fuwaXQ",
+      "name": "IBAN",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:iban|account|sender|receiver)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:NO\\d{2}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{3}|BE\\d{2}(?:[ \\-]?\\d{4}){3}|(?:DK|FO|FI|GL|SD)\\d{2}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|NL\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{2}|MK\\d{2}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]\\d{2}|SI\\d{17}|(?:AT|BA|EE|LT|XK)\\d{18}|(?:LU|KZ|EE|LT)\\d{5}[A-Z0-9]{13}|LV\\d{2}[A-Z]{4}[A-Z0-9]{13}|(?:LI|CH)\\d{2}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]|HR\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d|GE\\d{2}[ \\-]?[A-Z0-9]{2}\\d{2}\\d{14}|VA\\d{20}|BG\\d{2}[A-Z]{4}\\d{6}[A-Z0-9]{8}|BH\\d{2}[A-Z]{4}[A-Z0-9]{14}|GB\\d{2}[A-Z]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|IE\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{2}|(?:CR|DE|ME|RS)\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d{2}|(?:AE|TL|IL)\\d{2}(?:[ \\-]?\\d{4}){4}[ \\-]?\\d{3}|GI\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){3}[ \\-]?[A-Z0-9]{3}|IQ\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){3}[ \\-]?\\d{3}|MD\\d{2}(?:[ \\-]?[A-Z0-9]{4}){5}|SA\\d{2}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){4}|RO\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){4}|(?:PK|VG)\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){4}|AD\\d{2}(?:[ \\-]?\\d{4}){2}(?:[ \\-]?[A-Z0-9]{4}){3}|(?:CZ|SK|ES|SE|TN)\\d{2}(?:[ \\-]?\\d{4}){5}|(?:LY|PT|ST)\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d|TR\\d{2}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{4}){3}[ \\-]?[A-Z0-9]{2}|IS\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{2}|(?:IT|SM)\\d{2}[ \\-]?[A-Z]\\d{3}[ \\-]?\\d{4}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]{3}|GR\\d{2}[ \\-]?\\d{4}[ \\-]?\\d{3}[A-Z0-9](?:[ \\-]?[A-Z0-9]{4}){3}[A-Z0-9]{3}|(?:FR|MC)\\d{2}(?:[ \\-]?\\d{4}){2}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){2}[ \\-]?[A-Z0-9]\\d{2}|MR\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{3}|(?:SV|DO)\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){5}|BY\\d{2}[ \\-]?[A-Z]{4}[ \\-]?\\d{4}(?:[ \\-]?[A-Z0-9]{4}){4}|GT\\d{2}(?:[ \\-]?[A-Z0-9]{4}){6}|AZ\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{5}){4}|LB\\d{2}[ \\-]?\\d{4}(?:[ \\-]?[A-Z0-9]{5}){4}|(?:AL|CY)\\d{2}(?:[ \\-]?\\d{4}){2}(?:[ \\-]?[A-Z0-9]{4}){4}|(?:HU|PL)\\d{2}(?:[ \\-]?\\d{4}){6}|QA\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){5}[ \\-]?[A-Z0-9]|PS\\d{2}[ \\-]?[A-Z0-9]{4}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d|UA\\d{2}[ \\-]?\\d{4}[ \\-]?\\d{2}[A-Z0-9]{2}(?:[ \\-]?[A-Z0-9]{4}){4}[ \\-]?[A-Z0-9]|BR\\d{2}(?:[ \\-]?\\d{4}){5}[ \\-]?\\d{3}[A-Z0-9][ \\-]?[A-Z0-9]|EG\\d{2}(?:[ \\-]?\\d{4}){6}\\d|MU\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){4}\\d{3}[A-Z][ \\-]?[A-Z]{2}|(?:KW|JO)\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){5}[ \\-]?[A-Z0-9]{2}|MT\\d{2}[ \\-]?[A-Z]{4}[ \\-]?\\d{4}[ \\-]?\\d[A-Z0-9]{3}(?:[ \\-]?[A-Z0-9]{3}){4}[ \\-]?[A-Z0-9]{3}|SC\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?\\d{4}){5}[ \\-]?[A-Z]{3}|LC\\d{2}[ \\-]?[A-Z]{4}(?:[ \\-]?[A-Z0-9]{4}){6})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 15
+          }
+        }
+      },
+      "tags": {
+        "type": "iban",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "h6WJcecQTwqvN9KeEtwDvg",
+      "name": "JCB Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "gcEaMu_VSJ2-bGCEkgyC0w",
+      "name": "JCB Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "imTliuhXT5GAeRNhqChXQQ",
+      "name": "JCB Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b35(?:2[89]|[3-9][0-9])(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "jcb",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "9osY3xc9Q7ONAV0zw9Uz4A",
+      "name": "JSON Web Token",
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bey[I-L][\\w=-]+\\.ey[I-L][\\w=-]+(\\.[\\w.+\\/=-]+)?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 20
+          }
+        }
+      },
+      "tags": {
+        "type": "json_web_token",
+        "category": "credentials"
+      }
+    },
+    {
+      "id": "d1Q9D3YMRxuVKf6CZInJPw",
+      "name": "Maestro Card Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{2}|6\\d{3})(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "M3YIQKKjRVmoeQuM3pjzrw",
+      "name": "Maestro Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{6}|6\\d{7})(?:\\s\\d{8}|\\.\\d{8}|-\\d{8}|,\\d{8})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "hRxiQBlSSVKcjh5U7LZYLA",
+      "name": "Maestro Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:5[06-9]\\d{2}|6\\d{3})(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "maestro",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "NwhIYNS4STqZys37WlaIKA",
+      "name": "MasterCard Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:(?:\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "axxJkyjhRTOuhjwlsA35Vw",
+      "name": "MasterCard Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3}|(?:,\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "76EhmoK3TPqJcpM-fK0pLw",
+      "name": "MasterCard Scanner (1x16 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:(?:5[1-5]\\d{2})|(?:222[1-9])|(?:22[3-9]\\d)|(?:2[3-6]\\d{2})|(?:27[0-1]\\d)|(?:2720))(?:\\d{12})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "mastercard",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "de0899e0cbaaa812bb624cf04c912071012f616d-mod",
+      "name": "UK National Insurance Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "^nin$|\\binsurance\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-Z]{2}[\\s-]?\\d{6}[\\s-]?[A-Z]?\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "uk_nin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "d962f7ddb3f55041e39195a60ff79d4814a7c331",
+      "name": "US Passport Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\bpassport\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[0-9A-Z]{9}\\b|\\b[0-9]{6}[A-Z][0-9]{2}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 8
+          }
+        }
+      },
+      "tags": {
+        "type": "passport_number",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "7771fc3b-b205-4b93-bcef-28608c5c1b54",
+      "name": "United States Social Security Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:SSN|(?:(?:social)?[\\s_]?(?:security)?[\\s_]?(?:number)?)?)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b\\d{3}[-\\s\\.]{1}\\d{2}[-\\s\\.]{1}\\d{4}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 11
+          }
+        }
+      },
+      "tags": {
+        "type": "us_ssn",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "ac6d683cbac77f6e399a14990793dd8fd0fca333",
+      "name": "US Vehicle Identification Number Scanner",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:vehicle[_\\s-]*identification[_\\s-]*number|vin)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b[A-HJ-NPR-Z0-9]{17}\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 17
+          }
+        }
+      },
+      "tags": {
+        "type": "vin",
+        "category": "pii"
+      }
+    },
+    {
+      "id": "wJIgOygRQhKkR69b_9XbRQ",
+      "name": "Visa Card Scanner (2x8 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b4\\d{3}(?:(?:\\d{4}(?:(?:,\\d{8})|(?:-\\d{8})|(?:\\s\\d{8})|(?:\\.\\d{8}))))\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "0o71SJxXQNK7Q6gMbBesFQ",
+      "name": "Visa Card Scanner (4x4 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b4\\d{3}(?:(?:,\\d{4}){3}|(?:\\s\\d{4}){3}|(?:\\.\\d{4}){3}|(?:-\\d{4}){3})\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 16
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
+    },
+    {
+      "id": "QrHD6AfgQm6z-j0wStxTvA",
+      "name": "Visa Card Scanner (1x15 & 1x16 & 1x19 digits)",
+      "key": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "\\b(?:card|cc|credit|debit|payment|amex|visa|mastercard|maestro|discover|jcb|diner)\\b",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 3
+          }
+        }
+      },
+      "value": {
+        "operator": "match_regex",
+        "parameters": {
+          "regex": "4[0-9]{12}(?:[0-9]{3})?",
+          "options": {
+            "case_sensitive": false,
+            "min_length": 13
+          }
+        }
+      },
+      "tags": {
+        "type": "card",
+        "card_type": "visa",
+        "category": "payment"
+      }
     }
   ]
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Benchmarks.Trace.csproj
@@ -33,7 +33,7 @@
     <Content Include="..\..\..\src\Datadog.Trace\AppSec\Waf\ConfigFiles\rule-set.json">
       <Link>rule-set.json</Link>
     </Content>
-    <Content Update="Asm\rule-set.1.7.2.json">
+    <Content Update="Asm\rule-set.1.10.0.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
## Summary of changes

Run fewer but more realistic benchmarks.

## Reason for change

We noticed that the throughput tests showed a slow down while while the benchmarks didn't.

## Implementation details

We split the `AppSecWafBenchmark` class in two:
* `AppSecWafBenchmark` now tests a payload made of addresses with reasonably realistic values. We don't change the size of the payload any more, just whether or not there's an attack. The use of realistic address mean the results agree with what the throughput tests show.
* `AppSecEncoderBenchmark` uses the payloads that `AppSecWafBenchmark` used to, which don't use realistic addresses, but vary in nesting. They are just tested with the encoder part, which is more sensitive to changes in the payload size.  

