### PR TITLE
Convert integration tests to async

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -53,6 +53,7 @@
     the */** trick here ensures that there's at least one subdirectory, which indicates the files comes
     from a source generator as opposed to something that is coming from some other tool. -->
     <Compile Remove="$(GeneratedFolder)/*/**/*.cs" />
+    <None Include="$(GeneratedFolder)/*/**/*.cs" />
     <Compile Update="Configuration\ConfigurationKeys.*.cs" DependentUpon="ConfigurationKeys.cs" />
   </ItemGroup>
 

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -27,6 +27,7 @@
     the */** trick here ensures that there's at least one subdirectory, which indicates the files comes
     from a source generator as opposed to something that is coming from some other tool. -->
     <Compile Remove="$(GeneratedFolder)/*/**/*.cs" />
+    <None Include="$(GeneratedFolder)/*/**/*.cs" />
     <Compile Update="Configuration\ConfigurationKeys.*.cs" DependentUpon="ConfigurationKeys.cs" />
   </ItemGroup>
 

--- a/tracer/src/Datadog.Trace/Vendors/IndieSystem.Text.RegularExpressions/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
+++ b/tracer/src/Datadog.Trace/Vendors/IndieSystem.Text.RegularExpressions/System/Text/RegularExpressions/Symbolic/SymbolicRegexNode.cs
@@ -1955,7 +1955,7 @@ namespace Datadog.Trace.Vendors.IndieSystem.Text.RegularExpressions.Symbolic
 
                 default:
                     return false;
-            };
+            }
         }
 
         /// <summary>Computes the set that includes all elements that can start a match.</summary>

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3863,10 +3863,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID funct
 HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId,
                                                   HRESULT hrStatus)
 {
+    Logger::Warn("ReJITError: [functionId: ", functionId, ", moduleId: ", moduleId, ", methodId: ", methodId,
+                 ", hrStatus: ", hrStatus, "]");
+
     if (!is_attached_)
     {
-        Logger::Warn("ReJITError: [functionId: ", functionId, ", moduleId: ", moduleId, ", methodId: ", methodId,
-                     ", hrStatus: ", hrStatus, "]");
         return S_OK;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3863,11 +3863,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID funct
 HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId,
                                                   HRESULT hrStatus)
 {
-    Logger::Warn("ReJITError: [functionId: ", functionId, ", moduleId: ", moduleId, ", methodId: ", methodId,
-                 ", hrStatus: ", hrStatus, "]");
-
     if (!is_attached_)
     {
+        Logger::Warn("ReJITError: [functionId: ", functionId, ", moduleId: ", moduleId, ", methodId: ", methodId,
+                     ", hrStatus: ", hrStatus, "]");
         return S_OK;
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsDynamoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsDynamoDbTests.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
 #if NETFRAMEWORK
                 var expectedCount = 34;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsKinesisTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
 #if NETFRAMEWORK
                 var expectedCount = 10;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NET6_OR_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NET6_0_OR_GREATER
+#if NET6_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
             using var extensionNoContext = new MockLambdaExtension(shouldSendContext: false, port: 9003, Output);
             using var agent = EnvironmentHelper.GetMockAgent(fixedPort: 5002);
             agent.Output = Output;
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var requests = 9 // param tests
                                   + 3 // param with context

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSnsTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
 #if NETFRAMEWORK
                 var expectedCount = 8;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsSqsTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
 #if NETFRAMEWORK
                 var expectedCount = 56;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/DapperTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,13 +24,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesV0() => RunTest("v0");
+        public Task SubmitsTracesV0() => RunTest("v0");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesV1() => RunTest("v1");
+        public Task SubmitsTracesV1() => RunTest("v1");
 
-        private void RunTest(string metadataSchemaVersion)
+        private async Task RunTest(string metadataSchemaVersion)
         {
             const int expectedSpanCount = 17;
             const string dbType = "postgres";
@@ -40,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             var clientSpanServiceName = isExternalSpan ? $"{EnvironmentHelper.FullSampleName}-{dbType}" : EnvironmentHelper.FullSampleName;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/FakeCommandTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -23,13 +24,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesV0() => RunTest("v0");
+        public Task SubmitsTracesV0() => RunTest("v0");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTracesV1() => RunTest("v1");
+        public Task SubmitsTracesV1() => RunTest("v1");
 
-        private void RunTest(string metadataSchemaVersion)
+        private async Task RunTest(string metadataSchemaVersion)
         {
             // ALWAYS: 91 spans
             // - FakeCommand: 21 spans (3 groups * 7 spans)
@@ -50,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqlClientTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -33,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
         {
             // ALWAYS: 133 spans
             // - SqlCommand: 21 spans (3 groups * 7 spans)
@@ -73,7 +74,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
 
@@ -85,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 21;
             const string expectedOperationName = "sql-server.query";
@@ -95,7 +96,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             string packageVersion = PackageVersions.MicrosoftDataSqlClient.First()[0] as string;
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MicrosoftDataSqliteTests.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -35,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
         {
 #if NETCOREAPP3_0
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("IsAlpine")) // set in dockerfile
@@ -56,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);
@@ -69,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 21;
             const string expectedOperationName = "sqlite.query";
@@ -79,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             string packageVersion = PackageVersions.MicrosoftDataSqlite.First()[0] as string;
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlCommandTests.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 21;
             const string expectedOperationName = "mysql.query";
@@ -109,7 +109,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             // don't use the first package version which is 6.x and is not supported on ARM64.
             // use the default package version for the sample, currently 8.0.17.
             // string packageVersion = PackageVersions.MySqlData.First()[0] as string;
-            using var process = RunSampleAndWaitForExit(agent /* , packageVersion: packageVersion */);
+            using var process = await RunSampleAndWaitForExit(agent /* , packageVersion: packageVersion */);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
@@ -147,7 +147,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
             var filteredSpans = spans.Where(s => s.ParentId.HasValue && !s.Resource.Equals("SHOW WARNINGS", StringComparison.OrdinalIgnoreCase)).ToList();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/MySqlConnectorTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [SkippableTheory]
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]
-        public void SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
         {
             // ALWAYS: 75 spans
             // - MySqlCommand: 21 spans (3 groups * 7 spans - 6 missing spans)
@@ -61,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue && !s.Resource.Equals("SHOW WARNINGS", StringComparison.OrdinalIgnoreCase)); // Remove unexpected DB spans from the calculation
 
@@ -72,7 +73,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 21;
             const string expectedOperationName = "mysql.query";
@@ -82,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             using var telemetry = this.ConfigureTelemetry();
             string packageVersion = PackageVersions.MySqlConnector.First()[0] as string;
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/NpgsqlCommandTests.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
             int actualSpanCount = spans.Count(s => s.ParentId.HasValue); // Remove unexpected DB spans from the calculation
             var filteredSpans = spans.Where(s => s.ParentId.HasValue).ToList();
@@ -97,7 +97,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 21;
             const string expectedOperationName = "postgres.query";
@@ -107,7 +107,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             string packageVersion = PackageVersions.Npgsql.First()[0] as string;
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SqlCommand20Tests.cs
@@ -5,6 +5,7 @@
 
 #if NETFRAMEWORK
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -26,17 +27,17 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesV0() => RunTest("v0");
+        public Task SubmitsTracesV0() => RunTest("v0");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTracesV1() => RunTest("v1");
+        public Task SubmitsTracesV1() => RunTest("v1");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 9;
             const string expectedOperationName = "sql-server.query";
@@ -45,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
@@ -53,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             telemetry.AssertIntegrationDisabled(IntegrationId.SqlClient);
         }
 
-        private void RunTest(string metadataSchemaVersion)
+        private async Task RunTest(string metadataSchemaVersion)
         {
             const int expectedSpanCount = 28; // 7 queries * 3 groups + CallTarget support instrumenting a constrained generic caller.
             const string dbType = "sql-server";
@@ -65,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqlClientTests.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             spans.Count.Should().Be(expectedSpanCount);
@@ -106,7 +106,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 21;
             const string expectedOperationName = "sql-server.query";
@@ -116,7 +116,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             string packageVersion = PackageVersions.SystemDataSqlClient.First()[0] as string;
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/SystemDataSqliteTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -25,19 +26,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTracesV0() => RunTest("v0");
+        public Task SubmitsTracesV0() => RunTest("v0");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTracesV1() => RunTest("v1");
+        public Task SubmitsTracesV1() => RunTest("v1");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             const int totalSpanCount = 21;
             const string expectedOperationName = "sqlite.query";
@@ -45,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.Sqlite)}_ENABLED", "false");
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.WaitForSpans(totalSpanCount, returnAllOperations: true);
 
             Assert.NotEmpty(spans);
@@ -53,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
             telemetry.AssertIntegrationDisabled(IntegrationId.Sqlite);
         }
 
-        private void RunTest(string metadataSchemaVersion)
+        private async Task RunTest(string metadataSchemaVersion)
         {
             const int expectedSpanCount = 91;
             const string dbType = "sqlite";
@@ -65,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AdoNet
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
 
             Assert.Equal(expectedSpanCount, spans.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 const int expectedSpanCount = 10 + 9; // Sync + async
                 var spans = agent.WaitForSpans(expectedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
 
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
 
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName, timeoutInMilliseconds: 40000);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AppTrimmingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AppTrimmingTests.cs
@@ -1,9 +1,10 @@
-﻿// <copyright file="AppTrimmingTests.cs" company="Datadog">
+// <copyright file="AppTrimmingTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -22,14 +23,14 @@ public class AppTrimmingTests : TestHelper
     }
 
     [Fact]
-    public void TrimmerTest()
+    public async Task TrimmerTest()
     {
         var httpPort = TcpPortProvider.GetOpenPort();
         Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
 
         using var agent = EnvironmentHelper.GetMockAgent();
         var aspnetPort = TcpPortProvider.GetOpenPort();
-        using var processResult = RunSampleAndWaitForExit(agent, aspNetCorePort: aspnetPort, usePublishWithRID: true);
+        using var processResult = await RunSampleAndWaitForExit(agent, aspNetCorePort: aspnetPort, usePublishWithRID: true);
         var spans = agent.WaitForSpans(30);
 
         // Target app does 10 request, so it generates 30 spans (Http Request + AspNetCore + AspNetCore.Mvc)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetAsyncHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetAsyncHandlerTests.cs
@@ -5,7 +5,6 @@
 
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -27,7 +26,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNet
         }
     }
 
-    public abstract class AspNetAsyncHandlerTests : TracingIntegrationTest, IClassFixture<IisFixture>
+    public abstract class AspNetAsyncHandlerTests : TracingIntegrationTest, IClassFixture<IisFixture>, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
 
@@ -38,7 +37,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNet
 
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/shutdown";
-            _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) =>
@@ -63,6 +61,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNet
 
             customSpan.ParentId.Should().NotBeNull("traces should be correlated");
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 #endif
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5QueryStringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetMvc5QueryStringTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
     }
 
     [UsesVerify]
-    public abstract class AspNetMvc5QueryStringTests : TracingIntegrationTest, IClassFixture<IisFixture>
+    public abstract class AspNetMvc5QueryStringTests : TracingIntegrationTest, IClassFixture<IisFixture>, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
@@ -52,7 +52,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/home/shutdown";
-            _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
             _testName = nameof(AspNetMvc5QueryStringTests)
                       + (enableQueryStringReporting ? ".WithQueryString" : ".WithoutQueryString");
         }
@@ -87,6 +86,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                           .UseMethodName("_")
                           .UseTypeName(_testName);
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -17,7 +17,7 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
     [Collection("IisTests")]
-    public class AspNetWebFormsTests : TracingIntegrationTest, IClassFixture<IisFixture>
+    public class AspNetWebFormsTests : TracingIntegrationTest, IClassFixture<IisFixture>, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
 
@@ -30,7 +30,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             _iisFixture = iisFixture;
             _iisFixture.ShutdownPath = "/account/login?shutdown=1";
-            _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
         }
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) =>
@@ -102,6 +101,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 Assert.Equal("elasticsearch", span.Type);
             }
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, IisAppType.AspNetIntegrated);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/OwinWebApi2Tests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             _output = output;
             _testName = nameof(OwinWebApi2Tests)
                       + (enableRouteTemplateExpansion ? ".WithExpansion" :
-                        (enableRouteTemplateResourceNames ?  ".WithFF" : ".NoFF"));
+                        (enableRouteTemplateResourceNames ? ".WithFF" : ".NoFF"));
         }
 
         public static TheoryData<string, int, int> Data() => new()
