### PR TITLE
Reenable tracer flare and handle debug request

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -31,7 +31,6 @@ internal class TracerFlareManager : ITracerFlareManager
     private readonly IDiscoveryService _discoveryService;
     private readonly IRcmSubscriptionManager _subscriptionManager;
     private readonly TracerFlareApi _flareApi;
-    private readonly bool _enableFlare;
     private ISubscription? _subscription;
     private Timer? _resetTimer = null;
 
@@ -40,24 +39,17 @@ internal class TracerFlareManager : ITracerFlareManager
     public TracerFlareManager(
         IDiscoveryService discoveryService,
         IRcmSubscriptionManager subscriptionManager,
-        TracerFlareApi flareApi,
-        bool enableFlare = true)
+        TracerFlareApi flareApi)
     {
         _subscriptionManager = subscriptionManager;
         _flareApi = flareApi;
         _discoveryService = discoveryService;
-        _enableFlare = enableFlare;
     }
 
     public bool? CanSendTracerFlare { get; private set; } = null;
 
     public void Start()
     {
-        if (!_enableFlare)
-        {
-            return;
-        }
-
         if (Interlocked.Exchange(ref _subscription, new Subscription(RcmProductReceived, RcmProducts.TracerFlareInitiated, RcmProducts.TracerFlareRequested)) == null)
         {
             _discoveryService.SubscribeToChanges(HandleConfigUpdate);
@@ -68,11 +60,6 @@ internal class TracerFlareManager : ITracerFlareManager
 
     public void Dispose()
     {
-        if (!_enableFlare)
-        {
-            return;
-        }
-
         if (_resetTimer is not null)
         {
             // If we have a timer, we should reset debugging now

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -180,7 +180,7 @@ namespace Datadog.Trace
             }
 
             dynamicConfigurationManager ??= new DynamicConfigurationManager(RcmSubscriptionManager.Instance);
-            tracerFlareManager ??= new TracerFlareManager(discoveryService, RcmSubscriptionManager.Instance, TracerFlareApi.Create(settings.ExporterInternal), enableFlare: false);
+            tracerFlareManager ??= new TracerFlareManager(discoveryService, RcmSubscriptionManager.Instance, TracerFlareApi.Create(settings.ExporterInternal));
 
             return CreateTracerManagerFrom(
                 settings,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -35,7 +35,7 @@ public class TracerFlareTests : TestHelper
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "5");
     }
 
-    [SkippableFact(Skip = "Temporarily disabled for release")]
+    [SkippableFact]
     [Trait("RunOnWindows", "True")]
     public async Task SendTracerFlare()
     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -73,7 +73,7 @@ public class TracerFlareTests : TestHelper
 
     private async Task InitializeFlare(MockTracerAgent agent, LogEntryWatcher logEntryWatcher)
     {
-        var fileId = Guid.NewGuid().ToString();
+        var fileId = "flare-log-level.debug";
 
         var request = await agent.SetupRcmAndWait(Output, new[] { ((object)new { }, RcmProducts.TracerFlareInitiated, fileId) });
 


### PR DESCRIPTION
## Summary of changes

- Reenable the tracer flare
- Restrict handling of `AGENT_CONFIG` remote configuration to only `flare-log-level.debug` and `flare-log-level.trace`

## Reason for change

When we subscribe to `AGENT_CONFIG`, you always receive a config on app start that describes the different log levels available, regardless of whether a tracer flare is activated. We should not enable debug mode when we receive that initial config.

## Implementation details

Check the `Id` of the `AGENT_CONFIG` details to listen for `flare-log-level.debug` and `flare-log-level.trace`. Only treat the addition (or removal) of those configs as the tracer-flare ones we want

## Test coverage

Updated integration test to cover this. Considered refactoring the `TracerFlareManager` to test more thoroughly, but the logic is simple enough (and the complexity is more around what we _actually_ receive, which these wouldn't test for) so it didn't seem worth it 🤷‍♂️ 

## Other details
We may well want to handle other `flare-log-level.*` `AGENT_CONFIG` events (e.g. `flare-log-level.warn`) and treat those in the _opposite_ way (i.e. _disabled_ debug when received, and _enable_ debug when removed). But they're usage as part of the flare isn't clear/specified currently, so deferring that till we have more concrete cases.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
