### PR TITLE
Dont catch CallTargetBubbleUpException native side, like on managed side

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -335,7 +335,6 @@ src/Datadog.Trace/Ci/Tags/IntelligentTestRunnerTags.cs
 src/Datadog.Trace/Ci/Tags/TestTags.cs
 src/Datadog.Trace/Ci/Telemetry/TelemetryHelper.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AutoInstrumentationExtensions.cs
-src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetBubbleUpException.cs
 src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvoker.cs
 src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetInvokerException.cs
 src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetReturn.cs

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -930,6 +930,7 @@
       <type fullname="System.Text.RegularExpressions.Match" />
       <type fullname="System.Text.RegularExpressions.MatchCollection" />
       <type fullname="System.Text.RegularExpressions.Regex" />
+      <type fullname="System.Text.RegularExpressions.RegexMatchTimeoutException" />
       <type fullname="System.Text.RegularExpressions.RegexOptions" />
    </assembly>
    <assembly fullname="System.Threading">

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetBubbleUpException.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/CallTargetBubbleUpException.cs
@@ -1,8 +1,9 @@
-﻿// <copyright file="CallTargetBubbleUpException.cs" company="Datadog">
+// <copyright file="CallTargetBubbleUpException.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
 using System;
 
 namespace Datadog.Trace.ClrProfiler.CallTarget;
@@ -49,5 +50,25 @@ public class CallTargetBubbleUpException : Exception
     public CallTargetBubbleUpException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
         : base(info, context)
     {
+    }
+
+    /// <summary>
+    /// To know if any inner exception is of type CallTargetBubbleUpException
+    /// </summary>
+    /// <param name="exception">exception</param>
+    /// <returns>whether any child  is of type</returns>
+    public static bool IsCallTargetBubbleUpException(Exception? exception)
+    {
+        while (exception is not null)
+        {
+            if (exception is CallTargetBubbleUpException)
+            {
+                return true;
+            }
+
+            exception = exception.InnerException;
+        }
+
+        return false;
     }
 }

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -888,8 +888,13 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
         RewritingPInvokeMaps(module_metadata, WStr("fault_tolerant"), fault_tolerant_nonwindows_nativemethods_type);
 #endif // _WIN32
 
-        call_target_bubble_up_exception_available = EnsureCallTargetBubbleUpExceptionTypeAvailable(module_metadata);
-        
+        mdTypeDef bubbleUpTypeDef;
+        call_target_bubble_up_exception_available = EnsureCallTargetBubbleUpExceptionTypeAvailable(module_metadata, &bubbleUpTypeDef);
+        if(call_target_bubble_up_exception_available)
+        {
+            call_target_bubble_up_exception_function_available = EnsureIsCallTargetBubbleUpExceptionFunctionAvailable(module_metadata, bubbleUpTypeDef);
+        }
+
         auto native_loader_library_path = GetNativeLoaderFilePath();
         if (fs::exists(native_loader_library_path))
         {
@@ -2950,15 +2955,27 @@ std::string CorProfiler::GetILCodes(const std::string& title, ILRewriter* rewrit
     return orig_sstream.str();
 }
 
-bool CorProfiler::EnsureCallTargetBubbleUpExceptionTypeAvailable(const ModuleMetadata& module_metadata)
+bool CorProfiler::EnsureCallTargetBubbleUpExceptionTypeAvailable(const ModuleMetadata& module_metadata, mdTypeDef* typeDef)
 {
     // *** Ensure Datadog.Trace.ClrProfiler.CallTarget.CallTargetBubbleUpException available
-    mdTypeDef bubbleUpException;
     const auto bubble_up_type_name = calltargetbubbleexception_tracer_type_name.c_str();
-    const auto found_call_target_bubble_up_exception_type = module_metadata.metadata_import->FindTypeDefByName(bubble_up_type_name, mdTokenNil, &bubbleUpException);
+    const auto found_call_target_bubble_up_exception_type = module_metadata.metadata_import->FindTypeDefByName(bubble_up_type_name, mdTokenNil, typeDef);
     Logger::Debug("CallTargetBubbleUpException type available test, hresult is: ", found_call_target_bubble_up_exception_type);
     return SUCCEEDED(found_call_target_bubble_up_exception_type);
 }
+
+bool CorProfiler::EnsureIsCallTargetBubbleUpExceptionFunctionAvailable(const ModuleMetadata& module_metadata, mdTypeDef typeDef)
+{
+    const auto bubble_up_function_name = calltargetbubbleexception_tracer_function_name.c_str();
+
+    mdMethodDef methodDef = mdTokenNil;
+    const auto found_call_target_bubble_up_exception_function = module_metadata.metadata_import->FindMethod(typeDef, bubble_up_function_name, 0, 0, &methodDef);
+
+    auto res = SUCCEEDED(found_call_target_bubble_up_exception_function);
+    Logger::Debug("CallTargetBubbleUpException.IsCallTargetBubbleUpException method found: ", res);
+    return res;
+}
+
 //
 // Startup methods
 //
@@ -3156,7 +3173,7 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
                                                     ELEMENT_TYPE_U1};
     ULONG start_length = sizeof(appdomain_load_signature_start);
     ULONG end_length = sizeof(appdomain_load_signature_end);
