### PR TITLE
[tracer] match sampling rules by resource name and span tags

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -19,6 +19,12 @@ namespace Datadog.Trace.Sampling
 {
     internal class CustomSamplingRule : ISamplingRule
     {
+#if NETCOREAPP3_1_OR_GREATER
+        private const RegexOptions DefaultRegexOptions = RegexOptions.Compiled | RegexOptions.NonBacktracking;
+#else
+        private const RegexOptions DefaultRegexOptions = RegexOptions.Compiled;
+#endif
+
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CustomSamplingRule>();
 
         private readonly float _samplingRate;

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -140,9 +140,9 @@ namespace Datadog.Trace.Sampling
                 // if a regex is null (not specified), it always matches.
                 // stop as soon as we find a non-match.
                 // TODO: match tags
-                return (_serviceNameRegex?.Match(span.ServiceName).Success ?? true) &&
-                       (_operationNameRegex?.Match(span.OperationName).Success ?? true) &&
-                       (_resourceNameRegex?.Match(span.ResourceName).Success ?? true);
+                return (_serviceNameRegex is null || _serviceNameRegex.Match(span.ServiceName).Success) &&
+                       (_operationNameRegex is null || _operationNameRegex.Match(span.OperationName).Success) &&
+                       (_resourceNameRegex is null || _resourceNameRegex.Match(span.ResourceName).Success);
             }
             catch (RegexMatchTimeoutException e)
             {

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -118,28 +118,13 @@ namespace Datadog.Trace.Sampling
                 return false;
             }
 
-            try
-            {
-                // if a regex is null (not specified), it always matches.
-                // stop as soon as we find a non-match.
-                return (_serviceNameRegex is null || _serviceNameRegex.Match(span.ServiceName).Success) &&
-                       (_operationNameRegex is null || _operationNameRegex.Match(span.OperationName).Success) &&
-                       (_resourceNameRegex is null || _resourceNameRegex.Match(span.ResourceName).Success) &&
-                       (_tagRegexes is null || _tagRegexes.Count == 0 || SamplingRuleHelper.MatchSpanByTags(span, _tagRegexes));
-            }
-            catch (RegexMatchTimeoutException e)
-            {
-                // flag regex so we don't try to use it again
-                _regexTimedOut = true;
-
-                Log.Error(
-                    e,
-                    """Regex timed out when trying to match value "{Input}" against pattern "{Pattern}".""",
-                    e.Input,
-                    e.Pattern);
-
-                return false;
-            }
+            return SamplingRuleHelper.IsMatch(
+                span,
+                serviceNameRegex: _serviceNameRegex,
+                operationNameRegex: _operationNameRegex,
+                resourceNameRegex: _resourceNameRegex,
+                tagRegexes: _tagRegexes,
+                out _regexTimedOut);
         }
 
         public float GetSamplingRate(Span span)

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Sampling
             string serviceNamePattern,
             string operationNamePattern,
             string resourceNamePattern,
