### PR TITLE
Temporarily disable the tracer flare functionality

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -180,7 +180,7 @@ namespace Datadog.Trace
             }
 
             dynamicConfigurationManager ??= new DynamicConfigurationManager(RcmSubscriptionManager.Instance);
-            tracerFlareManager ??= new TracerFlareManager(discoveryService, RcmSubscriptionManager.Instance, TracerFlareApi.Create(settings.ExporterInternal));
+            tracerFlareManager ??= new TracerFlareManager(discoveryService, RcmSubscriptionManager.Instance, TracerFlareApi.Create(settings.ExporterInternal), enableFlare: false);
 
             return CreateTracerManagerFrom(
                 settings,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -35,7 +35,7 @@ public class TracerFlareTests : TestHelper
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "5");
     }
 
-    [SkippableFact]
+    [SkippableFact(Skip = "Temporarily disabled for release")]
     [Trait("RunOnWindows", "True")]
     public async Task SendTracerFlare()
     {


### PR DESCRIPTION
## Summary of changes

Disables the tracer flare functionality

## Reason for change

We discovered a discrepancy between the expected sequence of configuration and the actual sequence, so disabling until the next release to give time to iron out any further issues

## Implementation details

Just disable the RCM functionality

## Test coverage

Still has the same test coverage, as we only disable in the "real" tracer manager

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
