### PR TITLE
[ASM] Fix path params not being all transformed to waf encodable values

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -200,6 +200,7 @@
    <assembly fullname="System.Data.SqlClient" />
    <assembly fullname="System.Data.SQLite" />
    <assembly fullname="System.Diagnostics.Debug">
+      <type fullname="System.Diagnostics.Debug" />
       <type fullname="System.Diagnostics.Debugger" />
       <type fullname="System.Diagnostics.DebuggerBrowsableAttribute" />
       <type fullname="System.Diagnostics.DebuggerBrowsableState" />
@@ -507,6 +508,7 @@
       <type fullname="System.Diagnostics.CodeAnalysis.DisallowNullAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute" />
+      <type fullname="System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.MaybeNullAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.MemberNotNullAttribute" />
@@ -516,6 +518,8 @@
       <type fullname="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute" />
       <type fullname="System.Diagnostics.ConditionalAttribute" />
+      <type fullname="System.Diagnostics.Debug" />
+      <type fullname="System.Diagnostics.Debug/AssertInterpolatedStringHandler" />
       <type fullname="System.Diagnostics.DebuggableAttribute" />
       <type fullname="System.Diagnostics.DebuggableAttribute/DebuggingModes" />
       <type fullname="System.Diagnostics.Debugger" />
@@ -607,6 +611,7 @@
       <type fullname="System.MethodAccessException" />
       <type fullname="System.MidpointRounding" />
       <type fullname="System.MulticastDelegate" />
+      <type fullname="System.Net.WebUtility" />
       <type fullname="System.NonSerializedAttribute" />
       <type fullname="System.NotImplementedException" />
       <type fullname="System.NotSupportedException" />
@@ -844,6 +849,7 @@
       <type fullname="System.IO.TextReader" />
       <type fullname="System.IO.TextWriter" />
       <type fullname="System.Math" />
+      <type fullname="System.Net.WebUtility" />
       <type fullname="System.Numerics.BitOperations" />
       <type fullname="System.OperatingSystem" />
       <type fullname="System.PlatformID" />

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -200,7 +200,6 @@
    <assembly fullname="System.Data.SqlClient" />
    <assembly fullname="System.Data.SQLite" />
    <assembly fullname="System.Diagnostics.Debug">
-      <type fullname="System.Diagnostics.Debug" />
       <type fullname="System.Diagnostics.Debugger" />
       <type fullname="System.Diagnostics.DebuggerBrowsableAttribute" />
       <type fullname="System.Diagnostics.DebuggerBrowsableState" />
@@ -508,7 +507,6 @@
       <type fullname="System.Diagnostics.CodeAnalysis.DisallowNullAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.DoesNotReturnIfAttribute" />
-      <type fullname="System.Diagnostics.CodeAnalysis.DynamicDependencyAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.MaybeNullAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.MemberNotNullAttribute" />
@@ -518,8 +516,6 @@
       <type fullname="System.Diagnostics.CodeAnalysis.NotNullWhenAttribute" />
       <type fullname="System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessageAttribute" />
       <type fullname="System.Diagnostics.ConditionalAttribute" />
-      <type fullname="System.Diagnostics.Debug" />
-      <type fullname="System.Diagnostics.Debug/AssertInterpolatedStringHandler" />
       <type fullname="System.Diagnostics.DebuggableAttribute" />
       <type fullname="System.Diagnostics.DebuggableAttribute/DebuggingModes" />
       <type fullname="System.Diagnostics.Debugger" />
@@ -611,7 +607,6 @@
       <type fullname="System.MethodAccessException" />
       <type fullname="System.MidpointRounding" />
       <type fullname="System.MulticastDelegate" />
-      <type fullname="System.Net.WebUtility" />
       <type fullname="System.NonSerializedAttribute" />
       <type fullname="System.NotImplementedException" />
       <type fullname="System.NotSupportedException" />
@@ -849,7 +844,6 @@
       <type fullname="System.IO.TextReader" />
       <type fullname="System.IO.TextWriter" />
       <type fullname="System.Math" />
-      <type fullname="System.Net.WebUtility" />
       <type fullname="System.Numerics.BitOperations" />
       <type fullname="System.OperatingSystem" />
       <type fullname="System.PlatformID" />

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -212,7 +212,7 @@ internal readonly partial struct SecurityCoordinator
         return formData;
     }
 
-    internal IDictionary<string, object> GetPathParams() => _context.Request.RequestContext.RouteData.Values.ToDictionary(c => c.Key, c => c.Value);
+    internal object GetPathParams() => ObjectExtractor.Extract(_context.Request.RequestContext.RouteData.Values);
 
     /// <summary>
     /// Framework can do it all at once, but framework only unfortunately


### PR DESCRIPTION
## Summary of changes

In some cases in Net FX we would get sub values in the dictionary of path params with a complex object like so:
![image](https://github.com/DataDog/dd-trace-dotnet/assets/8353486/cdd695cd-a03b-46f4-bbae-dc462d4cace2)
which would end up in an error encoding it later: `[WRN] Couldn't encode object of unknown type System.Web.Http.Routing.HttpRouteData, falling back to ToString` 
This makes sure it's transformed first.

## Reason for change

Getting error `[WRN] Couldn't encode object of unknown type System.Web.Http.Routing.HttpRouteData, falling back to ToString` and not encoding all params to the waf

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