@@ -160,18 +160,15 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     return;
                 }
 
-                lock (this)
+                if (_process is null)
                 {
-                    if (_process is null)
-                    {
-                        var initialAgentPort = TcpPortProvider.GetOpenPort();
-                        HttpPort = TcpPortProvider.GetOpenPort();
+                    var initialAgentPort = TcpPortProvider.GetOpenPort();
+                    HttpPort = TcpPortProvider.GetOpenPort();
 
-                        Agent = MockTracerAgent.Create(output, initialAgentPort);
-                        Agent.SpanFilters.Add(IsNotServerLifeCheck);
-                        output.WriteLine($"Starting OWIN sample, agentPort: {Agent.Port}, samplePort: {HttpPort}");
-                        _process = helper.StartSample(Agent, arguments: null, packageVersion: string.Empty, aspNetCorePort: HttpPort);
-                    }
+                    Agent = MockTracerAgent.Create(output, initialAgentPort);
+                    Agent.SpanFilters.Add(IsNotServerLifeCheck);
+                    output.WriteLine($"Starting OWIN sample, agentPort: {Agent.Port}, samplePort: {HttpPort}");
+                    _process = await helper.StartSample(Agent, arguments: null, packageVersion: string.Empty, aspNetCorePort: HttpPort);
                 }
 
                 await EnsureServerStarted(output);
@@ -179,26 +176,23 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             public void Dispose()
             {
-                lock (this)
+                if (_process is not null)
                 {
-                    if (_process is not null)
+                    try
                     {
-                        try
+                        if (!_process.HasExited)
                         {
-                            if (!_process.HasExited)
-                            {
-                                SubmitRequest(null, "/shutdown").GetAwaiter().GetResult();
+                            SubmitRequest(null, "/shutdown").GetAwaiter().GetResult();
 
-                                _process.Kill();
-                            }
+                            _process.Kill();
                         }
-                        catch
-                        {
-                            // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
-                        }
-
-                        _process.Dispose();
                     }
+                    catch
+                    {
+                        // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
+                    }
+
+                    _process.Dispose();
                 }
 
                 Agent?.Dispose();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMinimalApisTests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         }
     }
 
-    public abstract class AspNetCoreIisMinimalApisTests : AspNetCoreIisMvcTestBase
+    public abstract class AspNetCoreIisMinimalApisTests : AspNetCoreIisMvcTestBase, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
@@ -62,7 +62,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             _testName = GetTestName(nameof(AspNetCoreIisMinimalApisTests));
             _iisFixture = fixture;
-            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
         }
 
         [SkippableTheory]
@@ -90,6 +89,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                           .UseMethodName("_")
                           .UseTypeName(_testName);
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, InProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc21Tests.cs
@@ -36,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         }
     }
 
-    public abstract class AspNetCoreIisMvc21Tests : AspNetCoreIisMvcTestBase
+    public abstract class AspNetCoreIisMvc21Tests : AspNetCoreIisMvcTestBase, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
@@ -46,7 +46,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             _testName = GetTestName(nameof(AspNetCoreIisMvc21Tests));
             _iisFixture = fixture;
-            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
         }
 
         [SkippableTheory]
@@ -74,6 +73,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                           .UseMethodName("_")
                           .UseTypeName(_testName);
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, InProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc30Tests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         }
     }
 
-    public abstract class AspNetCoreIisMvc30Tests : AspNetCoreIisMvcTestBase
+    public abstract class AspNetCoreIisMvc30Tests : AspNetCoreIisMvcTestBase, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
@@ -62,7 +62,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             _testName = GetTestName(nameof(AspNetCoreIisMvc30Tests));
             _iisFixture = fixture;
-            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
         }
 
         [SkippableTheory]
@@ -90,6 +89,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                           .UseMethodName("_")
                           .UseTypeName(_testName);
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, InProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvc31Tests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         }
     }
 
-    public abstract class AspNetCoreIisMvc31Tests : AspNetCoreIisMvcTestBase
+    public abstract class AspNetCoreIisMvc31Tests : AspNetCoreIisMvcTestBase, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
@@ -62,7 +62,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         {
             _testName = GetTestName(nameof(AspNetCoreIisMvc31Tests));
             _iisFixture = fixture;
-            _iisFixture.TryStartIis(this, inProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
         }
 
         [SkippableTheory]
@@ -90,6 +89,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
                           .UseMethodName("_")
                           .UseTypeName(_testName);
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, InProcess ? IisAppType.AspNetCoreInProcess : IisAppType.AspNetCoreOutOfProcess);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/AspNetCoreIisMvcTestBase.cs
@@ -15,13 +15,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
     [UsesVerify]
     public abstract class AspNetCoreIisMvcTestBase : TracingIntegrationTest, IClassFixture<IisFixture>
     {
-        private readonly bool _inProcess;
         private readonly bool _enableRouteTemplateResourceNames;
 
         protected AspNetCoreIisMvcTestBase(string sampleName, IisFixture fixture, ITestOutputHelper output, bool inProcess, bool enableRouteTemplateResourceNames)
             : base(sampleName, output)
         {
-            _inProcess = inProcess;
+            InProcess = inProcess;
             _enableRouteTemplateResourceNames = enableRouteTemplateResourceNames;
             SetEnvironmentVariable(ConfigurationKeys.HttpServerErrorStatusCodes, "400-403, 500-503");
 
@@ -31,6 +30,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
 
             Fixture = fixture;
         }
+
+        protected bool InProcess { get; }
 
         protected IisFixture Fixture { get; }
 
@@ -62,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AspNetCore
         protected string GetTestName(string testName)
         {
             return testName
-                 + (_inProcess ? ".InProcess" : ".OutOfProcess")
+                 + (InProcess ? ".InProcess" : ".OutOfProcess")
                  + (_enableRouteTemplateResourceNames ? ".WithFF" : ".NoFF");
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
 
             using (var telemetry = this.ConfigureTelemetry())
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 const int expectedProcessorSpanCount = 91;
                 agent.SpanFilters.Add(s =>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
@@ -44,7 +44,7 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
 
         using var assertionScope = new AssertionScope();
         using var agent = EnvironmentHelper.GetMockAgent();
-        using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+        using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
         {
             agent.SpanFilters.Add(s => s.Tags.TryGetValue("messaging.system", out var value) && value == "servicebus"); // Exclude the Admin requests
             var spans = agent.WaitForSpans(23);
@@ -62,7 +62,7 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
     [SkippableTheory(Skip = "This has only been tested on a live Azure Service Bus namespace using a connection string. Unskip this if you'd like to run locally or if you've correctly configured piotr-rojek/devopsifyme-sbemulator in CI")]
     [MemberData(nameof(GetPackageVersions))]
     [Trait("Category", "EndToEnd")]
-    public void ValidateSpanTags(string packageVersion)
+    public async Task ValidateSpanTags(string packageVersion)
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
         SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
@@ -72,7 +72,7 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
 
         using var assertionScope = new AssertionScope();
         using var agent = EnvironmentHelper.GetMockAgent();
-        using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+        using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
         {
             agent.SpanFilters.Add(s => s.Tags.TryGetValue("messaging.system", out var value) && value == "servicebus"); // Exclude the Admin requests
             var spans = agent.WaitForSpans(23);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -120,7 +120,7 @@ public abstract class AzureFunctionsTests : TestHelper
         public async Task SubmitsTraces()
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
-            using (RunAzureFunctionAndWaitForExit(agent))
+            using (await RunAzureFunctionAndWaitForExit(agent))
             {
                 const int expectedSpanCount = 21;
                 var spans = agent.WaitForSpans(expectedSpanCount);
@@ -152,7 +152,7 @@ public abstract class AzureFunctionsTests : TestHelper
         public async Task SubmitsTraces()
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
-            using (RunAzureFunctionAndWaitForExit(agent, framework: "net6.0"))
+            using (await RunAzureFunctionAndWaitForExit(agent, framework: "net6.0"))
             {
                 const int expectedSpanCount = 21;
                 var spans = agent.WaitForSpans(expectedSpanCount);
@@ -184,7 +184,7 @@ public abstract class AzureFunctionsTests : TestHelper
         public async Task SubmitsTraces()
         {
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
-            using (RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
+            using (await RunAzureFunctionAndWaitForExit(agent, expectedExitCode: -1))
             {
                 const int expectedSpanCount = 21;
                 var spans = agent.WaitForSpans(expectedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AzureFunctionsTests.cs" company="Datadog">
+// <copyright file="AzureFunctionsTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -43,12 +43,12 @@ public abstract class AzureFunctionsTests : TestHelper
         SetEnvironmentVariable("DD_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS", ImmutableAzureAppServiceSettings.DefaultHttpClientExclusions + ", devstoreaccount1/azure-webjobs-hosts");
     }
 
-    protected ProcessResult RunAzureFunctionAndWaitForExit(MockTracerAgent agent, string framework = null, int expectedExitCode = 0)
+    protected async Task<ProcessResult> RunAzureFunctionAndWaitForExit(MockTracerAgent agent, string framework = null, int expectedExitCode = 0)
     {
         // run the azure function
         var binFolder = EnvironmentHelper.GetSampleApplicationOutputDirectory(packageVersion: string.Empty, framework, usePublishFolder: false);
         Output.WriteLine("Using binFolder: " + binFolder);
-        var process = ProfilerHelper.StartProcessWithProfiler(
+        var process = await ProfilerHelper.StartProcessWithProfiler(
             executable: "func",
             EnvironmentHelper,
             agent,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
@@ -37,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.MSTest), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion)
         {
             var version = string.IsNullOrEmpty(packageVersion) ? new Version("2.2.8") : new Version(packageVersion);
             var tests = new List<MockCIVisibilityTest>();
@@ -88,7 +89,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         }
                     };
 
-                    using (ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         // Check the tests, suites and modules count
                         Assert.Equal(expectedTestCount, tests.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.MSTest), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion)
         {
             var version = string.IsNullOrEmpty(packageVersion) ? new Version("2.2.8") : new Version(packageVersion);
             List<MockSpan> spans = null;
@@ -46,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
                     agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2")).ToArray();
-                    using (ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         spans = agent.WaitForSpans(expectedSpanCount)
                                      .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
@@ -53,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.NUnit), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion)
         {
             if (new Version(FrameworkDescription.Instance.ProductVersion).Major >= 5)
             {
@@ -118,7 +119,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         }
                     };
 
-                    using (ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         // Check the tests, suites and modules count
                         Assert.Equal(ExpectedTestCount, tests.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
@@ -48,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.NUnit), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion)
         {
             if (new Version(FrameworkDescription.Instance.ProductVersion).Major >= 5)
             {
@@ -68,7 +69,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
                     agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2")).ToArray();
-                    using (ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         spans = agent.WaitForSpans(ExpectedSpanCount)
                                      .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
@@ -39,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion)
         {
             var tests = new List<MockCIVisibilityTest>();
             var testSuites = new List<MockCIVisibilityTestSuite>();
@@ -94,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                         }
                     };
 
-                    using (ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         // Check the tests, suites and modules count
                         Assert.Equal(ExpectedTestCount, tests.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Configuration;
@@ -37,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public void SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion)
         {
             List<MockSpan> spans = null;
             string[] messages = null;
@@ -53,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
                     agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2")).ToArray();
-                    using (ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
+                    using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         spans = agent.WaitForSpans(ExpectedSpanCount)
                                      .Where(s => !(s.Tags.TryGetValue(Tags.InstrumentationName, out var sValue) && sValue == "HttpMessageHandler"))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -6,6 +6,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -33,11 +34,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [MemberData(nameof(MethodArgumentsData))]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void MethodArgumentsInstrumentation(int numberOfArguments, bool fastPath)
+        public async Task MethodArgumentsInstrumentation(int numberOfArguments, bool fastPath)
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: numberOfArguments.ToString()))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: numberOfArguments.ToString()))
             {
                 string beginMethodString = $"ProfilerOK: BeginMethod\\({numberOfArguments}\\)";
                 if (!fastPath)
@@ -85,11 +86,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void MethodRefArguments()
+        public async Task MethodRefArguments()
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "withref"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: "withref"))
             {
                 int beginMethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({1}\\)").Count;
                 int begin2MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({2}\\)").Count;
@@ -116,11 +117,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void MethodOutArguments()
+        public async Task MethodOutArguments()
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "without"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: "without"))
             {
                 int beginMethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({1}\\)").Count;
                 int begin2MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({2}\\)").Count;
@@ -146,11 +147,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void MethodAbstract()
+        public async Task MethodAbstract()
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "abstract"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: "abstract"))
             {
                 int beginMethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({0}\\)").Count;
                 int begin1MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({1}\\)").Count;
@@ -176,12 +177,12 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [SkippableFact]
-        public void MethodInterface()
+        public async Task MethodInterface()
         {
             int agentPort = TcpPortProvider.GetOpenPort();
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "interface"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: "interface"))
             {
                 int begin1MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\(").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
@@ -204,11 +205,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void RemoveIntegrations()
+        public async Task RemoveIntegrations()
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "remove"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: "remove"))
             {
                 int beginMethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\(").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
@@ -227,11 +228,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void ExtraIntegrations()
+        public async Task ExtraIntegrations()
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "extras"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: "extras"))
             {
                 int begin1MethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\({0}\\)").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;
@@ -247,11 +248,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void CategorizedCallTargetIntegrations()
+        public async Task CategorizedCallTargetIntegrations()
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: "categories"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: "categories"))
             {
                 int beginMethodCount = Regex.Matches(processResult.StandardOutput, $"ProfilerOK: BeginMethod\\(").Count;
                 int endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod\\(").Count;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(10, 500)
                                  .Where(s => s.Type == "db")

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.TestHelpers;
@@ -33,7 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
             var isExternalSpan = metadataSchemaVersion == "v0";
@@ -41,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(13, 500);
                 Assert.True(spans.Count >= 13, $"Expecting at least 13 spans, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs
@@ -38,7 +38,7 @@ public class DataStreamsMonitoringRabbitMQTests : TestHelper
 
         using var assertionScope = new AssertionScope();
         using var agent = EnvironmentHelper.GetMockAgent();
-        using (RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
+        using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
         {
             var spans = agent.WaitForSpans(31);
             spans.Should().HaveCount(31);
@@ -55,13 +55,13 @@ public class DataStreamsMonitoringRabbitMQTests : TestHelper
     [SkippableTheory]
     [MemberData(nameof(PackageVersions.RabbitMQ), MemberType = typeof(PackageVersions))]
     [Trait("Category", "EndToEnd")]
-    public void ValidateSpanTags(string packageVersion)
+    public async Task ValidateSpanTags(string packageVersion)
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
 
         using var assertionScope = new AssertionScope();
         using var agent = EnvironmentHelper.GetMockAgent();
-        using (RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
+        using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
         {
             var spans = agent.WaitForSpans(31);
             spans.Should().HaveCount(31);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DataStreamsMonitoringTests.cs" company="Datadog">
+// <copyright file="DataStreamsMonitoringTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -72,7 +72,7 @@ public class DataStreamsMonitoringTests : TestHelper
 
         using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 
-        using var processResult = RunSampleAndWaitForExit(agent);
+        using var processResult = await RunSampleAndWaitForExit(agent);
 
         using var assertionScope = new AssertionScope();
         var payload = NormalizeDataStreams(agent.DataStreams);
@@ -125,7 +125,7 @@ public class DataStreamsMonitoringTests : TestHelper
 
         using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
 
-        using var processResult = RunSampleAndWaitForExit(agent, arguments: "--fan-in");
+        using var processResult = await RunSampleAndWaitForExit(agent, arguments: "--fan-in");
 
         using var assertionScope = new AssertionScope();
 
@@ -143,12 +143,12 @@ public class DataStreamsMonitoringTests : TestHelper
     [SkippableFact]
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "ArmUnsupported")]
-    public void WhenDisabled_DoesNotSubmitDataStreams()
+    public async Task WhenDisabled_DoesNotSubmitDataStreams()
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "0");
 
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var processResult = RunSampleAndWaitForExit(agent);
+        using var processResult = await RunSampleAndWaitForExit(agent);
 
         using var assertionScope = new AssertionScope();
         // We don't expect any streams here, so no point waiting for ages
@@ -159,13 +159,13 @@ public class DataStreamsMonitoringTests : TestHelper
     [SkippableFact]
     [Trait("Category", "EndToEnd")]
     [Trait("Category", "ArmUnsupported")]
-    public void WhenNotSupported_DoesNotSubmitDataStreams()
+    public async Task WhenNotSupported_DoesNotSubmitDataStreams()
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
 
         using var agent = EnvironmentHelper.GetMockAgent();
         agent.Configuration = new MockTracerAgent.AgentConfiguration { Endpoints = Array.Empty<string>() };
-        using var processResult = RunSampleAndWaitForExit(agent);
+        using var processResult = await RunSampleAndWaitForExit(agent);
 
         using var assertionScope = new AssertionScope();
         var dataStreams = agent.DataStreams;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
-            using var sample = StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
+            using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
 
             try
             {
@@ -106,7 +106,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
 
             SetEnvironmentVariable("DD_TRACE_SAMPLE_RATE", "0.9");
-            using var sample = StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
+            using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
 
             try
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var expected = new List<string>();
 
@@ -177,14 +177,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             using var telemetry = this.ConfigureTelemetry();
             string packageVersion = PackageVersions.ElasticSearch5.First()[0] as string;
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.ElasticsearchNet)}_ENABLED", "false");
 
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
 
             Assert.Empty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var expected = new List<string>();
                 var version = string.IsNullOrEmpty(packageVersion) ? null : new Version(packageVersion);
@@ -194,13 +194,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             using var telemetry = this.ConfigureTelemetry();
             string packageVersion = PackageVersions.ElasticSearch6.First()[0] as string;
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.ElasticsearchNet)}_ENABLED", "false");
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
 
             Assert.Empty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var expected = new List<string>();
 
@@ -182,13 +182,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             using var telemetry = this.ConfigureTelemetry();
             string packageVersion = PackageVersions.ElasticSearch7.First()[0] as string;
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.ElasticsearchNet)}_ENABLED", "false");
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var process = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
             var spans = agent.WaitForSpans(1).Where(s => s.Type == "elasticsearch").ToList();
 
             Assert.Empty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             GuardAlpine();
 
@@ -66,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
 
             GuardArm64(packageVersions[0]);
-            RunIntegrationDisabled(packageVersions[0]);
+            await RunIntegrationDisabled(packageVersions[0]);
         }
     }
 
@@ -102,7 +102,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             GuardAlpine();
 
@@ -121,7 +121,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             GuardArm64(packageVersions[0]);
 
-            RunIntegrationDisabled(packageVersions[0]);
+            await RunIntegrationDisabled(packageVersions[0]);
         }
     }
 
@@ -151,7 +151,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             GuardAlpine();
             GuardLinux();
@@ -168,7 +168,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             GuardArm64(packageVersions[0]);
 
-            RunIntegrationDisabled(packageVersions[0]);
+            await RunIntegrationDisabled(packageVersions[0]);
         }
 
         private static void GuardLinux()
