### PR TITLE
Fix - Change DelegateInstrumentation set continuations behaviour to copy Calltarget

### DIFF
--- a/tracer/src/Datadog.Trace/Util/Delegates/DelegateInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Util/Delegates/DelegateInstrumentation.cs
@@ -824,17 +824,17 @@ internal static class DelegateInstrumentation
             {
                 try
                 {
+                    if (SetContinuation is { } setContinuation)
+                    {
+                        returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
+                    }
+
                     returnValue = Callbacks.OnDelegateEnd(sender, returnValue, exception, state);
                 }
                 catch (Exception innerException)
                 {
                     Callbacks.OnException(sender, innerException);
                 }
-            }
-
-            if (SetContinuation is { } setContinuation)
-            {
-                returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
             }
 
             return returnValue;
@@ -894,17 +894,17 @@ internal static class DelegateInstrumentation
             {
                 try
                 {
+                    if (SetContinuation is { } setContinuation)
+                    {
+                        returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
+                    }
+
                     returnValue = Callbacks.OnDelegateEnd(sender, returnValue, exception, state);
                 }
                 catch (Exception innerException)
                 {
                     Callbacks.OnException(sender, innerException);
                 }
-            }
-
-            if (SetContinuation is { } setContinuation)
-            {
-                returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
             }
 
             return returnValue;
@@ -965,17 +965,17 @@ internal static class DelegateInstrumentation
             {
                 try
                 {
+                    if (SetContinuation is { } setContinuation)
+                    {
+                        returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
+                    }
+
                     returnValue = Callbacks.OnDelegateEnd(sender, returnValue, exception, state);
                 }
                 catch (Exception innerException)
                 {
                     Callbacks.OnException(sender, innerException);
                 }
-            }
-
-            if (SetContinuation is { } setContinuation)
-            {
-                returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
             }
 
             return returnValue;
@@ -1037,17 +1037,17 @@ internal static class DelegateInstrumentation
             {
                 try
                 {
+                    if (SetContinuation is { } setContinuation)
+                    {
+                        returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
+                    }
+
                     returnValue = Callbacks.OnDelegateEnd(sender, returnValue, exception, state);
                 }
                 catch (Exception innerException)
                 {
                     Callbacks.OnException(sender, innerException);
                 }
-            }
-
-            if (SetContinuation is { } setContinuation)
-            {
-                returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
             }
 
             return returnValue;
@@ -1110,17 +1110,17 @@ internal static class DelegateInstrumentation
             {
                 try
                 {
+                    if (SetContinuation is { } setContinuation)
+                    {
+                        returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
+                    }
+
                     returnValue = Callbacks.OnDelegateEnd(sender, returnValue, exception, state);
                 }
                 catch (Exception innerException)
                 {
                     Callbacks.OnException(sender, innerException);
                 }
-            }
-
-            if (SetContinuation is { } setContinuation)
-            {
-                returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
             }
 
             return returnValue;
@@ -1184,17 +1184,17 @@ internal static class DelegateInstrumentation
             {
                 try
                 {
+                    if (SetContinuation is { } setContinuation)
+                    {
+                        returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
+                    }
+
                     returnValue = Callbacks.OnDelegateEnd(sender, returnValue, exception, state);
                 }
                 catch (Exception innerException)
                 {
                     Callbacks.OnException(sender, innerException);
                 }
-            }
-
-            if (SetContinuation is { } setContinuation)
-            {
-                returnValue = setContinuation(Callbacks, sender, exception, state, returnValue);
             }
 
             return returnValue;


### PR DESCRIPTION
## Summary of changes

This PR changes the set continuations behaviour of the delegate instrumentation to copy the same behaviour used in CallTarget instrumentation.

## Reason for change

AWS instrumentations wraps an async delegate (return Task) that can throw when is called, in those cases the Delegate Instrumentation were not calling the `OnDelegateEndAsync` method, so opened spans were not getting close.

This scenario only occurs when the delegate returns a Task but it doesn't await anything so there's no State Machine in the method.

## Implementation details

Just moved the set continuation call inside the finally clause and before calling the OnDelegateEnd.

## Test coverage
2 new unit tests catch the scenario of throwing inside the target async delegate and calling the OnDelegateEndAsync method.