### PR TITLE
[Tracer] Update signature parsing in the tracer's native library to account for `ELEMENT_TYPE_PTR` byte

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -519,6 +519,13 @@ shared::WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaData
         ref_flag = true;
     }
 
+    bool pointer_flag = false;
+    if (*pbCur == ELEMENT_TYPE_PTR)
+    {
+        pbCur++;
+        pointer_flag = true;
+    }
+
     switch (*pbCur)
     {
         case ELEMENT_TYPE_BOOLEAN:
@@ -641,6 +648,10 @@ shared::WSTRING GetSigTypeTokName(PCCOR_SIGNATURE& pbCur, const ComPtr<IMetaData
     if (ref_flag)
     {
         tokenName += WStr("&");
+    }
+    if (pointer_flag)
+    {
+        tokenName += WStr("*");
     }
     return tokenName;
 }
@@ -865,6 +876,8 @@ bool ParseParamOrLocal(PCCOR_SIGNATURE& pbCur, PCCOR_SIGNATURE pbEnd)
     if (*pbCur == ELEMENT_TYPE_TYPEDBYREF) return false;
 
     if (*pbCur == ELEMENT_TYPE_BYREF) pbCur++;
+
+    if (*pbCur == ELEMENT_TYPE_PTR) pbCur++;
 
     return ParseType(pbCur, pbEnd);
 }


### PR DESCRIPTION
## Summary of changes

## Reason for change

## Implementation details

## Test coverage
Added minimal unit tests to cover the new scenarios.

## Other details
We haven't seen any issues in our current usage, but this [bug fix](https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/pull/3196/commits/d3f2eb2ba6dacfa076fb8567923993791b9c99a7) was required for the opentelemetry/opentelemetry-dotnet-instrumentation project to implement their initial version of their continuous profiler.