### PR TITLE
[Tracing] Send the Datadog-Entity-ID header, containing either the container-id or the cgroup inode if available (AIT-9281)

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Api.cs
+++ b/tracer/src/Datadog.Trace/Agent/Api.cs
@@ -33,6 +33,7 @@ namespace Datadog.Trace.Agent
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly IDogStatsd _statsd;
         private readonly string _containerId;
+        private readonly string _entityId;
         private readonly Uri _tracesEndpoint;
         private readonly Uri _statsEndpoint;
         private readonly Action<Dictionary<string, float>> _updateSampleRates;
@@ -57,6 +58,7 @@ namespace Datadog.Trace.Agent
             _updateSampleRates = updateSampleRates;
             _statsd = statsd;
             _containerId = ContainerMetadata.GetContainerId();
+            _entityId = ContainerMetadata.GetEntityId();
             _apiRequestFactory = apiRequestFactory;
             _partialFlushEnabled = partialFlushEnabled;
             _tracesEndpoint = _apiRequestFactory.GetEndpoint(TracesPath);
@@ -198,6 +200,11 @@ namespace Datadog.Trace.Agent
                 request.AddHeader(AgentHttpHeaderNames.ContainerId, _containerId);
             }
 
+            if (_entityId != null)
+            {
+                request.AddHeader(AgentHttpHeaderNames.EntityId, _entityId);
+            }
+
             using var stream = new MemoryStream();
             state.Stats.Serialize(stream, state.BucketDuration);
 
@@ -270,6 +277,11 @@ namespace Datadog.Trace.Agent
             if (_containerId != null)
             {
                 request.AddHeader(AgentHttpHeaderNames.ContainerId, _containerId);
+            }
+
+            if (_entityId != null)
+            {
+                request.AddHeader(AgentHttpHeaderNames.EntityId, _entityId);
             }
 
             if (statsComputationEnabled)

--- a/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -44,6 +44,14 @@ namespace Datadog.Trace
         public const string ContainerId = "Datadog-Container-ID";
 
         /// <summary>
+        /// The unique identifier of the container where the traced application is running, either as the container id
+        /// or the inode number.
+        /// This differs from <see cref="ContainerId"/> which is always the container id, which may not always be
+        /// accessible due to new Pod Security Standards starting in Kubernetes 1.25.
+        /// </summary>
+        public const string EntityId = "Datadog-Entity-ID";
+
+        /// <summary>
         /// Tells the agent whether top-level spans are computed by the tracer
         /// </summary>
         public const string ComputedTopLevelSpan = "Datadog-Client-Computed-Top-Level";

--- a/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
+++ b/tracer/src/Datadog.Trace/AgentHttpHeaderNames.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace
 
         /// <summary>
         /// The unique identifier of the container where the traced application is running, either as the container id
