### PR TITLE
[SLES-1357] set exception on the aws.lambda span

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -569,7 +569,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-8.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-8.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --filter Category=Lambda --code-coverage ${runCodeCoverage:-true}
+    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-net6.0} --filter Category=Lambda --code-coverage ${runCodeCoverage:-true}
     volumes:
       - ./:/project
     cap_add:

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -95,6 +95,11 @@ internal abstract class LambdaCommon
 
         try
         {
+            if (exception != null && scope is { Span: var span })
+            {
+                span.SetException(exception);
+            }
+
             SendEndInvocation(requestBuilder, scope, exception != null, returnValue);
         }
         catch (Exception ex)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/AwsLambdaTests.cs
@@ -97,6 +97,14 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
         private static MockSpan ToMockSpan(MockLambdaExtension.EndExtensionRequest endInvocation, DateTimeOffset? startTime)
         {
             var start = startTime ?? endInvocation.Created.AddMilliseconds(100);
+            var tags = new Dictionary<string, string> { { "_sampling_priority_v1", endInvocation.SamplingPriority?.ToString("N1") } };
+            if (endInvocation.IsError)
+            {
+                tags["error.msg"] = endInvocation.ErrorMsg ?? string.Empty;
+                tags["error.type"] = endInvocation.ErrorType ?? string.Empty;
+                tags["error.stack"] = endInvocation.ErrorStack ?? string.Empty;
+            }
+
             return new MockSpan
             {
                 Duration = endInvocation.Created.Subtract(start).ToNanoseconds(),
@@ -107,7 +115,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.AWS
                 SpanId = endInvocation.SpanId ?? 0,
                 Start = start.ToUnixTimeNanoseconds(),
                 Error = endInvocation.IsError ? (byte)1 : (byte)0,
-                Tags = new Dictionary<string, string> { { "_sampling_priority_v1", endInvocation.SamplingPriority?.ToString("N1") } }
+                Tags = tags
             };
         }
     }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockLambdaExtension.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockLambdaExtension.cs
@@ -139,7 +139,10 @@ public class MockLambdaExtension : IDisposable
             ulong? spanId = ulong.TryParse(headers.Get("x-datadog-span-id"), out var s) ? s : null;
             int? samplingPriority = int.TryParse(headers.Get("x-datadog-sampling-priority"), out var p) ? p : null;
             bool isError = headers.Get("x-datadog-invocation-error") == "true";
-            var invocation = new EndExtensionRequest(headers, body, traceId, spanId, samplingPriority, isError);
+            string? errorMsg = headers.Get("x-datadog-invocation-error-msg") ?? null;
+            string? errorType = headers.Get("x-datadog-invocation-error-type") ?? null;
+            string? errorStack = headers.Get("x-datadog-invocation-error-stack") ?? null;
+            var invocation = new EndExtensionRequest(headers, body,  traceId, spanId, samplingPriority, isError, errorMsg, errorType, errorStack);
 
             EndInvocations.Push(invocation);
             Output?.WriteLine($"[LambdaExtension]Received end-invocation. traceId:{traceId}, spanId:{spanId}");
@@ -226,7 +229,10 @@ public class MockLambdaExtension : IDisposable
             ulong? traceId,
             ulong? spanId,
             int? samplingPriority,
-            bool isError)
+            bool isError,
+            string? errorMsg,
+            string? errorType,
+            string? errorStack)
         {
             Headers = headers;
             Body = body;
@@ -234,6 +240,9 @@ public class MockLambdaExtension : IDisposable
             SpanId = spanId;
             SamplingPriority = samplingPriority;
             IsError = isError;
+            ErrorMsg = errorMsg;
+            ErrorType = errorType;
+            ErrorStack = errorStack;
         }
 
         public NameValueCollection Headers { get; }
@@ -247,6 +256,12 @@ public class MockLambdaExtension : IDisposable
         public int? SamplingPriority { get; }
 
         public bool IsError { get; }
+
+        public string? ErrorMsg { get; }
+
+        public string? ErrorType { get; }
+
+        public string? ErrorStack { get; }
 
         public DateTimeOffset Created { get; } = DateTimeOffset.UtcNow;
     }

--- a/tracer/test/snapshots/AwsLambdaTests.verified.txt
+++ b/tracer/test/snapshots/AwsLambdaTests.verified.txt
@@ -237,6 +237,9 @@
     Service: LambdaExtension,
     Error: 1,
     Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
       _sampling_priority_v1: 1.0
     }
   },
@@ -248,6 +251,9 @@
     Service: LambdaExtension,
     Error: 1,
     Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
       _sampling_priority_v1: 1.0
     }
   },
@@ -259,6 +265,9 @@
     Service: LambdaExtension,
     Error: 1,
     Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
       _sampling_priority_v1: 1.0
     }
   },
@@ -270,6 +279,9 @@
     Service: LambdaExtension,
     Error: 1,
     Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
       _sampling_priority_v1: 1.0
     }
   },
@@ -281,6 +293,9 @@
     Service: LambdaExtension,
     Error: 1,
     Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
       _sampling_priority_v1: 1.0
     }
   },
@@ -292,6 +307,9 @@
     Service: LambdaExtension,
     Error: 1,
     Tags: {
+      error.msg: Cannot assign requested address,
+      error.stack: Cannot assign requested address (SocketException),
+      error.type: System.Net.WebException,
       _sampling_priority_v1: 1.0
     }
   },


### PR DESCRIPTION
Fixes #3204

## Summary of changes
This is the last missing piece to add error message and status to the `aws.lambda` span.
Previously, @DylanLovesCoffee already implemented the ending method to send Datadog-Extension(Datadog agent in serverless case) the error messages [in this PR](https://github.com/DataDog/dd-trace-dotnet/pull/4743). But in order to get the information from the span, we need to first `SetException(exception)` on the span here.

## Test coverage
I first just tested it using one of the available lambda i have and see the `aws.lambda` span has it.
<img width="1033" alt="Screenshot 2024-01-12 at 10 47 38 AM" src="https://github.com/DataDog/dd-trace-dotnet/assets/5253430/89db2c95-4ef8-4528-9158-c81a8ad68f5f">

P.S. I am actually working on a project to rethink how to do integration tests for tracing in aws lambda world. I'll try adding a corresponding test there.


## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
