### PR TITLE
[v3] Minor updates for subsequent work

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -964,7 +964,7 @@ partial class Build
                  // current (not released version)
                  var version = new Version(Version);
                  var versionsToCheck = 3;
-                 while (versionsToCheck > 0)
+                 while (versionsToCheck > 0 && version.Minor > 0)
                  {
                      // only looking back across minor releases (ignoring patch etc)
                      versionsToCheck--;

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -11,12 +11,8 @@ src/Datadog.Trace/HttpHeaderNames.cs
 src/Datadog.Trace/IDatadogOpenTracingTracer.cs
 src/Datadog.Trace/IDatadogTracer.cs
 src/Datadog.Trace/ILockedTracer.cs
-src/Datadog.Trace/IScope.cs
 src/Datadog.Trace/IScopeManager.cs
 src/Datadog.Trace/IScopeRawAccess.cs
-src/Datadog.Trace/ISpan.cs
-src/Datadog.Trace/ISpanContext.cs
-src/Datadog.Trace/ITracer.cs
 src/Datadog.Trace/LifetimeManager.cs
 src/Datadog.Trace/Metrics.cs
 src/Datadog.Trace/NativeLoader.cs
@@ -31,7 +27,6 @@ src/Datadog.Trace/Scope.IScope.cs
 src/Datadog.Trace/Span.cs
 src/Datadog.Trace/Span.ISpan.cs
 src/Datadog.Trace/SpanContext.cs
-src/Datadog.Trace/SpanCreationSettings.cs
 src/Datadog.Trace/SpanExtensions.Core.cs
 src/Datadog.Trace/SpanExtensions.cs
 src/Datadog.Trace/SpanExtensions.Framework.cs

--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/WafLibraryInvoker.cs
@@ -217,9 +217,9 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
             }
 
             // tracer >= 2.34.0 needs waf >= 1.11 cause it passes a ddwafobject for diagnostics instead of a ruleset info struct which causes unpredictable unmanaged crashes
