### PR TITLE
[ASM][IAST] New scrubbing for location data

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -172,6 +172,9 @@ src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
 src/Datadog.Trace/Iast/Iast.cs
 src/Datadog.Trace/Iast/ITaintedMap.cs
 src/Datadog.Trace/Iast/SourceType.cs
+src/Datadog.Trace/Iast/SourceTypeName.cs
+src/Datadog.Trace/PDBs/DatadogPdbReader.cs
+src/Datadog.Trace/PDBs/SymbolMethodExtensions.cs
 src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
 src/Datadog.Trace/PlatformHelpers/AzureContext.cs
 src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -172,9 +172,6 @@ src/Datadog.Trace/HttpOverStreams/IHttpContent.cs
 src/Datadog.Trace/Iast/Iast.cs
 src/Datadog.Trace/Iast/ITaintedMap.cs
 src/Datadog.Trace/Iast/SourceType.cs
-src/Datadog.Trace/Iast/SourceTypeName.cs
-src/Datadog.Trace/PDBs/DatadogPdbReader.cs
-src/Datadog.Trace/PDBs/SymbolMethodExtensions.cs
 src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
 src/Datadog.Trace/PlatformHelpers/AzureContext.cs
 src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -458,46 +458,6 @@ internal static class IastModule
         var vulnerability = (hash is null) ?
             new Vulnerability(vulnerabilityType, location, new Evidence(evidenceValue, tainted?.Ranges), integrationId) :
             new Vulnerability(vulnerabilityType, (int)hash, location, new Evidence(evidenceValue, tainted?.Ranges), integrationId);
-        // Print the stack trace to the console for debugging purposes
-        var stackTrace = new StackTrace(0, true);
-        Log.Warning("Stack trace debugging: {StackTrace}", stackTrace);
-        Console.Error.WriteLine("Stack trace debugging: {0}", stackTrace);
-
-        var stackFrameSelected = frameInfo.StackFrame;
-        var stackFrameMethod = stackFrameSelected?.GetMethod();
-        var filename = stackFrameSelected?.GetFileName();
-        var line = string.IsNullOrEmpty(filename) ? 0 : (stackFrameSelected?.GetFileLineNumber() ?? 0);
-        var methodeTypeName = string.IsNullOrEmpty(filename) ? GetMethodTypeName(stackFrameSelected) : null;
-
-        Log.Warning("Stack frame debugging 2: {StackFrame}", stackFrameSelected);
-        Log.Warning("Stack frame debugging method: {StackFrameMethod} - {Method}", stackFrameMethod, stackFrameMethod?.Name);
-        Log.Warning("Stack frame debugging filename: {Filename}", filename);
-        Log.Warning("Stack frame debugging line: {Line}", line.ToString());
-        Log.Warning("Stack frame debugging method type name: {MethodTypeName}", methodeTypeName);
-
-        Console.Error.WriteLine("Stack frame debugging 2: {0}", stackFrameSelected);
-        Console.Error.WriteLine("Stack frame debugging method: {0} - {1}", stackFrameMethod, stackFrameMethod?.Name);
-        Console.Error.WriteLine("Stack frame debugging filename: {0}", filename);
-        Console.Error.WriteLine("Stack frame debugging line: {0}", line);
-        Console.Error.WriteLine("Stack frame debugging method type name: {0}", methodeTypeName);
-
-        return IastModuleResponse.Empty;
-
-        /*
-        // Sometimes we do not have the file/line but we have the method/class.
-        var stackFrame = frameInfo.StackFrame;
-        var filename = stackFrame?.GetFileName();
-        var line = string.IsNullOrEmpty(filename) ? 0 : (stackFrame?.GetFileLineNumber() ?? 0);
-        var vulnerability = new Vulnerability(
-            vulnerabilityType,
-            new Location(
-                stackFile: filename,
-                methodName: string.IsNullOrEmpty(filename) ? stackFrame?.GetMethod()?.Name : null,
-                line: line > 0 ? line : null,
-                spanId: currentSpan?.SpanId,
-                methodTypeName: string.IsNullOrEmpty(filename) ? GetMethodTypeName(stackFrame) : null),
-            new Evidence(evidenceValue, tainted?.Ranges),
-            integrationId);
 
         if (!iastSettings.DeduplicationEnabled || HashBasedDeduplication.Instance.Add(vulnerability))
         {

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -463,6 +463,27 @@ internal static class IastModule
         Log.Warning("Stack trace debugging: {StackTrace}", stackTrace);
         Console.Error.WriteLine("Stack trace debugging: {0}", stackTrace);
 
+        var stackFrameSelected = frameInfo.StackFrame;
+        var stackFrameMethod = stackFrameSelected?.GetMethod();
+        var filename = stackFrameSelected?.GetFileName();
+        var line = string.IsNullOrEmpty(filename) ? 0 : (stackFrameSelected?.GetFileLineNumber() ?? 0);
+        var methodeTypeName = string.IsNullOrEmpty(filename) ? GetMethodTypeName(stackFrameSelected) : null;
+
+        Log.Warning("Stack frame debugging 2: {StackFrame}", stackFrameSelected);
+        Log.Warning("Stack frame debugging method: {StackFrameMethod} - {Method}", stackFrameMethod, stackFrameMethod?.Name);
+        Log.Warning("Stack frame debugging filename: {Filename}", filename);
+        Log.Warning("Stack frame debugging line: {Line}", line.ToString());
+        Log.Warning("Stack frame debugging method type name: {MethodTypeName}", methodeTypeName);
+
+        Console.Error.WriteLine("Stack frame debugging 2: {0}", stackFrameSelected);
+        Console.Error.WriteLine("Stack frame debugging method: {0} - {1}", stackFrameMethod, stackFrameMethod?.Name);
+        Console.Error.WriteLine("Stack frame debugging filename: {0}", filename);
+        Console.Error.WriteLine("Stack frame debugging line: {0}", line);
+        Console.Error.WriteLine("Stack frame debugging method type name: {0}", methodeTypeName);
+
+        return IastModuleResponse.Empty;
+
+        /*
         // Sometimes we do not have the file/line but we have the method/class.
         var stackFrame = frameInfo.StackFrame;
         var filename = stackFrame?.GetFileName();
@@ -492,6 +513,7 @@ internal static class IastModule
         }
 
         return IastModuleResponse.Empty;
+        */
     }
 
     private static IastModuleResponse AddVulnerabilityAsSingleSpan(Tracer tracer, IntegrationId integrationId, string operationName, List<Vulnerability> vulnerabilities)

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -513,7 +513,6 @@ internal static class IastModule
         }
 
         return IastModuleResponse.Empty;
