### PR TITLE
Minor CI fixes

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Datadog.Trace.Ci;
+using Datadog.Trace.TestHelpers;
 using Xunit;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
@@ -13,65 +14,65 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
     {
         public static IEnumerable<object[]> GetParserData()
         {
-            yield return new[]
-            {
-                new Dictionary<string, string>
+            yield return
+            [
+                new SerializableDictionary
                 {
-                    ["config1"] = "value1",
-                    ["config2"] = "value2",
-                    ["config3"] = "value3",
-                    ["test.configuration.key01"] = "value1",
-                    ["test.configuration.key02"] = "value2",
-                    ["test.configuration.key03"] = "value3",
-                    ["test.configuration."] = "value3",
+                    { "config1", "value1" },
+                    { "config2", "value2" },
+                    { "config3", "value3" },
+                    { "test.configuration.key01", "value1" },
+                    { "test.configuration.key02", "value2" },
+                    { "test.configuration.key03", "value3" },
+                    { "test.configuration.", "value3" },
                 },
-                new Dictionary<string, string>
+                new SerializableDictionary
                 {
-                    ["key01"] = "value1",
-                    ["key02"] = "value2",
-                    ["key03"] = "value3",
+                    { "key01", "value1" },
+                    { "key02", "value2" },
+                    { "key03", "value3" },
                 }
-            };
+            ];
 
-            yield return new[]
-            {
-                new Dictionary<string, string>
+            yield return
+            [
+                new SerializableDictionary
                 {
-                    ["config1"] = "value1",
-                    ["test.configuration.key01"] = "value1",
-                    ["test.configurations.key01"] = "value1",
+                    { "config1", "value1" },
+                    { "test.configuration.key01", "value1" },
+                    { "test.configurations.key01", "value1" },
                 },
-                new Dictionary<string, string>
+                new SerializableDictionary
                 {
-                    ["key01"] = "value1",
+                    { "key01", "value1" },
                 }
-            };
+            ];
 
-            yield return new[]
-            {
-                new Dictionary<string, string>
+            yield return
+            [
+                new SerializableDictionary
                 {
-                    ["test.configuration."] = "invalid test configuration",
+                    { "test.configuration.", "invalid test configuration" },
                 },
                 null
-            };
+            ];
 
-            yield return new[]
-            {
-                new Dictionary<string, string>
+            yield return
+            [
+                new SerializableDictionary
                 {
-                    ["config1"] = "value1",
-                    ["config2"] = "value2",
-                    ["config3"] = "value3",
+                    { "config1", "value1" },
+                    { "config2", "value2" },
+                    { "config3", "value3" },
                 },
                 null
-            };
+            ];
 
-            yield return new object[]
-            {
+            yield return
+            [
                 null,
                 null
-            };
+            ];
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/CIVisibilityTests.cs
@@ -101,9 +101,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
         [SkippableTheory]
         [MemberData(nameof(GetParserData))]
-        public void CustomTestConfigurationParser(IDictionary<string, string> tags, Dictionary<string, string> expected)
+        public void CustomTestConfigurationParser(SerializableDictionary tags, SerializableDictionary expected)
         {
-            Assert.Equal((IEnumerable<KeyValuePair<string, string>>)expected, IntelligentTestRunnerClient.GetCustomTestsConfigurations(tags));
+            Assert.Equal(expected, IntelligentTestRunnerClient.GetCustomTestsConfigurations(tags?.ToDictionary()));
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -19,7 +19,6 @@ using Xunit.Abstractions;
 namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 
 [CollectionDefinition(nameof(DynamicConfigurationTests), DisableParallelization = true)]
-[Collection(nameof(DynamicConfigurationTests))]
 public class TracerFlareTests : TestHelper
 {
     private const string CaseId = "abc123";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -18,7 +18,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests;
 
-[CollectionDefinition(nameof(DynamicConfigurationTests), DisableParallelization = true)]
+[Collection(nameof(DynamicConfigurationTests))]
 public class TracerFlareTests : TestHelper
 {
     private const string CaseId = "abc123";

--- a/tracer/test/Datadog.Trace.TestHelpers/SerializableDictionary.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/SerializableDictionary.cs
@@ -31,5 +31,7 @@ namespace Datadog.Trace.TestHelpers
         {
             info.AddValue(nameof(Values), JsonConvert.SerializeObject(Values));
         }
+
+        public Dictionary<string, string> ToDictionary() => new(Values);
     }
 }


### PR DESCRIPTION
## Summary of changes

- Remove duplicate collection definition
- Fix using unserializable data in tests

## Reason for change

xunit was warning about them. The latter one means we weren't actually running all those tests

## Implementation details

Use `SerializableDictionary` and remove the duplicate

## Test coverage

Should be covered!

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