@@ -297,7 +297,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             try
             {
-                using (processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
+                using (processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
                 {
                     var spans = agent.WaitForSpans(totalExpectedSpans, 500);
 
@@ -440,7 +440,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        protected void RunIntegrationDisabled(string packageVersion)
+        protected async Task RunIntegrationDisabled(string packageVersion)
         {
             using var telemetry = this.ConfigureTelemetry();
             SetEnvironmentVariable($"DD_TRACE_{nameof(IntegrationId.Grpc)}_ENABLED", "false");
@@ -448,7 +448,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             ProcessResult processResult = null;
             try
             {
-                using (processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
+                using (processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
                 {
                     var spans = agent.WaitForSpans(1, timeoutInMilliseconds: 500).Where(s => s.Type == "grpc.request").ToList();
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Tagging;
@@ -68,7 +69,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
         [MemberData(nameof(IntegrationConfigWithObfuscation))]
-        public void HttpClient_SubmitsTraces(
+        public async Task HttpClient_SubmitsTraces(
             InstrumentationOptions instrumentation,
             bool socketsHandlerEnabled,
             bool queryStringCaptureEnabled,
@@ -104,7 +105,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 using var telemetry = this.ConfigureTelemetry();
                 using (var agent = EnvironmentHelper.GetMockAgent())
-                using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+                using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
                 {
                     agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
                     var spans = agent.WaitForSpans(expectedSpanCount);
@@ -189,7 +190,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
         [MemberData(nameof(IntegrationConfig))]
-        public void TracingDisabled_DoesNotSubmitsTraces(InstrumentationOptions instrumentation, bool enableSocketsHandler)
+        public async Task TracingDisabled_DoesNotSubmitsTraces(InstrumentationOptions instrumentation, bool enableSocketsHandler)
         {
             try
             {
@@ -200,7 +201,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 int httpPort = TcpPortProvider.GetOpenPort();
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
-                using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
+                using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
                 {
                     var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
                     Assert.Empty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Collections.Specialized;
 using System.IO;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -23,14 +23,14 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
 
     [Fact]
     [Trait("Category", "LinuxUnsupported")] // Linux support is not implemented yet
-    public void WriteInstrumentationToDisk_IsEnabled_FilesGetWrittenToTheAppropriateFolder()
+    public async Task WriteInstrumentationToDisk_IsEnabled_FilesGetWrittenToTheAppropriateFolder()
     {
         // Arrange
         SetEnvironmentVariable(InstrumentationVerification.InstrumentationVerificationEnabled, "true");
 
         // Act
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var processResult = RunSampleAndWaitForExit(agent);
+        using var processResult = await RunSampleAndWaitForExit(agent);
 
         // Assert
         var folderFullPath = InstrumentationVerification.FindInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory);
@@ -44,14 +44,14 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
 
     [Fact]
     [Trait("Category", "LinuxUnsupported")] // Linux support is not implemented yet
-    public void WriteInstrumentationToDisk_IsDisabled_NothingGetsWrittenToDisk()
+    public async Task WriteInstrumentationToDisk_IsDisabled_NothingGetsWrittenToDisk()
     {
         // Arrange
         SetEnvironmentVariable(InstrumentationVerification.InstrumentationVerificationEnabled, "false");
 
         // Act
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var processResult = RunSampleAndWaitForExit(agent);
+        using var processResult = await RunSampleAndWaitForExit(agent);
 
         // Assert
         InstrumentationVerification.FindInstrumentationLogsFolder(processResult.Process, EnvironmentHelper.LogDirectory)
@@ -61,11 +61,11 @@ public class InstrumentationVerificationSanityCheckTests : TestHelper
 
     [Fact]
     [Trait("Category", "LinuxUnsupported")] // Linux support is not implemented yet
-    public void WriteInstrumentationToDisk_IsNotSpecified_DefaultsToFalseAndNothingGetsWrittenToDisk()
+    public async Task WriteInstrumentationToDisk_IsNotSpecified_DefaultsToFalseAndNothingGetsWrittenToDisk()
     {
         // Act
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var processResult = RunSampleAndWaitForExit(agent);
+        using var processResult = await RunSampleAndWaitForExit(agent);
 
         // Assert
         processResult.Process.StartInfo.

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -59,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "ArmUnsupported")]
-        public void SubmitsTraces(string packageVersion, string metadataSchemaVersion)
+        public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
         {
             var topic = $"sample-topic-{TestPrefix}-{packageVersion}".Replace('.', '-');
 
@@ -69,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var processResult = RunSampleAndWaitForExit(agent, arguments: topic, packageVersion: packageVersion);
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: topic, packageVersion: packageVersion);
 
             var allSpans = agent.WaitForSpans(TotalExpectedSpanCount, timeoutInMilliseconds: 10_000);
             using var assertionScope = new AssertionScope();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Log4Net.DirectSubmission;
 using Datadog.Trace.Configuration;
@@ -69,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void InjectsLogsWhenEnabled(string packageVersion, bool enableLogShipping)
+        public async Task InjectsLogsWhenEnabled(string packageVersion, bool enableLogShipping)
         {
             SetInstrumentationVerification();
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
@@ -83,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedCorrelatedSpanCount = 1;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -110,7 +111,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DoesNotInjectLogsWhenDisabled(string packageVersion, bool enableLogShipping)
+        public async Task DoesNotInjectLogsWhenDisabled(string packageVersion, bool enableLogShipping)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "false");
             SetInstrumentationVerification();
@@ -124,7 +125,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedCorrelatedSpanCount = 0;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -151,7 +152,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DirectlyShipsLogs(string packageVersion)
+        public async Task DirectlyShipsLogs(string packageVersion)
         {
             var hostName = "integration_log4net_tests";
             using var logsIntake = new MockLogsIntake();
@@ -163,7 +164,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
             ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ManualInstrumentationTests.cs" company="Datadog">
+// <copyright file="ManualInstrumentationTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -29,7 +29,7 @@ public class ManualInstrumentationTests : TestHelper
         using var telemetry = this.ConfigureTelemetry();
         using var agent = EnvironmentHelper.GetMockAgent();
         using var assert = new AssertionScope();
-        using var process = RunSampleAndWaitForExit(agent);
+        using var process = await RunSampleAndWaitForExit(agent);
 
         var spans = agent.WaitForSpans(expectedSpans);
         spans.Should().HaveCount(expectedSpans);
@@ -48,7 +48,7 @@ public class ManualInstrumentationTests : TestHelper
         using var telemetry = this.ConfigureTelemetry();
         using var agent = EnvironmentHelper.GetMockAgent();
         using var assert = new AssertionScope();
-        using var process = RunSampleAndWaitForExit(agent);
+        using var process = await RunSampleAndWaitForExit(agent);
 
         var spans = agent.WaitForSpans(expectedSpans);
         spans.Should().HaveCount(expectedSpans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(3, 500);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs
@@ -6,6 +6,7 @@
 #if NETFRAMEWORK
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -34,14 +35,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [SkippableFact]
-        public void SubmitTracesV0() => RunTest("v0");
+        public Task SubmitTracesV0() => RunTest("v0");
 
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [SkippableFact]
-        public void SubmitTracesV1() => RunTest("v1");
+        public Task SubmitTracesV1() => RunTest("v1");
 
-        private void RunTest(string metadataSchemaVersion)
+        private async Task RunTest(string metadataSchemaVersion)
         {
             const int expectedTransactionalTraces = 13;
             const int expectedNonTransactionalTracesTraces = 12;
@@ -64,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var processResult = RunSampleAndWaitForExit(agent, arguments: $"5 5");
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: $"5 5");
 
             var spans = agent.WaitForSpans(totalTransactions);
             Assert.True(spans.Count >= totalTransactions, $"Expecting at least {totalTransactions} spans, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.DirectSubmission.Formatting;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
@@ -246,7 +247,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void InjectsLogsWhenEnabled(string packageVersion, DirectLogSubmission enableLogShipping, string context, ConfigurationType configType)
+        public async Task InjectsLogsWhenEnabled(string packageVersion, DirectLogSubmission enableLogShipping, string context, ConfigurationType configType)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
             SetInstrumentationVerification();
@@ -260,7 +261,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedCorrelatedSpanCount = 1;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType })))
+            using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType })))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -277,7 +278,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DoesNotInjectLogsWhenDisabled(string packageVersion, DirectLogSubmission enableLogShipping, string context, ConfigurationType configType)
+        public async Task DoesNotInjectLogsWhenDisabled(string packageVersion, DirectLogSubmission enableLogShipping, string context, ConfigurationType configType)
         {
             if (configType != ConfigurationType.LogsInjection)
             {
@@ -296,7 +297,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedCorrelatedSpanCount = 0;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType })))
+            using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType })))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -314,7 +315,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DirectlyShipsLogs(string packageVersion, DirectLogSubmission enableLogShipping, string context, ConfigurationType configType)
+        public async Task DirectlyShipsLogs(string packageVersion, DirectLogSubmission enableLogShipping, string context, ConfigurationType configType)
         {
             if (enableLogShipping != DirectLogSubmission.Enable) { throw new Xunit.SkipException("Direct log submission disabled does not apply to this test"); }
 
@@ -328,7 +329,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType }));
+            using var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, arguments: string.Join(" ", new object[] { context, configType }));
 
             ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NativeProfilerChecks.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NativeProfilerChecks.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.IO;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -21,11 +22,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void RunChecksProject()
+        public async Task RunChecksProject()
         {
             SetInstrumentationVerification();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent))