-        */
     }
 
     private static IastModuleResponse AddVulnerabilityAsSingleSpan(Tracer tracer, IntegrationId integrationId, string operationName, List<Vulnerability> vulnerabilities)

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -460,7 +460,8 @@ internal static class IastModule
             new Vulnerability(vulnerabilityType, (int)hash, location, new Evidence(evidenceValue, tainted?.Ranges), integrationId);
         // Print the stack trace to the console for debugging purposes
         var stackTrace = new StackTrace(0, true);
-        Log.Information("Stack trace debugging: {StackTrace}", stackTrace);
+        Log.Warning("Stack trace debugging: {StackTrace}", stackTrace);
+        Console.Error.WriteLine("Stack trace debugging: {0}", stackTrace);
 
         // Sometimes we do not have the file/line but we have the method/class.
         var stackFrame = frameInfo.StackFrame;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastVerifyScrubberExtensions.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastVerifyScrubberExtensions.cs
@@ -12,12 +12,14 @@ namespace Datadog.Trace.Security.IntegrationTests.IAST
 {
     public static class IastVerifyScrubberExtensions
     {
-        private static readonly (Regex RegexPattern, string Replacement) LocationMsgRegex = (new Regex(@"(\S)*""location"": {(\r|\n){1,2}(.*(\r|\n){1,2}){0,3}(\s)*},"), string.Empty);
         private static readonly (Regex RegexPattern, string Replacement) ClientIp = (new Regex(@"["" ""]*http.client_ip: .*,(\r|\n){1,2}"), string.Empty);
         private static readonly (Regex RegexPattern, string Replacement) NetworkClientIp = (new Regex(@"["" ""]*network.client.ip: .*,(\r|\n){1,2}"), string.Empty);
         private static readonly (Regex RegexPattern, string Replacement) HashRegex = (new Regex(@"(\S)*""hash"": (-){0,1}([0-9]){1,12},(\r|\n){1,2}      "), string.Empty);
         private static readonly (Regex RegexPattern, string Replacement) RequestTaintedRegex = (new Regex(@"_dd.iast.telemetry.request.tainted:(\s)*([1-9])(\d*).?(\d*),"), "_dd.iast.telemetry.request.tainted:,");
         private static readonly (Regex RegexPattern, string Replacement) TelemetryExecutedSinks = (new Regex(@"_dd\.iast\.telemetry\.executed\.sink\.weak_.+: .{3},"), string.Empty);
+
+        private static readonly (Regex RegexPattern, string Replacement) SpanIdRegex = (new Regex("\"spanId\": \\d+"), "\"spanId\": XXX");
+        private static readonly (Regex RegexPattern, string Replacement) LineRegex = (new Regex("\"line\": \\d+"), "\"line\": XXX");
 
         public static VerifySettings AddIastScrubbing(this VerifySettings settings, bool scrubHash = true)
         {
@@ -28,11 +30,13 @@ namespace Datadog.Trace.Security.IntegrationTests.IAST
 
         public static VerifySettings AddIastScrubbing(this VerifySettings settings, IEnumerable<(Regex RegexPattern, string Replacement)> extraScrubbers)
         {
-            settings.AddRegexScrubber(LocationMsgRegex);
             settings.AddRegexScrubber(ClientIp);
             settings.AddRegexScrubber(NetworkClientIp);
             settings.AddRegexScrubber(RequestTaintedRegex);
             settings.AddRegexScrubber(TelemetryExecutedSinks);
+
+            settings.AddRegexScrubber(SpanIdRegex);
+            settings.AddRegexScrubber(LineRegex);
 
             if (extraScrubbers != null)
             {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "PATH_TRAVERSAL",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TestCookieName"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieName.AspNetCore5.TelemetryEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
-        "method": "ExecuteCommandInternal"
+        "path": "IastController.cs",
+        "line": XXX
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ExecuteCommandFromHeader.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -65,6 +65,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "slack-app-token"
       }
@@ -97,6 +101,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "grafana-service-account-token"
       }
@@ -129,6 +137,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "gitlab-pat"
       }
@@ -161,6 +173,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "github-app-token"
       }

--- a/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.verified.txt
@@ -65,6 +65,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "slack-app-token"
       }