-
+    
     BYTE system_reflection_assembly_type_ref_compressed_token[4];
     ULONG token_length =
         CorSigCompressToken(system_reflection_assembly_type_ref, system_reflection_assembly_type_ref_compressed_token);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1198,6 +1198,16 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
     return S_OK;
 }
 
+bool CorProfiler::IsCallTargetBubbleUpExceptionTypeAvailable() const
+{
+    return call_target_bubble_up_exception_available;
+}
+
+bool CorProfiler::IsCallTargetBubbleUpFunctionAvailable() const
+{
+    return call_target_bubble_up_exception_function_available;
+}
+
 HRESULT STDMETHODCALLTYPE CorProfiler::ModuleUnloadStarted(ModuleID module_id)
 {
     if (!is_attached_)

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -250,6 +250,13 @@ public:
     friend class MethodRewriter;
     friend class fault_tolerant::FaultTolerantMethodDuplicator;
     friend class fault_tolerant::FaultTolerantRewriter;
+
+    //
+    // Getters for exception filter
+    //
+
+    bool IsCallTargetBubbleUpExceptionTypeAvailable() const;
+    bool IsCallTargetBubbleUpFunctionAvailable() const;
 };
 
 // Note: Generally you should not have a single, global callback implementation,

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -76,6 +76,7 @@ private:
     std::unique_ptr<TracerRejitPreprocessor> tracer_integration_preprocessor = nullptr;
     bool trace_annotations_enabled = false;
     bool call_target_bubble_up_exception_available = false;
+    bool call_target_bubble_up_exception_function_available = false;
 
     //
     // Debugger Members