+            using (var processResult = await RunSampleAndWaitForExit(agent))
             {
                 var exitCode = processResult.ExitCode;
                 if (exitCode == 139)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using (var telemetry = this.ConfigureTelemetry())
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 const int expectedSpanCount = 47;
                 var spans = agent.WaitForSpans(expectedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs
@@ -6,6 +6,7 @@
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.TestHelpers;
 using DiffEngine;
@@ -24,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
-        public void SingleLoaderTest()
+        public async Task SingleLoaderTest()
         {
             string tmpFile = Path.GetTempFileName();
             // Using obsolete variable so we can be sure it will only
@@ -34,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // Clear any existing log path values, as these take precedence over DD_TRACE_LOG_PATH
             SetEnvironmentVariable(Configuration.ConfigurationKeys.LogDirectory, string.Empty);
 
-            using ProcessResult processResult = RunSampleAndWaitForExit(MockTracerAgent.Create(Output, 9696, doNotBindPorts: true));
+            using ProcessResult processResult = await RunSampleAndWaitForExit(MockTracerAgent.Create(Output, 9696, doNotBindPorts: true));
             string[] logFileContent = File.ReadAllLines(tmpFile);
             int numOfLoadersLoad = logFileContent.Count(line => line.Contains("Datadog.Trace.ClrProfiler.Managed.Loader loaded"));
             Assert.Equal(1, numOfLoadersLoad);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using (var telemetry = this.ConfigureTelemetry())
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 const int expectedSpanCount = 35;
                 var spans = agent.WaitForSpans(expectedSpanCount);
@@ -137,7 +137,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using (var telemetry = this.ConfigureTelemetry())
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 const int expectedSpanCount = 35;
                 var spans = agent.WaitForSpans(expectedSpanCount);
@@ -166,11 +166,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [MemberData(nameof(PackageVersions.OpenTelemetry), MemberType = typeof(PackageVersions))]
-        public void IntegrationDisabled(string packageVersion)
+        public async Task IntegrationDisabled(string packageVersion)
         {
             using (var telemetry = this.ConfigureTelemetry())
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.Spans;
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -24,7 +25,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void RenamesService()
+        public async Task RenamesService()
         {
             var expectedSpanCount = 87;
 
@@ -37,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommandsCollectionTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommandsCollectionTests.cs
@@ -38,6 +38,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled() => IntegrationDisabledMethod();
+        public Task IntegrationDisabled() => IntegrationDisabledMethod();
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -83,7 +83,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
 
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
             ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartCommonTests.cs
@@ -30,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsProcess(metadataSchemaVersion);
 
-        protected void IntegrationDisabledMethod()
+        protected async Task IntegrationDisabledMethod()
         {
             const string expectedOperationName = "command_execution";
 
@@ -38,7 +38,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.Spans; // no spans expected
 
             Assert.Empty(spans.Where(s => s.Name.Equals(expectedOperationName)));

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ProcessStartTests/ProcessStartTests.cs
@@ -39,6 +39,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
 
-        public void IntegrationDisabled() => IntegrationDisabledMethod();
+        public Task IntegrationDisabled() => IntegrationDisabledMethod();
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs
@@ -65,7 +65,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
             {
                 using var assertionScope = new AssertionScope();
                 var spans = agent.WaitForSpans(expectedSpanCount); // Do not filter on operation name because they will vary depending on instrumented method

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RemotingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RemotingTests.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=http"))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=http"))
             {
                 const int expectedSpanCount = 8;
                 var spans = agent.WaitForSpans(expectedSpanCount);
@@ -88,7 +88,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=tcp"))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=tcp"))
             {
                 const int expectedSpanCount = 6;
                 var spans = agent.WaitForSpans(expectedSpanCount);
@@ -126,7 +126,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=ipc"))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"Port={remotingPort} Protocol=ipc"))
             {
                 const int expectedSpanCount = 6;
                 var spans = agent.WaitForSpans(expectedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs
@@ -31,13 +31,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void MetricsDisabled()
+        public async Task MetricsDisabled()
         {
             SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             SetEnvironmentVariable("DD_RUNTIME_METRICS_ENABLED", "0");
             using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
 
-            using var processResult = RunSampleAndWaitForExit(agent);
+            using var processResult = await RunSampleAndWaitForExit(agent);
             var requests = agent.StatsdRequests;
 
             Assert.True(requests.Count == 0, "Received metrics despite being disabled. Metrics received: " + string.Join("\n", requests));
@@ -47,22 +47,22 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void UdpSubmitsMetrics()
+        public async Task UdpSubmitsMetrics()
         {
             SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             EnvironmentHelper.EnableDefaultTransport();
-            RunTest();
+            await RunTest();
         }
 
 #if NETCOREAPP3_1_OR_GREATER
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "False")]
-        public void UdsSubmitsMetrics()
+        public async Task UdsSubmitsMetrics()
         {
             SkipOn.Platform(SkipOn.PlatformValue.MacOs);
             EnvironmentHelper.EnableUnixDomainSockets();
-            RunTest();
+            await RunTest();
         }
 #endif
 
@@ -84,7 +84,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 try
                 {
                     attemptsRemaining--;
-                    RunTest();
+                    await RunTest();
                     return;
                 }
                 catch (Exception ex) when (attemptsRemaining > 0 && ex is not SkipException)
@@ -94,7 +94,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        private void RunTest()
+        private async Task RunTest()
         {
             var inputServiceName = "12_$#Samples.$RuntimeMetrics";
             SetEnvironmentVariable("DD_SERVICE", inputServiceName);
@@ -103,7 +103,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_TAGS", "some:value"); // Should be added to the metrics
 
             using var agent = EnvironmentHelper.GetMockAgent(useStatsD: true);
-            using var processResult = RunSampleAndWaitForExit(agent);
+            using var processResult = await RunSampleAndWaitForExit(agent);
             var requests = agent.StatsdRequests;
 
             // Check if we receive 2 kinds of metrics:

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -48,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void InjectsLogsWhenEnabled(string packageVersion, bool enableLogShipping, bool loadFromConfig)
+        public async Task InjectsLogsWhenEnabled(string packageVersion, bool enableLogShipping, bool loadFromConfig)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
             SetSerilogConfiguration(loadFromConfig);
@@ -63,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedCorrelatedSpanCount = 1;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -79,7 +80,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DoesNotInjectLogsWhenDisabled(string packageVersion, bool enableLogShipping, bool loadFromConfig)
+        public async Task DoesNotInjectLogsWhenDisabled(string packageVersion, bool enableLogShipping, bool loadFromConfig)
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "false");
             SetSerilogConfiguration(loadFromConfig);
@@ -94,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var expectedCorrelatedSpanCount = 0;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+            using (var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");
@@ -110,7 +111,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void DirectlyShipsLogs(string packageVersion, bool enableLogShipping, bool loadFromConfig)
+        public async Task DirectlyShipsLogs(string packageVersion, bool enableLogShipping, bool loadFromConfig)
         {
             if (!enableLogShipping)
             {
@@ -129,7 +130,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var processResult = RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
+            using var processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion);
 
             ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void RenamesService()
+        public async Task RenamesService()
         {
             var expectedSpanCount = 87;
 
@@ -35,7 +36,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 var spans = agent.WaitForSpans(expectedSpanCount, operationName: expectedOperationName);
                 Assert.Equal(expectedSpanCount, spans.Count);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
             {
 #if NETCOREAPP3_1_OR_GREATER
                 var numberOfRuns = 3;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyLoadContextRedirectSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyLoadContextRedirectSmokeTest.cs
@@ -5,6 +5,7 @@
 
 #if !NETFRAMEWORK
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,9 +20,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke();
+            await CheckForSmoke();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyLoadFileNotFoundExceptionSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyLoadFileNotFoundExceptionSmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,9 +18,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyResolveMscorlibResourcesInfiniteRecursionCrashSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/AssemblyResolveMscorlibResourcesInfiniteRecursionCrashSmokeTest.cs
@@ -22,9 +22,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke();
+            await CheckForSmoke();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DeepNestedHierarchySmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DeepNestedHierarchySmokeTest.cs
@@ -1,8 +1,9 @@
-﻿// <copyright file="DeepNestedHierarchySmokeTest.cs" company="Datadog">
+// <copyright file="DeepNestedHierarchySmokeTest.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,8 +18,8 @@ public class DeepNestedHierarchySmokeTest : SmokeTestBase
 
     [SkippableFact]
     [Trait("Category", "Smoke")]
-    public void NoExceptions()
+    public async Task NoExceptions()
     {
-        CheckForSmoke(shouldDeserializeTraces: false);
+        await CheckForSmoke(shouldDeserializeTraces: false);
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DevArtDataDBCommandSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DevArtDataDBCommandSmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,9 +18,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void HasSpans()
+        public async Task HasSpans()
         {
-            CheckForSmoke();
+            await CheckForSmoke();
             Assert.True(Spans.Count > 0);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DuplicateTypeProxySmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/DuplicateTypeProxySmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,9 +18,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/EnumerateAssemblyReferencesTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,9 +18,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/HttpHandlerStackOverflowExceptionSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/HttpHandlerStackOverflowExceptionSmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,9 +18,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/IBMDataDB2CommandSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/IBMDataDB2CommandSmokeTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +19,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void HasSpans()
+        public async Task HasSpans()
         {
-            CheckForSmoke();
+            await CheckForSmoke();
             Assert.True(Spans.Count > 0);
         }
     }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/MultiThreadedSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/MultiThreadedSmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -17,9 +18,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [Fact(Skip = "Investigation needed to understand timeout issues.")]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/NetCoreAssemblyLoadFailureOlderNuGetSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/NetCoreAssemblyLoadFailureOlderNuGetSmokeTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if !NETFRAMEWORK
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +19,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxAutomaticInstrumentationSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxAutomaticInstrumentationSmokeTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +19,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void Fails()
+        public async Task Fails()
         {
-            CheckForSmoke(shouldDeserializeTraces: false, expectedExitCode: 0);
+            await CheckForSmoke(shouldDeserializeTraces: false, expectedExitCode: 0);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxLegacySecurityPolicySmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SandboxLegacySecurityPolicySmokeTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -23,9 +24,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void Fails()
+        public async Task Fails()
         {
-            CheckForSmoke(shouldDeserializeTraces: false, expectedExitCode: 0);
+            await CheckForSmoke(shouldDeserializeTraces: false, expectedExitCode: 0);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalMassTransitTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalMassTransitTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,9 +20,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalNServiceBusTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalNServiceBusTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +19,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalRebusTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/ServiceBusMinimalRebusTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +19,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -51,7 +52,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         /// </summary>
         /// <param name="shouldDeserializeTraces">Optimization parameter, pass false when the resulting traces aren't being verified</param>
         /// <param name="expectedExitCode">Expected exit code</param>
-        protected void CheckForSmoke(bool shouldDeserializeTraces = true, int expectedExitCode = 0)
+        /// <returns>Async operation</returns>
+        protected async Task CheckForSmoke(bool shouldDeserializeTraces = true, int expectedExitCode = 0)
         {
             var applicationPath = EnvironmentHelper.GetSampleApplicationPath().Replace(@"\\", @"\");
             Output.WriteLine($"Application path: {applicationPath}");
@@ -79,7 +81,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                 // Command becomes: dotnet.exe <applicationPath>
                 var args = EnvironmentHelper.IsCoreClr() ? applicationPath : null;
                 // Using the following code to avoid possible hangs on WaitForExit due to synchronous reads: https://stackoverflow.com/questions/139593/processstartinfo-hanging-on-waitforexit-why
-                using (var process = ProfilerHelper.StartProcessWithProfiler(executable, EnvironmentHelper, agent, arguments: args, aspNetCorePort: aspNetCorePort, processToProfile: executable))
+                using (var process = await ProfilerHelper.StartProcessWithProfiler(executable, EnvironmentHelper, agent, arguments: args, aspNetCorePort: aspNetCorePort, processToProfile: executable))
                 {
                     using var helper = new ProcessHelper(process);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Xunit;
 using Xunit.Abstractions;
@@ -20,9 +21,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [Fact(Skip = ".NET Framework test, but cannot run on Windows because it requires Redis")]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictSdkProjectSmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -21,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
             if (EnvironmentTools.IsWindows())
             {
@@ -29,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                 return;
             }
 
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisStackOverflowExceptionSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisStackOverflowExceptionSmokeTest.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.TestCollections;
 using Datadog.Trace.TestHelpers;
 using Xunit;
@@ -21,7 +22,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
 
         [SkippableFact]
         [Trait("Category", "Smoke")]
-        public void NoExceptions()
+        public async Task NoExceptions()
         {
             if (EnvironmentTools.IsWindows())
             {
@@ -29,7 +30,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                 return;
             }
 
-            CheckForSmoke(shouldDeserializeTraces: false);
+            await CheckForSmoke(shouldDeserializeTraces: false);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs
@@ -62,7 +62,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using var a = new AssertionScope();
             using var telemetry = this.ConfigureTelemetry();
             using var agent = EnvironmentHelper.GetMockAgent();
-            using (RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"{TestPrefix}", packageVersion: packageVersion))
             {
                 var calculatedVersion = GetPackageVersion(packageVersion);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
@@ -90,7 +90,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
@@ -121,7 +121,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
@@ -172,7 +172,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                 int httpPort = TcpPortProvider.GetOpenPort();
                 Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-                using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+                using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
                 {
                     ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
@@ -208,7 +208,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
@@ -237,7 +237,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
@@ -314,7 +314,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 
@@ -361,7 +361,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var httpPort = TcpPortProvider.GetOpenPort();
 
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs
@@ -99,7 +99,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // FIXME: Could be fixed with an upgrade to the NuGet package (after .NET 8?)
             MockTelemetryAgent telemetry = _enableTelemetry ? this.ConfigureTelemetry() : null;
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(expectedSpanCount);
 
@@ -166,7 +166,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void IntegrationDisabled()
+        public async Task IntegrationDisabled()
         {
             // Don't bother with telemetry in version mismatch scenarios because older versions may only support V1 telemetry
             // which we no longer support in our mock telemetry agent
@@ -176,7 +176,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_TRACE_ANNOTATIONS_ENABLED", "false");
 
             using var agent = EnvironmentHelper.GetMockAgent();
-            using var process = RunSampleAndWaitForExit(agent);
+            using var process = await RunSampleAndWaitForExit(agent);
             var spans = agent.Spans;
 
             Assert.Empty(spans);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TracerFlareTests.cs" company="Datadog">
+// <copyright file="TracerFlareTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -42,7 +42,7 @@ public class TracerFlareTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
         using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
-        using var sample = StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
+        using var sample = await StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
 
         try
         {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             int httpPort = TcpPortProvider.GetOpenPort();
             Output.WriteLine($"Assigning port {httpPort} for the httpPort.");
-            using (var processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (var processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 ExitCodeException.ThrowIfNonZero(processResult.ExitCode, processResult.StandardError);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/DefaultTransportLargePayloadTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/DefaultTransportLargePayloadTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -18,9 +19,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTraces()
-        {
-            RunTest();
-        }
+        public Task SubmitsTraces() => RunTest();
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/LargePayloadTestBase.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -29,11 +30,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public int ExpectedSpans => TracesToTrigger + (TracesToTrigger * SpansPerTrace);
 
-        protected void RunTest()
+        protected async Task RunTest()
         {
             using (var agent = EnvironmentHelper.GetMockAgent())
             {
-                using (var sample = RunSampleAndWaitForExit(agent, arguments: $" -t {TracesToTrigger} -s {SpansPerTrace} -f {FillerTagLength}"))
+                using (var sample = await RunSampleAndWaitForExit(agent, arguments: $" -t {TracesToTrigger} -s {SpansPerTrace} -f {FillerTagLength}"))
                 {
                     // Extra long time out because big payloads
                     var timeoutInMilliseconds = 60_000;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/UnixDomainSocketLargePayloadTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/UnixDomainSocketLargePayloadTests.cs
@@ -5,6 +5,7 @@
 
 #if NETCOREAPP3_1_OR_GREATER
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -21,10 +22,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("RunOnWindows", "True")]
-        public void SubmitsTraces()
+        public async Task SubmitsTraces()
         {
             EnvironmentHelper.EnableUnixDomainSockets();
-            RunTest();
+            await RunTest();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/WindowsNamedPipeLargePayloadTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/LargePayload/WindowsNamedPipeLargePayloadTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -23,10 +24,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableFact(Skip = "Windows named pipes are not yet supported in the MockTracerAgent")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "LinuxUnsupported")]
-        public void SubmitsTraces()
+        public async Task SubmitsTraces()
         {
             EnvironmentHelper.EnableWindowsNamedPipes();
-            RunTest();
+            await RunTest();
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/ILoggerVersionConflict2xTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -34,7 +35,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogs()
+        public async Task InjectsLogs()
         {
             // One of the traces starts by manual opening a span when the background service starts,
             // and then it sends a HTTP request to the server.
@@ -52,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 #endif
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, aspNetCorePort: 0))
+            using (await RunSampleAndWaitForExit(agent, aspNetCorePort: 0))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 spans.Should().HaveCountGreaterOrEqualTo(1);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Log4NetVersionConflict2xTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if !NETCOREAPP2_1
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -39,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogsWhenEnabled()
+        public async Task InjectsLogsWhenEnabled()
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
@@ -48,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = MockTracerAgent.Create(Output, agentPort))
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog10VersionConflict2xTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogsWhenEnabled()
+        public async Task InjectsLogsWhenEnabled()
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
@@ -41,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = MockTracerAgent.Create(Output, agentPort))
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLog20VersionConflict2xTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogsWhenEnabled()
+        public async Task InjectsLogsWhenEnabled()
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
@@ -41,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = MockTracerAgent.Create(Output, agentPort))
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/NLogVersionConflict2xTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if !NETCOREAPP2_1
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -39,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogsWhenEnabled()
+        public async Task InjectsLogsWhenEnabled()
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
@@ -48,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = MockTracerAgent.Create(Output, agentPort))
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/Serilog14VersionConflict2xTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETFRAMEWORK
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -32,7 +33,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogsWhenEnabled()
+        public async Task InjectsLogsWhenEnabled()
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
@@ -41,7 +42,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = MockTracerAgent.Create(Output, agentPort))
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/SerilogVersionConflict2xTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if !NETCOREAPP2_1
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -39,7 +40,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
-        public void InjectsLogsWhenEnabled()
+        public async Task InjectsLogsWhenEnabled()
         {
             SetEnvironmentVariable("DD_LOGS_INJECTION", "true");
 
@@ -48,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
 
             int agentPort = TcpPortProvider.GetOpenPort();
             using (var agent = MockTracerAgent.Create(Output, agentPort))
-            using (RunSampleAndWaitForExit(agent))
+            using (await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(1, 2500);
                 Assert.True(spans.Count >= 1, $"Expecting at least 1 span, only received {spans.Count}");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict1xTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -19,13 +20,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         }
 
         [SkippableFact]
-        public void SubmitTraces()
+        public async Task SubmitTraces()
         {
             // 1 manual span + 1 http span
             const int expectedSpanCount = 2;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent))
+            using (var processResult = await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(expectedSpanCount);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/VersionConflict2xTests.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -20,13 +21,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
         }
 
         [SkippableFact]
-        public void SubmitTraces()
+        public async Task SubmitTraces()
         {
             // 1 manual span + 2 http spans
             const int expectedSpanCount = 3;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (var processResult = RunSampleAndWaitForExit(agent))
+            using (var processResult = await RunSampleAndWaitForExit(agent))
             {
                 var spans = agent.WaitForSpans(expectedSpanCount);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs
@@ -101,7 +101,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int wcfPort = 8585;
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, arguments: $"{binding} Port={wcfPort}"))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"{binding} Port={wcfPort}"))
             {
                 // Filter out WCF spans unrelated to the actual request handling, and filter them before returning spans
                 // so we can wait on the exact number of spans we expect.
@@ -143,7 +143,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int wcfPort = 8585;
 
             using var agent = EnvironmentHelper.GetMockAgent();
-            using (RunSampleAndWaitForExit(agent, arguments: $"WebHttpBinding Port={wcfPort}"))
+            using (await RunSampleAndWaitForExit(agent, arguments: $"WebHttpBinding Port={wcfPort}"))
             {
                 // Filter out WCF spans unrelated to the actual request handling, and filter them before returning spans
                 // so we can wait on the exact number of spans we expect.

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs
@@ -6,6 +6,7 @@
 #if NETFRAMEWORK
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -28,19 +29,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void SubmitsTracesV0() => RunTest("v0");
+        public Task SubmitsTracesV0() => RunTest("v0");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void SubmitsTracesV1() => RunTest("v1");
+        public Task SubmitsTracesV1() => RunTest("v1");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void TracingDisabled_DoesNotSubmitsTraces()
+        public async Task TracingDisabled_DoesNotSubmitsTraces()
         {
             SetInstrumentationVerification();
 
@@ -48,7 +49,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
             {
                 var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
                 Assert.Empty(spans);
@@ -65,7 +66,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        private void RunTest(string metadataSchemaVersion)
+        private async Task RunTest(string metadataSchemaVersion)
         {
             int expectedSpanCount = 45;
 
@@ -78,7 +79,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 agent.SpanFilters.Add(s => s.Type == SpanTypes.Http);
                 var spans = agent.WaitForSpans(expectedSpanCount);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -5,6 +5,7 @@
 
 using System.Globalization;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.IntegrationTests.Helpers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -32,19 +33,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void SubmitsTracesV0() => RunTest("v0");
+        public Task SubmitsTracesV0() => RunTest("v0");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void SubmitsTracesV1() => RunTest("v1");
+        public Task SubmitsTracesV1() => RunTest("v1");
 
         [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("SupportsInstrumentationVerification", "True")]
-        public void TracingDisabled_DoesNotSubmitsTraces()
+        public async Task TracingDisabled_DoesNotSubmitsTraces()
         {
             SetInstrumentationVerification();
 
@@ -52,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"TracingDisabled Port={httpPort}"))
             {
                 var spans = agent.Spans.Where(s => s.Type == SpanTypes.Http);
                 Assert.Empty(spans);
@@ -69,7 +70,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        private void RunTest(string metadataSchemaVersion)
+        private async Task RunTest(string metadataSchemaVersion)
         {
             SetInstrumentationVerification();
             var expectedAllSpansCount = 130;
@@ -84,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             using var telemetry = this.ConfigureTelemetry();
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (ProcessResult processResult = RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
+            using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
                 var allSpans = agent.WaitForSpans(expectedAllSpansCount).OrderBy(s => s.Start);
                 allSpans.Should().OnlyHaveUniqueItems(s => new { s.SpanId, s.TraceId });

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             int aspnetCorePort = TcpPortProvider.GetOpenPort();
 
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: aspnetCorePort))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: aspnetCorePort))
             {
                 var spans = agent.WaitForSpans(expectedSpans, 1_000);
                 spans.Count.Should().Be(expectedSpans);

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Pdb;
 using Datadog.Trace.TestHelpers;
@@ -59,14 +60,14 @@ internal static class DebuggerTestHelper
         return type;
     }
 
-    internal static DebuggerSampleProcessHelper StartSample(TestHelper helper, MockTracerAgent agent, string testName)
+    internal static async Task<DebuggerSampleProcessHelper> StartSample(TestHelper helper, MockTracerAgent agent, string testName)
     {
         var listenPort = TcpPortProvider.GetOpenPort();
 
         var localHost = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "http://127.0.0.1" : "http://localhost";
         var listenUrl = $"{localHost}:{listenPort}/";
 
-        var process = helper.StartSample(agent, $"--test-name {testName} --listen-url {listenUrl}", string.Empty, aspNetCorePort: 5000);
+        var process = await helper.StartSample(agent, $"--test-name {testName} --listen-url {listenUrl}", string.Empty, aspNetCorePort: 5000);
         var processHelper = new DebuggerSampleProcessHelper(listenUrl, process);
 
         return processHelper;

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/LiveDebuggerTests.cs
@@ -60,7 +60,7 @@ public class LiveDebuggerTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         string processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Probes";
         using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*");
-        using var sample = StartSample(agent, $"--test-name {testType.TestType}", string.Empty, aspNetCorePort: 5000);
+        using var sample = await StartSample(agent, $"--test-name {testType.TestType}", string.Empty, aspNetCorePort: 5000);
         await logEntryWatcher.WaitForLogEntry(LiveDebuggerDisabledLogEntry);
 
         try

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -186,7 +186,7 @@ public class ProbesTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment(agent);
         using var logEntryWatcher = CreateLogEntryWatcher();
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             SetProbeConfiguration(agent, probes.Select(p => p.Probe).ToArray());
@@ -228,7 +228,7 @@ public class ProbesTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment(agent);
         using var logEntryWatcher = CreateLogEntryWatcher();
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             await RunSingle(phaseNumber: 1, captureSnapshot: false);
@@ -284,7 +284,7 @@ public class ProbesTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment(agent);
         using var logEntryWatcher = CreateLogEntryWatcher();
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             SetProbeConfiguration(agent, probes);
@@ -334,7 +334,7 @@ public class ProbesTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent();
         SetDebuggerEnvironment(agent);
         using var logEntryWatcher = CreateLogEntryWatcher();
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             await sample.RunCodeSample();
@@ -436,7 +436,7 @@ public class ProbesTests : TestHelper
         using var agent = EnvironmentHelper.GetMockAgent(useStatsD: useStatsD);
         SetDebuggerEnvironment(agent);
         using var logEntryWatcher = CreateLogEntryWatcher();
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             var isSinglePhase = probes.Select(p => p.ProbeTestData.Phase).Distinct().Count() == 1;
@@ -719,7 +719,7 @@ public class ProbesTests : TestHelper
         SetDebuggerEnvironment(agent);
 
         using var logEntryWatcher = CreateLogEntryWatcher();
-        using var sample = DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
+        using var sample = await DebuggerTestHelper.StartSample(this, agent, testDescription.TestType.FullName);
         try
         {
             SetProbeConfiguration(agent, probes);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreWithExternalRulesFileBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreWithExternalRulesFileBase.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task TestBlockedHeader(string test, HttpStatusCode expectedStatusCode, string url)
         {
-            TryStartApp();
+            await TryStartApp();
             var agent = Fixture.Agent;
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             var settings = VerifyHelper.GetSpanVerifierSettings(test, (int)expectedStatusCode, sanitisedUrl);
@@ -157,11 +157,11 @@ namespace Datadog.Trace.Security.IntegrationTests
             base.Dispose();
         }
 
-        public void TryStartApp()
+        public async Task TryStartApp()
         {
             SetEnvironmentVariable(ConfigurationKeys.AppSec.Rules, RuleFile);
             SetEnvironmentVariable(ConfigurationKeys.AppSec.Enabled, EnableSecurity.ToString());
-            Fixture.TryStartIis(this, AppType);
+            await Fixture.TryStartIis(this, AppType);
             SetHttpPort(Fixture.HttpPort);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -72,7 +72,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             _testName = "Security." + nameof(AspNetMvc5)
                      + (classicMode ? ".Classic" : ".Integrated")
                      + ".enableSecurity=" + enableSecurity;
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -109,7 +108,11 @@ namespace Datadog.Trace.Security.IntegrationTests
             await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, SecurityEnabled ? 1 : 2, settings, userAgent: "Hello/V");
         }
 
-        public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        public async Task InitializeAsync()
+        {
+            await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+            SetHttpPort(_iisFixture.HttpPort);
+        }
 
         public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -54,10 +54,11 @@ namespace Datadog.Trace.Security.IntegrationTests
         }
     }
 
-    public abstract class AspNetMvc5 : AspNetBase, IClassFixture<IisFixture>
+    public abstract class AspNetMvc5 : AspNetBase, IClassFixture<IisFixture>, IAsyncLifetime
     {
         private readonly IisFixture _iisFixture;
         private readonly string _testName;
+        private readonly bool _classicMode;
 
         public AspNetMvc5(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
             : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
@@ -66,8 +67,8 @@ namespace Datadog.Trace.Security.IntegrationTests
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.DebugEnabled, "1");
 
+            _classicMode = classicMode;
             _iisFixture = iisFixture;
-            _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             _testName = "Security." + nameof(AspNetMvc5)
                      + (classicMode ? ".Classic" : ".Integrated")
                      + ".enableSecurity=" + enableSecurity;
@@ -107,6 +108,10 @@ namespace Datadog.Trace.Security.IntegrationTests
             var settings = VerifyHelper.GetSpanVerifierSettings(test);
             await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, SecurityEnabled ? 1 : 2, settings, userAgent: "Hello/V");
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+
+        public Task DisposeAsync() => Task.CompletedTask;
 
         protected override string GetTestName() => _testName;
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -110,8 +110,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             {
                 SetEnvironmentVariable(ConfigurationKeys.AppSec.TraceRateLimit, _traceRateLimit.ToString());
             }
-
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -128,7 +126,11 @@ namespace Datadog.Trace.Security.IntegrationTests
             Thread.Sleep(1000);
         }
 
-        public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        public async Task InitializeAsync()
+        {
+            await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+            SetHttpPort(_iisFixture.HttpPort);
+        }
 
         public Task DisposeAsync() => Task.CompletedTask;
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetMvc5RateLimiterClassicWithSecurityWithCustomTraceRate : AspNetMvc5RateLimiter
     {
         public AspNetMvc5RateLimiterClassicWithSecurityWithCustomTraceRate(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, classicMode: true, enableSecurity: true,  traceRateLimit: 20)
+            : base(iisFixture, output, classicMode: true, enableSecurity: true, traceRateLimit: 20)
         {
         }
     }
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetMvc5RateLimiterIntegratedWithoutSecurityWithCustomTraceRate : AspNetMvc5RateLimiter
     {
         public AspNetMvc5RateLimiterIntegratedWithoutSecurityWithCustomTraceRate(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, classicMode: false, enableSecurity: false,  traceRateLimit: 20)
+            : base(iisFixture, output, classicMode: false, enableSecurity: false, traceRateLimit: 20)
         {
         }
     }
@@ -86,22 +86,24 @@ namespace Datadog.Trace.Security.IntegrationTests
     public class AspNetMvc5RateLimiterIntegratedWithSecurityWithCustomTraceRate : AspNetMvc5RateLimiter
     {
         public AspNetMvc5RateLimiterIntegratedWithSecurityWithCustomTraceRate(IisFixture iisFixture, ITestOutputHelper output)
-            : base(iisFixture, output, classicMode: false, enableSecurity: true,  traceRateLimit: 20)
+            : base(iisFixture, output, classicMode: false, enableSecurity: true, traceRateLimit: 20)
         {
         }
     }
 
-    public abstract class AspNetMvc5RateLimiter : AspNetBase, IClassFixture<IisFixture>
+    public abstract class AspNetMvc5RateLimiter : AspNetBase, IClassFixture<IisFixture>, IAsyncLifetime
     {
         private readonly int? _traceRateLimit = null;
         private readonly IisFixture _iisFixture;
         private readonly bool _enableSecurity;
+        private readonly bool _classicMode;
 
         public AspNetMvc5RateLimiter(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity, int? traceRateLimit)
             : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
         {
             SetSecurity(enableSecurity);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
+            _classicMode = classicMode;
             _iisFixture = iisFixture;
             _enableSecurity = enableSecurity;
             if (traceRateLimit.HasValue)
@@ -109,7 +111,6 @@ namespace Datadog.Trace.Security.IntegrationTests
                 SetEnvironmentVariable(ConfigurationKeys.AppSec.TraceRateLimit, _traceRateLimit.ToString());
             }
 
-            _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
             SetHttpPort(iisFixture.HttpPort);
         }
 
@@ -126,6 +127,10 @@ namespace Datadog.Trace.Security.IntegrationTests
             // have to wait a second for the rate limiter to reset (or restart iis express completely)
             Thread.Sleep(1000);
         }
+
+        public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+
+        public Task DisposeAsync() => Task.CompletedTask;
     }
 }
 #endif

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebApi.cs
@@ -69,7 +69,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             _testName = "Security." + nameof(AspNetWebApi)
                      + (classicMode ? ".Classic" : ".Integrated")
                      + ".enableSecurity=" + enableSecurity; // assume that arm is the same
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -105,7 +104,11 @@ namespace Datadog.Trace.Security.IntegrationTests
             await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, 1, settings, userAgent: "Hello/V");
         }
 
-        public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        public async Task InitializeAsync()
+        {
+            await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+            SetHttpPort(_iisFixture.HttpPort);
+        }
 
         public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetWebForms.cs
@@ -69,7 +69,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             _testName = "Security." + nameof(AspNetWebForms)
                      + (classicMode ? ".Classic" : ".Integrated")
                      + ".enableSecurity=" + enableSecurity;
-            SetHttpPort(iisFixture.HttpPort);
         }
 
         [Trait("Category", "EndToEnd")]
@@ -103,7 +102,11 @@ namespace Datadog.Trace.Security.IntegrationTests
             await TestAppSecRequestWithVerifyAsync(_iisFixture.Agent, url, null, 5, 1, settings, userAgent: "Hello/V");
         }
 
-        public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        public async Task InitializeAsync()
+        {
+            await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+            SetHttpPort(_iisFixture.HttpPort);
+        }
 
         public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -120,7 +120,6 @@ public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixtu
         _iisFixture = iisFixture;
         _testName = "Security." + nameof(AspNetMvc5) + ".TelemetryEnabled" +
                  ".Classic" + ".enableIast=true";
-        SetHttpPort(iisFixture.HttpPort);
     }
 
     [Trait("Category", "EndToEnd")]
@@ -159,7 +158,11 @@ public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixtu
                           .DisableRequireUniquePrefix();
     }
 
-    public Task InitializeAsync() => _iisFixture.TryStartIis(this, IisAppType.AspNetClassic);
+    public async Task InitializeAsync()
+    {
+        await _iisFixture.TryStartIis(this, IisAppType.AspNetClassic);
+        SetHttpPort(_iisFixture.HttpPort);
+    }
 
     public Task DisposeAsync() => Task.CompletedTask;
 }
@@ -199,10 +202,13 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         _testName = "Security." + nameof(AspNetMvc5)
                  + (classicMode ? ".Classic" : ".Integrated")
                  + ".enableIast=" + enableIast;
-        SetHttpPort(iisFixture.HttpPort);
     }
 
-    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+    public async Task InitializeAsync()
+    {
+        await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        SetHttpPort(_iisFixture.HttpPort);
+    }
 
     public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -101,7 +101,7 @@ public class AspNetMvc5ClassicWithIast : AspNetMvc5IastTests
 }
 
 [Collection("IisTests")]
-public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixture<IisFixture>
+public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixture<IisFixture>, IAsyncLifetime
 {
     private readonly IisFixture _iisFixture;
     private readonly string _testName;
@@ -118,7 +118,6 @@ public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixtu
         SetEnvironmentVariable("DD_IAST_VULNERABILITIES_PER_REQUEST", "100");
 
         _iisFixture = iisFixture;
-        _iisFixture.TryStartIis(this, IisAppType.AspNetClassic);
         _testName = "Security." + nameof(AspNetMvc5) + ".TelemetryEnabled" +
                  ".Classic" + ".enableIast=true";
         SetHttpPort(iisFixture.HttpPort);
@@ -159,6 +158,10 @@ public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixtu
                           .UseFileName($"{_testName}.path={sanitisedPath}")
                           .DisableRequireUniquePrefix();
     }
+
+    public Task InitializeAsync() => _iisFixture.TryStartIis(this, IisAppType.AspNetClassic);
+
+    public Task DisposeAsync() => Task.CompletedTask;
 }
 
 [Collection("IisTests")]
@@ -170,11 +173,12 @@ public class AspNetMvc5ClassicWithoutIast : AspNetMvc5IastTests
     }
 }
 
-public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture>
+public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture>, IAsyncLifetime
 {
     private readonly IisFixture _iisFixture;
     private readonly string _testName;
     private readonly bool _enableIast;
+    private readonly bool _classicMode;
 
     public AspNetMvc5IastTests(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableIast)
         : base(nameof(AspNetMvc5), output, "/home/shutdown", @"test\test-applications\security\aspnet")
@@ -190,13 +194,17 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
 
         _iisFixture = iisFixture;
+        _classicMode = classicMode;
         _enableIast = enableIast;
-        _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetMvc5)
                  + (classicMode ? ".Classic" : ".Integrated")
                  + ".enableIast=" + enableIast;
         SetHttpPort(iisFixture.HttpPort);
     }
+
+    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+
+    public Task DisposeAsync() => Task.CompletedTask;
 
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/Deduplication/DeduplicationTests.cs
@@ -48,7 +48,7 @@ public class DeduplicationTests : TestHelper
         var filename = deduplicationEnabled ? "iast.deduplication.deduplicated" : "iast.deduplication.duplicated";
 
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var process = RunSampleAndWaitForExit(agent, "5");
+        using var process = await RunSampleAndWaitForExit(agent, "5");
         var spans = agent.WaitForSpans(expectedSpanCount, operationName: ExpectedOperationName);
 
         var settings = VerifyHelper.GetSpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -17,6 +17,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -239,7 +240,7 @@ public class IastInstrumentationUnitTests : TestHelper
     [SkippableFact]
     [Trait("Category", "EndToEnd")]
     [Trait("RunOnWindows", "True")]
-    public void TestInstrumentedUnitTests()
+    public async Task TestInstrumentedUnitTests()
     {
         using (var agent = EnvironmentHelper.GetMockAgent())
         {
@@ -266,7 +267,7 @@ public class IastInstrumentationUnitTests : TestHelper
             SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Enabled, "0"); // without this key, ci visibility is enabled for the samples, which we don't really want
             SetEnvironmentVariable("DD_TRACE_LOG_DIRECTORY", logDirectory);
             SetEnvironmentVariable("DD_IAST_DEDUPLICATION_ENABLED", "0");
-            ProcessResult processResult = RunDotnetTestSampleAndWaitForExit(agent, arguments: arguments, forceVsTestParam: true);
+            ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, arguments: arguments, forceVsTestParam: true);
             processResult.StandardError.Should().BeEmpty("arguments: " + arguments + Environment.NewLine + processResult.StandardError + Environment.NewLine + processResult.StandardOutput);
         }
     }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