-        /// or the inode number.
+        /// or the cgroup node controller's inode.
         /// This differs from <see cref="ContainerId"/> which is always the container id, which may not always be
         /// accessible due to new Pod Security Standards starting in Kubernetes 1.25.
         /// </summary>

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -151,7 +151,6 @@ namespace Datadog.Trace.PlatformHelpers
         internal static bool TryGetInode(string path, out long result)
         {
             result = 0;
-            var context = SynchronizationContext.Current;
 
             try
             {

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -107,7 +107,9 @@ namespace Datadog.Trace.PlatformHelpers
         public static string ExtractInodeFromCgroupLines(string controlGroupsMountPath, IEnumerable<string> lines)
         {
             var tuples = lines.Select(ParseControllerAndPathFromCgroupLine)
-                               .Where(tuple => !string.IsNullOrEmpty(tuple.Item2) && (tuple.Item1 == string.Empty || string.Equals(tuple.Item1, "memory", StringComparison.OrdinalIgnoreCase)));
+                               .Where(tuple => tuple is not null
+                                               && !string.IsNullOrEmpty(tuple.Item2)
+                                               && (tuple.Item1 == string.Empty || string.Equals(tuple.Item1, "memory", StringComparison.OrdinalIgnoreCase)));
 
             foreach (var target in tuples)
             {

--- a/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/ContainerMetadata.cs
@@ -122,9 +122,9 @@ namespace Datadog.Trace.PlatformHelpers
             {
                 string controller = target.Item1;
                 string cgroupNodePath = target.Item2;
-                var path = Path.Combine(controlGroupsMountPath, controller, cgroupNodePath);
+                var path = Path.Combine(controlGroupsMountPath, controller, cgroupNodePath.TrimStart('/'));
 
-                if (TryGetInode(path, out long output))
+                if (Directory.Exists(path) && TryGetInode(path, out long output))
                 {
                     return output.ToString();
                 }
@@ -213,7 +213,7 @@ namespace Datadog.Trace.PlatformHelpers
             {
                 using var process = new Process();
                 process.StartInfo.FileName = "stat";
-                process.StartInfo.Arguments = $"-c '%i' {path}";
+                process.StartInfo.Arguments = $"--printf=%i {path}";
                 process.StartInfo.UseShellExecute = false;
                 process.StartInfo.RedirectStandardOutput = true;
                 process.StartInfo.RedirectStandardError = true;

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Transport/RemoteConfigurationApi.cs
@@ -23,6 +23,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
 
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly string _containerId;
+        private readonly string _entityId;
         private string _configEndpoint = null;
 
         private RemoteConfigurationApi(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService)
@@ -35,6 +36,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
                 });
 
             _containerId = ContainerMetadata.GetContainerId();
+            _entityId = ContainerMetadata.GetEntityId();
         }
 
         public static RemoteConfigurationApi Create(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService)
@@ -62,6 +64,11 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Transport
             if (_containerId != null)
             {
                 apiRequest.AddHeader(AgentHttpHeaderNames.ContainerId, _containerId);
+            }
+
+            if (_entityId != null)
+            {
+                apiRequest.AddHeader(AgentHttpHeaderNames.EntityId, _entityId);
             }
 
             using var apiResponse = await apiRequest.PostAsync(payload, MimeTypes.Json).ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryConstants.cs" company="Datadog">
+// <copyright file="TelemetryConstants.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -21,6 +21,7 @@ namespace Datadog.Trace.Telemetry
         public const string ClientLibraryLanguageHeader = "DD-Client-Library-Language";
         public const string ClientLibraryVersionHeader = "DD-Client-Library-Version";
         public const string ContainerIdHeader = "Datadog-Container-ID";
+        public const string EntityIdHeader = "Datadog-Entity-ID";
 
         public const string CloudProviderHeader = "DD-Cloud-Provider";
         public const string CloudResourceTypeHeader = "DD-Cloud-Resource-Type";

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryConstants.cs
@@ -20,8 +20,8 @@ namespace Datadog.Trace.Telemetry
         public const string RequestTypeHeader = "DD-Telemetry-Request-Type";
         public const string ClientLibraryLanguageHeader = "DD-Client-Library-Language";
         public const string ClientLibraryVersionHeader = "DD-Client-Library-Version";
-        public const string ContainerIdHeader = "Datadog-Container-ID";
-        public const string EntityIdHeader = "Datadog-Entity-ID";
+        public const string ContainerIdHeader = Datadog.Trace.AgentHttpHeaderNames.ContainerId;
+        public const string EntityIdHeader = Datadog.Trace.AgentHttpHeaderNames.EntityId;
 
         public const string CloudProviderHeader = "DD-Cloud-Provider";
         public const string CloudResourceTypeHeader = "DD-Cloud-Resource-Type";

--- a/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Transports/JsonTelemetryTransport.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.Telemetry.Transports
         private readonly IApiRequestFactory _requestFactory;
         private readonly Uri _endpoint;
         private readonly string? _containerId;
+        private readonly string? _entityId;
         private readonly bool _enableDebug;
 
         protected JsonTelemetryTransport(IApiRequestFactory requestFactory, bool enableDebug)
@@ -36,6 +37,7 @@ namespace Datadog.Trace.Telemetry.Transports
             _enableDebug = enableDebug;
             _endpoint = _requestFactory.GetEndpoint(TelemetryConstants.TelemetryPath);
             _containerId = ContainerMetadata.GetContainerId();
+            _entityId = ContainerMetadata.GetEntityId();
         }
 
         protected string GetEndpointInfo() => _requestFactory.Info(_endpoint);
@@ -63,6 +65,11 @@ namespace Datadog.Trace.Telemetry.Transports
                 if (_containerId is not null)
                 {
                     request.AddHeader(TelemetryConstants.ContainerIdHeader, _containerId);
+                }
+
+                if (_entityId is not null)
+                {
+                    request.AddHeader(TelemetryConstants.EntityIdHeader, _entityId);
                 }
 
                 TelemetryFactory.Metrics.RecordCountTelemetryApiRequests(endpointMetricTag);

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -77,8 +77,7 @@ namespace Datadog.Trace.IntegrationTests
                 else if (expectedEntitydId is not null)
                 {
                     // Note: This line hasn't been executed by CI yet
-                    throw new Exception("""Got to assertion where expectedEntitydId.StartsWith("in-").Should().BeTrue();""");
-                    // expectedEntitydId.StartsWith("in-").Should().BeTrue();
+                    expectedEntitydId.StartsWith("in-").Should().BeTrue();
                 }
             }
         }

