### PR TITLE
[CI Visibility] - Update Code Coverage percentage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -375,3 +375,6 @@ lib/
 libdatadog-*/
 *-prefix/
 cmake-build-debug/
+
+#jetbrains cache folder
+.cache/jb

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -339,8 +339,12 @@ namespace Datadog.Trace.Tools.Runner
                         if (CoverageUtils.TryCombineAndGetTotalCoverage(codeCoveragePath, outputPath, out var globalCoverage, useStdOut: false) &&
                             globalCoverage is not null)
                         {
-                            // Adds the global code coverage percentage to the session
-                            session.SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.GetTotalPercentage());
+                            // We only report the code coverage percentage if the customer manually sets the 'DD_CIVISIBILITY_CODE_COVERAGE_ENABLED' environment variable according to the new spec.
+                            if (EnvironmentHelpers.GetEnvironmentVariable(Configuration.ConfigurationKeys.CIVisibility.CodeCoverage).ToBoolean() == true)
+                            {
+                                // Adds the global code coverage percentage to the session
+                                session.SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.GetTotalPercentage());
+                            }
                         }
                     }
                     else

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -419,13 +419,14 @@ public sealed class TestModule
             CoverageReporter.Handler is DefaultWithGlobalCoverageEventHandler coverageHandler &&
             coverageHandler.GetCodeCoveragePercentage() is { } globalCoverage)
         {
-            // We only report global code coverage if we don't skip any test
-            if (!CIVisibility.HasSkippableTests())
+            // We only report global code coverage if ITR is disabled and we are in a fake session (like the internal testlogger scenario)
+            // For a normal customer session we never report the percentage of total lines on modules
+            if (!CIVisibility.Settings.IntelligentTestRunnerEnabled && _fakeSession is not null)
             {
                 // Adds the global code coverage percentage to the module
                 var codeCoveragePercentage = globalCoverage.GetTotalPercentage();
                 SetTag(CodeCoverageTags.PercentageOfTotalLines, codeCoveragePercentage);
-                _fakeSession?.SetTag(CodeCoverageTags.PercentageOfTotalLines, codeCoveragePercentage);
+                _fakeSession.SetTag(CodeCoverageTags.PercentageOfTotalLines, codeCoveragePercentage);
             }
 
             // If the code coverage path environment variable is set, we store the json file


### PR DESCRIPTION
## Summary of changes

This PR changes the scenarios were CI Visibility reports the code coverage percentage value according to the new spec.

## Reason for change

The spec changed following the table:
![image](https://github.com/DataDog/dd-trace-dotnet/assets/69803/7af01744-c6f3-49da-8298-e7847acf0f9b)