@@ -59,12 +59,12 @@ public class WeakCipherTests : TestHelper
     [InlineData("DD_IAST_ENABLED", "false")]
     [InlineData("DD_IAST_WEAK_CIPHER_ALGORITHMS", "invalidAlgorithm")]
     [InlineData($"DD_TRACE_{nameof(IntegrationId.SymmetricAlgorithm)}_ENABLED", "false")]
-    public void IntegrationDisabled(string variableName, string variableValue)
+    public async Task IntegrationDisabled(string variableName, string variableValue)
     {
         SetEnvironmentVariable("DD_IAST_ENABLED", "true");
         SetEnvironmentVariable(variableName, variableValue);
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var process = RunSampleAndWaitForExit(agent);
+        using var process = await RunSampleAndWaitForExit(agent);
         var spans = agent.Spans; // we expect no spans
 
         Assert.Empty(spans.Where(s => s.Name.Equals(ExpectedOperationName)));

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/WeakCipher/WeakCipherTests.cs
@@ -40,7 +40,7 @@ public class WeakCipherTests : TestHelper
         const int expectedSpanCount = 6;
         var filename = "WeakCipherTests.SubmitsTraces";
         using var agent = EnvironmentHelper.GetMockAgent();
-        using var process = RunSampleAndWaitForExit(agent);
+        using var process = await RunSampleAndWaitForExit(agent);
         var spans = agent.WaitForSpans(expectedSpanCount, operationName: ExpectedOperationName);
 
         var settings = VerifyHelper.GetSpanVerifierSettings();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmBlockingActions.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmBlockingActions.cs
@@ -76,7 +76,6 @@ public abstract class AspNetMvc5AsmBlockingActions : RcmBaseFramework, IClassFix
         _testName = "Security." + nameof(AspNetMvc5AsmBlockingActions)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity;
-        SetHttpPort(iisFixture.HttpPort);
     }
 
     [SkippableTheory]