--- a/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/ContainerTaggingTests.cs
@@ -57,6 +57,29 @@ namespace Datadog.Trace.IntegrationTests
                 {
                     headers.AllKeys.ToDictionary(x => x, x => headers[x]).Should().Contain(AgentHttpHeaderNames.ContainerId, expectedContainedId);
                 }
+
+                var expectedEntitydId = ContainerMetadata.GetEntityId();
+                if (expectedEntitydId == null)
+                {
+                    // we don't extract the entityId in some cases, such as when running on Windows.
+                    // In these cases, it should not appear in the headers at all.
+                    headers.AllKeys.Should().NotContain(AgentHttpHeaderNames.EntityId);
+                }
+                else
+                {
+                    headers.AllKeys.ToDictionary(x => x, x => headers[x]).Should().Contain(AgentHttpHeaderNames.EntityId, expectedEntitydId);
+                }
+
+                if (expectedContainedId is not null && expectedEntitydId is not null)
+                {
+                    expectedEntitydId.Should().Be($"cid-{expectedContainedId}");
+                }
+                else if (expectedEntitydId is not null)
+                {
+                    // Note: This line hasn't been executed by CI yet
+                    throw new Exception("""Got to assertion where expectedEntitydId.StartsWith("in-").Should().BeTrue();""");
+                    // expectedEntitydId.StartsWith("in-").Should().BeTrue();
+                }
             }
         }
     }

--- a/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
@@ -89,6 +89,11 @@ namespace Datadog.Trace.IntegrationTests
                 allExpected.Add("Datadog-Container-ID", containerId);
             }
 
