### PR TITLE
Use native debugging for procdump

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
@@ -69,7 +69,7 @@ namespace Datadog.Trace.TestHelpers
             _ = Task.Factory.StartNew(
                 () =>
                 {
-                    var args = $"-ma -accepteula -e {pid} {Path.GetTempPath()}";
+                    var args = $"-ma -accepteula -g -e {pid} {Path.GetTempPath()}";
 
                     using var dumpToolProcess = Process.Start(new ProcessStartInfo(_path, args)
                     {
@@ -95,7 +95,8 @@ namespace Datadog.Trace.TestHelpers
 
                     if (helper.StandardOutput.Contains("Dump count reached") || !helper.StandardOutput.Contains("Dump count not reached"))
                     {
-                        _output.Report($"procdump for process {pid} exited with code {helper.Process.ExitCode}");
+                        _output.Report($"[dump] procdump for process {pid} exited with code {helper.Process.ExitCode}");
+                        _output.Report($"[dump] Using {_path}");
 
                         _output.Report($"[dump][stdout] {helper.StandardOutput}");
                         _output.Report($"[dump][stderr] {helper.ErrorOutput}");
@@ -109,8 +110,6 @@ namespace Datadog.Trace.TestHelpers
                     }
                     else
                     {
-                        _output.Report($"[dump] Dumping the output as binary (have fun)");
-                        _output.Report(string.Join(",", helper.StandardOutput.Select(c => (int)c)));
                         tcs.TrySetCanceled();
                     }
                 },

--- a/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
@@ -31,6 +31,12 @@ namespace Datadog.Trace.TestHelpers
                 return;
             }
 
+            if (!EnvironmentTools.IsTestTarget64BitProcess())
+            {
+                // We currently have an issue with procdump on x86
+                return;
+            }
+
             // We don't know if procdump is available, so download it fresh
             const string url = "https://download.sysinternals.com/files/Procdump.zip";
             var client = new HttpClient();


### PR DESCRIPTION
## Summary of changes

 - Disable managed debugging in procdump.
 - Disable procdump on x86

## Reason for change

Procdump is having weird problems on x86, and also causing some long-forgotten deadlocks: https://github.com/dotnet/runtime/issues/37571

Enabling the native mode should (hopefully) fix those. The downside is that we won't get memory dumps for managed crashes, but we mostly care about native ones anyway.

## Implementation details

Call procdump with the `-g` flag.
