### PR TITLE
[ASM] Add max concurrent request setting for api sec

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/ApiSecurity.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ApiSecurity.cs
@@ -23,7 +23,7 @@ internal class ApiSecurity
 
     public ApiSecurity(SecuritySettings securitySettings)
     {
-        _overheadController = new(1, (int)(securitySettings.ApiSecuritySampling * 100));
+        _overheadController = new(securitySettings.ApiSecurityMaxConcurrentRequests, (int)(securitySettings.ApiSecuritySampling * 100));
         // todo: later, will be enabled by default, depending on if Security is enabled
         _enabled = securitySettings.ApiSecurityEnabled;
     }

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -82,11 +82,18 @@ namespace Datadog.Trace.AppSec
                                  .AsDouble(val => val is <= 1 and >= 0)
                                  .GetValueOrDefault(0.1);
 
+            ApiSecurityMaxConcurrentRequests = config
+                                              .WithKeys(ConfigurationKeys.AppSec.ApiSecurityMaxConcurrentRequests)
+                                              .AsInt32(val => val >= 0)
+                                              .GetValueOrDefault(1);
+
             ApiSecurityEnabled = config.WithKeys(ConfigurationKeys.AppSec.ApiExperimentalSecurityEnabled)
                                        .AsBool(false);
         }
 
         public double ApiSecuritySampling { get; }
+
+        public int ApiSecurityMaxConcurrentRequests { get; }
 
         public bool Enabled { get; }
 

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -84,7 +84,7 @@ namespace Datadog.Trace.AppSec
 
             ApiSecurityMaxConcurrentRequests = config
                                               .WithKeys(ConfigurationKeys.AppSec.ApiSecurityMaxConcurrentRequests)
-                                              .AsInt32(val => val >= 0)
+                                              .AsInt32(val => val >= 1)
                                               .GetValueOrDefault(1);
 
             ApiSecurityEnabled = config.WithKeys(ConfigurationKeys.AppSec.ApiExperimentalSecurityEnabled)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -82,6 +82,12 @@ namespace Datadog.Trace.Configuration
             internal const string ApiSecurityRequestSampleRate = "DD_API_SECURITY_REQUEST_SAMPLE_RATE";
 
             /// <summary>
+            /// Configuration key for the maximum number of requests
+            /// to be analyzed by api security concurrently. Defaults to 1.
+            /// </summary>
+            internal const string ApiSecurityMaxConcurrentRequests = "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS";
+
+            /// <summary>
             /// Unless set to true or 1, tracers don’t collect schemas. After the experiment, the environment variable will be removed and schema collection will be enabled only when ASM is enabled
             /// </summary>
             internal const string ApiExperimentalSecurityEnabled = "DD_EXPERIMENTAL_API_SECURITY_ENABLED";

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -401,6 +401,7 @@
   "DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON": "appsec_blocked_template_json",
   "DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING": "appsec_auto_user_events_tracking",
   "DD_API_SECURITY_REQUEST_SAMPLE_RATE":"api_security_request_sample_rate",
+  "DD_API_SECURITY_MAX_CONCURRENT_REQUESTS":"api_security_max_concurrent_requests",
   "DD_EXPERIMENTAL_API_SECURITY_ENABLED":"experimental_api_security_enabled",
   "DD_AZURE_APP_SERVICES": "aas_enabled",
   "DD_AAS_DOTNET_EXTENSION_VERSION": "aas_site_extensions_version",


### PR DESCRIPTION
## Summary of changes

Add max concurrent request for api security like in iast, mostly for testing purposes, but clients might be wanting to use it as well

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