+            if (ContainerMetadata.GetEntityId() is { } entityId)
+            {
+                allExpected.Add("Datadog-Entity-ID", entityId);
+            }
+
             if (agentless)
             {
                 allExpected.Add(TelemetryConstants.ApiKeyHeader, apiKey);

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using Datadog.Trace.PlatformHelpers;
 using Xunit;
@@ -114,7 +116,38 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 
         public const string PcfContainer2 = "1:name=systemd:/system.slice/garden.service/garden/6f265890-5165-7fab-6b52-18d1";
 
-        public static IEnumerable<object[]> GetCgroupFiles()
+        public const string InodeCgroupV2 =
+            """
+            "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope"
+            """;
+
+        public const string InodeCgroupV1 =
+            """
+            3:memory:/system.slice/docker-abcdef0123456789abcdef0123456789.scope
+            2:net_cls,net_prio:c
+            1:name=systemd:b
+            0::a
+            """;
+
+        public const string InodeCgroupV1UnrecognizedController =
+            """
+            3:cpu:/system.slice/docker-abcdef0123456789abcdef0123456789.scope
+            2:net_cls,net_prio:c
+            1:name=systemd:b
+            0::a
+            """;
+
+        public const string InodeCgroupV1PathDoesNotExist =
+            """
+            3:memory:/system.slice/docker-abcdef0123456789abcdef0123456789.scope
+            2:net_cls,net_prio:c
+            1:name=systemd:b
+            0::a
+            """;
+
+        public const string InodeCgroupV1NoEntries = "nothing";
+
+        public static IEnumerable<object[]> GetContainerIds()
         {
             yield return new object[] { Docker, "3726184226f5d3147c25fdeab5b60097e378e8a720503a5e19ecfdf29f869860" };
             yield return new object[] { Kubernetes, "3e74d3fd9db4c9dd921ae05c2502fb984d0cde1b36e581b13f79c639da4518a1" };
@@ -124,6 +157,15 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             yield return new object[] { EksNodegroup, "26cfbe35e08b24f053011af4ada23d8fcbf81f27f8331a94f56de5b677c903e4" };
             yield return new object[] { PcfContainer1, "6f265890-5165-7fab-6b52-18d1" };
             yield return new object[] { PcfContainer2, "6f265890-5165-7fab-6b52-18d1" };
+        }
+
+        public static IEnumerable<object[]> GetInodes()
+        {
+            yield return new object[] { InodeCgroupV2, "system.slice/docker-abcdef0123456789abcdef0123456789.scope", true };
+            yield return new object[] { InodeCgroupV1, "system.slice/docker-abcdef0123456789abcdef0123456789.scope", true };
+            yield return new object[] { InodeCgroupV1, "dummy.scope", false };
+            yield return new object[] { InodeCgroupV1UnrecognizedController, "system.slice/docker-abcdef0123456789abcdef0123456789.scope", true };
+            yield return new object[] { InodeCgroupV1NoEntries, "dummy.scope", false };
         }
 
         /// <summary>
@@ -155,17 +197,66 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         }
 
         [Theory]
-        [MemberData(nameof(GetCgroupFiles))]
+        [MemberData(nameof(GetContainerIds))]
         public void Parse_ContainerId_From_Cgroup_File(string file, string expected)
         {
             // arrange
             var lines = SplitLines(file);
 
             // act
-            string actual = ContainerMetadata.ParseCgroupLines(lines);
+            string actual = ContainerMetadata.ParseContainerIdFromCgroupLines(lines);
 
             // assert
             Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInodes))]
