### PR TITLE
Fix AWS Lambda tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NET6_OR_GREATER
+#if NET6_0_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -376,15 +376,25 @@
     }
   },
   {
+    TraceId: Id_75,
+    SpanId: Id_76,
+    Name: lambda.invocation,
+    Resource: /lambda/end-invocation,
+    Service: LambdaExtension,
+    Tags: {
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
     TraceId: Id_1,
-    SpanId: Id_75,
+    SpanId: Id_77,
     Name: manual.HandlerNoParamSync,
     Resource: manual.HandlerNoParamSync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_2,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_1,
+      runtime-id: Guid_1
     },
     Metrics: {
       process_id: 0,
@@ -395,14 +405,14 @@
   },
   {
     TraceId: Id_3,
-    SpanId: Id_76,
+    SpanId: Id_78,
     Name: manual.HandlerOneParamSync,
     Resource: manual.HandlerOneParamSync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_4,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_2,
+      runtime-id: Guid_2
     },
     Metrics: {
       process_id: 0,
@@ -413,14 +423,14 @@
   },
   {
     TraceId: Id_5,
-    SpanId: Id_77,
+    SpanId: Id_79,
     Name: manual.HandlerTwoParamsSync,
     Resource: manual.HandlerTwoParamsSync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_6,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_3,
+      runtime-id: Guid_3
     },
     Metrics: {
       process_id: 0,
@@ -431,14 +441,14 @@
   },
   {
     TraceId: Id_7,
-    SpanId: Id_78,
+    SpanId: Id_80,
     Name: manual.HandlerNoParamAsync,
     Resource: manual.HandlerNoParamAsync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_8,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_4,
+      runtime-id: Guid_4
     },
     Metrics: {
       process_id: 0,
@@ -449,14 +459,14 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_79,
+    SpanId: Id_81,
     Name: manual.HandlerOneParamAsync,
     Resource: manual.HandlerOneParamAsync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_10,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_5,
+      runtime-id: Guid_5
     },
     Metrics: {
       process_id: 0,
@@ -467,14 +477,14 @@
   },
   {
     TraceId: Id_11,
-    SpanId: Id_80,
+    SpanId: Id_82,
     Name: manual.HandlerTwoParamsAsync,
     Resource: manual.HandlerTwoParamsAsync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_12,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_6,
+      runtime-id: Guid_6
     },
     Metrics: {
       process_id: 0,
@@ -485,14 +495,14 @@
   },
   {
     TraceId: Id_13,
-    SpanId: Id_81,
+    SpanId: Id_83,
     Name: manual.HandlerNoParamVoid,
     Resource: manual.HandlerNoParamVoid,
     Service: Samples.AWS.Lambda,
     ParentId: Id_14,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_7,
+      runtime-id: Guid_7
     },
     Metrics: {
       process_id: 0,
@@ -503,14 +513,14 @@
   },
   {
     TraceId: Id_15,
-    SpanId: Id_82,
+    SpanId: Id_84,
     Name: manual.HandlerOneParamVoid,
     Resource: manual.HandlerOneParamVoid,
     Service: Samples.AWS.Lambda,
     ParentId: Id_16,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_8,
+      runtime-id: Guid_8
     },
     Metrics: {
       process_id: 0,
@@ -521,14 +531,14 @@
   },
   {
     TraceId: Id_17,
-    SpanId: Id_83,
+    SpanId: Id_85,
     Name: manual.HandlerTwoParamsVoid,
     Resource: manual.HandlerTwoParamsVoid,
     Service: Samples.AWS.Lambda,
     ParentId: Id_18,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_9,
+      runtime-id: Guid_9
     },
     Metrics: {
       process_id: 0,
@@ -539,7 +549,7 @@
   },
   {
     TraceId: Id_19,
-    SpanId: Id_84,
+    SpanId: Id_86,
     Name: manual.HandlerNoParamSyncWithContext,
     Resource: manual.HandlerNoParamSyncWithContext,
     Service: Samples.AWS.Lambda,
@@ -557,7 +567,7 @@
   },
   {
     TraceId: Id_21,
-    SpanId: Id_85,
+    SpanId: Id_87,
     Name: manual.HandlerOneParamSyncWithContext,
     Resource: manual.HandlerOneParamSyncWithContext,
     Service: Samples.AWS.Lambda,
@@ -575,7 +585,7 @@
   },
   {
     TraceId: Id_23,
-    SpanId: Id_86,
+    SpanId: Id_88,
     Name: manual.HandlerTwoParamsSyncWithContext,
     Resource: manual.HandlerTwoParamsSyncWithContext,
     Service: Samples.AWS.Lambda,
@@ -593,14 +603,14 @@
   },
   {
     TraceId: Id_25,
-    SpanId: Id_87,
+    SpanId: Id_89,
     Name: manual.BaseHandlerNoParamSync,
     Resource: manual.BaseHandlerNoParamSync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_26,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_13,
+      runtime-id: Guid_13
     },
     Metrics: {
       process_id: 0,
@@ -611,14 +621,14 @@
   },
   {
     TraceId: Id_27,
-    SpanId: Id_88,
+    SpanId: Id_90,
     Name: manual.BaseHandlerTwoParamsSync,
     Resource: manual.BaseHandlerTwoParamsSync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_28,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_14,
+      runtime-id: Guid_14
     },
     Metrics: {
       process_id: 0,
@@ -629,7 +639,7 @@
   },
   {
     TraceId: Id_29,
-    SpanId: Id_89,
+    SpanId: Id_91,
     Name: manual.BaseHandlerOneParamSyncWithContext,
     Resource: manual.BaseHandlerOneParamSyncWithContext,
     Service: Samples.AWS.Lambda,
@@ -647,14 +657,14 @@
   },
   {
     TraceId: Id_31,
-    SpanId: Id_90,
+    SpanId: Id_92,
     Name: manual.BaseHandlerOneParamAsync,
     Resource: manual.BaseHandlerOneParamAsync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_32,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_16,
+      runtime-id: Guid_16
     },
     Metrics: {
       process_id: 0,
@@ -665,14 +675,14 @@
   },
   {
     TraceId: Id_33,
-    SpanId: Id_91,
+    SpanId: Id_93,
     Name: manual.BaseHandlerTwoParamsVoid,
     Resource: manual.BaseHandlerTwoParamsVoid,
     Service: Samples.AWS.Lambda,
     ParentId: Id_34,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_17,
+      runtime-id: Guid_17
     },
     Metrics: {
       process_id: 0,
@@ -683,14 +693,14 @@
   },
   {
     TraceId: Id_35,
-    SpanId: Id_92,
+    SpanId: Id_94,
     Name: manual.HandlerStructParam,
     Resource: manual.HandlerStructParam,
     Service: Samples.AWS.Lambda,
     ParentId: Id_36,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_18,
+      runtime-id: Guid_18
     },
     Metrics: {
       process_id: 0,
@@ -701,14 +711,14 @@
   },
   {
     TraceId: Id_37,
-    SpanId: Id_93,
+    SpanId: Id_95,
     Name: manual.HandlerNestedClassParam,
     Resource: manual.HandlerNestedClassParam,
     Service: Samples.AWS.Lambda,
     ParentId: Id_38,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_19,
+      runtime-id: Guid_19
     },
     Metrics: {
       process_id: 0,
@@ -719,14 +729,14 @@
   },
   {
     TraceId: Id_39,
-    SpanId: Id_94,
+    SpanId: Id_96,
     Name: manual.HandlerNestedStructParam,
     Resource: manual.HandlerNestedStructParam,
     Service: Samples.AWS.Lambda,
     ParentId: Id_40,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_20,
+      runtime-id: Guid_20
     },
     Metrics: {
       process_id: 0,
@@ -737,14 +747,14 @@
   },
   {
     TraceId: Id_41,
-    SpanId: Id_95,
+    SpanId: Id_97,
     Name: manual.HandlerGenericDictionaryParam,
     Resource: manual.HandlerGenericDictionaryParam,
     Service: Samples.AWS.Lambda,
     ParentId: Id_42,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_21,
+      runtime-id: Guid_21
     },
     Metrics: {
       process_id: 0,
@@ -755,14 +765,14 @@
   },
   {
     TraceId: Id_43,
-    SpanId: Id_96,
+    SpanId: Id_98,
     Name: manual.HandlerNestedGenericDictionaryParam,
     Resource: manual.HandlerNestedGenericDictionaryParam,
     Service: Samples.AWS.Lambda,
     ParentId: Id_44,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_22,
+      runtime-id: Guid_22
     },
     Metrics: {
       process_id: 0,
@@ -773,14 +783,14 @@
   },
   {
     TraceId: Id_45,
-    SpanId: Id_97,
+    SpanId: Id_99,
     Name: manual.HandlerDoublyNestedGenericDictionaryParam,
     Resource: manual.HandlerDoublyNestedGenericDictionaryParam,
     Service: Samples.AWS.Lambda,
     ParentId: Id_46,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_23,
+      runtime-id: Guid_23
     },
     Metrics: {
       process_id: 0,
@@ -791,14 +801,14 @@
   },
   {
     TraceId: Id_47,
-    SpanId: Id_98,
+    SpanId: Id_100,
     Name: manual.ThrowingHandler,
     Resource: manual.ThrowingHandler,
     Service: Samples.AWS.Lambda,
     ParentId: Id_48,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_24,
+      runtime-id: Guid_24
     },
     Metrics: {
       process_id: 0,
@@ -809,14 +819,14 @@
   },
   {
     TraceId: Id_49,
-    SpanId: Id_99,
+    SpanId: Id_101,
     Name: manual.ThrowingHandlerAsync,
     Resource: manual.ThrowingHandlerAsync,
     Service: Samples.AWS.Lambda,
     ParentId: Id_50,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_25,
+      runtime-id: Guid_25
     },
     Metrics: {
       process_id: 0,
@@ -827,14 +837,14 @@
   },
   {
     TraceId: Id_51,
-    SpanId: Id_100,
+    SpanId: Id_102,
     Name: manual.ThrowingHandlerAsyncTask,
     Resource: manual.ThrowingHandlerAsyncTask,
     Service: Samples.AWS.Lambda,
     ParentId: Id_52,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_26,
+      runtime-id: Guid_26
     },
     Metrics: {
       process_id: 0,
@@ -845,7 +855,7 @@
   },
   {
     TraceId: Id_53,
-    SpanId: Id_101,
+    SpanId: Id_103,
     Name: manual.ThrowingHandler,
     Resource: manual.ThrowingHandler,
     Service: Samples.AWS.Lambda,
@@ -863,7 +873,7 @@
   },
   {
     TraceId: Id_55,
-    SpanId: Id_102,
+    SpanId: Id_104,
     Name: manual.ThrowingHandlerAsync,
     Resource: manual.ThrowingHandlerAsync,
     Service: Samples.AWS.Lambda,
@@ -881,7 +891,7 @@
   },
   {
     TraceId: Id_57,
-    SpanId: Id_103,
+    SpanId: Id_105,
     Name: manual.ThrowingHandlerAsyncTask,
     Resource: manual.ThrowingHandlerAsyncTask,
     Service: Samples.AWS.Lambda,
@@ -899,14 +909,14 @@
   },
   {
     TraceId: Id_59,
-    SpanId: Id_104,
+    SpanId: Id_106,
     Name: manual.GenericBaseType1,
     Resource: manual.GenericBaseType1,
     Service: Samples.AWS.Lambda,
     ParentId: Id_60,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_30,
+      runtime-id: Guid_30
     },
     Metrics: {
       process_id: 0,
@@ -917,14 +927,14 @@
   },
   {
     TraceId: Id_61,
-    SpanId: Id_105,
+    SpanId: Id_107,
     Name: manual.GenericBaseType2,
     Resource: manual.GenericBaseType2,
     Service: Samples.AWS.Lambda,
     ParentId: Id_62,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_31,
+      runtime-id: Guid_31
     },
     Metrics: {
       process_id: 0,
@@ -935,14 +945,14 @@
   },
   {
     TraceId: Id_63,
-    SpanId: Id_106,
+    SpanId: Id_108,
     Name: manual.VirtualGenericBaseType3,
     Resource: manual.VirtualGenericBaseType3,
     Service: Samples.AWS.Lambda,
     ParentId: Id_64,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_32,
+      runtime-id: Guid_32
     },
     Metrics: {
       process_id: 0,
@@ -953,14 +963,14 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_107,
+    SpanId: Id_109,
     Name: manual.VirtualGenericBaseType4,
     Resource: manual.VirtualGenericBaseType4,
     Service: Samples.AWS.Lambda,
     ParentId: Id_66,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_33,
+      runtime-id: Guid_33
     },
     Metrics: {
       process_id: 0,
@@ -971,14 +981,14 @@
   },
   {
     TraceId: Id_67,
-    SpanId: Id_108,
+    SpanId: Id_110,
     Name: manual.AbstractGenericBaseType5,
     Resource: manual.AbstractGenericBaseType5,
     Service: Samples.AWS.Lambda,
     ParentId: Id_68,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_34,
+      runtime-id: Guid_34
     },
     Metrics: {
       process_id: 0,
@@ -989,14 +999,14 @@
   },
   {
     TraceId: Id_69,
-    SpanId: Id_109,
+    SpanId: Id_111,
     Name: manual.AbstractGenericBaseType6,
     Resource: manual.AbstractGenericBaseType6,
     Service: Samples.AWS.Lambda,
     ParentId: Id_70,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_35,
+      runtime-id: Guid_35
     },
     Metrics: {
       process_id: 0,
@@ -1007,14 +1017,14 @@
   },
   {
     TraceId: Id_71,
-    SpanId: Id_110,
+    SpanId: Id_112,
     Name: manual.ComplexNestedGeneric,
     Resource: manual.ComplexNestedGeneric,
     Service: Samples.AWS.Lambda,
     ParentId: Id_72,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_36,
+      runtime-id: Guid_36
     },
     Metrics: {
       process_id: 0,
@@ -1025,14 +1035,32 @@
   },
   {
     TraceId: Id_73,
-    SpanId: Id_111,
+    SpanId: Id_113,
     Name: manual.ComplexNestedGeneric,
     Resource: manual.ComplexNestedGeneric,
     Service: Samples.AWS.Lambda,
     ParentId: Id_74,
     Tags: {
       language: dotnet,
-      runtime-id: Guid_37,
+      runtime-id: Guid_37
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_114,
+    Name: manual.ToplevelStatements,
+    Resource: manual.ToplevelStatements,
+    Service: Samples.Amazon.Lambda.RuntimeSupport,
+    ParentId: Id_76,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_38
     },
     Metrics: {
       process_id: 0,
@@ -1043,12 +1071,12 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_112,
+    SpanId: Id_115,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamSync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_75,
+    ParentId: Id_77,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1064,12 +1092,12 @@
   },
   {
     TraceId: Id_3,
-    SpanId: Id_113,
+    SpanId: Id_116,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamSync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_76,
+    ParentId: Id_78,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1085,12 +1113,12 @@
   },
   {
     TraceId: Id_5,
-    SpanId: Id_114,
+    SpanId: Id_117,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsSync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_77,
+    ParentId: Id_79,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1106,12 +1134,12 @@
   },
   {
     TraceId: Id_7,
-    SpanId: Id_115,
+    SpanId: Id_118,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamAsync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_78,
+    ParentId: Id_80,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1127,12 +1155,12 @@
   },
   {
     TraceId: Id_9,
-    SpanId: Id_116,
+    SpanId: Id_119,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamAsync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_79,
+    ParentId: Id_81,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1148,12 +1176,12 @@
   },
   {
     TraceId: Id_11,
-    SpanId: Id_117,
+    SpanId: Id_120,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsAsync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_80,
+    ParentId: Id_82,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1169,12 +1197,12 @@
   },
   {
     TraceId: Id_13,
-    SpanId: Id_118,
+    SpanId: Id_121,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamVoid,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_81,
+    ParentId: Id_83,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1190,12 +1218,12 @@
   },
   {
     TraceId: Id_15,
-    SpanId: Id_119,
+    SpanId: Id_122,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamVoid,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_82,
+    ParentId: Id_84,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1211,12 +1239,12 @@
   },
   {
     TraceId: Id_17,
-    SpanId: Id_120,
+    SpanId: Id_123,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsVoid,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_83,
+    ParentId: Id_85,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1232,12 +1260,12 @@
   },
   {
     TraceId: Id_19,
-    SpanId: Id_121,
+    SpanId: Id_124,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNoParamSyncWithContext,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_84,
+    ParentId: Id_86,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1253,12 +1281,12 @@
   },
   {
     TraceId: Id_21,
-    SpanId: Id_122,
+    SpanId: Id_125,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerOneParamSyncWithContext,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_85,
+    ParentId: Id_87,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1274,12 +1302,12 @@
   },
   {
     TraceId: Id_23,
-    SpanId: Id_123,
+    SpanId: Id_126,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerTwoParamsSyncWithContext,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_86,
+    ParentId: Id_88,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1295,12 +1323,12 @@
   },
   {
     TraceId: Id_25,
-    SpanId: Id_124,
+    SpanId: Id_127,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerNoParamSync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_87,
+    ParentId: Id_89,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1316,12 +1344,12 @@
   },
   {
     TraceId: Id_27,
-    SpanId: Id_125,
+    SpanId: Id_128,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerTwoParamsSync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_88,
+    ParentId: Id_90,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1337,12 +1365,12 @@
   },
   {
     TraceId: Id_29,
-    SpanId: Id_126,
+    SpanId: Id_129,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerOneParamSyncWithContext,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_89,
+    ParentId: Id_91,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1358,12 +1386,12 @@
   },
   {
     TraceId: Id_31,
-    SpanId: Id_127,
+    SpanId: Id_130,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerOneParamAsync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_90,
+    ParentId: Id_92,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1379,12 +1407,12 @@
   },
   {
     TraceId: Id_33,
-    SpanId: Id_128,
+    SpanId: Id_131,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/BaseHandlerTwoParamsVoid,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_91,
+    ParentId: Id_93,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1400,12 +1428,12 @@
   },
   {
     TraceId: Id_35,
-    SpanId: Id_129,
+    SpanId: Id_132,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerStructParam,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_92,
+    ParentId: Id_94,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1421,12 +1449,12 @@
   },
   {
     TraceId: Id_37,
-    SpanId: Id_130,
+    SpanId: Id_133,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNestedClassParam,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_93,
+    ParentId: Id_95,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1442,12 +1470,12 @@
   },
   {
     TraceId: Id_39,
-    SpanId: Id_131,
+    SpanId: Id_134,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNestedStructParam,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_94,
+    ParentId: Id_96,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1463,12 +1491,12 @@
   },
   {
     TraceId: Id_41,
-    SpanId: Id_132,
+    SpanId: Id_135,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerGenericDictionaryParam,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_95,
+    ParentId: Id_97,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1484,12 +1512,12 @@
   },
   {
     TraceId: Id_43,
-    SpanId: Id_133,
+    SpanId: Id_136,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerNestedGenericDictionaryParam,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_96,
+    ParentId: Id_98,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1505,12 +1533,12 @@
   },
   {
     TraceId: Id_45,
-    SpanId: Id_134,
+    SpanId: Id_137,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/HandlerDoublyNestedGenericDictionaryParam,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_97,
+    ParentId: Id_99,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1526,12 +1554,12 @@
   },
   {
     TraceId: Id_47,
-    SpanId: Id_135,
+    SpanId: Id_138,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandler,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_98,
+    ParentId: Id_100,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1550,12 +1578,12 @@
   },
   {
     TraceId: Id_49,
-    SpanId: Id_136,
+    SpanId: Id_139,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_99,
+    ParentId: Id_101,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1574,12 +1602,12 @@
   },
   {
     TraceId: Id_51,
-    SpanId: Id_137,
+    SpanId: Id_140,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsyncTask,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_100,
+    ParentId: Id_102,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1598,12 +1626,12 @@
   },
   {
     TraceId: Id_53,
-    SpanId: Id_138,
+    SpanId: Id_141,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandler,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_101,
+    ParentId: Id_103,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1622,12 +1650,12 @@
   },
   {
     TraceId: Id_55,
-    SpanId: Id_139,
+    SpanId: Id_142,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsync,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_102,
+    ParentId: Id_104,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1646,12 +1674,12 @@
   },
   {
     TraceId: Id_57,
-    SpanId: Id_140,
+    SpanId: Id_143,
     Name: http.request,
     Resource: GET localhost/function/ThrowingHandlerAsyncTask,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_103,
+    ParentId: Id_105,
     Error: 1,
     Tags: {
       component: WebRequest,
@@ -1670,12 +1698,12 @@
   },
   {
     TraceId: Id_59,
-    SpanId: Id_141,
+    SpanId: Id_144,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/GenericBaseType1,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_104,
+    ParentId: Id_106,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1691,12 +1719,12 @@
   },
   {
     TraceId: Id_61,
-    SpanId: Id_142,
+    SpanId: Id_145,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/GenericBaseType2,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_105,
+    ParentId: Id_107,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1712,12 +1740,12 @@
   },
   {
     TraceId: Id_63,
-    SpanId: Id_143,
+    SpanId: Id_146,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/VirtualGenericBaseType3,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_106,
+    ParentId: Id_108,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1733,12 +1761,12 @@
   },
   {
     TraceId: Id_65,
-    SpanId: Id_144,
+    SpanId: Id_147,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/VirtualGenericBaseType4,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_107,
+    ParentId: Id_109,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1754,12 +1782,12 @@
   },
   {
     TraceId: Id_67,
-    SpanId: Id_145,
+    SpanId: Id_148,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/AbstractGenericBaseType5,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_108,
+    ParentId: Id_110,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1775,12 +1803,12 @@
   },
   {
     TraceId: Id_69,
-    SpanId: Id_146,
+    SpanId: Id_149,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/AbstractGenericBaseType6,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_109,
+    ParentId: Id_111,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1796,12 +1824,12 @@
   },
   {
     TraceId: Id_71,
-    SpanId: Id_147,
+    SpanId: Id_150,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/ComplexNestedGeneric,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_110,
+    ParentId: Id_112,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1817,12 +1845,12 @@
   },
   {
     TraceId: Id_73,
-    SpanId: Id_148,
+    SpanId: Id_151,
     Name: http.request,
     Resource: GET serverless-dummy-api:9005/function/ComplexNestedGeneric,
     Service: Samples.AWS.Lambda-http-client,
     Type: http,
-    ParentId: Id_111,
+    ParentId: Id_113,
     Tags: {
       component: WebRequest,
       http.method: GET,
@@ -1830,6 +1858,27 @@
       http.url: http://serverless-dummy-api:9005/function/ComplexNestedGeneric,
       out.host: serverless-dummy-api,
       runtime-id: Guid_37,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_75,
+    SpanId: Id_152,
+    Name: http.request,
+    Resource: GET serverless-dummy-api:9005/function/ToplevelStatements,
+    Service: Samples.Amazon.Lambda.RuntimeSupport-http-client,
+    Type: http,
+    ParentId: Id_114,
+    Tags: {
+      component: WebRequest,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://serverless-dummy-api:9005/function/ToplevelStatements,
+      out.host: serverless-dummy-api,
+      runtime-id: Guid_38,
       span.kind: client
     },
     Metrics: {

--- a/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/Function.cs
+++ b/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/Function.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json.Serialization;
 using Amazon.Lambda.Core;
 using Amazon.Lambda.RuntimeSupport;
 using Amazon.Lambda.Serialization.SystemTextJson;
@@ -20,7 +21,7 @@ void MakeRequest(string url)
 }
 
 // The function handler that will be called for each Lambda event
-var handler = (string input, ILambdaContext context) =>
+var handler = (CustomInput input, ILambdaContext context) =>
 {
     using var scope = SampleHelpers.CreateScope("manual.ToplevelStatements");
     var host = Environment.GetEnvironmentVariable("DUMMY_API_HOST")!;
@@ -37,3 +38,9 @@ var handler = (string input, ILambdaContext context) =>
 await LambdaBootstrapBuilder.Create(handler, new DefaultLambdaJsonSerializer())
         .Build()
         .RunAsync();
+
+public class CustomInput
+{
+    public string Field1 { get; set; }
+    public int Field2 { get; set; }
+}


### PR DESCRIPTION
## Summary of changes

- Reenables `AwsLambdaTests` that were (accidentally) not running
- Fix incorrect function signature in top-level handler sample
- Update snapshots

## Reason for change

We spotted that the AWS lambda tests were accidentally disabled due to an invalid `#if` directive. After fixing the directive, we discovered one bug (Fixed in #5049) and also some issues with the sample introduced in #4535 (because the tests weren't running, so not surprising!) 

## Implementation details

- `#if NET6_OR_GREATER` -> `#if NET6_0_OR_GREATER`
- Fix incorrect function handler (`Error converting the Lambda event JSON payload to type System.String: The JSON value could not be converted to System.String` - changed to a type and that fixed it)
- Update snapshots (add missing top-level function handler span after fixing above)

## Test coverage

We have some now 😄 

## Other details

The snapshot diff looks big because all the span IDs changed, but it's actually just three additions from the fixed top-level handler execution:

```diff
+  {
+    TraceId: Id_75,
+    SpanId: Id_76,
+    Name: lambda.invocation,
+    Resource: /lambda/end-invocation,
+    Service: LambdaExtension,
+    Tags: {
+      _sampling_priority_v1: 1.0
+    }
+  },
```

```diff
+  {
+    TraceId: Id_75,
+    SpanId: Id_114,
+    Name: manual.ToplevelStatements,
+    Resource: manual.ToplevelStatements,
+    Service: Samples.Amazon.Lambda.RuntimeSupport,
+    ParentId: Id_76,
+    Tags: {
+      language: dotnet,
+      runtime-id: Guid_38
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
```

```diff
+  {
+    TraceId: Id_75,
+    SpanId: Id_152,
+    Name: http.request,
+    Resource: GET serverless-dummy-api:9005/function/ToplevelStatements,
+    Service: Samples.Amazon.Lambda.RuntimeSupport-http-client,
+    Type: http,
+    ParentId: Id_114,
+    Tags: {
+      component: WebRequest,
+      http.method: GET,
+      http.status_code: 200,
+      http.url: http://serverless-dummy-api:9005/function/ToplevelStatements,
+      out.host: serverless-dummy-api,
+      runtime-id: Guid_38,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
```
<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
