### PR TITLE
Always log rejit errors

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3863,10 +3863,11 @@ HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID funct
 HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId,
                                                   HRESULT hrStatus)
 {
+    Logger::Warn("ReJITError: [functionId: ", functionId, ", moduleId: ", moduleId, ", methodId: ", methodId,
+                 ", hrStatus: ", hrStatus, "]");
+
     if (!is_attached_)
     {
-        Logger::Warn("ReJITError: [functionId: ", functionId, ", moduleId: ", moduleId, ", methodId: ", methodId,
-                     ", hrStatus: ", hrStatus, "]");
         return S_OK;
     }
 


### PR DESCRIPTION
## Summary of changes

Currently we log rejit errors only if the profiler is not initialized, which... doesn't seem quite right.

## Reason for change

There are some rejit errors on the automapper tests.

## Implementation details

Moved a line.