@@ -97,6 +101,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "grafana-service-account-token"
       }
@@ -129,6 +137,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "gitlab-pat"
       }
@@ -161,6 +173,10 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "location": {
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "HardcodedSecrets"
+      },
       "evidence": {
         "value": "github-app-token"
       }

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "LDAP_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "LDAP_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ldap"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "LDAP_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "LDAP_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ldap"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "LDAP_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ldap"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "LDAP_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "LDAP_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ldap"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "LDAP_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "LDAP_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -34,6 +39,11 @@
     },
     {
       "type": "LDAP_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.Ldap.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "LDAP_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ldap"
       },
       "evidence": {
         "valueParts": [
@@ -41,8 +41,8 @@
       "type": "LDAP_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ldap"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "PATH_TRAVERSAL",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "GetFileContent"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.TelemetryEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "PATH_TRAVERSAL",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "GetFileContent"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore2.TelemetryEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "PATH_TRAVERSAL",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "GetFileContent"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.TelemetryEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "PATH_TRAVERSAL",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "GetFileContent"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.TelemetryEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "PATH_TRAVERSAL",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "GetFileContent"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "DataRazorIastPage.cshtml.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "DataRazorIastPage.cshtml.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore2.Pages.DataRazorIastPageModel",
+        "method": "OnPost"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "DataRazorIastPage.cshtml.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "DataRazorIastPage.cshtml.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore2.Pages.DataRazorIastPageModel",
+        "method": "OnPost"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "DataRazorIastPage.cshtml.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "DataRazorIastPage.cshtml.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.DataRazorIastPageModel",
+        "method": "OnPost"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "DataRazorIastPage.cshtml.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "COMMAND_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "DataRazorIastPage.cshtml.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.DataRazorIastPageModel",
+        "method": "OnPost"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "SSRF",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ssrf"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "SSRF",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "SSRF",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ssrf"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "SSRF",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "SSRF",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "SSRF",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ssrf"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "SSRF",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "SSRF",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ssrf"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SSRF.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "SSRF",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "Ssrf"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SSRF.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "SSRF",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "SqlQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.RedactionEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "SqlQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "SqlQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "SqlQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "SqlQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore2.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore2.verified.txt
@@ -31,6 +31,11 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
   "vulnerabilities": [
     {
       "type": "STACKTRACE_LEAK",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore2.Controllers.IastController",
+        "method": "StackTraceLeak"
+      },
       "evidence": {
         "value": "Samples.Security.AspNetCore2,SystemException"
       }

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore2.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore2.verified.txt
@@ -33,7 +33,7 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
       "type": "STACKTRACE_LEAK",
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetCore2.Controllers.IastController",
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "StackTraceLeak"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore5.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetCore5.verified.txt
@@ -32,6 +32,11 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
   "vulnerabilities": [
     {
       "type": "STACKTRACE_LEAK",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "StackTraceLeak"
+      },
       "evidence": {
         "value": "Samples.Security.AspNetCore5,SystemException"
       }

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetMvc5.IastEnabled.verified.txt
@@ -31,7 +31,7 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
       "type": "STACKTRACE_LEAK",
       "location": {
         "spanId": XXX,
-        "path": "Samples.Security.AspNetMvc5.Controllers.IastController",
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "StackTraceLeak"
       },
       "evidence": {

--- a/tracer/test/snapshots/Iast.StackTraceLeak.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.StackTraceLeak.AspNetMvc5.IastEnabled.verified.txt
@@ -29,6 +29,11 @@ at Samples.Security.AspNetCore5.Controllers.IastController.StackTraceLeak(),
   "vulnerabilities": [
     {
       "type": "STACKTRACE_LEAK",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetMvc5.Controllers.IastController",
+        "method": "StackTraceLeak"
+      },
       "evidence": {
         "value": "Samples.Security.AspNetMvc5,SystemException"
       }

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [
@@ -44,8 +44,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [
@@ -60,8 +60,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -37,6 +42,11 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -48,6 +58,11 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [
@@ -44,8 +44,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [
@@ -60,8 +60,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -37,6 +42,11 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -48,6 +58,11 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [
@@ -41,8 +41,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [
@@ -57,8 +57,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [
@@ -73,8 +73,8 @@
       "type": "TRUST_BOUNDARY_VIOLATION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "TrustBoundaryViolation"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
@@ -39,6 +39,11 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -82,11 +87,6 @@
     },
     {
       "type": "NO_SAMESITE_COOKIE",
-      "location": {
-        "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
-      },
       "evidence": {
         "value": "ASP.NET_SessionId"
       }

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -45,6 +50,11 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -56,6 +66,11 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {
@@ -67,6 +82,11 @@
     },
     {
       "type": "NO_SAMESITE_COOKIE",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "value": "ASP.NET_SessionId"
       }

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -75,6 +75,11 @@
   "vulnerabilities": [
     {
       "type": "UNVALIDATED_REDIRECT",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -77,8 +77,8 @@
       "type": "UNVALIDATED_REDIRECT",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "UnvalidatedRedirect"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.verified.txt
@@ -75,6 +75,11 @@
   "vulnerabilities": [
     {
       "type": "UNVALIDATED_REDIRECT",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.verified.txt
@@ -77,8 +77,8 @@
       "type": "UNVALIDATED_REDIRECT",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "UnvalidatedRedirect"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "UNVALIDATED_REDIRECT",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "UnvalidatedRedirect"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "UNVALIDATED_REDIRECT",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.SingleVulnerability.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.SingleVulnerability.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
       "evidence": {
         "value": "MD5"
       }

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore2.IastEnabled.verified.txt
@@ -25,12 +25,22 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
       "evidence": {
         "value": "MD5"
       }
     },
     {
       "type": "WEAK_HASH",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
       "evidence": {
         "value": "SHA1"
       }

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.SingleVulnerability.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.SingleVulnerability.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
       "evidence": {
         "value": "MD5"
       }

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.verified.txt
@@ -26,12 +26,22 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
       "evidence": {
         "value": "MD5"
       }
     },
     {
       "type": "WEAK_HASH",
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakHashing"
+      },
       "evidence": {
         "value": "SHA1"
       }

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore2.IastEnabled.verified.txt
@@ -25,6 +25,11 @@
   "vulnerabilities": [
     {
       "type": "WEAK_RANDOMNESS",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "value": "System.Random"
       }

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore2.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore2.IastEnabled.verified.txt
@@ -27,8 +27,8 @@
       "type": "WEAK_RANDOMNESS",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakRandomness"
       },
       "evidence": {
         "value": "System.Random"

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "WEAK_RANDOMNESS",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "value": "System.Random"
       }

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
@@ -28,8 +28,8 @@
       "type": "WEAK_RANDOMNESS",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakRandomness"
       },
       "evidence": {
         "value": "System.Random"

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetMvc5.IastEnabled.verified.txt
@@ -25,8 +25,8 @@
       "type": "WEAK_RANDOMNESS",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "WeakRandomness"
       },
       "evidence": {
         "value": "System.Random"

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetMvc5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetMvc5.IastEnabled.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "WEAK_RANDOMNESS",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "value": "System.Random"
       }

--- a/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
@@ -26,6 +26,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
@@ -28,6 +28,11 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteQuery"
+      },
+      "location": {
+        "spanId": XXX,
         "path": "IastController.cs",
         "line": XXX
       },

--- a/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5IastAsm._.verified.txt
@@ -31,11 +31,6 @@
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "ExecuteQuery"
       },
-      "location": {
-        "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
-      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
@@ -25,8 +25,8 @@
       "type": "PATH_TRAVERSAL",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "GetFileContent"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_QueryOwnUrl.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_QueryOwnUrl.verified.txt
@@ -23,6 +23,11 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "location": {
+        "spanId": XXX,
+        "path": "IastController.cs",
+        "line": XXX
+      },
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_QueryOwnUrl.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_QueryOwnUrl.verified.txt
@@ -25,8 +25,8 @@
       "type": "SQL_INJECTION",
       "location": {
         "spanId": XXX,
-        "path": "IastController.cs",
-        "line": XXX
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "SqlQuery"
       },
       "evidence": {
         "valueParts": [

--- a/tracer/test/snapshots/WeakCipherTests.SubmitsTraces.verified.txt
+++ b/tracer/test/snapshots/WeakCipherTests.SubmitsTraces.verified.txt
@@ -17,6 +17,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_CIPHER",
+      "location": {
+        "path": "Samples.WeakCipher.Program",
+        "method": "VulnerableSection"
+      },
       "evidence": {
         "value": "DES"
       }
@@ -50,6 +54,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_CIPHER",
+      "location": {
+        "path": "Samples.WeakCipher.Program",
+        "method": "VulnerableSection"
+      },
       "evidence": {
         "value": "DES"
       }
@@ -83,6 +91,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_CIPHER",
+      "location": {
+        "path": "Samples.WeakCipher.Program",
+        "method": "VulnerableSection"
+      },
       "evidence": {
         "value": "RC2"
       }
@@ -116,6 +128,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_CIPHER",
+      "location": {
+        "path": "Samples.WeakCipher.Program",
+        "method": "VulnerableSection"
+      },
       "evidence": {
         "value": "RC2"
       }
@@ -149,6 +165,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_CIPHER",
+      "location": {
+        "path": "Samples.WeakCipher.Program",
+        "method": "VulnerableSection"
+      },
       "evidence": {
         "value": "TripleDES"
       }
@@ -182,6 +202,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_CIPHER",
+      "location": {
+        "path": "Samples.WeakCipher.Program",
+        "method": "VulnerableSection"
+      },
       "evidence": {
         "value": "TripleDES"
       }

--- a/tracer/test/snapshots/iast.deduplication.deduplicated.verified.txt
+++ b/tracer/test/snapshots/iast.deduplication.deduplicated.verified.txt
@@ -17,6 +17,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "path": "Samples.Deduplication.Program",
+        "method": "ComputeHashNTimes"
+      },
       "evidence": {
         "value": "MD5"
       }

--- a/tracer/test/snapshots/iast.deduplication.duplicated.verified.txt
+++ b/tracer/test/snapshots/iast.deduplication.duplicated.verified.txt
@@ -17,6 +17,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "path": "Samples.Deduplication.Program",
+        "method": "ComputeHashNTimes"
+      },
       "evidence": {
         "value": "MD5"
       }
@@ -50,6 +54,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "path": "Samples.Deduplication.Program",
+        "method": "ComputeHashNTimes"
+      },
       "evidence": {
         "value": "MD5"
       }
@@ -83,6 +91,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "path": "Samples.Deduplication.Program",
+        "method": "ComputeHashNTimes"
+      },
       "evidence": {
         "value": "MD5"
       }
@@ -116,6 +128,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "path": "Samples.Deduplication.Program",
+        "method": "ComputeHashNTimes"
+      },
       "evidence": {
         "value": "MD5"
       }
@@ -149,6 +165,10 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "location": {
+        "path": "Samples.Deduplication.Program",
+        "method": "ComputeHashNTimes"
+      },
       "evidence": {
         "value": "MD5"
       }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Pages/DataRazorIastPage.cshtml.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Pages/DataRazorIastPage.cshtml.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Samples.Security.AspNetCore5.Models;
@@ -21,7 +20,6 @@ namespace Samples.Security.AspNetCore2.Pages
         [BindProperty]
         public MyModel MyModelInstance { get; set; }
 
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult OnPost()
         {
             if (MyModelInstance.Property == "Execute")

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Pages/DataRazorIastPage.cshtml.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Pages/DataRazorIastPage.cshtml.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Samples.Security.AspNetCore5.Models;
@@ -20,6 +21,7 @@ namespace Samples.Security.AspNetCore2.Pages
         [BindProperty]
         public MyModel MyModelInstance { get; set; }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult OnPost()
         {
             if (MyModelInstance.Property == "Execute")

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
-    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -8,7 +8,7 @@ using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Text;
@@ -91,6 +91,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("SqlQuery")]
         [Route("SqlQuery")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult SqlQuery(string username, string query)
         {
             try
@@ -123,6 +124,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("ExecuteCommand")]
         [Route("ExecuteCommand")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult ExecuteCommand(string file, string argumentLine)
         {
             return ExecuteCommandInternal(file, argumentLine);
@@ -154,6 +156,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         //It uses Newtonsoft by default for netcore 2.1
         [Route("ExecuteQueryFromBodyQueryData")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public ActionResult ExecuteQueryFromBodyQueryData([FromBody] QueryData query)
         {
             try
@@ -273,6 +276,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("ExecuteCommandFromHeader")]
         [Route("ExecuteCommandFromHeader")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult ExecuteCommandFromHeader()
         {
             return ExecuteCommandInternal(Request.Headers["file"], Request.Headers["argumentLine"]);
@@ -280,6 +284,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("ExecuteCommandFromCookie")]
         [Route("ExecuteCommandFromCookie")]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult ExecuteCommandFromCookie()
         {
             return ExecuteCommandInternal(Request.Cookies["file"], Request.Cookies["argumentLine"]);

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -8,7 +8,6 @@ using System.Drawing.Drawing2D;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Text;
@@ -91,7 +90,6 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("SqlQuery")]
         [Route("SqlQuery")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult SqlQuery(string username, string query)
         {
             try
@@ -124,7 +122,6 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("ExecuteCommand")]
         [Route("ExecuteCommand")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult ExecuteCommand(string file, string argumentLine)
         {
             return ExecuteCommandInternal(file, argumentLine);
@@ -156,7 +153,6 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         //It uses Newtonsoft by default for netcore 2.1
         [Route("ExecuteQueryFromBodyQueryData")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public ActionResult ExecuteQueryFromBodyQueryData([FromBody] QueryData query)
         {
             try
@@ -276,7 +272,6 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("ExecuteCommandFromHeader")]
         [Route("ExecuteCommandFromHeader")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult ExecuteCommandFromHeader()
         {
             return ExecuteCommandInternal(Request.Headers["file"], Request.Headers["argumentLine"]);
@@ -284,7 +279,6 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         [HttpGet("ExecuteCommandFromCookie")]
         [Route("ExecuteCommandFromCookie")]
-        [MethodImpl(MethodImplOptions.NoInlining)]
         public IActionResult ExecuteCommandFromCookie()
         {
             return ExecuteCommandInternal(Request.Cookies["file"], Request.Cookies["argumentLine"]);

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
-    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCoreBare/Samples.Security.AspNetCoreBare.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCoreBare/Samples.Security.AspNetCoreBare.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
 </Project>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <DebugType>None</DebugType>
-    <DebugSymbols>false</DebugSymbols>
     <ProductVersion>
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -42,7 +40,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>false</DebugSymbols>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\</OutputPath>
@@ -59,7 +57,7 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>false</DebugSymbols>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
@@ -76,7 +74,7 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>false</DebugSymbols>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
@@ -41,8 +41,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
-    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -58,11 +58,11 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
@@ -75,11 +75,11 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
@@ -5,6 +5,8 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
     <ProductVersion>
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <DebugType>None</DebugType>
     <ProductVersion>
     </ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>


### PR DESCRIPTION
## Summary of changes

Update all snapshots:
- With a correct location data
- Without git tags that can't be generated without symbols

## Reason for change

In integration tests for IAST, the vulnerability location is completely removed because it can vary between FW versions. We want a way of keeping locations getting rid of this variance, by scrubbing the data in a smart way.

## Implementation details

- Removing all symbols for consistencies between all archs and frameworks.
    - Side effect: Removing all git tags that are inside pdbs