-            if ((tracerVersion is { Minor: >= 34, Major: >= 2 } && wafMajor == 1 && wafMinor <= 10) ||
-                (tracerVersion is { Minor: >= 38, Major: >= 2 } && wafMajor == 1 && wafMinor < 13) ||
-                (tracerVersion is { Minor: >= 44, Major: >= 2 } && wafMajor == 1 && wafMinor < 15))
+            if ((tracerVersion is { Minor: >= 34, Major: 2 } or { Major: > 2 } && wafMajor == 1 && wafMinor <= 10) ||
+                (tracerVersion is { Minor: >= 38, Major: 2 } or { Major: > 2 } && wafMajor == 1 && wafMinor < 13) ||
+                (tracerVersion is { Minor: >= 44, Major: 2 } or { Major: > 2 } && wafMajor == 1 && wafMinor < 15))
             {
                 Log.Warning("Waf version {WafVersion} is not compatible with tracer version {TracerVersion}", versionWaf, tracerVersion);
                 return false;

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -220,17 +220,7 @@ public sealed class TestModule
     public static TestModule Create(string name)
     {
         TelemetryFactory.Metrics.RecordCountCIVisibilityManualApiEvent(MetricTags.CIVisibilityTestingEventType.Module);
-        return InternalCreate(name);
-    }
-
-    /// <summary>
-    /// Create a new Test Module
-    /// </summary>
-    /// <param name="name">Test module name</param>
-    /// <returns>New test module instance</returns>
-    internal static TestModule InternalCreate(string name)
-    {
-        return new TestModule(name, null, null, null);
+        return InternalCreate(name, framework: null, frameworkVersion: null, startDate: null);
     }
 
     /// <summary>
@@ -244,19 +234,7 @@ public sealed class TestModule
     public static TestModule Create(string name, string framework, string frameworkVersion)
     {
         TelemetryFactory.Metrics.RecordCountCIVisibilityManualApiEvent(MetricTags.CIVisibilityTestingEventType.Module);
-        return InternalCreate(name, framework, frameworkVersion);
-    }
-
-    /// <summary>
-    /// Create a new Test Module
-    /// </summary>
-    /// <param name="name">Test module name</param>
-    /// <param name="framework">Testing framework name</param>
-    /// <param name="frameworkVersion">Testing framework version</param>
-    /// <returns>New test module instance</returns>
-    internal static TestModule InternalCreate(string name, string framework, string frameworkVersion)
-    {
-        return new TestModule(name, framework, frameworkVersion, null);
+        return InternalCreate(name, framework, frameworkVersion, startDate: null);
     }
 
     /// <summary>
@@ -280,9 +258,19 @@ public sealed class TestModule
     /// <param name="name">Test module name</param>
     /// <param name="framework">Testing framework name</param>
     /// <param name="frameworkVersion">Testing framework version</param>
+    /// <returns>New test module instance</returns>
+    internal static TestModule InternalCreate(string name, string? framework, string? frameworkVersion)
+        => InternalCreate(name, framework, frameworkVersion, null);
+
+    /// <summary>
+    /// Create a new Test Module
+    /// </summary>
+    /// <param name="name">Test module name</param>
+    /// <param name="framework">Testing framework name</param>
+    /// <param name="frameworkVersion">Testing framework version</param>
     /// <param name="startDate">Test session start date</param>
     /// <returns>New test module instance</returns>
-    internal static TestModule InternalCreate(string name, string framework, string frameworkVersion, DateTimeOffset startDate)
+    internal static TestModule InternalCreate(string name, string? framework, string? frameworkVersion, DateTimeOffset? startDate)
     {
         return new TestModule(name, framework, frameworkVersion, startDate);
     }

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -137,22 +137,7 @@ public sealed class TestSession
     public static TestSession GetOrCreate(string command)
     {
         TelemetryFactory.Metrics.RecordCountCIVisibilityManualApiEvent(MetricTags.CIVisibilityTestingEventType.Session);
-        return InternalGetOrCreate(command);
-    }
-
-    /// <summary>
-    /// Get or create a new Test Session
-    /// </summary>
-    /// <param name="command">Test session command</param>
-    /// <returns>New test session instance</returns>
-    internal static TestSession InternalGetOrCreate(string command)
-    {
-        if (Current is { } current)
-        {
-            return current;
-        }
-
-        return new TestSession(command, null, null, null, false);
+        return InternalGetOrCreate(command, workingDirectory: null, framework: null, startDate: null);
     }
 
     /// <summary>
@@ -165,23 +150,7 @@ public sealed class TestSession
     public static TestSession GetOrCreate(string command, string workingDirectory)
     {
         TelemetryFactory.Metrics.RecordCountCIVisibilityManualApiEvent(MetricTags.CIVisibilityTestingEventType.Session);
-        return InternalGetOrCreate(command, workingDirectory);
-    }
-
-    /// <summary>
-    /// Get or create a new Test Session
-    /// </summary>
-    /// <param name="command">Test session command</param>
-    /// <param name="workingDirectory">Test session working directory</param>
-    /// <returns>New test session instance</returns>
-    internal static TestSession InternalGetOrCreate(string command, string workingDirectory)
-    {
-        if (Current is { } current)
-        {
-            return current;
-        }
-
-        return new TestSession(command, workingDirectory, null, null, false);
+        return InternalGetOrCreate(command, workingDirectory, framework: null, startDate: null);
     }
 
     /// <summary>
@@ -195,24 +164,7 @@ public sealed class TestSession
     public static TestSession GetOrCreate(string command, string workingDirectory, string framework)
     {
         TelemetryFactory.Metrics.RecordCountCIVisibilityManualApiEvent(MetricTags.CIVisibilityTestingEventType.Session);
-        return InternalGetOrCreate(command, workingDirectory, framework);
-    }
-
-    /// <summary>
-    /// Get or create a new Test Session
-    /// </summary>
-    /// <param name="command">Test session command</param>
-    /// <param name="workingDirectory">Test session working directory</param>
-    /// <param name="framework">Testing framework name</param>
-    /// <returns>New test session instance</returns>
-    internal static TestSession InternalGetOrCreate(string command, string workingDirectory, string framework)
-    {
-        if (Current is { } current)
-        {
-            return current;
-        }
-
-        return new TestSession(command, workingDirectory, framework, null, false);
+        return InternalGetOrCreate(command, workingDirectory, framework, startDate: null);
     }
 
     /// <summary>
@@ -228,24 +180,6 @@ public sealed class TestSession
     {
         TelemetryFactory.Metrics.RecordCountCIVisibilityManualApiEvent(MetricTags.CIVisibilityTestingEventType.Session);
         return InternalGetOrCreate(command, workingDirectory, framework, startDate);
-    }
-
-    /// <summary>
-    /// Get or create a new Test Session
-    /// </summary>
-    /// <param name="command">Test session command</param>
-    /// <param name="workingDirectory">Test session working directory</param>
-    /// <param name="framework">Testing framework name</param>
-    /// <param name="startDate">Test session start date</param>
-    /// <returns>New test session instance</returns>
-    internal static TestSession InternalGetOrCreate(string command, string workingDirectory, string framework, DateTimeOffset startDate)
-    {
-        if (Current is { } current)
-        {
-            return current;
-        }
-
-        return new TestSession(command, workingDirectory, framework, startDate, false);
     }
 
     /// <summary>
@@ -273,7 +207,7 @@ public sealed class TestSession
     /// <param name="startDate">Test session start date</param>
     /// <param name="propagateEnvironmentVariables">Propagate session data through environment variables (out of proc session)</param>
     /// <returns>New test session instance</returns>
-    internal static TestSession InternalGetOrCreate(string command, string? workingDirectory, string? framework, DateTimeOffset? startDate, bool propagateEnvironmentVariables)
+    internal static TestSession InternalGetOrCreate(string command, string? workingDirectory, string? framework, DateTimeOffset? startDate, bool propagateEnvironmentVariables = false)
     {
         if (Current is { } current)
         {

--- a/tracer/src/Datadog.Trace/IScope.cs
+++ b/tracer/src/Datadog.Trace/IScope.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace

--- a/tracer/src/Datadog.Trace/ISpan.cs
+++ b/tracer/src/Datadog.Trace/ISpan.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace
@@ -63,7 +65,7 @@ namespace Datadog.Trace
         /// <param name="key">The tag's key.</param>
         /// <param name="value">The tag's value.</param>
         /// <returns>This span to allow method chaining.</returns>
-        ISpan SetTag(string key, string value);
+        ISpan SetTag(string key, string? value);
 
         /// <summary>
         /// Record the end time of the span and flushes it to the backend.
@@ -89,6 +91,6 @@ namespace Datadog.Trace
         /// </summary>
         /// <param name="key">The tag's key</param>
         /// <returns> The value for the tag with the key specified, or null if the tag does not exist</returns>
-        string GetTag(string key);
+        string? GetTag(string key);
     }
 }

--- a/tracer/src/Datadog.Trace/ISpanContext.cs
+++ b/tracer/src/Datadog.Trace/ISpanContext.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace
 {
     /// <summary>
@@ -23,6 +25,6 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the service name to propagate to child spans.
         /// </summary>
-        string ServiceName { get; }
+        string? ServiceName { get; }
     }
 }

