### PR TITLE
[IAST] Removed Activator calls in SourceGenerator for performance reasons

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/AspectsDefinitions/AspectsDefinitionsGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/AspectsDefinitions/AspectsDefinitionsGenerator.cs
@@ -158,7 +158,7 @@ public class AspectsDefinitionsGenerator : IIncrementalGenerator
             var arguments = attribute.ConstructorArguments.Select(a => GetArgument(a)).ToArray();
             var type = Resolve(attribute);
             if (type == null) { return null; }
-            var res = Activator.CreateInstance(type, arguments);
+            var res = Helpers.CreateAttributeInstance(type, arguments); // Activator.CreateInstance(type, arguments);
             return res;
         }
         catch (Exception err)

--- a/tracer/src/Datadog.Trace.SourceGenerators/AspectsDefinitions/Helpers.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/AspectsDefinitions/Helpers.cs
@@ -7,7 +7,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using Datadog.Trace.Iast;
+using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.SourceGenerators.AspectsDefinitions
 {
@@ -22,6 +23,45 @@ namespace Datadog.Trace.SourceGenerators.AspectsDefinitions
             Array destinationArray = Array.CreateInstance(elementType, array.Length);
             Array.Copy(array, destinationArray, array.Length);
             return destinationArray;
+        }
+
+        internal static object? CreateAttributeInstance(Type attributeType, object?[] arguments)
+        {
+            int x = 0;
+            if (attributeType == typeof(AspectClassAttribute))
+            {
+                if (arguments == null || arguments.Length == 0) { return new AspectClassAttribute(); }
+                else if (arguments.Length == 1) { return new AspectClassAttribute((string)arguments[x++]!); }
+                else if (arguments.Length == 3) { return new AspectClassAttribute((string)arguments[x++]!, (AspectType)arguments[x++]!, (VulnerabilityType[])arguments[x++]!); }
+                else if (arguments.Length == 4 && arguments[1]?.GetType() == typeof(AspectFilter)) { return new AspectClassAttribute((string)arguments[x++]!, (AspectFilter)arguments[x++]!, (AspectType)arguments[x++]!, (VulnerabilityType[])arguments[x++]!); }
+                else if (arguments.Length == 4) { return new AspectClassAttribute((string)arguments[x++]!, (AspectFilter[])arguments[x++]!, (AspectType)arguments[x++]!, (VulnerabilityType[])arguments[x++]!); }
+            }
+            else if (attributeType == typeof(AspectMethodReplaceAttribute))
+            {
+                if (arguments.Length == 1) { return new AspectMethodReplaceAttribute((string)arguments[x++]!); }
+                else if (arguments.Length == 2) { return new AspectMethodReplaceAttribute((string)arguments[x++]!, (AspectFilter[])arguments[x++]!); }
+                else if (arguments.Length == 3 && arguments[1]?.GetType() == typeof(string)) { return new AspectMethodReplaceAttribute((string)arguments[x++]!, (string)arguments[x++]!, (AspectFilter[])arguments[x++]!); }
+                else if (arguments.Length == 3) { return new AspectMethodReplaceAttribute((string)arguments[x++]!, (AspectType)arguments[x++]!, (VulnerabilityType[])arguments[x++]!); }
+            }
+            else if (attributeType == typeof(AspectCtorReplaceAttribute))
+            {
+                if (arguments.Length == 1) { return new AspectCtorReplaceAttribute((string)arguments[x++]!); }
+                else if (arguments.Length == 2) { return new AspectCtorReplaceAttribute((string)arguments[x++]!, (AspectFilter[])arguments[x++]!); }
+                else if (arguments.Length == 3) { return new AspectCtorReplaceAttribute((string)arguments[x++]!, (AspectType)arguments[x++]!, (VulnerabilityType[])arguments[x++]!); }
+            }
+            else if (attributeType == typeof(AspectMethodInsertAfterAttribute))
+            {
+                if (arguments.Length == 1) { return new AspectMethodInsertAfterAttribute((string)arguments[x++]!); }
+                else if (arguments.Length == 3) { return new AspectMethodInsertAfterAttribute((string)arguments[x++]!, (AspectType)arguments[x++]!, (VulnerabilityType[])arguments[x++]!); }
+            }
+            else if (attributeType == typeof(AspectMethodInsertBeforeAttribute))
+            {
+                if (arguments.Length == 2) { return new AspectMethodInsertBeforeAttribute((string)arguments[x++]!, (int[])arguments[x++]!); }
+                else if (arguments.Length == 3 && arguments[1]?.GetType() == typeof(int)) { return new AspectMethodInsertBeforeAttribute((string)arguments[x++]!, (int)arguments[x++]!, (bool)arguments[x++]!); }
+                else if (arguments.Length == 3) { return new AspectMethodInsertBeforeAttribute((string)arguments[x++]!, (int[])arguments[x++]!, (bool[])arguments[x++]!); }
+            }
+
+            throw new ArgumentException($"No constructor helper for {attributeType} and {arguments.Length} arguments", "attributeType");
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
Removed all the `Activator.CreateInstance` calls in the AspectsGenerator source code gen.

## Reason for change
Improve the performance of the code generator

## Implementation details
Added a helper to directly call the correcponding attribute constructor based on the class name and parameters kinds

