### PR TITLE
[CI Visibility] - Enable AutomaticDecompression on CI Visibility http clients

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -351,6 +351,7 @@
       <type fullname="System.Net.IPHostEntry" />
    </assembly>
    <assembly fullname="System.Net.Primitives">
+      <type fullname="System.Net.DecompressionMethods" />
       <type fullname="System.Net.DnsEndPoint" />
       <type fullname="System.Net.EndPoint" />
       <type fullname="System.Net.HttpStatusCode" />

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -361,7 +361,14 @@ namespace Datadog.Trace.Ci
 
 #if NETCOREAPP
             Log.Information("Using {FactoryType} for trace transport.", nameof(HttpClientRequestFactory));
-            factory = new HttpClientRequestFactory(tracerSettings.ExporterInternal.AgentUriInternal, AgentHttpHeaderNames.DefaultHeaders, timeout: timeout);
+            factory = new HttpClientRequestFactory(
+                tracerSettings.ExporterInternal.AgentUriInternal,
+                AgentHttpHeaderNames.DefaultHeaders,
+                handler: new System.Net.Http.HttpClientHandler
+                {
+                    AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                },
+                timeout: timeout);
 #else
             Log.Information("Using {FactoryType} for trace transport.", nameof(ApiWebRequestFactory));
             factory = new ApiWebRequestFactory(tracerSettings.ExporterInternal.AgentUriInternal, AgentHttpHeaderNames.DefaultHeaders, timeout: timeout);


### PR DESCRIPTION
## Summary of changes

This PR enables the AutomaticDecompression flag on CI Visibility http clients.

## Reason for change

When using Intelligent Test Runner the backend send us a lot of data like commits shas or the test list to be skipped. Recently the backend endpoints added support to return compressed payloads, and we want to start taking advantage of this.

## Implementation details

Just enable the flag on a custom `HttpClientHandler`.

This PR only enables the feature on  `NETCOREAPP` frameworks for now, most of the transaction are made by the dotnet tool (only supported on .NET Core and greater). Maybe in the future we will enable it for .NET Framework, we will see. 