### PR TITLE
[Dynamic Instrumentation] Add `instanceof` expression to EL

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -267,6 +267,11 @@ internal partial class ProbeExpressionParser<T>
                                         return GetReference(reader, parameters, itParameter);
                                     }
 
+                                case "instanceof":
+                                    {
+                                        return IsInstanceOf(reader, parameters, itParameter);
+                                    }
+
                                 case "isUndefined":
                                     {
                                         return IsUndefined(reader, parameters, itParameter);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfEmptyType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfEmptyType.verified.txt
@@ -1,0 +1,45 @@
+﻿Condition:
+Json:
+{
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    ""
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = false;
+
+    return $dd_el_result;
+}
+Result: False
+Errors:
+EvaluationError { Expression = this.String is ?, Message = failed to parse type name }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
@@ -1,0 +1,43 @@
+﻿Condition:
+Json:
+{
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    "System.Int32"
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = this.String is int;
+
+    return $dd_el_result;
+}
+Result: False

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
@@ -1,0 +1,43 @@
+﻿Condition:
+Json:
+{
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    "System.String"
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = this.String is string;
+
+    return $dd_el_result;
+}
+Result: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
@@ -1,0 +1,45 @@
+﻿Condition:
+Json:
+{
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    "string"
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = false;
+
+    return $dd_el_result;
+}
+Result: False
+Errors:
+EvaluationError { Expression = this.String is string, Message = 'string' is unknown type }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfEmptyType.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfEmptyType.json
@@ -1,0 +1,14 @@
+{
+  "dsl": "{instanceof(this.String, )}",
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    ""
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfFalse.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfFalse.json
@@ -1,0 +1,14 @@
+{
+  "dsl": "{instanceof(this.String, System.Int32)}",
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    "System.Int32"
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfTrue.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfTrue.json
@@ -1,0 +1,14 @@
+{
+  "dsl": "{instanceof(this.String, System.String)}",
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    "System.String"
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfUnknownType.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsInstanceOfUnknownType.json
@@ -1,0 +1,14 @@
+{
+  "dsl": "{instanceof(this.String, string)}",
+  "instanceof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    },
+    "string"
+  ]
+}


### PR DESCRIPTION
## Summary of changes
Add `instanceof` expression to EL

## Reason for change
Let the user write an expression based on the actual runtime type 

## Test coverage
InstanceOfTrue
InstanceOfFalse
InstanceOfEmptyType
InstanceOfUnknownType