@@ -106,7 +105,11 @@ public abstract class AspNetMvc5AsmBlockingActions : RcmBaseFramework, IClassFix
         await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload { Actions = Array.Empty<Action>() }, asmProduct, fileId) });
     }
 
-    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+    public async Task InitializeAsync()
+    {
+        await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        SetHttpPort(_iisFixture.HttpPort);
+    }
 
     public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
@@ -73,7 +73,6 @@ public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFix
         _testName = "Security." + nameof(AspNetMvc5AsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity;
-        SetHttpPort(iisFixture.HttpPort);
     }
 
     [SkippableTheory]
@@ -137,7 +136,11 @@ public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFix
         }
     }
 
-    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+    public async Task InitializeAsync()
+    {
+        await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        SetHttpPort(_iisFixture.HttpPort);
+    }
 
     public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmData.cs
@@ -57,18 +57,19 @@ public class AspNetMvc5AsmDataClassicWithoutSecurity : AspNetMvc5AsmData
     }
 }
 
-public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFixture>
+public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFixture>, IAsyncLifetime
 {
     private readonly IisFixture _iisFixture;
     private readonly string _testName;
+    private readonly bool _classicMode;
 
     public AspNetMvc5AsmData(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
         : base("AspNetMvc5", output, "/home/shutdown", @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
 
+        _classicMode = classicMode;
         _iisFixture = iisFixture;
-        _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetMvc5AsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity;
@@ -135,6 +136,10 @@ public abstract class AspNetMvc5AsmData : RcmBaseFramework, IClassFixture<IisFix
             SetClientIp(MainIp);
         }
     }
+
+    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+
+    public Task DisposeAsync() => Task.CompletedTask;
 
     protected override string GetTestName() => _testName;
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmRulesToggle.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetMvc5AsmRulesToggle.cs
@@ -76,7 +76,6 @@ public abstract class AspNetMvc5AsmRulesToggle : RcmBaseFramework, IClassFixture
         _testName = "Security." + nameof(AspNetMvc5AsmRulesToggle)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity;
-        SetHttpPort(iisFixture.HttpPort);
     }
 
     [SkippableFact]
