### PR TITLE
[CI Visibility] - Intelligent Test Runner: reduce overhead of the default branch

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -178,6 +178,17 @@ namespace Datadog.Trace.Tools.Runner
 
                         // we skip the framework info because we are interested in the target projects info not the runner one.
                         var itrSettings = await lazyItrClient.Value.GetSettingsAsync(skipFrameworkInfo: true).ConfigureAwait(false);
+
+                        // we check if the backend require the git metadata first
+                        if (itrSettings.RequireGit == true)
+                        {
+                            Log.Debug("RunCiCommand: require git received, awaiting for the git repository upload.");
+                            await uploadRepositoryChangesTask.ConfigureAwait(false);
+
+                            Log.Debug("RunCiCommand: calling the configuration api again.");
+                            itrSettings = await lazyItrClient.Value.GetSettingsAsync(skipFrameworkInfo: true).ConfigureAwait(false);
+                        }
+
                         codeCoverageEnabled = itrSettings.CodeCoverage == true || itrSettings.TestsSkipping == true;
                         testSkippingEnabled = itrSettings.TestsSkipping == true;
                     }

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -1049,6 +1049,9 @@ internal class IntelligentTestRunnerClient
 
         [JsonProperty("tests_skipping")]
         public readonly bool? TestsSkipping;
+
+        [JsonProperty("require_git")]
+        public readonly bool? RequireGit;
 #pragma warning restore CS0649
     }
 


### PR DESCRIPTION
## Summary of changes

This PR applies Intelligent Test Runner overhead improvements in the default branch proposed in the RFC: https://docs.google.com/document/d/1E2w-xYl8pY_3dpPgZFJzQkIXm-8VKK1DxyYVnpswlaU/edit

## Reason for change
We are making improvements to reduce overhead when the Intelligent Test Runner is enabled.

## Implementation details

Updating the logic to follow the diagram:
<img width="1436" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/742aef5f-b357-4c1d-b908-46a8f3140c54">

## Test coverage

Tested locally but, CI tests are going to be implemented in the `test-environment` repo later.

