### PR TITLE
AutoGenerator bug fixes

### DIFF
--- a/tracer/src/Datadog.AutoInstrumentation.Generator/EditorHelper.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator/EditorHelper.cs
@@ -86,13 +86,13 @@ internal static class EditorHelper
         var parameters = methodDef.Parameters.Where(p => !p.IsHiddenThisParameter).ToArray();
         if (parameters.Length == 0)
         {
-            return "new string[0]";
+            return "[]";
         }
 
         var sb = new StringBuilder();
-        sb.Append("new[] { ")
+        sb.Append('[')
             .Append(string.Join(", ", parameters.Select(p => CreateTypeName(p.Type))))
-            .Append(" }");
+            .Append(']');
         return sb.ToString();
     }
 

--- a/tracer/src/Datadog.AutoInstrumentation.Generator/EditorHelper.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator/EditorHelper.cs
@@ -135,7 +135,7 @@ internal static class EditorHelper
 
                 if (i < genArgs.Count - 1)
                 {
-                    sb.Append(", ");
+                    sb.Append(",");
                 }
             }
 

--- a/tracer/src/Datadog.AutoInstrumentation.Generator/EditorHelper.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator/EditorHelper.cs
@@ -40,7 +40,7 @@ internal static class EditorHelper
 
     public static string GetIntegrationClassName(MethodDef methodDef)
     {
-        return CleanTypeName(methodDef.DeclaringType.Name + "_" + methodDef.Name);
+        return CleanTypeName(methodDef.DeclaringType.Name + methodDef.Name);
     }
 
     public static string CleanTypeName(string typeName)

--- a/tracer/src/Datadog.AutoInstrumentation.Generator/ViewModels/MainViewModel.Editor.cs
+++ b/tracer/src/Datadog.AutoInstrumentation.Generator/ViewModels/MainViewModel.Editor.cs
@@ -86,7 +86,7 @@ internal partial class MainViewModel
             integrationSourceBuilder.Replace("$(Namespace)", EditorHelper.GetNamespace(methodDef));
             integrationSourceBuilder.Replace("$(FullName)", EditorHelper.GetMethodFullNameForComments(methodDef));
             integrationSourceBuilder.Replace("$(AssemblyName)", methodDef.DeclaringType.DefinitionAssembly.Name);
-            integrationSourceBuilder.Replace("$(TypeName)", methodDef.DeclaringType.Name);
+            integrationSourceBuilder.Replace("$(TypeName)", methodDef.DeclaringType.FullName);
             integrationSourceBuilder.Replace("$(MethodName)", methodDef.Name);
             integrationSourceBuilder.Replace("$(ReturnTypeName)", EditorHelper.GetReturnType(methodDef));
             integrationSourceBuilder.Replace("$(ParameterTypeNames)", EditorHelper.GetParameterTypeArray(methodDef));


### PR DESCRIPTION
## Summary of changes

- Fix: ensure we include the full type name in the `[InstrumentMethod]` attribute
- Fix: ensure generics are defined correctly (previously incorrectly had a space in the name)
- nit: Remove `_` from typename
- Use `[]` C#12 (as suggested in IDE by default now)

## Reason for change

The first 2 are bugs, the other 2 are just quality of life fixes

## Implementation details

Pretty self-explanatory. Tested locally with `.\tracer\build.ps1 RunInstrumentationGenerator` and looks good to me

## Test coverage

Manual testing

```diff
[InstrumentMethod(
    AssemblyName = "Datadog.Trace.Custom",
-   TypeName = "ITest",
+   TypeName = "Datadog.Trace.Ci.ITest",
    MethodName = "SetTraits",
    ReturnTypeName = ClrNames.Void,
-   ParameterTypeNames = new []{ "System.Collections.Generic.Dictionary`2[System.String, System.Collections.Generic.List`1[System.String]]"},
+   ParameterTypeNames = ["System.Collections.Generic.Dictionary`2[System.String,System.Collections.Generic.List`1[System.String]]"],
    MinimumVersion = "3.0.0",
    MaximumVersion = "3.*.*",
    IntegrationName = IntegrationName)]
[Browsable(false)]
[EditorBrowsable(EditorBrowsableState.Never)]
-public class ITest_SetTraitsIntegration
+public class ITestSetTraitsIntegration
```

## Other details

Thanks @tonyredondo 😄 


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