@@ -110,7 +109,11 @@ public abstract class AspNetMvc5AsmRulesToggle : RcmBaseFramework, IClassFixture
         await agent.SetupRcmAndWait(Output, new[] { ((object)new Payload { Actions = Array.Empty<Action>() }, asmProduct, fileId) });
     }
 
-    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+    public async Task InitializeAsync()
+    {
+        await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        SetHttpPort(_iisFixture.HttpPort);
+    }
 
     public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebApiAsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebApiAsmData.cs
@@ -57,18 +57,19 @@ public class AspNetWebApiAsmDataClassicWithoutSecurity : AspNetWebApiAsmData
     }
 }
 
-public abstract class AspNetWebApiAsmData : RcmBaseFramework, IClassFixture<IisFixture>
+public abstract class AspNetWebApiAsmData : RcmBaseFramework, IClassFixture<IisFixture>, IAsyncLifetime
 {
     private readonly IisFixture _iisFixture;
     private readonly string _testName;
+    private readonly bool _classicMode;
 
     public AspNetWebApiAsmData(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
         : base("WebApi", output, "/api/home/shutdown", @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
 
+        _classicMode = classicMode;
         _iisFixture = iisFixture;
-        _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetWebApiAsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity; // assume that arm is the same
@@ -149,6 +150,10 @@ public abstract class AspNetWebApiAsmData : RcmBaseFramework, IClassFixture<IisF
             SetClientIp(MainIp);
         }
     }
+
+    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+
+    public Task DisposeAsync() => Task.CompletedTask;
 
     protected override string GetTestName() => _testName;
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebApiAsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebApiAsmData.cs
@@ -73,7 +73,6 @@ public abstract class AspNetWebApiAsmData : RcmBaseFramework, IClassFixture<IisF
         _testName = "Security." + nameof(AspNetWebApiAsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity; // assume that arm is the same
-        SetHttpPort(iisFixture.HttpPort);
     }
 
     [SkippableTheory]
@@ -151,7 +150,11 @@ public abstract class AspNetWebApiAsmData : RcmBaseFramework, IClassFixture<IisF
         }
     }
 
-    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+    public async Task InitializeAsync()
+    {
+        await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        SetHttpPort(_iisFixture.HttpPort);
+    }
 
     public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebFormsAsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebFormsAsmData.cs
@@ -57,18 +57,19 @@ public class AspNetWebFormsAsmDataClassicWithoutSecurity : AspNetWebFormsAsmData
     }
 }
 
