### PR TITLE
[CIVisibility] - Add support for GZip compression in Multipart payloads

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -717,6 +717,7 @@
       <type fullname="System.Runtime.CompilerServices.TaskAwaiter`1" />
       <type fullname="System.Runtime.CompilerServices.TupleElementNamesAttribute" />
       <type fullname="System.Runtime.CompilerServices.TypeForwardedFromAttribute" />
+      <type fullname="System.Runtime.CompilerServices.ValueTaskAwaiter" />
       <type fullname="System.Runtime.ExceptionServices.ExceptionDispatchInfo" />
       <type fullname="System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs" />
       <type fullname="System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute" />

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -717,7 +717,6 @@
       <type fullname="System.Runtime.CompilerServices.TaskAwaiter`1" />
       <type fullname="System.Runtime.CompilerServices.TupleElementNamesAttribute" />
       <type fullname="System.Runtime.CompilerServices.TypeForwardedFromAttribute" />
-      <type fullname="System.Runtime.CompilerServices.ValueTaskAwaiter" />
       <type fullname="System.Runtime.ExceptionServices.ExceptionDispatchInfo" />
       <type fullname="System.Runtime.ExceptionServices.FirstChanceExceptionEventArgs" />
       <type fullname="System.Runtime.ExceptionServices.HandleProcessCorruptedStateExceptionsAttribute" />

--- a/tracer/src/Datadog.Trace/Agent/IMultipartApiRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/IMultipartApiRequest.cs
@@ -6,11 +6,12 @@
 #nullable enable
 
 using System.Threading.Tasks;
+using Datadog.Trace.Agent.Transports;
 
 namespace Datadog.Trace.Agent
 {
     internal interface IMultipartApiRequest
     {
-        Task<IApiResponse> PostAsync(params MultipartFormItem[] items);
+        Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
@@ -92,8 +92,9 @@ namespace Datadog.Trace.Agent.Transports
                 if (multipartCompression == MultipartCompression.GZip)
                 {
                     Log.Debug("Using MultipartCompression.GZip");
-                    using var gzip = new GZipStream(reqStream, CompressionMode.Compress, true);
+                    using var gzip = new GZipStream(reqStream, CompressionMode.Compress, leaveOpen: true);
                     await WriteToStreamAsync(items, gzip).ConfigureAwait(false);
+                    await gzip.FlushAsync().ConfigureAwait(false);
                     Log.Debug("Compressing multipart payload...");
                 }
                 else

--- a/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
@@ -1,0 +1,50 @@
+// <copyright file="GzipCompressedContent.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+#if NETCOREAPP
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Datadog.Trace.Logging;
+
+namespace Datadog.Trace.Agent.Transports;
+
+internal class GzipCompressedContent : HttpContent
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<GzipCompressedContent>();
+
+    private readonly HttpContent _content;
+
+    public GzipCompressedContent(HttpContent content)
+    {
+        // Copy original headers
+        foreach (var header in content.Headers)
+        {
+            Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        Headers.ContentEncoding.Add("gzip");
+        _content = content;
+    }
+
+    protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+    {
+        Log.Debug("Compressing multipart payload...");
+        using var gzip = new GZipStream(stream, CompressionMode.Compress, true);
+        await _content.CopyToAsync(gzip).ConfigureAwait(false);
+    }
+
+    protected override bool TryComputeLength(out long length)
+    {
+        length = -1;
+        return false;
+    }
+}
+
+#endif

--- a/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
@@ -36,10 +36,9 @@ internal class GzipCompressedContent : HttpContent
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
         Log.Debug("GZip compressing payload...");
-#pragma warning disable CA2007
-        await using var gzip = new GZipStream(stream, CompressionMode.Compress, true);
-#pragma warning restore CA2007
+        using var gzip = new GZipStream(stream, CompressionMode.Compress, leaveOpen: true);
         await _content.CopyToAsync(gzip).ConfigureAwait(false);
+        await gzip.FlushAsync().ConfigureAwait(false);
     }
 
     protected override bool TryComputeLength(out long length)

--- a/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
@@ -35,7 +35,7 @@ internal class GzipCompressedContent : HttpContent
 
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
-        Log.Debug("Compressing multipart payload...");
+        Log.Debug("GZip compressing payload...");
         using var gzip = new GZipStream(stream, CompressionMode.Compress, true);
         await _content.CopyToAsync(gzip).ConfigureAwait(false);
     }

--- a/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/GzipCompressedContent.cs
@@ -36,7 +36,9 @@ internal class GzipCompressedContent : HttpContent
     protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context)
     {
         Log.Debug("GZip compressing payload...");
-        using var gzip = new GZipStream(stream, CompressionMode.Compress, true);
+#pragma warning disable CA2007
+        await using var gzip = new GZipStream(stream, CompressionMode.Compress, true);
+#pragma warning restore CA2007
         await _content.CopyToAsync(gzip).ConfigureAwait(false);
     }
 