-            Dictionary<string, string> tagPatterns)
+            ICollection<KeyValuePair<string, string>> tagPatterns)
         {
             _samplingRate = rate;
             RuleName = ruleName;
@@ -46,21 +46,7 @@ namespace Datadog.Trace.Sampling
             _serviceNameRegex = RegexBuilder.Build(serviceNamePattern, patternFormat);
             _operationNameRegex = RegexBuilder.Build(operationNamePattern, patternFormat);
             _resourceNameRegex = RegexBuilder.Build(resourceNamePattern, patternFormat);
-
-            if (tagPatterns is { Count: > 0 })
-            {
-                var tagRegexList = new List<KeyValuePair<string, Regex>>(tagPatterns.Count);
-
-                foreach (var tagPattern in tagPatterns)
-                {
-                    if (RegexBuilder.Build(tagPattern.Value, patternFormat) is { } regex)
-                    {
-                        tagRegexList.Add(new KeyValuePair<string, Regex>(tagPattern.Key, regex));
-                    }
-                }
-
-                _tagRegexes = tagRegexList;
-            }
+            _tagRegexes = RegexBuilder.Build(tagPatterns, patternFormat);
 
             if (_serviceNameRegex is null &&
                 _operationNameRegex is null &&

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -158,6 +158,12 @@ namespace Datadog.Trace.Sampling
 
             [JsonProperty(PropertyName = "service")]
             public string Service { get; set; }
+
+            [JsonProperty(PropertyName = "resource")]
+            public string Resource { get; set; }
+
+            [JsonProperty(PropertyName = "tags")]
+            public KeyValuePair<string, string>[] Tags { get; set; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -54,9 +54,7 @@ namespace Datadog.Trace.Sampling
 
                 foreach (var tagPattern in tagPatterns)
                 {
-                    var regex = RegexBuilder.Build(tagPattern.Value, patternFormat);
-
-                    if (regex != null)
+                    if (RegexBuilder.Build(tagPattern.Value, patternFormat) is { } regex)
                     {
                         tagRegexList.Add(new KeyValuePair<string, Regex>(tagPattern.Key, regex));
                     }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -19,12 +19,6 @@ namespace Datadog.Trace.Sampling
 {
     internal class CustomSamplingRule : ISamplingRule
     {
-#if NETCOREAPP3_1_OR_GREATER
-        private const RegexOptions DefaultRegexOptions = RegexOptions.Compiled | RegexOptions.NonBacktracking;
-#else
-        private const RegexOptions DefaultRegexOptions = RegexOptions.Compiled;
-#endif
-
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CustomSamplingRule>();
 
         private readonly float _samplingRate;
@@ -145,6 +139,7 @@ namespace Datadog.Trace.Sampling
             {
                 // if a regex is null (not specified), it always matches.
                 // stop as soon as we find a non-match.
+                // TODO: match tags
                 return (_serviceNameRegex?.Match(span.ServiceName).Success ?? true) &&
                        (_operationNameRegex?.Match(span.OperationName).Success ?? true) &&
                        (_resourceNameRegex?.Match(span.ResourceName).Success ?? true);

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 
@@ -39,7 +38,7 @@ namespace Datadog.Trace.Sampling
             string serviceNamePattern,
             string operationNamePattern,
             string resourceNamePattern,
-            KeyValuePair<string, string>[] tagPatterns)
+            Dictionary<string, string> tagPatterns)
         {
             _samplingRate = rate;
             RuleName = ruleName;
@@ -48,9 +47,9 @@ namespace Datadog.Trace.Sampling
             _operationNameRegex = RegexBuilder.Build(operationNamePattern, patternFormat);
             _resourceNameRegex = RegexBuilder.Build(resourceNamePattern, patternFormat);
 
-            if (tagPatterns is { Length: > 0 })
+            if (tagPatterns is { Count: > 0 })
             {
-                var tagRegexList = new List<KeyValuePair<string, Regex>>(tagPatterns.Length);
+                var tagRegexList = new List<KeyValuePair<string, Regex>>(tagPatterns.Count);
 
                 foreach (var tagPattern in tagPatterns)
                 {
@@ -183,7 +182,7 @@ namespace Datadog.Trace.Sampling
             public string Resource { get; set; }
 
             [JsonProperty(PropertyName = "tags")]
-            public KeyValuePair<string, string>[] Tags { get; set; }
+            public Dictionary<string, string> Tags { get; set; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
@@ -5,8 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using Datadog.Trace.Logging;
-using Datadog.Trace.Util;
 
 #if NETCOREAPP3_1_OR_GREATER
 using Datadog.Trace.Vendors.IndieSystem.Text.RegularExpressions;
@@ -20,8 +18,6 @@ namespace Datadog.Trace.Sampling;
 
 internal static class RegexBuilder
 {
-    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RegexBuilder));
-
     public static Regex? Build(string? pattern, string format)
     {
         if (pattern is null)
@@ -57,11 +53,11 @@ internal static class RegexBuilder
         }
     }
 
-    public static List<KeyValuePair<string, Regex>> Build(ICollection<KeyValuePair<string, string>> patterns, string format)
+    public static List<KeyValuePair<string, Regex?>> Build(ICollection<KeyValuePair<string, string?>> patterns, string format)
     {
         if (patterns is { Count: > 0 })
         {
-            var regexList = new List<KeyValuePair<string, Regex>>(patterns.Count);
+            var regexList = new List<KeyValuePair<string, Regex?>>(patterns.Count);
 
             foreach (var pattern in patterns)
             {
@@ -69,7 +65,7 @@ internal static class RegexBuilder
 
                 if (regex != null)
                 {
-                    regexList.Add(new KeyValuePair<string, Regex>(pattern.Key, regex));
+                    regexList.Add(new KeyValuePair<string, Regex?>(pattern.Key, regex));
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 
@@ -54,6 +55,28 @@ internal static class RegexBuilder
             default:
                 return null; // should be unreachable because we validate the format earlier
         }
+    }
+
+    public static List<KeyValuePair<string, Regex>> Build(ICollection<KeyValuePair<string, string>> patterns, string format)
+    {
+        if (patterns is { Count: > 0 })
+        {
+            var regexList = new List<KeyValuePair<string, Regex>>(patterns.Count);
+
+            foreach (var pattern in patterns)
+            {
+                var regex = Build(pattern.Value, format);
+
+                if (regex != null)
+                {
+                    regexList.Add(new KeyValuePair<string, Regex>(pattern.Key, regex));
+                }
+            }
+
+            return regexList;
+        }
+
+        return [];
     }
 
     private static string WrapWithLineCharacters(string regex)

--- a/tracer/src/Datadog.Trace/Sampling/SamplingRuleHelper.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingRuleHelper.cs
@@ -67,6 +67,13 @@ internal static class SamplingRuleHelper
         {
             var tagName = pair.Key;
             var tagRegex = pair.Value;
+
+            if (tagRegex is null)
+            {
+                // if a regex is null (not specified), it always matches.
+                continue;
+            }
+
             var tagValue = GetSpanTag(span, tagName);
 
             if (tagValue is null || !tagRegex.Match(tagValue).Success)

--- a/tracer/src/Datadog.Trace/Sampling/SamplingRuleHelper.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingRuleHelper.cs
@@ -1,0 +1,58 @@
+// <copyright file="SamplingRuleHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+#if NETCOREAPP3_1_OR_GREATER
+using Datadog.Trace.Vendors.IndieSystem.Text.RegularExpressions;
+#else
+using System.Text.RegularExpressions;
+#endif
+
+namespace Datadog.Trace.Sampling;
+
+#nullable enable
+
+internal class SamplingRuleHelper
+{
+    public static bool MatchSpanByTags(Span span, List<KeyValuePair<string, Regex>> tagRegexes)
+    {
+        foreach (var pair in tagRegexes)
+        {
+            var tagName = pair.Key;
+            var tagRegex = pair.Value;
+            var tagValue = GetSpanTag(span, tagName);
+
+            if (tagValue is null || !tagRegex.Match(tagValue).Success)
+            {
+                // stop as soon as we find a tag that isn't set or doesn't match
+                return false;
+            }
+        }
+
+        // all specified tags exist and matched
+        return true;
+    }
+
+    private static string? GetSpanTag(Span span, string tagName)
+    {
+        if (span.GetTag(tagName) is { } tagValue)
+        {
+            return tagValue;
+        }
+
+        // if the string tag doesn't exist, try to get it as a numeric tag...
+        if (span.GetMetric(tagName) is not { } numericTagValue)
+        {
+            return null;
+        }
+
+        // ...but only if it is an integer
+        var intValue = (int)numericTagValue;
+        return Math.Abs(intValue - numericTagValue) < 0.0001 ? intValue.ToString(CultureInfo.InvariantCulture) : null;
+    }
+}

--- a/tracer/src/Datadog.Trace/Sampling/SamplingRuleHelper.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingRuleHelper.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using Datadog.Trace.Logging;
 
 #if NETCOREAPP3_1_OR_GREATER
 using Datadog.Trace.Vendors.IndieSystem.Text.RegularExpressions;
@@ -17,9 +18,50 @@ namespace Datadog.Trace.Sampling;
 
 #nullable enable
 
-internal class SamplingRuleHelper
+internal static class SamplingRuleHelper
 {
-    public static bool MatchSpanByTags(Span span, List<KeyValuePair<string, Regex>> tagRegexes)
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SamplingRuleHelper));
+
+    public static bool IsMatch(
+        Span span,
+        Regex? serviceNameRegex,
+        Regex? operationNameRegex,
+        Regex? resourceNameRegex,
+        List<KeyValuePair<string, Regex>>? tagRegexes,
+        out bool timedOut)
+    {
+        timedOut = false;
+
+        if (span == null!)
+        {
+            return false;
+        }
+
+        try
+        {
+            // if a regex is null (not specified), it always matches.
+            // stop as soon as we find a non-match.
+            return (serviceNameRegex is null || serviceNameRegex.Match(span.ServiceName).Success) &&
+                   (operationNameRegex is null || operationNameRegex.Match(span.OperationName).Success) &&
+                   (resourceNameRegex is null || resourceNameRegex.Match(span.ResourceName).Success) &&
+                   (tagRegexes is null || tagRegexes.Count == 0 || MatchSpanByTags(span, tagRegexes));
+        }
+        catch (RegexMatchTimeoutException e)
+        {
+            // flag rule so we don't try to use one of its regexes again
+            timedOut = true;
+
+            Log.Error(
+                e,
+                """Regex timed out when trying to match value "{Input}" against pattern "{Pattern}".""",
+                e.Input,
+                e.Pattern);
+
+            return false;
+        }
+    }
+
+    private static bool MatchSpanByTags(Span span, List<KeyValuePair<string, Regex>> tagRegexes)
     {
         foreach (var pair in tagRegexes)
         {

--- a/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
@@ -158,10 +158,10 @@ namespace Datadog.Trace.Sampling
 
             // if a regex is null (not specified), it always matches.
             // stop as soon as we find a non-match.
-            // TODO: match tags
-            return (_serviceNameRegex?.Match(span.ServiceName).Success ?? true) &&
-                   (_operationNameRegex?.Match(span.OperationName).Success ?? true) &&
-                   (_resourceNameRegex?.Match(span.ResourceName).Success ?? true);
+            return (_serviceNameRegex is null || _serviceNameRegex.Match(span.ServiceName).Success) &&
+                   (_operationNameRegex is null || _operationNameRegex.Match(span.OperationName).Success) &&
+                   (_resourceNameRegex is null || _resourceNameRegex.Match(span.ResourceName).Success) &&
+                   (_tagRegexes is null || _tagRegexes.Count == 0 || SamplingRuleHelper.MatchSpanByTags(span, _tagRegexes));
         }
 
         /// <inheritdoc/>

--- a/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
@@ -48,7 +47,7 @@ namespace Datadog.Trace.Sampling
             string serviceNameGlob,
             string operationNameGlob,
             string resourceNameGlob,
-            KeyValuePair<string, string>[] tagGlobs,
+            Dictionary<string, string> tagGlobs,
             float samplingRate = 1.0f,
             float? maxPerSecond = null)
         {
@@ -72,9 +71,9 @@ namespace Datadog.Trace.Sampling
             _operationNameRegex = RegexBuilder.Build(operationNameGlob, SamplingRulesFormat.Glob);
             _resourceNameRegex = RegexBuilder.Build(resourceNameGlob, SamplingRulesFormat.Glob);
 
-            if (tagGlobs is { Length: > 0 })
+            if (tagGlobs is { Count: > 0 })
             {
-                var tagRegexList = new List<KeyValuePair<string, Regex>>(tagGlobs.Length);
+                var tagRegexList = new List<KeyValuePair<string, Regex>>(tagGlobs.Count);
 
                 foreach (var tagRegex in tagGlobs)
                 {
@@ -197,7 +196,7 @@ namespace Datadog.Trace.Sampling
             public string ResourceNameGlob { get; set; }
 
             [JsonProperty(PropertyName = "tags")]
-            public KeyValuePair<string, string>[] TagGlobs { get; set; }
+            public Dictionary<string, string> TagGlobs { get; set; }
 
             [JsonProperty(PropertyName = "sample_rate")]
             public float SampleRate { get; set; } = 1.0f; // default to accept all

--- a/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SpanSamplingRule.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Sampling
             string serviceNameGlob,
             string operationNameGlob,
             string resourceNameGlob,
-            Dictionary<string, string> tagGlobs,
+            ICollection<KeyValuePair<string, string>> tagGlobs,
             float samplingRate = 1.0f,
             float? maxPerSecond = null)
         {
@@ -70,23 +70,7 @@ namespace Datadog.Trace.Sampling
             _serviceNameRegex = RegexBuilder.Build(serviceNameGlob, SamplingRulesFormat.Glob);
             _operationNameRegex = RegexBuilder.Build(operationNameGlob, SamplingRulesFormat.Glob);
             _resourceNameRegex = RegexBuilder.Build(resourceNameGlob, SamplingRulesFormat.Glob);
-
-            if (tagGlobs is { Count: > 0 })
-            {
-                var tagRegexList = new List<KeyValuePair<string, Regex>>(tagGlobs.Count);
-
-                foreach (var tagRegex in tagGlobs)
-                {
-                    var regex = RegexBuilder.Build(tagRegex.Value, SamplingRulesFormat.Glob);
-
-                    if (regex != null)
-                    {
-                        tagRegexList.Add(new KeyValuePair<string, Regex>(tagRegex.Key, regex));
-                    }
-                }
-
-                _tagRegexes = tagRegexList;
-            }
+            _tagRegexes = RegexBuilder.Build(tagGlobs, SamplingRulesFormat.Glob);
 
             if (_serviceNameRegex is null &&
                 _operationNameRegex is null &&

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
@@ -51,6 +51,18 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
+        public void Constructs_With_ResourceName()
+        {
+            var config = """[{"sample_rate":0.3, resource: "/api/v1/user/123"}]""";
+            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/*" };
+            var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/*" };
+
+            VerifyRate(config, 0.3f);
+            VerifySingleRule(config, matchingSpan, isMatch: true);
+            VerifySingleRule(config, nonMatchingSpan, isMatch: false);
+        }
+
+        [Fact]
         public void Constructs_All_Expected_From_Config_String()
         {
             const string config = """

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
@@ -53,9 +53,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void Constructs_With_ResourceName()
         {
-            var config = """[{"sample_rate":0.3, resource: "/api/v1/user/123"}]""";
-            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/*" };
-            var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/*" };
+            var config = """[{"sample_rate":0.3, resource: "/api/v1/*"}]""";
+            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
+            var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
 
             VerifyRate(config, 0.3f);
             VerifySingleRule(config, matchingSpan, isMatch: true);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
@@ -53,13 +53,37 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void Constructs_With_ResourceName()
         {
-            var config = """[{"sample_rate":0.3, resource: "/api/v1/*"}]""";
+            const string config = """[{ "sample_rate":0.3, resource: "/api/v1/*" }]""";
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
 
-            VerifyRate(config, 0.3f);
-            VerifySingleRule(config, matchingSpan, isMatch: true);
-            VerifySingleRule(config, nonMatchingSpan, isMatch: false);
+            VerifyRate(rule, 0.3f);
+            VerifySingleRule(rule, matchingSpan, isMatch: true);
+            VerifySingleRule(rule, nonMatchingSpan, isMatch: false);
+        }
+
+        [Fact]
+        public void Constructs_With_Tags()
+        {
+            const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE?", "http.status_code": "200" } }]""";
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+
+            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
+            matchingSpan.SetTag("http.method", "GET");
+            matchingSpan.SetMetric("http.status_code", 200);
+
+            var nonMatchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
+            nonMatchingSpan1.SetTag("http.method", "GET");
+
+            var nonMatchingSpan2 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
+            nonMatchingSpan2.SetTag("http.method", "POST");
+
+            VerifyRate(rule, 0.3f);
+            VerifySingleRule(rule, matchingSpan, isMatch: true);
+            VerifySingleRule(rule, nonMatchingSpan1, isMatch: false);
+            VerifySingleRule(rule, nonMatchingSpan2, isMatch: false);
         }
 
         [Fact]
@@ -136,6 +160,11 @@ namespace Datadog.Trace.Tests.Sampling
         private static void VerifyRate(string config, float expectedRate)
         {
             var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+            VerifyRate(rule, expectedRate);
+        }
+
+        private static void VerifyRate(ISamplingRule rule, float expectedRate)
+        {
             rule.GetSamplingRate(TestSpans.CartCheckoutSpan).Should().Be(expectedRate);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
@@ -51,6 +51,18 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
+        public void Constructs_With_ResourceName()
+        {
+            var config = """[{"sample_rate":0.3, resource: "/api/v1/user/123"}]""";
+            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = """\/api\/v1\/.*""" };
+            var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = """\/api\/v2\/.*""" };
+
+            VerifyRate(config, 0.3f);
+            VerifySingleRule(config, matchingSpan, isMatch: true);
+            VerifySingleRule(config, nonMatchingSpan, isMatch: false);
+        }
+
+        [Fact]
         public void Constructs_All_Expected_From_Config_String()
         {
             var config = """

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
@@ -53,9 +53,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void Constructs_With_ResourceName()
         {
-            var config = """[{"sample_rate":0.3, resource: "/api/v1/user/123"}]""";
-            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = """\/api\/v1\/.*""" };
-            var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = """\/api\/v2\/.*""" };
+            var config = """[{ "sample_rate": 0.3, resource: "\/api\/v1\/.*" }]""";
+            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
+            var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
 
             VerifyRate(config, 0.3f);
             VerifySingleRule(config, matchingSpan, isMatch: true);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
@@ -133,15 +133,20 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Theory]
-        [InlineData("*", "*", "*", true)]
-        public void MatchAll_ShouldMatchAll(string serviceGlob, string operationGlob, string resourceGlob, bool shouldMatch)
+        [InlineData("*", "*", "*")]
+        public void MatchAll_ShouldMatchAll(string serviceGlob, string operationGlob, string resourceGlob)
         {
-            var rule = new SpanSamplingRule(serviceGlob, operationGlob, resourceGlob, tagGlobs: null);
-            rule.IsMatch(TestSpans.CartCheckoutSpan).Should().Be(shouldMatch);
-            rule.IsMatch(TestSpans.AddToCartSpan).Should().Be(shouldMatch);
-            rule.IsMatch(TestSpans.ShippingAuthSpan).Should().Be(shouldMatch);
-            rule.IsMatch(TestSpans.ShippingRevertSpan).Should().Be(shouldMatch);
-            rule.IsMatch(TestSpans.RequestShippingSpan).Should().Be(shouldMatch);
+            var rule = new SpanSamplingRule(
+                serviceNameGlob: serviceGlob,
+                operationNameGlob: operationGlob,
+                resourceNameGlob: resourceGlob,
+                tagGlobs: null);
+
+            rule.IsMatch(TestSpans.CartCheckoutSpan).Should().Be(true);
+            rule.IsMatch(TestSpans.AddToCartSpan).Should().Be(true);
+            rule.IsMatch(TestSpans.ShippingAuthSpan).Should().Be(true);
+            rule.IsMatch(TestSpans.ShippingRevertSpan).Should().Be(true);
+            rule.IsMatch(TestSpans.RequestShippingSpan).Should().Be(true);
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
@@ -20,7 +20,14 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData(" ")] // whitespace
         public void Constructor_ShouldThrow_ArgumentException_WhenServiceNameGlob_EmptyOrNull(string serviceNameGlob)
         {
-            var ctor = () => new SpanSamplingRule(serviceNameGlob, "*", 1.0f, null);
+            var ctor = () => new SpanSamplingRule(
+                serviceNameGlob: serviceNameGlob,
+                operationNameGlob: "*",
+                resourceNameGlob: null,
+                tagGlobs: null,
+                samplingRate: 1.0f,
+                maxPerSecond: null);
+
             ctor.Should().Throw<ArgumentException>().WithParameterName("serviceNameGlob");
         }
 
@@ -30,7 +37,14 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData(" ")] // whitespace
         public void Constructor_ShouldThrow_ArgumentException_WhenOperationNameGlob_EmptyOrNull(string operationNameGlob)
         {
-            var ctor = () => new SpanSamplingRule("*", operationNameGlob, 1.0f, null);
+            var ctor = () => new SpanSamplingRule(
+                "*",
+                operationNameGlob,
+                resourceNameGlob: null,
+                tagGlobs: null,
+                samplingRate: 1.0f,
+                maxPerSecond: null);
+
             ctor.Should().Throw<ArgumentException>().WithParameterName("operationNameGlob");
         }
 
@@ -44,8 +58,8 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Theory]
-        [InlineData("[{\"service\":\"shopping-cart*\", \"name\":\"checkou?\", \"sample_rate\":0.5}]")]
-        [InlineData("[{\"service\":\"shopping-cart*\", \"name\":\"checkou?\", \"max_per_second\":1000.5}]")]
+        [InlineData("""[{"service":"shopping-cart*", "name":"checkou?", "sample_rate":0.5}]""")]
+        [InlineData("""[{"service":"shopping-cart*", "name":"checkou?", "max_per_second":1000.5}]""")]
         public void BuildFromConfigurationString_ShouldHandle_MissingOptionals(string config)
         {
             SpanSamplingRule.BuildFromConfigurationString(config).Should().ContainSingle();
@@ -61,7 +75,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void BuildFromConfigurationString_Should_ReturnSingleRule()
         {
-            var config = "[{\"service\":\"shopping-cart*\", \"name\":\"checkou?\", \"sample_rate\":0.5, \"max_per_second\":1000.5}]";
+            var config = """[{"service":"shopping-cart*", "name":"checkou?", "sample_rate":0.5, "max_per_second":1000.5}]""";
 
             VerifySingleRule(config, TestSpans.CartCheckoutSpan, true);
             VerifySingleRule(config, TestSpans.AddToCartSpan, false);
@@ -73,7 +87,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void WildcardService_ShouldMatch_OnOperation()
         {
-            var config = "[{\"service\":\"*\", \"name\":\"authorize\", \"sample_rate\":0.5, \"max_per_second\":1000.5}]";
+            var config = """[{"service":"*", "name":"authorize", "sample_rate":0.5, "max_per_second":1000.5}]""";
 
             VerifySingleRule(config, TestSpans.CartCheckoutSpan, false);
             VerifySingleRule(config, TestSpans.AddToCartSpan, false);
@@ -85,7 +99,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void WildcardOperation_ShouldMatch_OnService()
         {
-            var config = "[{\"service\":\"shopping-cart-service\", \"name\":\"*\", \"sample_rate\":0.5, \"max_per_second\":1000.5}]";
+            var config = """[{"service":"shopping-cart-service", "name":"*", "sample_rate":0.5, "max_per_second":1000.5}]""";
 
             VerifySingleRule(config, TestSpans.CartCheckoutSpan, true);
             VerifySingleRule(config, TestSpans.AddToCartSpan, true);
@@ -95,10 +109,10 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Theory]
-        [InlineData("*", "*", true)]
-        public void MatchAll_ShouldMatchAll(string serviceGlob, string operationGlob, bool shouldMatch)
+        [InlineData("*", "*", "*", true)]
+        public void MatchAll_ShouldMatchAll(string serviceGlob, string operationGlob, string resourceGlob, bool shouldMatch)
         {
-            var rule = new SpanSamplingRule(serviceGlob, operationGlob);
+            var rule = new SpanSamplingRule(serviceGlob, operationGlob, resourceGlob, tagGlobs: null);
             rule.IsMatch(TestSpans.CartCheckoutSpan).Should().Be(shouldMatch);
             rule.IsMatch(TestSpans.AddToCartSpan).Should().Be(shouldMatch);
             rule.IsMatch(TestSpans.ShippingAuthSpan).Should().Be(shouldMatch);
@@ -109,7 +123,11 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void IsMatch_ShouldReturnFalse_ForNullSpan()
         {
-            var rule = new SpanSamplingRule("*", "*");
+            var rule = new SpanSamplingRule(
+                serviceNameGlob: "*",
+                operationNameGlob: "*",
+                resourceNameGlob: "*",
+                tagGlobs: null);
 
             rule.IsMatch(null).Should().BeFalse();
         }
@@ -117,7 +135,11 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void ShouldSample_ShouldReturnFalse_ForNullSpan()
         {
-            var rule = new SpanSamplingRule("*", "*");
+            var rule = new SpanSamplingRule(
+                serviceNameGlob: "*",
+                operationNameGlob: "*",
+                resourceNameGlob: "*",
+                tagGlobs: null);
 
             rule.ShouldSample(null).Should().BeFalse();
         }
@@ -125,7 +147,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void IsMatch_ShouldReturnFalse_WhenServiceAndOperationDontMatch()
         {
-            var config = "[{\"service\":\"test\", \"name\":\"test\"}]";
+            var config = """[{"service":"test", "name":"test"}]""";
             var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
 
             rule.IsMatch(TestSpans.CartCheckoutSpan).Should().BeFalse();
@@ -134,7 +156,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void ShouldSample_ShouldReturnFalse_WhenSamplerIsZero()
         {
-            var config = "[{\"service\":\"*\", \"name\":\"*\", \"sample_rate\":0.0}]";
+            var config = """[{"service":"*", "name":"*", "sample_rate":0.0}]""";
             var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
 
             rule.ShouldSample(TestSpans.CartCheckoutSpan).Should().BeFalse();
@@ -143,7 +165,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void ShouldSample_ShouldReturnTrue_WhenEverythingMatches()
         {
-            var config = "[{\"service\":\"*\", \"name\":\"*\"}]";
+            var config = """[{"service":"*", "name":"*"}]""";
             var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
 
             rule.IsMatch(TestSpans.CartCheckoutSpan).Should().BeTrue();
@@ -153,7 +175,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void MaxPerSecond_ShouldDefaultTo_NullWhenAbsent()
         {
-            var config = "[{\"service\":\"*\", \"name\":\"*\"}]";
+            var config = """[{"service":"*", "name":"*"}]""";
             var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
 
             rule.MaxPerSecond.Should().BeNull();
@@ -162,7 +184,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void SampleRate_ShouldDefaultTo_OneWhenAbsent()
         {
-            var config = "[{\"service\":\"*\", \"name\":\"*\"}]";
+            var config = """[{"service":"*", "name":"*"}]""";
             var rule = SpanSamplingRule.BuildFromConfigurationString(config).Single();
 
             rule.SamplingRate.Should().Be(1.0f);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
@@ -108,6 +108,30 @@ namespace Datadog.Trace.Tests.Sampling
             VerifySingleRule(config, TestSpans.RequestShippingSpan, false);
         }
 
+        [Fact]
+        public void WildcardOperation_ShouldMatch_OnResource()
+        {
+            var config = """[{"service":"*", "name":"*", "resource": "/api/users/*", "sample_rate":0.5, "max_per_second":1000.5}]""";
+
+            VerifySingleRule(config, TestSpans.CartCheckoutSpan, true);
+            VerifySingleRule(config, TestSpans.AddToCartSpan, false);
+            VerifySingleRule(config, TestSpans.ShippingAuthSpan, false);
+            VerifySingleRule(config, TestSpans.ShippingRevertSpan, true);
+            VerifySingleRule(config, TestSpans.RequestShippingSpan, true);
+        }
+
+        [Fact]
+        public void WildcardOperation_ShouldMatch_OnTags()
+        {
+            var config = """[{"service":"shopping-cart-service", "name":"*", "sample_rate":0.5, "max_per_second":1000.5}]""";
+
+            VerifySingleRule(config, TestSpans.CartCheckoutSpan, true);
+            VerifySingleRule(config, TestSpans.AddToCartSpan, true);
+            VerifySingleRule(config, TestSpans.ShippingAuthSpan, false);
+            VerifySingleRule(config, TestSpans.ShippingRevertSpan, false);
+            VerifySingleRule(config, TestSpans.RequestShippingSpan, false);
+        }
+
         [Theory]
         [InlineData("*", "*", "*", true)]
         public void MatchAll_ShouldMatchAll(string serviceGlob, string operationGlob, string resourceGlob, bool shouldMatch)

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplingRuleTests.cs
@@ -123,7 +123,18 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void WildcardOperation_ShouldMatch_OnTags()
         {
-            var config = """[{"service":"shopping-cart-service", "name":"*", "sample_rate":0.5, "max_per_second":1000.5}]""";
+            var config = """
+                         [{
+                            "service":"*",
+                            "name":"*",
+                            "tags": {
+                                "tag1": "value*",
+                                "tag2": "40?",
+                            },
+                            "sample_rate":0.5,
+                            "max_per_second":1000.5
+                         }]
+                         """;
 
             VerifySingleRule(config, TestSpans.CartCheckoutSpan, true);
             VerifySingleRule(config, TestSpans.AddToCartSpan, true);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TestSpans.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TestSpans.cs
@@ -9,13 +9,36 @@ namespace Datadog.Trace.Tests.Sampling;
 
 public static class TestSpans
 {
-    internal static readonly Span CartCheckoutSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), DateTimeOffset.Now) { OperationName = "checkout", ResourceName = "/api/users/1" };
+    internal static readonly Span CartCheckoutSpan;
 
-    internal static readonly Span AddToCartSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), DateTimeOffset.Now) { OperationName = "cart-add", ResourceName = "/api/cart" };
+    internal static readonly Span AddToCartSpan;
 
-    internal static readonly Span ShippingAuthSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), DateTimeOffset.Now) { OperationName = "authorize", ResourceName = "/api/items/1" };
+    internal static readonly Span ShippingAuthSpan;
 
-    internal static readonly Span ShippingRevertSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), DateTimeOffset.Now) { OperationName = "authorize-revert", ResourceName = "/api/users/2" };
+    internal static readonly Span ShippingRevertSpan;
 
-    internal static readonly Span RequestShippingSpan = new Span(new SpanContext(1, 1, serviceName: "request-shipping"), DateTimeOffset.Now) { OperationName = "submit", ResourceName = "/api/users/3" };
+    internal static readonly Span RequestShippingSpan;
+
+    static TestSpans()
+    {
+        var now = DateTimeOffset.Now;
+
+        CartCheckoutSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), now) { OperationName = "checkout", ResourceName = "/api/users/1" };
+        CartCheckoutSpan.SetTag("tag1", "value1");
+        CartCheckoutSpan.SetMetric("tag2", 401);
+
+        AddToCartSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), now) { OperationName = "cart-add", ResourceName = "/api/cart" };
+        AddToCartSpan.SetTag("tag1", "value2");
+        AddToCartSpan.SetMetric("tag2", 402);
+
+        ShippingAuthSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), now) { OperationName = "authorize", ResourceName = "/api/items/1" };
+        ShippingAuthSpan.SetTag("tag1", "value3");
+        ShippingAuthSpan.SetMetric("tag2", 410);
+
+        ShippingRevertSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), now) { OperationName = "authorize-revert", ResourceName = "/api/users/2" };
+        ShippingRevertSpan.SetTag("tag1", "value4");
+
+        RequestShippingSpan = new Span(new SpanContext(1, 1, serviceName: "request-shipping"), now) { OperationName = "submit", ResourceName = "/api/users/3" };
+        RequestShippingSpan.SetMetric("tag2", 403);
+    }
 }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TestSpans.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TestSpans.cs
@@ -9,9 +9,13 @@ namespace Datadog.Trace.Tests.Sampling;
 
 public static class TestSpans
 {
-    internal static readonly Span CartCheckoutSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), DateTimeOffset.Now) { OperationName = "checkout" };
-    internal static readonly Span AddToCartSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), DateTimeOffset.Now) { OperationName = "cart-add" };
-    internal static readonly Span ShippingAuthSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), DateTimeOffset.Now) { OperationName = "authorize" };
-    internal static readonly Span ShippingRevertSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), DateTimeOffset.Now) { OperationName = "authorize-revert" };
-    internal static readonly Span RequestShippingSpan = new Span(new SpanContext(1, 1, serviceName: "request-shipping"), DateTimeOffset.Now) { OperationName = "submit" };
+    internal static readonly Span CartCheckoutSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), DateTimeOffset.Now) { OperationName = "checkout", ResourceName = "/api/users/1" };
+
+    internal static readonly Span AddToCartSpan = new Span(new SpanContext(1, 1, serviceName: "shopping-cart-service"), DateTimeOffset.Now) { OperationName = "cart-add", ResourceName = "/api/cart" };
+
+    internal static readonly Span ShippingAuthSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), DateTimeOffset.Now) { OperationName = "authorize", ResourceName = "/api/items/1" };
+
+    internal static readonly Span ShippingRevertSpan = new Span(new SpanContext(1, 1, serviceName: "shipping-auth-service"), DateTimeOffset.Now) { OperationName = "authorize-revert", ResourceName = "/api/users/2" };
+
+    internal static readonly Span RequestShippingSpan = new Span(new SpanContext(1, 1, serviceName: "request-shipping"), DateTimeOffset.Now) { OperationName = "submit", ResourceName = "/api/users/3" };
 }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -46,7 +46,8 @@ namespace Datadog.Trace.Tests.Sampling
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
-                    resourceNamePattern: ".*"));
+                    resourceNamePattern: ".*",
+                    tagPatterns: null));
 
             RunSamplerTest(
                 sampler,
@@ -68,7 +69,8 @@ namespace Datadog.Trace.Tests.Sampling
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
-                    resourceNamePattern: ".*"));
+                    resourceNamePattern: ".*",
+                    tagPatterns: null));
 
             RunSamplerTest(
                 sampler,
@@ -90,7 +92,8 @@ namespace Datadog.Trace.Tests.Sampling
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
-                    resourceNamePattern: ".*"));
+                    resourceNamePattern: ".*",
+                    tagPatterns: null));
 
             RunSamplerTest(
                 sampler,
@@ -112,7 +115,8 @@ namespace Datadog.Trace.Tests.Sampling
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
-                    resourceNamePattern: ".*"));
+                    resourceNamePattern: ".*",
+                    tagPatterns: null));
 
             RunSamplerTest(
                 sampler,

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -45,7 +45,8 @@ namespace Datadog.Trace.Tests.Sampling
                     ruleName: "Allow_all",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
-                    operationNamePattern: ".*"));
+                    operationNamePattern: ".*",
+                    resourceNamePattern: ".*"));
 
             RunSamplerTest(
                 sampler,
@@ -66,7 +67,8 @@ namespace Datadog.Trace.Tests.Sampling
                     ruleName: "Allow_all",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
-                    operationNamePattern: ".*"));
+                    operationNamePattern: ".*",
+                    resourceNamePattern: ".*"));
 
             RunSamplerTest(
                 sampler,
@@ -87,7 +89,8 @@ namespace Datadog.Trace.Tests.Sampling
                     ruleName: "Allow_nothing",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
-                    operationNamePattern: ".*"));
+                    operationNamePattern: ".*",
+                    resourceNamePattern: ".*"));
 
             RunSamplerTest(
                 sampler,
@@ -108,7 +111,8 @@ namespace Datadog.Trace.Tests.Sampling
                     ruleName: "Allow_half",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
-                    operationNamePattern: ".*"));
+                    operationNamePattern: ".*",
+                    resourceNamePattern: ".*"));
 
             RunSamplerTest(
                 sampler,

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.Tests.Sampling
         private const string ServiceName = "my-service-name";
         private const string Env = "my-test-env";
         private const string OperationName = "test";
+        private const string ResourceName = "test-resource-name";
 
         private static readonly Dictionary<string, float> MockAgentRates = new() { { $"service:{ServiceName},env:{Env}", FallbackRate } };
 
@@ -182,6 +183,7 @@ namespace Datadog.Trace.Tests.Sampling
             {
                 using var scope = (Scope)tracer.StartActive(OperationName);
                 scope.Span.Context.TraceContext.Environment = Env;
+                scope.Span.ResourceName = ResourceName;
 
                 var decision = sampler.MakeSamplingDecision(scope.Span);
 


### PR DESCRIPTION
## Summary of changes

Allow matching by resource name and tags in trace and single-span sampling rules.

## Reason for change

These additions provide users with sampling scenarios that were not available before.

## Implementation details

Add fields `resource` and `tags` to the sampling rules models for traces and single spans. Matching works the same as previously existing fields.

## Test coverage

Added tests:
- trace sampling, match by resource or tags (regex)
- trace sampling, match by resource or tags (glob)
- single-span sampling, match by resource or tags (glob only)

## Other details

Follows #4984