-public abstract class AspNetWebFormsAsmData : RcmBaseFramework, IClassFixture<IisFixture>
+public abstract class AspNetWebFormsAsmData : RcmBaseFramework, IClassFixture<IisFixture>, IAsyncLifetime
 {
     private readonly IisFixture _iisFixture;
     private readonly string _testName;
+    private readonly bool _classicMode;
 
     public AspNetWebFormsAsmData(IisFixture iisFixture, ITestOutputHelper output, bool classicMode, bool enableSecurity)
         : base("WebForms", output, "/home/shutdown", @"test\test-applications\security\aspnet")
     {
         SetSecurity(enableSecurity);
 
+        _classicMode = classicMode;
         _iisFixture = iisFixture;
-        _iisFixture.TryStartIis(this, classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
         _testName = "Security." + nameof(AspNetWebFormsAsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity;
@@ -141,6 +142,10 @@ public abstract class AspNetWebFormsAsmData : RcmBaseFramework, IClassFixture<Ii
             SetClientIp(MainIp);
         }
     }
+
+    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+
+    public Task DisposeAsync() => Task.CompletedTask;
 
     protected override string GetTestName() => _testName;
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebFormsAsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetWebFormsAsmData.cs
@@ -73,7 +73,6 @@ public abstract class AspNetWebFormsAsmData : RcmBaseFramework, IClassFixture<Ii
         _testName = "Security." + nameof(AspNetWebFormsAsmData)
                                 + (classicMode ? ".Classic" : ".Integrated")
                                 + ".enableSecurity=" + enableSecurity;
-        SetHttpPort(iisFixture.HttpPort);
     }
 
     [SkippableTheory]
@@ -143,7 +142,11 @@ public abstract class AspNetWebFormsAsmData : RcmBaseFramework, IClassFixture<Ii
         }
     }
 
-    public Task InitializeAsync() => _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+    public async Task InitializeAsync()
+    {
+        await _iisFixture.TryStartIis(this, _classicMode ? IisAppType.AspNetClassic : IisAppType.AspNetIntegrated);
+        SetHttpPort(_iisFixture.HttpPort);
+    }
 
     public Task DisposeAsync() => Task.CompletedTask;
 

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -120,10 +120,10 @@ namespace Datadog.Trace.TestHelpers
                 Process.BeginOutputReadLine();
                 Process.BeginErrorReadLine();
 
-                    if (!mutex.Wait(TimeSpan.FromSeconds(60)))
-                    {
-                        WriteToOutput("Timeout while waiting for the proces to start");
-                    }
+                if (!mutex.Wait(TimeSpan.FromSeconds(60)))
+                {
+                    WriteToOutput("Timeout while waiting for the proces to start");
+                }
 
                 if (port == null)
                 {

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -7,6 +7,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Datadog.Trace.TestHelpers
@@ -26,23 +27,20 @@ namespace Datadog.Trace.TestHelpers
 
         public bool UseGac { get; set; } = true;
 
-        public void TryStartIis(TestHelper helper, IisAppType appType)
+        public async Task TryStartIis(TestHelper helper, IisAppType appType)
         {
-            lock (this)
+            if (IisExpress.Process == null)
             {
-                if (IisExpress.Process == null)
+                if (UseGac)
                 {
-                    if (UseGac)
-                    {
-                        AddAssembliesToGac();
-                    }
-
-                    var initialAgentPort = TcpPortProvider.GetOpenPort();
-                    Agent = MockTracerAgent.Create(null, initialAgentPort);
-
-                    HttpPort = TcpPortProvider.GetOpenPort();
-                    IisExpress = helper.StartIISExpress(Agent, HttpPort, appType, VirtualApplicationPath);
+                    AddAssembliesToGac();
                 }
+
+                var initialAgentPort = TcpPortProvider.GetOpenPort();
+                Agent = MockTracerAgent.Create(null, initialAgentPort);
+
+                HttpPort = TcpPortProvider.GetOpenPort();
+                IisExpress = await helper.StartIISExpress(Agent, HttpPort, appType, VirtualApplicationPath);
             }
         }
 
@@ -56,43 +54,40 @@ namespace Datadog.Trace.TestHelpers
 
             Agent?.Dispose();
 
-            lock (this)
+            if (IisExpress.Process != null)
             {
-                if (IisExpress.Process != null)
+                try
                 {
-                    try
+                    if (!IisExpress.Process.HasExited)
                     {
-                        if (!IisExpress.Process.HasExited)
-                        {
-                            // sending "Q" to standard input does not work because
-                            // iisexpress is scanning console key press, so just kill it.
-                            // maybe try this in the future:
-                            // https://github.com/roryprimrose/Headless/blob/master/Headless.IntegrationTests/IisExpress.cs
-                            IisExpress.Process.Kill();
-                            IisExpress.Process.WaitForExit(8000);
-                        }
+                        // sending "Q" to standard input does not work because
+                        // iisexpress is scanning console key press, so just kill it.
+                        // maybe try this in the future:
+                        // https://github.com/roryprimrose/Headless/blob/master/Headless.IntegrationTests/IisExpress.cs
+                        IisExpress.Process.Kill();
+                        IisExpress.Process.WaitForExit(8000);
                     }
-                    catch
-                    {
-                        // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
-                    }
+                }
+                catch
+                {
+                    // in some circumstances the HasExited property throws, this means the process probably hasn't even started correctly
+                }
 
-                    IisExpress.Process.Dispose();
+                IisExpress.Process.Dispose();
 
-                    try
-                    {
-                        File.Delete(IisExpress.ConfigFile);
-                    }
-                    catch
-                    {
-                    }
+                try
+                {
+                    File.Delete(IisExpress.ConfigFile);
+                }
+                catch
+                {
+                }
 
-                    // If the operation fails, it could leave files in the GAC and impact the next tests
-                    // Therefore, we don't wrap this in a try/catch
-                    if (UseGac)
-                    {
-                        RemoveAssembliesFromGac();
-                    }
+                // If the operation fails, it could leave files in the GAC and impact the next tests
+                // Therefore, we don't wrap this in a try/catch
+                if (UseGac)
+                {
+                    RemoveAssembliesFromGac();
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -79,7 +79,7 @@ namespace Datadog.Trace.TestHelpers
         {
         }
 
-        public Process StartDotnetTestSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool forceVsTestParam = false)
+        public async Task<Process> StartDotnetTestSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool forceVsTestParam = false)
         {
             // get path to sample app that the profiler will attach to
             string sampleAppPath = EnvironmentHelper.GetTestCommandForSampleApplicationPath(packageVersion, framework);
@@ -94,7 +94,7 @@ namespace Datadog.Trace.TestHelpers
             string appPath = testCli.StartsWith("dotnet") || forceVsTestParam ? $"vstest {sampleAppPath}" : sampleAppPath;
             Output.WriteLine("Executable: " + exec);
             Output.WriteLine("ApplicationPath: " + appPath);
-            var process = ProfilerHelper.StartProcessWithProfiler(
+            var process = await ProfilerHelper.StartProcessWithProfiler(
                 exec,
                 EnvironmentHelper,
                 agent,
@@ -107,9 +107,9 @@ namespace Datadog.Trace.TestHelpers
             return process;
         }
 
-        public ProcessResult RunDotnetTestSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", bool forceVsTestParam = false)
+        public async Task<ProcessResult> RunDotnetTestSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", bool forceVsTestParam = false)
         {
-            var process = StartDotnetTestSample(agent, arguments, packageVersion, aspNetCorePort: 5000, framework: framework, forceVsTestParam: forceVsTestParam);
+            var process = await StartDotnetTestSample(agent, arguments, packageVersion, aspNetCorePort: 5000, framework: framework, forceVsTestParam: forceVsTestParam);
 
             using var helper = new ProcessHelper(process);
 
@@ -136,7 +136,7 @@ namespace Datadog.Trace.TestHelpers
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
-        public Process StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false)
+        public async Task<Process> StartSample(MockTracerAgent agent, string arguments, string packageVersion, int aspNetCorePort, string framework = "", bool? enableSecurity = null, string externalRulesFile = null, bool usePublishWithRID = false)
         {
             // get path to sample app that the profiler will attach to
             var sampleAppPath = EnvironmentHelper.GetSampleApplicationPath(packageVersion, framework, usePublishWithRID);
@@ -149,7 +149,7 @@ namespace Datadog.Trace.TestHelpers
             var executable = EnvironmentHelper.IsCoreClr() && !usePublishWithRID ? EnvironmentHelper.GetSampleExecutionSource() : sampleAppPath;
             var args = EnvironmentHelper.IsCoreClr() && !usePublishWithRID ? $"{sampleAppPath} {arguments ?? string.Empty}" : arguments;
 
-            var process = ProfilerHelper.StartProcessWithProfiler(
+            var process = await ProfilerHelper.StartProcessWithProfiler(
                 executable,
                 EnvironmentHelper,
                 agent,
@@ -165,9 +165,9 @@ namespace Datadog.Trace.TestHelpers
             return process;
         }
 
-        public ProcessResult RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool usePublishWithRID = false)
+        public async Task<ProcessResult> RunSampleAndWaitForExit(MockTracerAgent agent, string arguments = null, string packageVersion = "", string framework = "", int aspNetCorePort = 5000, bool usePublishWithRID = false)
         {
-            var process = StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID);
+            var process = await StartSample(agent, arguments, packageVersion, aspNetCorePort: aspNetCorePort, framework: framework, usePublishWithRID: usePublishWithRID);
             using var helper = new ProcessHelper(process);
 
             return WaitForProcessResult(helper);
@@ -215,7 +215,7 @@ namespace Datadog.Trace.TestHelpers
             return new ProcessResult(process, standardOutput, standardError, exitCode);
         }
 
-        public (Process Process, string ConfigFile) StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath)
+        public async Task<(Process Process, string ConfigFile)> StartIISExpress(MockTracerAgent agent, int iisPort, IisAppType appType, string subAppPath)
         {
             var iisExpress = EnvironmentHelper.GetIisExpressPath();
 
@@ -277,7 +277,7 @@ namespace Datadog.Trace.TestHelpers
 
             Output.WriteLine($"[webserver] starting {iisExpress} {string.Join(" ", args)}");
 
-            var process = ProfilerHelper.StartProcessWithProfiler(
+            var process = await ProfilerHelper.StartProcessWithProfiler(
                 iisExpress,
                 EnvironmentHelper,
                 agent,
@@ -287,11 +287,10 @@ namespace Datadog.Trace.TestHelpers
 
             var wh = new EventWaitHandle(false, EventResetMode.AutoReset);
 
-            Task.Factory.StartNew(
+            _ = Task.Factory.StartNew(
                 () =>
                 {
-                    string line;
-                    while ((line = process.StandardOutput.ReadLine()) != null)
+                    while (process.StandardOutput.ReadLine() is { } line)
                     {
                         Output.WriteLine($"[webserver][stdout] {line}");
 
@@ -303,11 +302,10 @@ namespace Datadog.Trace.TestHelpers
                 },
                 TaskCreationOptions.LongRunning);
 
-            Task.Factory.StartNew(
+            _ = Task.Factory.StartNew(
                 () =>
                 {
-                    string line;
-                    while ((line = process.StandardError.ReadLine()) != null)
+                    while (process.StandardError.ReadLine() is { } line)
                     {
                         Output.WriteLine($"[webserver][stderr] {line}");
                     }

--- a/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit.Abstractions;
 
 namespace Datadog.Trace.TestHelpers
@@ -20,7 +21,7 @@ namespace Datadog.Trace.TestHelpers
 
         private static string _corFlagsExe;
 
-        public static Process StartProcessWithProfiler(
+        public static async Task<Process> StartProcessWithProfiler(
             string executable,
             EnvironmentHelper environmentHelper,
             MockTracerAgent agent,
@@ -78,7 +79,7 @@ namespace Datadog.Trace.TestHelpers
             {
                 using var suspendedProcess = NativeProcess.CreateProcess.StartSuspendedProcess(startInfo);
 
-                MemoryDumpHelper.MonitorCrashes(suspendedProcess.Id).Wait();
+                await MemoryDumpHelper.MonitorCrashes(suspendedProcess.Id);
 
                 return suspendedProcess.ResumeProcess();
             }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/IisCheckTests.cs
@@ -229,7 +229,7 @@ public class IisCheckTests : ToolTestHelper
 
         try
         {
-            fixture.TryStartIis(this, appType);
+            await fixture.TryStartIis(this, appType);
         }
         catch (Exception)
         {

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/IisCheckTests.cs
@@ -285,7 +285,7 @@ public class IisCheckTests : TestHelper
 
         try
         {
-            fixture.TryStartIis(this, appType);
+            await fixture.TryStartIis(this, appType);
         }
         catch (Exception)
         {


### PR DESCRIPTION
## Summary of changes

Convert the integration tests to async.

## Reason for change

This is mainly done to avoid a sync-over-async introduced by the MemoryDumpHelper, but this should also allow us to convert other parts to async and reduce the pressure on the threadpool.

## Implementation details

:eyetwitch:

## Test coverage

Pretty much all the integration tests are impacted, so uh great coverage I guess.