--- a/tracer/src/Datadog.Trace/Agent/Transports/MultipartCompression.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/MultipartCompression.cs
@@ -1,0 +1,14 @@
+// <copyright file="MultipartCompression.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Agent.Transports;
+
+internal enum MultipartCompression
+{
+    None,
+    GZip
+}

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -255,7 +255,7 @@ namespace Datadog.Trace.Ci.Agent
                 {
                     if (request is IMultipartApiRequest multipartRequest)
                     {
-                        return multipartRequest.PostAsync(payloadArray, MultipartCompression.GZip);
+                        return multipartRequest.PostAsync(payloadArray, payload.UseEvpProxy ? MultipartCompression.None : MultipartCompression.GZip);
                     }
 
                     MultipartApiRequestNotSupported.Throw();

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -255,7 +255,7 @@ namespace Datadog.Trace.Ci.Agent
                 {
                     if (request is IMultipartApiRequest multipartRequest)
                     {
-                        return multipartRequest.PostAsync(payloadArray);
+                        return multipartRequest.PostAsync(payloadArray, MultipartCompression.GZip);
                     }
 
                     MultipartApiRequestNotSupported.Throw();

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -583,9 +583,9 @@ internal class IntelligentTestRunnerClient
 
                 try
                 {
-                    using var response = await multipartRequest.PostAsync(
+                    using var response = await multipartRequest.PostAsync([
                                                                     new MultipartFormItem("pushedSha", MimeTypes.Json, null, new ArraySegment<byte>(jsonPushedShaBytes)),
-                                                                    new MultipartFormItem("packfile", "application/octet-stream", null, fileStream))
+                                                                    new MultipartFormItem("packfile", "application/octet-stream", null, fileStream)])
                                                                .ConfigureAwait(false);
                     var responseContent = await response.ReadAsStringAsync().ConfigureAwait(false);
                     if (TelemetryHelper.GetErrorTypeFromStatusCode(response.StatusCode) is { } errorType)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/Agent/CiVisibilityProtocolWriterTests.cs
@@ -6,9 +6,15 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
+using Datadog.Trace.Agent.Transports;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.Agent;
 using Datadog.Trace.Ci.Coverage.Models.Tests;
@@ -18,6 +24,7 @@ using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Vendors.MessagePack;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -139,6 +146,29 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
                 Assert.True(finalItem.ContentInBytes.Value.ToArray().SequenceEqual(expectedItem.ContentInBytes.Value.ToArray()));
             }
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [Fact]
+        public async Task AgentlessCodeCoverageCompressedPayloadTest()
+        {
+            var requestFactory = new HttpClientRequestFactory(new Uri("http://localhost"), Array.Empty<KeyValuePair<string, string>>(), new TestMessageHandler());
+            var apiRequest = (IMultipartApiRequest)requestFactory.Create(new Uri("http://localhost/api"));
+            var response = await apiRequest.PostAsync(
+                                          new[] { new MultipartFormItem("TestName", "application/binary", "TestFileName", "TestContent"u8.ToArray()) },
+                                          MultipartCompression.GZip)
+                                     .ConfigureAwait(false);
+            var stream = await response.GetStreamAsync().ConfigureAwait(false);
+            using var unzippedStream = new GZipStream(stream, CompressionMode.Decompress, leaveOpen: true);
+            var ms = new MemoryStream();
+            await unzippedStream.CopyToAsync(ms).ConfigureAwait(false);
+            ms.Position = 0;
+            using var rs = new StreamReader(ms, Encoding.UTF8);
+            var requestContent = await rs.ReadToEndAsync().ConfigureAwait(false);
+            requestContent.Should().Contain("Content-Type: application/binary");
+            requestContent.Should().Contain("Content-Disposition: form-data; name=TestName; filename=TestFileName; filename*=utf-8''TestFileName");
+            requestContent.Should().Contain("TestContent");
+        }
+#endif
 
         [Fact]
         public async Task SlowSenderTest()
@@ -323,6 +353,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI.Agent
                 Assert.Equal(numItemsTrunc, payloadBuffer.Events.Count);
 
                 bufferSize *= 2;
+            }
+        }
+
+        internal class TestMessageHandler : HttpMessageHandler
+        {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var ms = new MemoryStream();
+                await request.Content.CopyToAsync(ms).ConfigureAwait(false);
+                var responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+                responseMessage.Content = new ByteArrayContent(ms.ToArray());
+                return responseMessage;
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

This PR enables Gzip compression on the Code Coverage track using Multipart-Form

Backend compression support:
<img width="694" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/0e289d63-7355-44a1-9ff0-21e7ff92917a">


## Reason for change

Currently we are sending all the code coverage data uncompressed to the backend, because these payload could potentially be huge we are enabling gzip support on upload only when we are in agentless mode.

## Implementation details

Changes a little bit the internal api to select wether we want compression or not, and implement the compression algorithm in both HttpClient and ApiClient factories.

## Test coverage

Tested manually, and added a new test for the Gzipped multipart form post in the `HttpClientRequest` object, other tests will be done in the `test-environment` repo.
