### PR TITLE
[IAST] Dani/asm/small string cache bugfix

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
+++ b/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
@@ -42,13 +42,15 @@ namespace Datadog.Trace.Iast
                     return arg.Length == 1 && char.IsDigit(arg[0]);
                 }
 
-                // 0 - 299 are cached
-                if (arg.Length > 3) { return false; }
-                if (!char.IsDigit(arg[0])) { return false; }
-                if (arg.Length > 1 && !char.IsDigit(arg[1])) { return false; }
-                if (arg.Length > 2 && (!char.IsDigit(arg[2]) || arg[0] - '0' >= 3)) { return false; }
-
-                return true;
+            return arg.Length switch
+            {
+                > 3 => false, // Only 0 - 299 are cached
+                _ when !char.IsDigit(arg[0]) => false, // Not a number
+                > 1 when !char.IsDigit(arg[1]) => false, // Not a number
+                > 2 when !char.IsDigit(arg[2]) => false, // Not a number
+                > 2 when arg[0] - '0' >= 3 => false, // Bigger than 299
+                _ => true
+            };
             }
 
             return false;

--- a/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
+++ b/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Iast
             bool IsFiltered(string arg)
             {
                 // Try to bail out ASAP
-                if (arg.Length == 0) { return true; }
+                if (string.IsNullOrEmpty(arg)) { return true; }
 
                 // 0 - 9 are cached only
                 if (!_largeNumericCache)

--- a/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
+++ b/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
@@ -39,8 +39,7 @@ namespace Datadog.Trace.Iast
                 // 0 - 9 are cached only
                 if (!_largeNumericCache)
                 {
-                    if (arg.Length > 1 || !char.IsDigit(arg[0])) { return false; }
-                    return true;
+                    return arg.Length == 1 && char.IsDigit(arg[0]);
                 }
 
                 // 0 - 299 are cached

--- a/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
+++ b/tracer/src/Datadog.Trace/Iast/TaintedObjects.cs
@@ -42,15 +42,15 @@ namespace Datadog.Trace.Iast
                     return arg.Length == 1 && char.IsDigit(arg[0]);
                 }
 
-            return arg.Length switch
-            {
-                > 3 => false, // Only 0 - 299 are cached
-                _ when !char.IsDigit(arg[0]) => false, // Not a number
-                > 1 when !char.IsDigit(arg[1]) => false, // Not a number
-                > 2 when !char.IsDigit(arg[2]) => false, // Not a number
-                > 2 when arg[0] - '0' >= 3 => false, // Bigger than 299
-                _ => true
-            };
+                return arg.Length switch
+                {
+                    > 3 => false, // Only 0 - 299 are cached
+                    _ when !char.IsDigit(arg[0]) => false, // Not a number
+                    > 1 when !char.IsDigit(arg[1]) => false, // Not a number
+                    > 2 when !char.IsDigit(arg[2]) => false, // Not a number
+                    > 2 when arg[0] - '0' >= 3 => false, // Bigger than 299
+                    _ => true
+                };
             }
 
             return false;

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/TaintedObjectsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/TaintedObjectsTests.cs
@@ -130,5 +130,9 @@ public class TaintedObjectsTests
         TaintInput(true, "50t");
         TaintInput(true, "Not");
         TaintInput(true, "Not Numeric");
+
+        TaintInput(true, "-1");
+        TaintInput(true, "-29");
+        TaintInput(true, "-35");
     }
 }


### PR DESCRIPTION
## Summary of changes
Avoid tainting of framework cached digit input strings

## Reason for change
Framework caches and reuses ToString() results for short (0-9) digits (pre DotNet 8.0) or 0-299 from DotNet 8.0 onwards. This has caused many false possitives, as any digit in an input would cause the use of the same digit in a sink to raise a false possitive.
It happened in a "Select TOP (value)" where the `value` was the same as the content of a header (small number).

## Implementation details
Filter and avoid tainting of digit input strings (`TaintedObjects.TaintInputString()`)

[PrivateCorelib implementation](https://github.com/dotnet/runtime/blob/e42a873a821e5fe8833254dd2bbdc60200d22e92/src/libraries/System.Private.CoreLib/src/System/Number.Formatting.cs#L287
)
![image](https://github.com/DataDog/dd-trace-dotnet/assets/108014683/0c5b77e0-ab40-42b9-9659-92afbe2e5647)


## Test coverage
Added unit test to check the behavior in pre and post DotNet 8.0