--- a/tracer/src/Datadog.Trace/ITracer.cs
+++ b/tracer/src/Datadog.Trace/ITracer.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.Configuration;
 using Datadog.Trace.SourceGenerators;
 
@@ -16,7 +18,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the active scope
         /// </summary>
-        IScope ActiveScope { get; }
+        IScope? ActiveScope { get; }
 
         /// <summary>
         /// Gets this tracer's settings.

--- a/tracer/src/Datadog.Trace/SpanCreationSettings.cs
+++ b/tracer/src/Datadog.Trace/SpanCreationSettings.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace
@@ -22,7 +24,7 @@ namespace Datadog.Trace
         /// set to <see cref="SpanContext.None"/>. If not set, defaults to <c>null</c> and
         /// the currently active span (if any) is used as the parent.
         /// </summary>
-        public ISpanContext Parent { get; set; }
+        public ISpanContext? Parent { get; set; }
 
         /// <summary>
         /// Gets or sets whether closing the new scope will close the contained span.

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
@@ -387,13 +387,13 @@ namespace Datadog.Trace
         string Type { get; set; }
         void Finish();
         void Finish(System.DateTimeOffset finishTimestamp);
-        string GetTag(string key);
+        string? GetTag(string key);
         void SetException(System.Exception exception);
-        Datadog.Trace.ISpan SetTag(string key, string value);
+        Datadog.Trace.ISpan SetTag(string key, string? value);
     }
     public interface ISpanContext
     {
-        string ServiceName { get; }
+        string? ServiceName { get; }
         ulong SpanId { get; }
         ulong TraceId { get; }
     }
@@ -403,7 +403,7 @@ namespace Datadog.Trace
     }
     public interface ITracer
     {
-        Datadog.Trace.IScope ActiveScope { get; }
+        Datadog.Trace.IScope? ActiveScope { get; }
         Datadog.Trace.Configuration.ImmutableTracerSettings Settings { get; }
         Datadog.Trace.IScope StartActive(string operationName);
         Datadog.Trace.IScope StartActive(string operationName, Datadog.Trace.SpanCreationSettings settings);
@@ -438,7 +438,7 @@ namespace Datadog.Trace
     public struct SpanCreationSettings
     {
         public bool? FinishOnClose { get; set; }
-        public Datadog.Trace.ISpanContext Parent { get; set; }
+        public Datadog.Trace.ISpanContext? Parent { get; set; }
         public System.DateTimeOffset? StartTime { get; set; }
     }
     public static class SpanExtensions


### PR DESCRIPTION
## Summary of changes

- Add `#nullable enable` attributes to public API interfaces
- Reduce some duplication in CI Visibility types
- Fix bug in WAF compatibility check that manifests in 3.0.0+
- Fix bug in the compare-throughput task

## Reason for change

These are prereqs for v3 public API changes. 

## Implementation details

- Add `#nulable enable` to `public` interfaces
- Explicitly check for > 2 in WAF check
- Remove number of internal methods in `TestMethod` etc
- Check for trying to use negative numbers in `Version()`

## Test coverage

All covered by existing

## Other details
We _could_ merge these into the v2 branch I think. Technically the nullability attributes are public API changes though so thought it was safest to delay? 🤷 

Dependent of
- https://github.com/DataDog/dd-trace-dotnet/pull/5071
- https://github.com/DataDog/dd-trace-dotnet/pull/5072
- https://github.com/DataDog/dd-trace-dotnet/pull/5073

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