@@ -124,7 +125,9 @@ private:
     HRESULT EmitDistributedTracerTargetMethod(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT TryRejitModule(ModuleID module_id, std::vector<ModuleID>& modules);
     static bool TypeNameMatchesTraceAttribute(WCHAR type_name[], DWORD type_name_len);
-    static bool EnsureCallTargetBubbleUpExceptionTypeAvailable(const ModuleMetadata& module_metadata);
+    static bool EnsureCallTargetBubbleUpExceptionTypeAvailable(const ModuleMetadata& module_metadata, mdTypeDef* mdTypeDefToken);
+    static bool EnsureIsCallTargetBubbleUpExceptionFunctionAvailable(const ModuleMetadata& module_metadata, mdTypeDef typeDef);
+    
     //
     // Startup methods
     //

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -109,6 +109,7 @@ const shared::WSTRING calltarget_modification_action = WStr("CallTargetModificat
 
 const shared::WSTRING distributed_tracer_type_name = WStr("Datadog.Trace.ClrProfiler.DistributedTracer");
 const shared::WSTRING calltargetbubbleexception_tracer_type_name = WStr("Datadog.Trace.ClrProfiler.CallTarget.CallTargetBubbleUpException");
+const shared::WSTRING calltargetbubbleexception_tracer_function_name = WStr("IsCallTargetBubbleUpException");
 const shared::WSTRING distributed_tracer_interface_name = WStr("Datadog.Trace.ClrProfiler.IDistributedTracer");
 const shared::WSTRING distributed_tracer_target_method_name = WStr("__GetInstanceForProfiler__");
 

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -27,7 +27,7 @@ namespace trace
 ///       - Invoke BeginMethod with object instance (or null if static method) and original method arguments
 ///       - Store result into CallTargetState local
 ///     }
-///     catch when exception is not Datadog.Trace.ClrProfiler.CallTarget.CallTargetBubbleUpException
+///     catch when (CallTargetBubbleUpException.IsCallTargetBubbleUpException(exception) == false)
 ///     {
 ///       - Invoke LogException(Exception)
 ///     }
@@ -51,7 +51,7 @@ namespace trace
 ///     - Store result into CallTargetReturn/CallTargetReturn<TReturn> local
 ///     - If non-void method, store CallTargetReturn<TReturn>.GetReturnValue() into TReturn local
 ///   }
-///   catch when exception is not Datadog.Trace.ClrProfiler.CallTarget.CallTargetBubbleUpException
+///     catch when (CallTargetBubbleUpException.IsCallTargetBubbleUpException(exception) == false)
 ///   {
 ///     - Invoke LogException(Exception)
 ///   }
@@ -397,6 +397,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
     {
         filter = CreateFilterForException(&reWriterWrapper, tracerTokens->GetExceptionTypeRef(),
                                           tracerTokens->GetBubbleUpExceptionTypeRef(),
+                                          tracerTokens->GetBubbleUpExceptionFunctionDef(),
                                           exceptionValueIndex);
         Logger::Debug("Creating filter for try / catch for CallTargetBubbleUpException. (begin method)");
         beginMethodCatchFirstInstr = reWriterWrapper.Pop();
@@ -560,6 +561,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
         Logger::Debug("Creating filter for try / catch for CallTargetBubbleUpException (end method).");
         filterEnd = CreateFilterForException(&reWriterWrapper, tracerTokens->GetExceptionTypeRef(),
                                              tracerTokens->GetBubbleUpExceptionTypeRef(),
+                                             tracerTokens->GetBubbleUpExceptionFunctionDef(),
                                              exceptionValueEndIndex);
         endMethodCatchFirstInstr = reWriterWrapper.Pop();
         reWriterWrapper.LoadLocal(exceptionValueEndIndex);
@@ -787,7 +789,7 @@ TracerMethodRewriter::GetResourceNameAndOperationName(const ComPtr<IMetaDataImpo
 }
 
 ILInstr* trace::TracerMethodRewriter::CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception,
-                                                               mdTypeRef type_ref, ULONG exceptionValueIndex) 
+                                                               mdTypeRef type_ref, mdMemberRef containsCallTargetBubbleUp, ULONG exceptionValueIndex)
 {
     ILInstr* filter = rewriter->CreateInstr(CEE_ISINST);
     filter->m_Arg32 = exception;
@@ -796,14 +798,22 @@ ILInstr* trace::TracerMethodRewriter::CreateFilterForException(ILRewriterWrapper
     rewriter->CreateInstr(CEE_POP);
     rewriter->LoadInt32(0);
     ILInstr* endNotException = rewriter->CreateInstr(CEE_BR_S);
-
-    ILInstr* testBubbleUpPart = rewriter->StLocal(exceptionValueIndex);
+    ILInstr* storeExceptionInIndex = rewriter->StLocal(exceptionValueIndex);
+    isException->m_pTarget = storeExceptionInIndex;
     rewriter->LoadLocal(exceptionValueIndex);
-    ILInstr* testBubbleUp = rewriter->CreateInstr(CEE_ISINST);
-    testBubbleUp->m_Arg32 = type_ref;
-    isException->m_pTarget = testBubbleUpPart;
-    rewriter->LoadNull();
-    rewriter->CreateInstr(CEE_CGT_UN);
+
+    if (m_corProfiler->call_target_bubble_up_exception_function_available)
+    {
+        rewriter->CallMember(containsCallTargetBubbleUp, false);
+    }
+    else
+    {
+        ILInstr* testBubbleUp = rewriter->CreateInstr(CEE_ISINST);
+        testBubbleUp->m_Arg32 = type_ref;
+        rewriter->LoadNull();
+        rewriter->CreateInstr(CEE_CGT_UN);
+    }
+   
     rewriter->LoadInt32(0);
     rewriter->CreateInstr(CEE_CEQ);
     rewriter->LoadInt32(0);

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.h
@@ -40,7 +40,7 @@ public:
 class TracerMethodRewriter : public MethodRewriter
 {
 private:
-    ILInstr* CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception, mdTypeRef type_ref, ULONG exceptionValueIndex);
+    ILInstr* CreateFilterForException(ILRewriterWrapper* rewriter, mdTypeRef exception, mdTypeRef type_ref, mdMethodDef containsCallTargetBubbleUpException, ULONG exceptionValueIndex);
 
 public:
 

--- a/tracer/src/Datadog.Tracer.Native/tracer_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/tracer_tokens.cpp
@@ -157,28 +157,46 @@ HRESULT TracerTokens::EnsureBaseCalltargetTokens()
     
 
     // *** Ensure Datadog.Trace.ClrProfiler.CallTarget.CallTargetBubbleUpException type ref, might not be available if tracer version is < 2.22
-    if (trace::profiler->IsCallTargetBubbleUpExceptionTypeAvailable() && bubbleUpExceptionTypeRef == mdTypeRefNil)
+    if (profiler->IsCallTargetBubbleUpExceptionTypeAvailable() && bubbleUpExceptionTypeRef == mdTypeRefNil)
     {
         const ModuleMetadata* module_metadata = GetMetadata();
-        const auto defined_call_target_bubble_up_exception_type = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef,
+        const auto defined_calltargetbubbleup_byname_hrresult = module_metadata->metadata_emit->DefineTypeRefByName(profilerAssemblyRef,
                                                             calltargetbubbleexception_tracer_type_name.c_str(),
                                                             &bubbleUpExceptionTypeRef);
-        if (SUCCEEDED(defined_call_target_bubble_up_exception_type) && trace::profiler->IsCallTargetBubbleUpFunctionAvailable() && bubbleUpExceptionFunctionRef == mdMemberRefNil)
+        if (SUCCEEDED(defined_calltargetbubbleup_byname_hrresult))
         {
-            // now reference the method IsCallTargetBubbleUpException in the type's reference
-            COR_SIGNATURE createInstanceSig[32];
-            COR_SIGNATURE* sigBuilder = createInstanceSig;
-            sigBuilder += CorSigCompressData(IMAGE_CEE_CS_CALLCONV_DEFAULT, sigBuilder); // static
-            sigBuilder += CorSigCompressData(1, sigBuilder); // arguments count
-            sigBuilder += CorSigCompressElementType(ELEMENT_TYPE_BOOLEAN, sigBuilder);     // return type
-            sigBuilder += CorSigCompressElementType(ELEMENT_TYPE_CLASS, sigBuilder); // argument type
-            sigBuilder += CorSigCompressToken(exTypeRef, sigBuilder);
-            
-            const auto defined_call_target_bubble_up_exception_function = module_metadata->metadata_emit->DefineMemberRef(
-                    bubbleUpExceptionTypeRef, calltargetbubbleexception_tracer_function_name.c_str(), createInstanceSig,
-                    sigBuilder - createInstanceSig, &bubbleUpExceptionFunctionRef);
-            Logger::Debug("Defined function ", calltargetbubbleexception_tracer_function_name, " on ",
-                          calltargetbubbleexception_tracer_type_name, " type: ", defined_call_target_bubble_up_exception_function);
+            if (profiler->IsCallTargetBubbleUpFunctionAvailable() && bubbleUpExceptionFunctionRef == mdMemberRefNil)
+            {
+                // now reference the method IsCallTargetBubbleUpException in the type's reference
+                COR_SIGNATURE createInstanceSig[32];
+                COR_SIGNATURE* sigBuilder = createInstanceSig;
+                sigBuilder += CorSigCompressData(IMAGE_CEE_CS_CALLCONV_DEFAULT, sigBuilder); // static
+                sigBuilder += CorSigCompressData(1, sigBuilder);                             // arguments count
+                sigBuilder += CorSigCompressElementType(ELEMENT_TYPE_BOOLEAN, sigBuilder);   // return type
+                sigBuilder += CorSigCompressElementType(ELEMENT_TYPE_CLASS, sigBuilder);     // argument type
+                sigBuilder += CorSigCompressToken(exTypeRef, sigBuilder);
+
+                const auto defined_iscalltargetbubbleup_member_hrresult = module_metadata->metadata_emit->
+                    DefineMemberRef(
+                        bubbleUpExceptionTypeRef, calltargetbubbleexception_tracer_function_name.c_str(),
+                        createInstanceSig,
+                        sigBuilder - createInstanceSig, &bubbleUpExceptionFunctionRef);
+               
+                if (SUCCEEDED(defined_iscalltargetbubbleup_member_hrresult))
+                {
+                    Logger::Debug("Defined function ", calltargetbubbleexception_tracer_function_name, " on ",
+                             calltargetbubbleexception_tracer_type_name, " type: ",
+                             defined_iscalltargetbubbleup_member_hrresult);
+                }
+                else
+                {
+                    bubbleUpExceptionFunctionRef = mdMemberRefNil;
+                }
+            }
+        }
+        else
+        {
+            bubbleUpExceptionTypeRef = mdTypeRefNil;
         }
     }
     return hr;

--- a/tracer/src/Datadog.Tracer.Native/tracer_tokens.h
+++ b/tracer/src/Datadog.Tracer.Native/tracer_tokens.h
@@ -16,6 +16,7 @@ private:
     mdMemberRef endVoidMemberRef = mdMemberRefNil;
     mdMemberRef logExceptionRef = mdMemberRefNil;
     mdTypeRef bubbleUpExceptionTypeRef = mdTypeRefNil;
+    mdMemberRef bubbleUpExceptionFunctionRef = mdMemberRefNil;
 
     HRESULT WriteBeginMethodWithArgumentsArray(void* rewriterWrapperPtr, mdTypeRef integrationTypeRef,
                                                const TypeInfo* currentType, ILInstr** instruction);
@@ -49,6 +50,8 @@ public:
                               ILInstr** instruction);
 
     mdTypeRef GetBubbleUpExceptionTypeRef() const;
+
+    mdMemberRef GetBubbleUpExceptionFunctionDef() const;
 
     const shared::WSTRING& GetTraceAttributeType();
 };

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -248,6 +248,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        public async Task CallTargetBubbleUpExceptionIntegrations()
+        {
+            SetInstrumentationVerification();
+            using var agent = EnvironmentHelper.GetMockAgent();
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: "calltargetbubbleupexceptions");
+            processResult.ExitCode.Should().Be(0);
+            var beginMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: BeginMethod\\(0\\)<CallTargetNativeTest.NoOp.CallTargetBubbleUpExceptionsIntegration").Count;
+            var endMethodCount = Regex.Matches(processResult.StandardOutput, "ProfilerOK: EndMethod(Async)?\\([0|1]\\)<CallTargetNativeTest.NoOp.CallTargetBubbleUpExceptionsIntegration, CallTargetNativeTest").Count;
+            beginMethodCount.Should().Be(6);
+            endMethodCount.Should().Be(6);
+        }
+
+        [SkippableFact]
+        [Trait("SupportsInstrumentationVerification", "True")]
         public async Task CategorizedCallTargetIntegrations()
         {
             SetInstrumentationVerification();

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetBubbleUpExceptions.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetBubbleUpExceptions.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using Datadog.Trace.ClrProfiler.CallTarget;
+
+namespace CallTargetNativeTest;
+
+partial class Program
+{
+    private static void CallTargetBubbleUpExceptions()
+    {
+        var callTargetBubbleUpExceptions = new CallTargetBubbleUpExceptionsThrowBubbleUpOnBegin();
+        Console.WriteLine($"{typeof(CallTargetBubbleUpExceptionsThrowBubbleUpOnBegin).FullName}.{nameof(CallTargetBubbleUpExceptionsThrowBubbleUpOnBegin.DoSomething)}");
+        RunMethod(callTargetBubbleUpExceptions.DoSomething, bubblingUpException: true);
+        
+        var callTargetBubbleUpExceptionsNestedOnBegin = new CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnBegin();
+        Console.WriteLine($"{typeof(CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnBegin).FullName}.{nameof(CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnBegin.DoSomething)}");
+        RunMethod(callTargetBubbleUpExceptionsNestedOnBegin.DoSomething, bubblingUpException: true);
+        
+        var callTargetBubbleUpExceptionsThrowBubbleUpOnEnd = new CallTargetBubbleUpExceptionsThrowBubbleUpOnEnd();
+        Console.WriteLine($"{typeof(CallTargetBubbleUpExceptionsThrowBubbleUpOnEnd).FullName}.{nameof(CallTargetBubbleUpExceptionsThrowBubbleUpOnEnd.DoSomething)}");
+        RunMethod(callTargetBubbleUpExceptionsThrowBubbleUpOnEnd.DoSomething, bubblingUpException: true);
+        
+        var callTargetBubbleUpExceptionsThrowNestedBubbleUpOnEnd = new CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnEnd();
+        Console.WriteLine($"{typeof(CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnEnd).FullName}.{nameof(CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnEnd.DoSomething)}");
+        RunMethod(callTargetBubbleUpExceptionsThrowNestedBubbleUpOnEnd.DoSomething, bubblingUpException: true);
+
+        var callTargetBubbleUpExceptionsThrowBubbleUpOnAsyncEnd = new CallTargetBubbleUpExceptionsThrowBubbleUpOnAsyncEnd();
+        Console.WriteLine($"{typeof(CallTargetBubbleUpExceptionsThrowBubbleUpOnAsyncEnd).FullName}.{nameof(CallTargetBubbleUpExceptionsThrowBubbleUpOnAsyncEnd.DoSomething)}");
+        RunMethod(() => callTargetBubbleUpExceptionsThrowBubbleUpOnAsyncEnd.DoSomething().Wait(), bubblingUpException: true);
+        
+        var callTargetBubbleUpExceptionsThrowNestedBubbleUpOnAsyncEnd = new CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnAsyncEnd();
+        Console.WriteLine($"{typeof(CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnAsyncEnd).FullName}.{nameof(CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnAsyncEnd.DoSomething)}");
+        RunMethod(() => callTargetBubbleUpExceptionsThrowNestedBubbleUpOnAsyncEnd.DoSomething().Wait(), bubblingUpException: true);
+    }
+}
+
+public class CallTargetBubbleUpExceptionsThrowBubbleUpOnBegin
+{
+    public void DoSomething()
+    {
+        Console.WriteLine("Instrumentation will throw a bubble up");
+    }
+}
+
+public class CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnBegin
+{
+    public void DoSomething()
+    {
+        Console.WriteLine("Instrumentation will throw a bubble up");
+    }
+}
+
+public class CallTargetBubbleUpExceptionsThrowBubbleUpOnEnd
+{
+    public void DoSomething()
+    {
+        Console.WriteLine("Instrumentation will throw a bubble up");
+    }
+}
+
+public class CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnEnd
+{
+    public void DoSomething()
+    {
+        Console.WriteLine("Instrumentation will throw a bubble up");
+    }
+}
+
+public class CallTargetBubbleUpExceptionsThrowBubbleUpOnAsyncEnd
+{
+    public Task DoSomething()
+    {
+        Console.WriteLine("Instrumentation will throw a bubble up");
+        return Task.CompletedTask;
+    }
+}
+
+public class CallTargetBubbleUpExceptionsThrowNestedBubbleUpOnAsyncEnd
+{
+    public Task DoSomething()
+    {
+        Console.WriteLine("Instrumentation will throw a bubble up");
+        return Task.CompletedTask;
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/CallTargetBubbleUpExceptionsIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/CallTargetBubbleUpExceptionsIntegration.cs
@@ -1,0 +1,122 @@
+using System;
+using Datadog.Trace.ClrProfiler.CallTarget;
+using Datadog.Trace.DuckTyping;
+
+namespace CallTargetNativeTest.NoOp
+{
+    /// <summary>
+    /// CallTargetBubbleUpExceptions Integration for 0 Arguments and Void Return
+    /// </summary>
+    public static class CallTargetBubbleUpExceptionsIntegration
+    {
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+        {
+            var returnValue = CallTargetState.GetDefault();
+            Console.WriteLine($"ProfilerOK: BeginMethod(0)<{typeof(CallTargetBubbleUpExceptionsIntegration)}, {typeof(TTarget)}>({instance})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
+            if (instance?.GetType().Name.Contains("ThrowBubbleUpOnBegin") == true)
+            {
+                Console.WriteLine("Bubbleup exception about to throw.");
+                throw new CallTargetBubbleUpException();
+            }
+
+            if (instance?.GetType().Name.Contains("ThrowNestedBubbleUpOnBegin") == true)
+            {
+                Console.WriteLine("Nested bubbleup exception about to throw.");
+                throw new Exception("nested bubble up", new CallTargetBubbleUpException());
+            }
+
+            return returnValue;
+        }
+
+        public static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception exception, in CallTargetState state)
+        {
+            var returnValue = CallTargetReturn.GetDefault();
+            Console.WriteLine($"ProfilerOK: EndMethod(0)<{typeof(CallTargetBubbleUpExceptionsIntegration)}, {typeof(TTarget)}>({instance}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance?.GetType().Name.Contains("ThrowOnEnd") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
+            if (instance?.GetType().Name.Contains("ThrowBubbleUpOnEnd") == true)
+            {
+                Console.WriteLine("Bubbleup exception about to throw.");
+                throw new CallTargetBubbleUpException();
+            }
+
+            if (instance?.GetType().Name.Contains("ThrowNestedBubbleUpOnEnd") == true)
+            {
+                Console.WriteLine("Nested bubbleup exception about to throw.");
+                throw new Exception("nested bubble up", new CallTargetBubbleUpException());
+            }
+
+            return returnValue;
+        }
+    }
+
+    public static class CallTargetBubbleUpExceptionsIntegrationAsync
+    {
+        public static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+        {
+            var returnValue = CallTargetState.GetDefault();
+            Console.WriteLine($"ProfilerOK: BeginMethod(0)<{typeof(CallTargetBubbleUpExceptionsIntegration)}, {typeof(TTarget)}>({instance})");
+            if (instance?.GetType().Name.Contains("ThrowOnBegin") == true)
+            {
+                Console.WriteLine("Exception thrown.");
+                throw new Exception();
+            }
+
+            if (instance?.GetType().Name.Contains("ThrowBubbleUpOnBegin") == true)
+            {
+                Console.WriteLine("Bubbleup exception about to throw.");
+                throw new CallTargetBubbleUpException();
+            }
+
+            if (instance?.GetType().Name.Contains("ThrowNestedBubbleUpOnBegin") == true)
+            {
+                Console.WriteLine("Nested bubbleup exception about to throw.");
+                throw new Exception("nested bubble up", new CallTargetBubbleUpException());
+            }
+
+            return returnValue;
+        }
+
+        public static TReturn OnAsyncMethodEnd<TTarget, TReturn>(TTarget instance, TReturn returnValue, Exception exception, in CallTargetState state)
+            where TTarget : IInstance, IDuckType
+            where TReturn : IReturnValue
+        {
+            Console.WriteLine($"ProfilerOK: EndMethodAsync(1)<{typeof(CallTargetBubbleUpExceptionsIntegration)}, {typeof(TTarget)}, {typeof(TReturn)}>({instance}, {returnValue}, {exception?.ToString() ?? "(null)"}, {state})");
+            if (instance.Instance?.GetType().Name.Contains("ThrowBubbleUpOnAsyncEnd") == true)
+            {
+                Console.WriteLine("Bubbleup exception about to throw.");
+                throw new CallTargetBubbleUpException();
+            }
+
+            if (instance.Instance?.GetType().Name.Contains("ThrowNestedBubbleUpOnAsyncEnd") == true)
+            {
+                Console.WriteLine("Nested bubbleup exception about to throw.");
+                throw new Exception("nested bubble up", new CallTargetBubbleUpException());
+            }
+
+            return returnValue;
+        }
+
+        public interface IInstance
+        {
+        }
+
+        public interface IArg
+        {
+        }
+
+        public interface IReturnValue
+        {
+        }
+    }
+}

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Program.cs
@@ -381,6 +381,8 @@ namespace CallTargetNativeTest
                         // GenericParentAbstractMethod();
                         Extras();
                         //.
+                        CallTargetBubbleUpExceptions();
+                        //.
                         CallSite();
                         break;
                     }

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/Properties/launchSettings.json
@@ -87,6 +87,28 @@
       },
       "nativeDebugging": true
     },
+    "CallTargetBubbleUpTest": {
+      "commandName": "Project",
+      "commandLineArgs": "calltargetbubbleupexceptions",
+      "environmentVariables": {
+        "DD_CTARGET_TESTMODE": "True",
+        "DD_CSITE_TESTMODE": "True",
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+        "COR_ENABLE_PROFILING": "1",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "COR_PROFILER_PATH_32": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+        "COR_PROFILER_PATH_64": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+        "DD_DUMP_ILREWRITE_ENABLED": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH_32": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+        "CORECLR_PROFILER_PATH_64": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+        "DD_VERSION": "1.0.0",
+        "DD_CLR_ENABLE_INLINING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "DD_IAST_ENABLED": "1"
+      },
+      "nativeDebugging": true
+    },
     "CallTargetRemove": {
       "commandName": "Project",
       "commandLineArgs": "remove",


### PR DESCRIPTION
## Summary of changes

Related to this: https://docs.google.com/document/d/1-Lnwj9x7uIxxFHCoJs3MsV5HyxqUZISQz7DEck2kJUQ/edit

## Reason for change

Being able to block requests without having to throw a first level `CallTargetBubbleUpException` but being able to detect a nested one and let it bubble up from the native side as well

## Implementation details

Test if the function IsCallTargetBubbleUpException() exists, if it does, define it to be called from outside a module.
If it doesn't, keep existing behavior. 
Now 2 compatibility levels exist for previous tracer versions:
- CallTargetBubbleUpException type doesn't exist, we catch all exceptions
- CallTargetBubbleUpException.IsCallTargetBubbleUpException doesn't exist, we only throw on first level ones

Improvements: if type or function dont exist, dont bother trying to define them

## Test coverage

- Added 6 test cases to the CallTargetNativeTests to make sure the exception and nested exception are actually bubbling up.
- Existing throwing tests in CallTargetNativeTests prove that other exceptions are caught
- Compatibility was tested manually: 
    - tested without the CallTargetBubbleException type. Without the type we fallback as such: 
![image](https://github.com/DataDog/dd-trace-dotnet/assets/8353486/aaf04bfb-35d4-4173-9f1a-19e9287de80b)
    - tested with the CallTargetBubbleException  type but without the function IsCallTargetBubbleUpException existing and here's the fallback 
![image](https://github.com/DataDog/dd-trace-dotnet/assets/8353486/bb7c86f3-aff1-4876-895f-d0d896cd97ed)


## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
