### PR TITLE
[Dynamic Instrumentation] Support `isDefined` in expression language

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -82,6 +82,11 @@ internal partial class ProbeExpressionParser<T>
         return Expression.TypeEqual(value, ProbeExpressionParserHelper.UndefinedValueType);
     }
 
+    private Expression IsDefined(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
+    {
+        return Expression.Not(IsUndefined(reader, parameters, itParameter));
+    }
+
     private Expression GetMember(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         var referralMember = ParseTree(reader, parameters, itParameter);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -256,7 +256,7 @@ internal partial class ProbeExpressionParser<T>
                                         return GetItemAtIndex(reader, parameters, itParameter);
                                     }
 
-                                // generic operations
+                                // general operations
                                 case "getmember":
                                     {
                                         return GetMember(reader, parameters, itParameter);
@@ -270,6 +270,11 @@ internal partial class ProbeExpressionParser<T>
                                 case "isUndefined":
                                     {
                                         return IsUndefined(reader, parameters, itParameter);
+                                    }
+
+                                case "isDefined":
+                                    {
+                                        return IsDefined(reader, parameters, itParameter);
                                     }
 
                                 case "Ignore":

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsDefined.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsDefined.verified.txt
@@ -1,0 +1,38 @@
+﻿Condition:
+Json:
+{
+  "isDefined": [
+    {
+      "ref": "Nested"
+    },
+    "NestedString"
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = !(this.Nested is UndefinedValue);
+
+    return $dd_el_result;
+}
+Result: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsUndefined.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsUndefined.verified.txt
@@ -1,0 +1,38 @@
+﻿Condition:
+Json:
+{
+  "isUndefined": [
+    {
+      "ref": "Nested"
+    },
+    "NestedString"
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = this.Nested is UndefinedValue;
+
+    return $dd_el_result;
+}
+Result: False

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsDefined.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsDefined.json
@@ -1,0 +1,9 @@
+{
+  "dsl": "isDefined(ref Nested, NestedString)",
+  "isDefined": [
+    {
+      "ref": "Nested"
+    },
+    "NestedString"
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsUndefined.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsUndefined.json
@@ -1,0 +1,9 @@
+{
+  "dsl": "isDefined(ref Nested, NestedString)",
+  "isUndefined": [
+    {
+      "ref": "Nested"
+    },
+    "NestedString"
+  ]
+}


### PR DESCRIPTION
## Summary of changes
Allow the ability to write this expression: isDefined(foo.bar). This will return a boolean result and will not throw an exception in any case.

## Test coverage
IsUndefined.json
IsDefined.json
