### PR TITLE
Include telemetry data in tracer flare

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -15,6 +15,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
@@ -30,6 +31,7 @@ internal class TracerFlareManager : ITracerFlareManager
 
     private readonly IDiscoveryService _discoveryService;
     private readonly IRcmSubscriptionManager _subscriptionManager;
+    private readonly ITelemetryController _telemetryController;
     private readonly TracerFlareApi _flareApi;
     private ISubscription? _subscription;
     private Timer? _resetTimer = null;
@@ -39,9 +41,11 @@ internal class TracerFlareManager : ITracerFlareManager
     public TracerFlareManager(
         IDiscoveryService discoveryService,
         IRcmSubscriptionManager subscriptionManager,
+        ITelemetryController telemetryController,
         TracerFlareApi flareApi)
     {
         _subscriptionManager = subscriptionManager;
+        _telemetryController = telemetryController;
         _flareApi = flareApi;
         _discoveryService = discoveryService;
     }

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -16,6 +16,7 @@ using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
@@ -98,7 +99,7 @@ internal class TracerFlareManager : ITracerFlareManager
         if (configByProduct.TryGetValue(RcmProducts.TracerFlareInitiated, out var initiatedConfig)
          && initiatedConfig.Count > 0)
         {
-            results = HandleTracerFlareInitiated(initiatedConfig);
+            results = await HandleTracerFlareInitiated(initiatedConfig).ConfigureAwait(false);
         }
 
         if (configByProduct.TryGetValue(RcmProducts.TracerFlareRequested, out var requestedConfig)
@@ -118,7 +119,7 @@ internal class TracerFlareManager : ITracerFlareManager
         return results ?? [];
     }
 
-    private ApplyDetails[] HandleTracerFlareInitiated(List<RemoteConfiguration> config)
+    private async Task<ApplyDetails[]> HandleTracerFlareInitiated(List<RemoteConfiguration> config)
     {
         try
         {
@@ -150,6 +151,18 @@ internal class TracerFlareManager : ITracerFlareManager
                 previous?.Dispose();
 
                 Log.Debug(TracerFlareInitializationLog);
+
+                // dump the telemetry (assuming we have somewhere to dump it)
+                if (Log.FileLogDirectory is { } logDir)
+                {
+                    // the filename here is chosen so that it will get cleaned up in the normal log rotation
+                    ProcessHelpers.GetCurrentProcessInformation(out _, out _, out var pid);
+                    var rid = Tracer.RuntimeId;
+                    var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                    var telemetryPath = Path.Combine(logDir, $"dotnet-tracer-telemetry-{pid}-{rid}-{timestamp}.log");
+                    Log.Debug("Requesting telemetry dump to {FileName}", telemetryPath);
+                    await _telemetryController.DumpTelemetry(telemetryPath).ConfigureAwait(false);
+                }
             }
 
             return AcknowledgeAll(config);

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/DependencyTelemetryCollector.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 
@@ -103,6 +104,9 @@ namespace Datadog.Trace.Telemetry
 
             return assembliesToRecord;
         }
+
+        // Not the best implementation, but we don't call this often enough to worry about
+        public List<DependencyTelemetryData> GetFullData() => _assemblies.Keys.ToList();
 
         private static bool IsTempPathPattern(string assemblyName)
         {

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/IDependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/IDependencyTelemetryCollector.cs
@@ -22,4 +22,9 @@ internal interface IDependencyTelemetryCollector
     /// </summary>
     /// <returns>Null if there are no changes, or the collector is not yet initialized</returns>
     List<DependencyTelemetryData>? GetData();
+
+    /// <summary>
+    /// Gets all the assembly data recorded so far
+    /// </summary>
+    List<DependencyTelemetryData>? GetFullData();
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/NullDependencyTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/NullDependencyTelemetryCollector.cs
@@ -18,4 +18,6 @@ internal class NullDependencyTelemetryCollector : IDependencyTelemetryCollector
     }
 
     public List<DependencyTelemetryData>? GetData() => null;
+
+    public List<DependencyTelemetryData>? GetFullData() => null;
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ProductsTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ProductsTelemetryCollector.cs
@@ -37,6 +37,16 @@ internal class ProductsTelemetryCollector
             return null;
         }
 
+        return BuildProductsData();
+    }
+
+    /// <summary>
+    /// Gets all the product data recorded so far
+    /// </summary>
+    public ProductsData? GetFullData() => BuildProductsData();
+
+    private ProductsData? BuildProductsData()
+    {
         var results = Interlocked.Exchange(ref _productsByType, new ProductDetail?[3]);
 
         var appsec = results[(int)TelemetryProductType.AppSec] is { } a ? new ProductData(a.Enabled, a.Error) : null;

--- a/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
@@ -54,5 +54,10 @@ namespace Datadog.Trace.Telemetry
         /// Should be called when the status (enabled/disabled) of a product (ASM/Profiler) changed.
         /// </summary>
         void ProductChanged(TelemetryProductType product, bool enabled, ErrorData? error);
+
+        /// <summary>
+        /// Dumps the current telemetry state to the provided filename.
+        /// </summary>
+        Task DumpTelemetry(string filePath);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
@@ -4,11 +4,8 @@
 // </copyright>
 
 using System.Threading.Tasks;
-using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
-using Datadog.Trace.Iast.Settings;
-using Datadog.Trace.PlatformHelpers;
 
 namespace Datadog.Trace.Telemetry
 {
@@ -48,5 +45,7 @@ namespace Datadog.Trace.Telemetry
         {
             return Task.CompletedTask;
         }
+
+        public Task DumpTelemetry(string filePath) => Task.CompletedTask;
     }
 }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -180,7 +180,7 @@ namespace Datadog.Trace
             }
 
             dynamicConfigurationManager ??= new DynamicConfigurationManager(RcmSubscriptionManager.Instance);
