### PR TITLE
Fix exception when the CodeCoverage environment variable value is null

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -351,7 +351,7 @@ namespace Datadog.Trace.Tools.Runner
                             globalCoverage is not null)
                         {
                             // We only report the code coverage percentage if the customer manually sets the 'DD_CIVISIBILITY_CODE_COVERAGE_ENABLED' environment variable according to the new spec.
-                            if (EnvironmentHelpers.GetEnvironmentVariable(Configuration.ConfigurationKeys.CIVisibility.CodeCoverage).ToBoolean() == true)
+                            if ((EnvironmentHelpers.GetEnvironmentVariable(Configuration.ConfigurationKeys.CIVisibility.CodeCoverage) ?? string.Empty).ToBoolean() == true)
                             {
                                 // Adds the global code coverage percentage to the session
                                 session.SetTag(CodeCoverageTags.PercentageOfTotalLines, globalCoverage.GetTotalPercentage());


### PR DESCRIPTION
## Summary of changes

This PR fixes an exception thrown when the `GetEnvironmentVariable` returns null ( `ToBoolean()` doesn't accept null value ).
