### PR TITLE
Disable remote configuration in Serverless and CI scenarios

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -80,6 +80,8 @@ namespace Datadog.Trace.Ci
             return new CISampler();
         }
 
+        protected override bool ShouldEnableRemoteConfiguration(ImmutableTracerSettings settings) => false;
+
         protected override IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, Action<Dictionary<string, float>> updateSampleRates, IDiscoveryService discoveryService)
         {
             // Check for agentless scenario

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -7,13 +7,11 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Ci;
-using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger;
 using Datadog.Trace.Debugger.Helpers;
@@ -21,7 +19,6 @@ using Datadog.Trace.DiagnosticListeners;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Processors;
 using Datadog.Trace.RemoteConfigurationManagement;
-using Datadog.Trace.RemoteConfigurationManagement.Transport;
 using Datadog.Trace.ServiceFabric;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
@@ -457,10 +454,6 @@ namespace Datadog.Trace.ClrProfiler
                 if (debuggerSettings.Enabled)
                 {
                     Log.Warning("Live Debugger is enabled but remote configuration is not available in this environment, so live debugger cannot be enabled.");
-                }
-                else
-                {
-                    Log.Information("Live Debugger is disabled. To enable it, please set DD_DYNAMIC_INSTRUMENTATION_ENABLED environment variable to 'true'.");
                 }
 
                 tracer.TracerManager.Telemetry.ProductChanged(TelemetryProductType.DynamicInstrumentation, enabled: false, error: null);

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -617,6 +617,16 @@ namespace Datadog.Trace.Configuration
         internal IConfigurationTelemetry Telemetry { get; }
 
         /// <summary>
+        /// Gets a value indicating whether remote configuration is potentially available.
+        /// RCM requires the "full" agent (not just the trace agent), so is not available in some scenarios
+        /// </summary>
+        internal bool IsRemoteConfigurationAvailable =>
+            !(IsRunningInAzureAppService
+           || IsRunningInAzureFunctionsConsumptionPlan
+           || IsRunningInGCPFunctions
+           || LambdaMetadata.IsRunningInLambda);
+
+        /// <summary>
         /// Create a <see cref="ImmutableTracerSettings"/> populated from the default sources
         /// returned by <see cref="GlobalConfigurationSource.Instance"/>.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Configuration/NullDynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/NullDynamicConfigurationManager.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="NullDynamicConfigurationManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Configuration;
+
+internal class NullDynamicConfigurationManager : IDynamicConfigurationManager
+{
+    public void Dispose()
+    {
+    }
+
+    public void Start()
+    {
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -33,6 +33,7 @@ internal class LiveDebuggerFactory
     {
         if (!debuggerSettings.Enabled)
         {
+            Log.Information("Live Debugger is disabled. To enable it, please set DD_DYNAMIC_INSTRUMENTATION_ENABLED environment variable to 'true'.");
             return LiveDebugger.Create(debuggerSettings, string.Empty, null, null, null, null, null, null, null, null);
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -29,19 +29,16 @@ internal class LiveDebuggerFactory
 {
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(LiveDebuggerFactory));
 
-    public static LiveDebugger Create(IDiscoveryService discoveryService, IRcmSubscriptionManager remoteConfigurationManager, ImmutableTracerSettings tracerSettings, string serviceName, ITelemetryController telemetry)
+    public static LiveDebugger Create(IDiscoveryService discoveryService, IRcmSubscriptionManager remoteConfigurationManager, ImmutableTracerSettings tracerSettings, string serviceName, ITelemetryController telemetry, DebuggerSettings debuggerSettings)
     {
-        var settings = DebuggerSettings.FromDefaultSource();
-        if (!settings.Enabled)
+        if (!debuggerSettings.Enabled)
         {
-            telemetry.ProductChanged(TelemetryProductType.DynamicInstrumentation, enabled: false, error: null);
-            Log.Information("Live Debugger is disabled. To enable it, please set DD_DYNAMIC_INSTRUMENTATION_ENABLED environment variable to 'true'.");
-            return LiveDebugger.Create(settings, string.Empty, null, null, null, null, null, null, null, null);
+            return LiveDebugger.Create(debuggerSettings, string.Empty, null, null, null, null, null, null, null, null);
         }
 
-        var snapshotSlicer = SnapshotSlicer.Create(settings);
-        var snapshotStatusSink = SnapshotSink.Create(settings, snapshotSlicer);
-        var probeStatusSink = ProbeStatusSink.Create(serviceName, settings);
+        var snapshotSlicer = SnapshotSlicer.Create(debuggerSettings);
+        var snapshotStatusSink = SnapshotSink.Create(debuggerSettings, snapshotSlicer);
+        var probeStatusSink = ProbeStatusSink.Create(serviceName, debuggerSettings);
 
         var apiFactory = AgentTransportStrategy.Get(
             tracerSettings.ExporterInternal,
@@ -53,14 +50,14 @@ internal class LiveDebuggerFactory
 
         var batchApi = AgentBatchUploadApi.Create(apiFactory, discoveryService);
         var batchUploader = BatchUploader.Create(batchApi);
-        var debuggerSink = DebuggerSink.Create(snapshotStatusSink, probeStatusSink, batchUploader, settings);
+        var debuggerSink = DebuggerSink.Create(snapshotStatusSink, probeStatusSink, batchUploader, debuggerSettings);
 
         var lineProbeResolver = LineProbeResolver.Create();
-        var probeStatusPoller = ProbeStatusPoller.Create(probeStatusSink, settings);
+        var probeStatusPoller = ProbeStatusPoller.Create(probeStatusSink, debuggerSettings);
 
         var configurationUpdater = ConfigurationUpdater.Create(tracerSettings.EnvironmentInternal, tracerSettings.ServiceVersionInternal);
 
-        var symbolsUploader = CreateSymbolsUploader(discoveryService, remoteConfigurationManager, tracerSettings, serviceName, settings);
+        var symbolsUploader = CreateSymbolsUploader(discoveryService, remoteConfigurationManager, tracerSettings, serviceName, debuggerSettings);
 
         IDogStatsd statsd;
         if (FrameworkDescription.Instance.IsWindows()
@@ -75,7 +72,7 @@ internal class LiveDebuggerFactory
         }
 
         telemetry.ProductChanged(TelemetryProductType.DynamicInstrumentation, enabled: true, error: null);
-        return LiveDebugger.Create(settings, serviceName, discoveryService, remoteConfigurationManager, lineProbeResolver, debuggerSink, symbolsUploader, probeStatusPoller, configurationUpdater, statsd);
+        return LiveDebugger.Create(debuggerSettings, serviceName, discoveryService, remoteConfigurationManager, lineProbeResolver, debuggerSink, symbolsUploader, probeStatusPoller, configurationUpdater, statsd);
     }
 
     private static ISymbolsUploader CreateSymbolsUploader(IDiscoveryService discoveryService, IRcmSubscriptionManager remoteConfigurationManager, ImmutableTracerSettings tracerSettings, string serviceName, DebuggerSettings settings)

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/NullTracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/NullTracerFlareManager.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="NullTracerFlareManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Logging.TracerFlare;
+
+internal class NullTracerFlareManager : ITracerFlareManager
+{
+    public void Start()
+    {
+    }
+
+    public void Dispose()
+    {
+    }
+}

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/NullRemoteConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/NullRemoteConfigurationManager.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="NullRemoteConfigurationManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.RemoteConfigurationManagement;
+
+internal class NullRemoteConfigurationManager : IRemoteConfigurationManager
+{
+    public void Dispose()
+    {
+    }
+
+    public void Start()
+    {
+    }
+}

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -537,6 +537,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("dbm_propagation_mode");
                     writer.WriteValue(instanceSettings.DbmPropagationMode.ToString());
 
+                    writer.WritePropertyName("remote_configuration_available");
+                    writer.WriteValue(instanceSettings.IsRemoteConfigurationAvailable);
+
                     writer.WritePropertyName("header_tags");
                     WriteDictionary(instanceSettings.HeaderTagsInternal);
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -156,7 +156,7 @@ namespace Datadog.Trace
 
             dataStreamsManager ??= DataStreamsManager.Create(settings, discoveryService, defaultServiceName);
 
-            if (settings.IsRemoteConfigurationAvailable)
+            if (ShouldEnableRemoteConfiguration(settings))
             {
                 if (remoteConfigurationManager == null)
                 {
@@ -224,6 +224,9 @@ namespace Datadog.Trace
         {
             return new GitMetadataTagsProvider(settings, scopeManager, TelemetryFactory.Config);
         }
+
+        protected virtual bool ShouldEnableRemoteConfiguration(ImmutableTracerSettings settings)
+            => settings.IsRemoteConfigurationAvailable;
 
         /// <summary>
         ///  Can be overriden to create a different <see cref="TracerManager"/>, e.g. <see cref="Ci.CITracerManager"/>

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -189,6 +189,11 @@ namespace Datadog.Trace
                 remoteConfigurationManager ??= new NullRemoteConfigurationManager();
                 dynamicConfigurationManager ??= new NullDynamicConfigurationManager();
                 tracerFlareManager ??= new NullTracerFlareManager();
+
+                if (RcmSubscriptionManager.Instance.HasAnySubscription)
+                {
+                    Log.Debug($"{nameof(RcmSubscriptionManager)} has subscriptions but remote configuration is not available in this scenario.");
+                }
             }
 
             return CreateTracerManagerFrom(

--- a/tracer/test/Datadog.Trace.Tests/TracerManagerFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerManagerFactoryTests.cs
@@ -1,0 +1,105 @@
+﻿// <copyright file="TracerManagerFactoryTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.DiscoveryService;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DataStreamsMonitoring;
+using Datadog.Trace.Logging.DirectSubmission;
+using Datadog.Trace.Logging.TracerFlare;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.RuntimeMetrics;
+using Datadog.Trace.Sampling;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Vendors.StatsdClient;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests;
+
+[Collection(nameof(EnvironmentVariablesTestCollection))]
+[EnvironmentRestorer("DD_AZURE_APP_SERVICES", "FUNCTIONS_WORKER_RUNTIME", "FUNCTION_TARGET", "AWS_LAMBDA_FUNCTION_NAME", "K_SERVICE", "_DD_EXTENSION_PATH")]
+public class TracerManagerFactoryTests : IAsyncLifetime
+{
+    private TracerManager _manager = null;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    public Task DisposeAsync() => _manager?.ShutdownAsync() ?? Task.CompletedTask;
+
+    [Fact]
+    public void RemoteConfigIsAvailableByDefault()
+    {
+        var settings = TracerSettings.FromDefaultSourcesInternal().Build();
+        settings.IsRemoteConfigurationAvailable.Should().BeTrue();
+
+        _manager = CreateTracerManager(settings);
+
+        _manager.RemoteConfigurationManager.Should().BeOfType<RemoteConfigurationManager>();
+        _manager.DynamicConfigurationManager.Should().BeOfType<DynamicConfigurationManager>();
+        _manager.TracerFlareManager.Should().BeOfType<TracerFlareManager>();
+    }
+
+    [Theory]
+    [InlineData("DD_AZURE_APP_SERVICES", "1")]
+    [InlineData("FUNCTIONS_WORKER_RUNTIME", "dotnet")]
+    [InlineData("FUNCTION_TARGET", "something")]
+    [InlineData("AWS_LAMBDA_FUNCTION_NAME", "something")]
+    public void RemoteConfigIsDisabledInServerlessScenarios(string key, string value)
+    {
+        Environment.SetEnvironmentVariable(key, value);
+
+        // These do nothing on their own but combine later to give an effect
+        Environment.SetEnvironmentVariable("K_SERVICE", "something");
+        Environment.SetEnvironmentVariable("_DD_EXTENSION_PATH", Path.GetTempFileName());
+
+        var settings = TracerSettings.FromDefaultSourcesInternal().Build();
+
+        settings.IsRemoteConfigurationAvailable.Should().BeFalse();
+
+        _manager = CreateTracerManager(settings);
+
+        _manager.RemoteConfigurationManager.Should().BeOfType<NullRemoteConfigurationManager>();
+        _manager.DynamicConfigurationManager.Should().BeOfType<NullDynamicConfigurationManager>();
+        _manager.TracerFlareManager.Should().BeOfType<NullTracerFlareManager>();
+    }
+
+    private static TracerManager CreateTracerManager(ImmutableTracerSettings settings)
+    {
+        return new TracerManagerFactory().CreateTracerManager(
+            settings,
+            Mock.Of<IAgentWriter>(),
+            Mock.Of<ITraceSampler>(),
+            Mock.Of<IScopeManager>(),
+            Mock.Of<IDogStatsd>(),
+            BuildRuntimeMetrics(),
+            BuildLogSubmissionManager(),
+            Mock.Of<ITelemetryController>(),
+            Mock.Of<IDiscoveryService>(),
+            new DataStreamsManager("env", "service", Mock.Of<IDataStreamsWriter>()),
+            remoteConfigurationManager: null,
+            dynamicConfigurationManager: null,
+            tracerFlareManager: null);
+
+        static DirectLogSubmissionManager BuildLogSubmissionManager()
+            => DirectLogSubmissionManager.Create(
+                previous: null,
+                settings: new ImmutableTracerSettings(NullConfigurationSource.Instance),
+                directLogSettings: ImmutableDirectLogSubmissionSettings.Create(new TracerSettings()),
+                azureAppServiceSettings: null,
+                serviceName: "test",
+                env: "test",
+                serviceVersion: "test",
+                gitMetadataTagsProvider: Mock.Of<IGitMetadataTagsProvider>());
+
+        static RuntimeMetricsWriter BuildRuntimeMetrics()
+            => new(Mock.Of<IDogStatsd>(), TimeSpan.FromMinutes(1), inAzureAppServiceContext: false, (_, _, _) => Mock.Of<IRuntimeMetricsListener>());
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Disables the `RemoteConfigurationManager` in scenarios where we know there's no agent available (Serverless)
- Disables `RemoteConfigurationManager` when we know it's not used (CI Visibility)
- Disable features that rely on RCM (tracer flare, live debugger, dynamic configuration)

## Reason for change

RCM is only available when we have the "full" agent, so it's not available in serverless scenarios. Having it enabled uses more resources for something we _know_ is never going to succeed. 

Also, CI Visibility does not use remote configuration, so disabled in that scenario too.

## Implementation details

- Create a property on `ImmutableTracerSettings` indicating if RCM may be available
- Created `Null*` implementations of the relevant types in `TracerManagerFactory` when not available
- Don't bother waiting for discovery service and trying to create live debugger if it's not available 

## Test coverage

Added unit test confirming null versions are used when in serverless scenarios

## Other details
With this setup we _don't_ initialize the `LiveDebugger` at all if RC is not available. Is that a problem? Is anything native-side expecting that to be initialized? If so, it may be best to create an `ILiveDebugger` and `NullLiveDebugger` and go from there. Otherwise this implementation is probably the easiest.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