-            tracerFlareManager ??= new TracerFlareManager(discoveryService, RcmSubscriptionManager.Instance, TracerFlareApi.Create(settings.ExporterInternal));
+            tracerFlareManager ??= new TracerFlareManager(discoveryService, RcmSubscriptionManager.Instance, telemetry, TracerFlareApi.Create(settings.ExporterInternal));
 
             return CreateTracerManagerFrom(
                 settings,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs
@@ -39,7 +39,7 @@ public class TracerFlareTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task SendTracerFlare()
     {
-        using var agent = EnvironmentHelper.GetMockAgent();
+        using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
         var processName = EnvironmentHelper.IsCoreClr() ? "dotnet" : "Samples.Console";
         using var logEntryWatcher = new LogEntryWatcher($"{LogFileNamePrefix}{processName}*", LogDirectory);
         using var sample = StartSample(agent, "wait", string.Empty, aspNetCorePort: 5000);
@@ -69,6 +69,12 @@ public class TracerFlareTests : TestHelper
 
         var zip = new ZipArchive(flareFile.Data, ZipArchiveMode.Read);
         zip.Entries.Should().NotBeNullOrEmpty();
+        zip.Entries
+           .Should()
+           .Contain(x => x.Name.StartsWith("dotnet-tracer-managed-"))
+           .And.Contain(x => x.Name.StartsWith("dotnet-native-loader-"))
+           .And.Contain(x => x.Name.StartsWith("dotnet-tracer-native-"))
+           .And.Contain(x => x.Name.StartsWith("dotnet-tracer-telemetry-"));
     }
 
     private async Task InitializeFlare(MockTracerAgent agent, LogEntryWatcher logEntryWatcher)

--- a/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/TracerFlare/TracerFlareManagerTests.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Logging.TracerFlare;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers.TransportHelpers;
 using Datadog.Trace.Tests.Agent;
 using FluentAssertions;
@@ -39,6 +40,7 @@ public class TracerFlareManagerTests
         var manager = new TracerFlareManager(
             discoveryService,
             Mock.Of<IRcmSubscriptionManager>(),
+            NullTelemetryController.Instance,
             new TracerFlareApi(Mock.Of<IApiRequestFactory>()));
 
         manager.Start();
@@ -56,6 +58,7 @@ public class TracerFlareManagerTests
         var manager = new TracerFlareManager(
             discoveryService,
             Mock.Of<IRcmSubscriptionManager>(),
+            NullTelemetryController.Instance,
             new TracerFlareApi(Mock.Of<IApiRequestFactory>()));
 
         manager.Start();
@@ -88,6 +91,7 @@ public class TracerFlareManagerTests
         var manager = new TracerFlareManager(
             new DiscoveryServiceMock(),
             Mock.Of<IRcmSubscriptionManager>(),
+            NullTelemetryController.Instance,
             new TracerFlareApi(requestMock.Object));
 
         var result = await manager.TrySendDebugLogs(ConfigPath, Encoding.UTF8.GetBytes(config), _requestId, _logsDir);
@@ -108,6 +112,7 @@ public class TracerFlareManagerTests
         var manager = new TracerFlareManager(
             new DiscoveryServiceMock(),
             Mock.Of<IRcmSubscriptionManager>(),
+            NullTelemetryController.Instance,
             new TracerFlareApi(requestMock.Object));
 
         var result = await manager.TrySendDebugLogs(ConfigPath, Encoding.UTF8.GetBytes(config), _requestId, _logsDir);
@@ -125,6 +130,7 @@ public class TracerFlareManagerTests
         var manager = new TracerFlareManager(
             new DiscoveryServiceMock(),
             Mock.Of<IRcmSubscriptionManager>(),
+            NullTelemetryController.Instance,
             new TracerFlareApi(requestMock.Object));
 
         // pre-create the sentinel, to simulate another tracer catching it
@@ -146,6 +152,7 @@ public class TracerFlareManagerTests
         var manager = new TracerFlareManager(
             new DiscoveryServiceMock(),
             Mock.Of<IRcmSubscriptionManager>(),
+            NullTelemetryController.Instance,
             new TracerFlareApi(requestFactory));
 
         // Create a new sentinel to make sure there's no flake

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
@@ -140,6 +140,8 @@ namespace Datadog.Trace.Tests.Telemetry
             public void ProductChanged(TelemetryProductType product, bool enabled, ErrorData? error)
             {
             }
+
+            public Task DumpTelemetry(string filePath) => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Includes telemetry results in the tracer flare zip

## Reason for change

Making this data immediately available in the tracer flare zip should help with MTTR

## Implementation details

Use the existing telemetry data structures and just dump to a file in the log folder. All the connected tracers will dump their telemetry, so we make sure to include pid/runtime-id in the filename, but if we get collisions, oh well 🤷‍♂️ 

Currently we dump
- Application/Host details
- Integrations (which are enabled, have executed, have errored)
- Dependencies loaded

We _don't_ dump the configuration, as we don't keep that in memory. As nice as it would be to have that too, doing so would increase memory usage so is hard to justify currently.

## Test coverage

Unit tests for the dumping behaviour, integration test that it gets included in the tracer flare zip

## Other details


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
