### PR TITLE
bump default kafka lib version in sample app to solve a bug with mac

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Kafka/Samples.Kafka.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Kafka/Samples.Kafka.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ApiVersion Condition="'$(ApiVersion)' == ''">1.4.3</ApiVersion>
+    <ApiVersion Condition="'$(ApiVersion)' == ''">1.9.2</ApiVersion>
     <RequiresDockerDependency>All</RequiresDockerDependency>
 
     <!-- Required to build multiple projects with the same Configuration|Platform -->


### PR DESCRIPTION
this newer version fixes https://github.com/confluentinc/confluent-kafka-dotnet/issues/1755 which prevented from running that sample app on mac.