+        public void Parse_Inode_From_Cgroup_File(string file, string relativePathToCreate, bool isSuccess)
+        {
+            // arrange
+            var lines = SplitLines(file);
+
+            // Set up directory on disk for testing
+            string sysFsCgroupPath = Path.Combine(Path.GetTempPath(), $"temp-sysfscgroup-{Guid.NewGuid():n}");
+            string controllerCgroupPath = Path.Combine(sysFsCgroupPath, relativePathToCreate);
+            Directory.CreateDirectory(controllerCgroupPath);
+            string expected = isSuccess ? GetInodeFromPath(controllerCgroupPath) : null;
+
+            // act
+            string actual = ContainerMetadata.ExtractInodeFromCgroupLines(sysFsCgroupPath, lines);
+
+            // assert
+            try
+            {
+                Assert.Equal(expected, actual);
+            }
+            finally
+            {
+                Directory.Delete(sysFsCgroupPath, recursive: true);
+            }
+        }
+
+        private string GetInodeFromPath(string path)
+        {
+            using var process = new Process();
+            process.StartInfo.FileName = "stat";
+            process.StartInfo.Arguments = $"-c '%i' {path}";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.StartInfo.CreateNoWindow = true;
+            process.Start();
+
+            string output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(1000);
+
+            if (process.ExitCode == 0 && long.TryParse(output, out _))
+            {
+                return output;
+            }
+
+            return null;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -119,7 +119,12 @@ namespace Datadog.Trace.Tests.PlatformHelpers
 
         public const string InodeCgroupV2 =
             """
-            "0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope"
+            0::/system.slice/docker-abcdef0123456789abcdef0123456789.scope
+            """;
+
+        public const string InodeCgroupV2EmptyNodePath =
+            """
+            0::/
             """;
 
         public const string InodeCgroupV1 =
@@ -133,14 +138,6 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public const string InodeCgroupV1UnrecognizedController =
             """
             3:cpu:/system.slice/docker-abcdef0123456789abcdef0123456789.scope
-            2:net_cls,net_prio:c
-            1:name=systemd:b
-            0::a
-            """;
-
-        public const string InodeCgroupV1PathDoesNotExist =
-            """
-            3:memory:/system.slice/docker-abcdef0123456789abcdef0123456789.scope
             2:net_cls,net_prio:c
             1:name=systemd:b
             0::a
@@ -163,9 +160,10 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         public static IEnumerable<object[]> GetInodes()
         {
             yield return new object[] { InodeCgroupV2, "system.slice/docker-abcdef0123456789abcdef0123456789.scope", true };
-            yield return new object[] { InodeCgroupV1, "system.slice/docker-abcdef0123456789abcdef0123456789.scope", true };
+            yield return new object[] { InodeCgroupV2EmptyNodePath, string.Empty, true };
+            yield return new object[] { InodeCgroupV1, "memory/system.slice/docker-abcdef0123456789abcdef0123456789.scope", true };
             yield return new object[] { InodeCgroupV1, "dummy.scope", false };
-            yield return new object[] { InodeCgroupV1UnrecognizedController, "system.slice/docker-abcdef0123456789abcdef0123456789.scope", true };
+            yield return new object[] { InodeCgroupV1UnrecognizedController, "cpu/system.slice/docker-abcdef0123456789abcdef0123456789.scope", false };
             yield return new object[] { InodeCgroupV1NoEntries, "dummy.scope", false };
         }
 
@@ -247,7 +245,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         {
             using var process = new Process();
             process.StartInfo.FileName = "stat";
-            process.StartInfo.Arguments = $"-c '%i' {path}";
+            process.StartInfo.Arguments = $"--printf=%i {path}";
             process.StartInfo.UseShellExecute = false;
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.RedirectStandardError = true;

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/ContainerMetadataTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using Datadog.Trace.PlatformHelpers;
+using Datadog.Trace.TestHelpers;
 using Xunit;
 
 namespace Datadog.Trace.Tests.PlatformHelpers
@@ -210,10 +211,15 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             Assert.Equal(expected, actual);
         }
 
-        [Theory]
+        [SkippableTheory]
         [MemberData(nameof(GetInodes))]
         public void Parse_Inode_From_Cgroup_File(string file, string relativePathToCreate, bool isSuccess)
         {
+            if (!EnvironmentTools.IsLinux())
+            {
+                throw new SkipException("Obtaining the inode is only supported on Linux");
+            }
+
             // arrange
             var lines = SplitLines(file);
 


### PR DESCRIPTION
## Summary of changes
This PR sends the `Datadog-Entity-ID` header when the `Datadog-Container-Id` header is usually sent, containing either the container-id or the cgroup inode if available.

## Reason for change
Using the cgroup inode will allow the trace-agent to retrieve the container-id, typically on cgroupv2 without UDS.

## Implementation details
This adds a new `Datadog-Entity-ID` header which will also be used for correlating the trace with its running container. The possible values of this are:
- If we have the container ID: `cid-<container_id>`
- If we have the inode number: `in-<inode_number>`

A couple notes:
- The calculation of the container ID and the value of the `Datadog-Container-Id` header is unchanged
- The inode is a property of the file system entry, so we have to calculate the correct path on the filesystem and then make a system call to get the inode value. The host and the container share the same `cgroup` node located at `/sys/fs/cgroup{$cgroup_node}`, so this is the target path. To extract the inode, this implementation starts and runs a new `stat` process and we parse the output for the number.

## Test coverage
- Unit tests:
  - Add `Datadog.Trace.Tests.PlatformHelpers.ContainerMetadataTests.Parse_Inode_From_Cgroup_File`
    - This tests the parsing of the cgroups file, the subidrectory lookup from the cgroup mounts file, and the inode extraction operation.
    - Covers both cgroupsv2 and cgroupsv1 cases
- Integration tests:
  - Extend `Datadog.Trace.IntegrationTests.ContainerTaggingTests.Http_Headers_Contain_ContainerId` test case
    - This has been tested in CI for cgroupsv1 behavior and locally for cgroupsv2 behavior
- System Tests:
  -  Passes the system-tests test case that is unskipped in https://github.com/DataDog/system-tests/pull/2040

## Other details
N/A
