### PR TITLE
Try play asm benchmark only on  appsec changed

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3153,8 +3153,12 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-    isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
-  condition: and(succeeded(), eq(variables.isMainRepository, true))
+  condition: >
+    and(
+      succeeded(),
+      eq(variables.isMainRepository, true),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True')
+    )
   dependsOn: [build_windows_tracer, build_windows_profiler, generate_variables, merge_commit_id]
   jobs:
     - template: steps/update-github-status-jobs.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3154,14 +3154,7 @@ stages:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
     isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
-  condition: and(
-    succeeded(), 
-    eq(variables.isMainRepository, true), 
-    or(
-        eq(variables.isAppSecChanged, 'True'), 
-        eq(variables.force_appsec_benchmarks_run, 'true')
-      )
-    )
+  condition: and(succeeded(), eq(variables.isMainRepository, true))
   dependsOn: [build_windows_tracer, build_windows_profiler, merge_commit_id]
   jobs:
     - template: steps/update-github-status-jobs.yml
@@ -3171,6 +3164,10 @@ stages:
     #### Windows
 
     - job: Windows
+      condition: or(
+          eq(variables.isAppSecChanged, 'True'),
+          eq(variables.force_appsec_benchmarks_run, 'true')
+        )
       strategy:
         matrix:
           BenchmarkAgent7:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3140,7 +3140,7 @@ stages:
     - publish: tracer/build_data/benchmarks
       artifact: benchmarks_results
 
-    - script: tracer\build.cmd CompareBenchmarksResults
+    - script: tracer\build.cmd CompareBenchmarksResults -BenchmarkCategory 'tracer'
       continueOnError: true
       displayName: Compare Benchmarks
       condition: and(succeeded(), eq(variables.isPullRequest, true))
@@ -3220,9 +3220,9 @@ stages:
         
         # upload the combined results for simplicity in other pipelines
         - publish: tracer/build_data/benchmarks
-          artifact: benchmarks_results
+          artifact: benchmarks_appsec_results
 
-        - script: tracer\build.cmd CompareBenchmarksResults
+        - script: tracer\build.cmd CompareBenchmarksResults -BenchmarkCategory 'appsec'
           continueOnError: true
           displayName: Compare AppSec Benchmarks
           condition: and(succeeded(), eq(variables.isPullRequest, true))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3204,6 +3204,10 @@ stages:
           artifact: benchmarks_results_$(agent)
 
     - job: compare_appsec_benchmarks
+      condition: or(
+        eq(variables.isAppSecChanged, 'True'),
+        eq(variables.force_appsec_benchmarks_run, 'true')
+        )
       timeoutInMinutes: 60 #default value
       dependsOn: [ Windows ]
       pool:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3150,11 +3150,19 @@ stages:
         GITHUB_TOKEN: $(GITHUB_TOKEN)
         
 - stage: appsec_benchmarks
-  condition: and(succeeded(), eq(variables.isMainRepository, true), or(eq(variables.isAppSecChanged, 'True'), eq(variables.force_appsec_benchmarks_run, 'true')))
+  condition: and(
+    succeeded(), 
+    eq(variables.isMainRepository, true), 
+    or(
+        eq(variables.isAppSecChanged, 'True'), 
+        eq(variables.force_appsec_benchmarks_run, 'true')
+      )
+    )
   dependsOn: [build_windows_tracer, build_windows_profiler, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3073,7 +3073,7 @@ stages:
         artifact: windows-profiler-home
         path: $(monitoringHome)
 
-    - script: tracer\build.cmd RunBenchmarks -BenchmarkCategory 'tracer'
+    - script: tracer\build.cmd RunBenchmarks -BenchmarkCategory tracer
       displayName: RunBenchmarks
       env:
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
@@ -3140,7 +3140,7 @@ stages:
     - publish: tracer/build_data/benchmarks
       artifact: benchmarks_results
 
-    - script: tracer\build.cmd CompareBenchmarksResults -BenchmarkCategory 'tracer'
+    - script: tracer\build.cmd CompareBenchmarksResults -BenchmarkCategory tracer
       continueOnError: true
       displayName: Compare Benchmarks
       condition: and(succeeded(), eq(variables.isPullRequest, true))
@@ -3192,7 +3192,7 @@ stages:
             artifact: windows-profiler-home
             path: $(monitoringHome)
 
-        - script: tracer\build.cmd RunBenchmarks -BenchmarkCategory 'appsec'
+        - script: tracer\build.cmd RunBenchmarks -BenchmarkCategory appsec
           displayName: RunAppSecBenchmarks
           env:
             DD_CIVISIBILITY_AGENTLESS_ENABLED: true
@@ -3227,7 +3227,7 @@ stages:
         - publish: tracer/build_data/benchmarks
           artifact: benchmarks_appsec_results
 
-        - script: tracer\build.cmd CompareBenchmarksResults -BenchmarkCategory 'appsec'
+        - script: tracer\build.cmd CompareBenchmarksResults -BenchmarkCategory appsec
           continueOnError: true
           displayName: Compare AppSec Benchmarks
           condition: and(succeeded(), eq(variables.isPullRequest, true))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3155,7 +3155,7 @@ stages:
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
     isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
   condition: and(succeeded(), eq(variables.isMainRepository, true))
-  dependsOn: [build_windows_tracer, build_windows_profiler, merge_commit_id]
+  dependsOn: [build_windows_tracer, build_windows_profiler, generate_variables, merge_commit_id]
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3150,6 +3150,10 @@ stages:
         GITHUB_TOKEN: $(GITHUB_TOKEN)
         
 - stage: appsec_benchmarks
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
   condition: and(
     succeeded(), 
     eq(variables.isMainRepository, true), 
@@ -3159,10 +3163,6 @@ stages:
       )
     )
   dependsOn: [build_windows_tracer, build_windows_profiler, merge_commit_id]
-  variables:
-    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
-    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-    isAppSecChanged: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.isAppSecChanged'] ]
   jobs:
     - template: steps/update-github-status-jobs.yml
       parameters:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3054,9 +3054,6 @@ stages:
           agent: "BenchmarkAgent5"
         BenchmarkAgent6:
           agent: "BenchmarkAgent6"
-        BenchmarkAgent7:
-          agent: "BenchmarkAgent7"
-
     timeoutInMinutes: 150
     pool:
       name: $(agent)
@@ -3076,7 +3073,7 @@ stages:
         artifact: windows-profiler-home
         path: $(monitoringHome)
 
-    - script: tracer\build.cmd RunBenchmarks
+    - script: tracer\build.cmd RunBenchmarks -BenchmarkCategory 'tracer'
       displayName: RunBenchmarks
       env:
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
@@ -3139,12 +3136,6 @@ stages:
         artifact: benchmarks_results_BenchmarkAgent6
         path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
 
-    - task: DownloadPipelineArtifact@2
-      displayName: Download results BenchmarkAgent7
-      inputs:
-        artifact: benchmarks_results_BenchmarkAgent7
-        path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
-
     # upload the combined results for simplicity in other pipelines
     - publish: tracer/build_data/benchmarks
       artifact: benchmarks_results
@@ -3157,6 +3148,88 @@ stages:
         PR_NUMBER: $(System.PullRequest.PullRequestNumber)
         AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
         GITHUB_TOKEN: $(GITHUB_TOKEN)
+        
+- stage: appsec_benchmarks
+  condition: and(succeeded(), eq(variables.isMainRepository, true), or(eq(variables.isAppSecChanged, 'True'), eq(variables.force_appsec_benchmarks_run, 'true')))
+  dependsOn: [build_windows_tracer, build_windows_profiler, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [Windows, compare_appsec_benchmarks]
+    
+    #### Windows
+
+    - job: Windows
+      strategy:
+        matrix:
+          BenchmarkAgent7:
+            agent: "BenchmarkAgent7"
+      
+      timeoutInMinutes: 150
+      pool:
+        name: $(agent)
+      
+      steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
+        - template: steps/install-dotnet-sdks.yml
+        - template: steps/restore-working-directory.yml
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download windows profiler home
+          inputs:
+            artifact: windows-profiler-home
+            path: $(monitoringHome)
+
+        - script: tracer\build.cmd RunBenchmarks -BenchmarkCategory 'appsec'
+          displayName: RunAppSecBenchmarks
+          env:
+            DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+            DD_PROFILING_ENABLED: true
+            DD_API_KEY: $(ddApiKey)
+            DD_DOTNET_TRACER_HOME: $(monitoringHome)
+
+        - publish: tracer/build_data/benchmarks
+          artifact: benchmarks_results_$(agent)
+
+    - job: compare_appsec_benchmarks
+      timeoutInMinutes: 60 #default value
+      dependsOn: [ Windows ]
+      pool:
+        vmImage: windows-2022
+      
+      steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
+        - template: steps/install-latest-dotnet-sdk.yml
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download results BenchmarkAgent7
+          inputs:
+            artifact: benchmarks_results_BenchmarkAgent7
+            path: $(System.DefaultWorkingDirectory)/tracer/build_data/benchmarks
+        
+        # upload the combined results for simplicity in other pipelines
+        - publish: tracer/build_data/benchmarks
+          artifact: benchmarks_results
+
+        - script: tracer\build.cmd CompareBenchmarksResults
+          continueOnError: true
+          displayName: Compare AppSec Benchmarks
+          condition: and(succeeded(), eq(variables.isPullRequest, true))
+          env:
+            PR_NUMBER: $(System.PullRequest.PullRequestNumber)
+            AZURE_DEVOPS_TOKEN: $(AZURE_DEVOPS_TOKEN)
+            GITHUB_TOKEN: $(GITHUB_TOKEN)
 
 - stage: dotnet_tool
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3157,7 +3157,7 @@ stages:
     and(
       succeeded(),
       eq(variables.isMainRepository, true),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True')
+      or(eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.isAppSecChanged'], 'True'), eq(variables.force_appsec_benchmarks_run, 'true'))
     )
   dependsOn: [build_windows_tracer, build_windows_profiler, generate_variables, merge_commit_id]
   jobs:
@@ -3168,10 +3168,6 @@ stages:
     #### Windows
 
     - job: Windows
-      condition: or(
-          eq(variables.isAppSecChanged, 'True'),
-          eq(variables.force_appsec_benchmarks_run, 'true')
-        )
       strategy:
         matrix:
           BenchmarkAgent7:
@@ -3208,10 +3204,6 @@ stages:
           artifact: benchmarks_results_$(agent)
 
     - job: compare_appsec_benchmarks
-      condition: or(
-        eq(variables.isAppSecChanged, 'True'),
-        eq(variables.force_appsec_benchmarks_run, 'true')
-        )
       timeoutInMinutes: 60 #default value
       dependsOn: [ Windows ]
       pool:

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -26,6 +26,10 @@
           "type": "integer",
           "description": "The specific Azure DevOps Build ID to use"
         },
+        "BenchmarkCategory": {
+          "type": "string",
+          "description": "Override the default category filter for running benchmarks. (Optional)"
+        },
         "BuildConfiguration": {
           "type": "string",
           "description": "Configuration to build - Default is 'Release'",

--- a/tracer/build/_build/BenchmarkComparison/BenchmarkMarkdownGenerator.cs
+++ b/tracer/build/_build/BenchmarkComparison/BenchmarkMarkdownGenerator.cs
@@ -19,10 +19,10 @@ namespace BenchmarkComparison
     {
         private const int ShowTopNResults = 10;
 
-        public static string GetMarkdown(List<MatchedSummary> comparison, string oldBranchMarkdown, string newBranchMarkdown)
+        public static string GetMarkdown(List<MatchedSummary> comparison, string oldBranchMarkdown, string newBranchMarkdown, string category)
         {
             var sb = new StringBuilder(
-                $@"## Benchmarks Report :snail:
+                $@"## Benchmarks Report for {category} :snail:
 
 Benchmarks for {newBranchMarkdown} compared to {oldBranchMarkdown}: 
 ");

--- a/tracer/build/_build/BenchmarkComparison/CompareBenchmarks.cs
+++ b/tracer/build/_build/BenchmarkComparison/CompareBenchmarks.cs
@@ -8,7 +8,7 @@ namespace BenchmarkComparison
 {
     public static class CompareBenchmarks
     {
-        public static string GetMarkdown(string masterDir, string prDir, int prNumber, string oldCommit, string repositoryName)
+        public static string GetMarkdown(string masterDir, string prDir, int prNumber, string oldCommit, string repositoryName, string category)
         {
             var oldBranchMarkdown = $"[master](https://github.com/DataDog/{repositoryName}/tree/{oldCommit})";
             var newBranchMarkdown = $"#{prNumber}";
@@ -18,7 +18,7 @@ namespace BenchmarkComparison
 
             var comparison = BenchmarkComparer.MatchAndCompareResults(baseJsonResults, prJsonResults);
 
-            return BenchmarkMarkdownGenerator.GetMarkdown(comparison, oldBranchMarkdown, newBranchMarkdown);
+            return BenchmarkMarkdownGenerator.GetMarkdown(comparison, oldBranchMarkdown, newBranchMarkdown, category);
         }
     }
 }

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -910,7 +910,7 @@ partial class Build
 
              var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, oldBuild.SourceVersion, GitHubRepositoryName);
 
-             await ReplaceCommentInPullRequest(prNumber, $"## Benchmarks Report for {BenchmarkCategory}", markdown);
+             await ReplaceCommentInPullRequest(prNumber, $"## Benchmarks Report", markdown);
          });
 
     Target CompareThroughputResults => _ => _

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1247,29 +1247,26 @@ partial class Build
         foreach (var build in completedBuilds.OrderByDescending(x => x.Id).ThenByDescending(x=>x.FinishTime))
         {
             var artifactsName = getArtifactsName(build);
-            try
+
+            foreach (var artifactName in artifactsName)
             {
-                foreach (var artifactName in artifactsName)
+                try
                 {
                     var artifact = await buildHttpClient.GetArtifactAsync(
-                                   project: AzureDevopsProjectId,
-                                   buildId: build.Id,
-                                   artifactName: artifactName);
-
-                    if (artifact is null)
-                    {
-                        continue;
-                    }
+                                       project: AzureDevopsProjectId,
+                                       buildId: build.Id,
+                                       artifactName: artifactName);
                     artifacts.Add(artifact);
-                }   
+                }
+                catch (ArtifactNotFoundException)
+                {
+                    Console.WriteLine($"Could not find {artifactName} artifact for build {build.Id}. Skipping");
+                }
+            }   
 
-                artifactBuild = build;
-                break;
-            }
-            catch (ArtifactNotFoundException)
-            {
-                Console.WriteLine($"Could not find {string.Join(',', artifactsName)} artifact for build {build.Id}. Skipping");
-            }
+            artifactBuild = build;
+            break;
+        
         }
 
         if (artifacts.Count == 0)

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1249,6 +1249,11 @@ partial class Build
                                    project: AzureDevopsProjectId,
                                    buildId: build.Id,
                                    artifactName: artifactName);
+
+                    if (artifact is null)
+                    {
+                        continue;
+                    }
                     artifacts.Add(artifact);
                 }   
 

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -898,9 +898,10 @@ partial class Build
              {
                  case  "tracer": artifactName = "benchmarks_results"; break;
                  case  "appsec": artifactName = "benchmarks_appsec_results"; break;
+                 default: Logger.Warning("Unknown benchmark category {BenchmarkCategory}. Skipping comparison", BenchmarkCategory); break;
              }
 
-             var (oldBuild, _) = await FindAndDownloadAzureArtifact(buildHttpClient, "refs/heads/master", build => artifactName, masterDir, buildReason: null);
+             var (oldBuild, _) = await FindAndDownloadAzureArtifact(buildHttpClient, "refs/heads/master", _ => artifactName, masterDir, buildReason: null);
 
              if (oldBuild is null)
              {

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -873,6 +873,7 @@ partial class Build
          .Requires(() => AzureDevopsToken)
          .Requires(() => GitHubRepositoryName)
          .Requires(() => GitHubToken)
+         .Requires(()=>BenchmarkCategory)
          .Executes(async () =>
          {
              if (!int.TryParse(Environment.GetEnvironmentVariable("PR_NUMBER"), out var prNumber))
@@ -884,7 +885,7 @@ partial class Build
              var masterDir = BuildDataDirectory / "previous_benchmarks";
              var prDir = BuildDataDirectory / "benchmarks";
 
-             FileSystemTasks.EnsureCleanDirectory(masterDir);
+             EnsureCleanDirectory(masterDir);
 
              // Connect to Azure DevOps Services
              var connection = new VssConnection(
@@ -893,11 +894,11 @@ partial class Build
 
              using var buildHttpClient = connection.GetClient<BuildHttpClient>();
 
-             var (oldBuild, _) = await FindAndDownloadAzureArtifact(buildHttpClient, "refs/heads/master", build => "benchmarks_results", masterDir, buildReason: null);
+             var (oldBuild, _) = await FindAndDownloadAzureArtifacts(buildHttpClient, "refs/heads/master", build => { return new [] { "benchmarks_results", "benchmarks_appsec_results" }; }, masterDir, buildReason: null);
 
              var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, oldBuild.SourceVersion, GitHubRepositoryName);
 
-             await ReplaceCommentInPullRequest(prNumber, "## Benchmarks Report", markdown);
+             await ReplaceCommentInPullRequest(prNumber, $"## Benchmarks Report for {BenchmarkCategory}", markdown);
          });
 
     Target CompareThroughputResults => _ => _
@@ -1185,7 +1186,19 @@ partial class Build
     async Task<(Microsoft.TeamFoundation.Build.WebApi.Build, BuildArtifact)> FindAndDownloadAzureArtifact(
         BuildHttpClient buildHttpClient,
         string branch,
-        Func<Microsoft.TeamFoundation.Build.WebApi.Build, string> getArtifactName,
+        Func<Microsoft.TeamFoundation.Build.WebApi.Build, string> getArtifactsName,
+        AbsolutePath outputDirectory,
+        BuildReason? buildReason = BuildReason.IndividualCI,
+        bool completedBuildsOnly = true)
+    {
+        var result = await FindAndDownloadAzureArtifacts(buildHttpClient, branch, a => new[] { getArtifactsName(a) }, outputDirectory, buildReason, completedBuildsOnly);
+        return (result.Item1, result.Item2.FirstOrDefault());
+    }
+
+    async Task<(Microsoft.TeamFoundation.Build.WebApi.Build, BuildArtifact[])> FindAndDownloadAzureArtifacts(
+        BuildHttpClient buildHttpClient,
+        string branch,
+        Func<Microsoft.TeamFoundation.Build.WebApi.Build, string[]> getArtifactsName,
         AbsolutePath outputDirectory,
         BuildReason? buildReason = BuildReason.IndividualCI,
         bool completedBuildsOnly = true)
@@ -1212,7 +1225,7 @@ partial class Build
         }
 
         var successfulBuilds = completedBuilds
-                              .Where(x => x.Result == BuildResult.Succeeded || x.Result == BuildResult.PartiallySucceeded)
+                              .Where(x => x.Result is BuildResult.Succeeded or BuildResult.PartiallySucceeded)
                               .ToList();
 
         if (!successfulBuilds.Any())
@@ -1223,33 +1236,41 @@ partial class Build
 
         Console.WriteLine($"Found {completedBuilds.Count} completed builds for {branch}. Looking for artifacts...");
 
-        BuildArtifact artifact = null;
+        var artifacts = new List<BuildArtifact>();
         Microsoft.TeamFoundation.Build.WebApi.Build artifactBuild = null;
         foreach (var build in completedBuilds.OrderByDescending(x => x.Id).ThenByDescending(x=>x.FinishTime))
         {
-            var artifactName = getArtifactName(build);
+            var artifactsName = getArtifactsName(build);
             try
             {
-                artifact = await buildHttpClient.GetArtifactAsync(
-                               project: AzureDevopsProjectId,
-                               buildId: build.Id,
-                               artifactName: artifactName);
+                foreach (var artifactName in artifactsName)
+                {
+                    var artifact = await buildHttpClient.GetArtifactAsync(
+                                   project: AzureDevopsProjectId,
+                                   buildId: build.Id,
+                                   artifactName: artifactName);
+                    artifacts.Add(artifact);
+                }   
+
                 artifactBuild = build;
                 break;
             }
             catch (ArtifactNotFoundException)
             {
-                Console.WriteLine($"Could not find {artifactName} artifact for build {build.Id}. Skipping");
+                Console.WriteLine($"Could not find {string.Join(',', artifactsName)} artifact for build {build.Id}. Skipping");
             }
         }
 
-        if (artifact is null)
+        if (artifacts.Count == 0)
         {
             throw new Exception($"Error: no artifacts available for {branch}");
         }
 
-        await DownloadAzureArtifact(outputDirectory, artifact, AzureDevopsToken);
-        return (artifactBuild, artifact);
+        foreach (var artifact in artifacts)
+        {
+            await DownloadAzureArtifact(outputDirectory, artifact, AzureDevopsToken);
+        }
+        return (artifactBuild, artifacts.ToArray());
     }
 
     static async Task DownloadAzureArtifact(AbsolutePath outputDirectory, BuildArtifact artifact, string token)

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -908,9 +908,9 @@ partial class Build
                     return;
              }
 
-             var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, oldBuild.SourceVersion, GitHubRepositoryName);
+             var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, oldBuild.SourceVersion, GitHubRepositoryName, BenchmarkCategory);
 
-             await ReplaceCommentInPullRequest(prNumber, $"## Benchmarks Report", markdown);
+             await ReplaceCommentInPullRequest(prNumber, $"## Benchmarks Report for " + BenchmarkCategory, markdown);
          });
 
     Target CompareThroughputResults => _ => _

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -896,6 +896,12 @@ partial class Build
 
              var (oldBuild, _) = await FindAndDownloadAzureArtifacts(buildHttpClient, "refs/heads/master", build => { return new [] { "benchmarks_results", "benchmarks_appsec_results" }; }, masterDir, buildReason: null);
 
+             if (oldBuild is null)
+             {
+                    Logger.Warning("Old build is null");
+                    return;
+             }
+
              var markdown = CompareBenchmarks.GetMarkdown(masterDir, prDir, prNumber, oldBuild.SourceVersion, GitHubRepositoryName);
 
              await ReplaceCommentInPullRequest(prNumber, $"## Benchmarks Report for {BenchmarkCategory}", markdown);

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -76,6 +76,9 @@ partial class Build : NukeBuild
     [Parameter("Override the default test filters for integration tests. (Optional)")]
     readonly string Filter;
 
+    [Parameter("Override the default category filter for running benchmarks. (Optional)")]
+    readonly string BenchmarkCategory;
+
     [Parameter("Enables code coverage")]
     readonly bool CodeCoverage;
 
@@ -516,7 +519,7 @@ partial class Build : NukeBuild
                     .SetFramework(framework)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --iterationTime 2000")
+                    .SetApplicationArguments($"-r {runtimes} -m -f {Filter ?? "*"} --anyCategories {BenchmarkCategory ?? "tracer"} --iterationTime 2000")
                     .SetProcessEnvironmentVariable("DD_SERVICE", "dd-trace-dotnet")
                     .SetProcessEnvironmentVariable("DD_ENV", "CI")
                     .SetProcessEnvironmentVariable("DD_DOTNET_TRACER_HOME", MonitoringHome)

--- a/tracer/test/benchmarks/Benchmarks.Trace/ActivityBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ActivityBenchmark.cs
@@ -21,6 +21,7 @@ namespace Benchmarks.Trace;
 
 [MemoryDiagnoser]
 [BenchmarkAgent6]
+[BenchmarkCategory(Constants.TracerCategory)]
 public class ActivityBenchmark
 {
     private const string SourceName = "BenchmarkSource";

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -14,6 +14,8 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent1]
+    [BenchmarkCategory(Constants.TracerCategory)]
+
     public class AgentWriterBenchmark
     {
         private const int SpanCount = 1000;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -23,7 +23,7 @@ using Microsoft.AspNetCore.Http.Features;
 namespace Benchmarks.Trace.Asm
 {
     [MemoryDiagnoser]
-    [BenchmarkAgent2]
+    [BenchmarkAgent7]
     [BenchmarkCategory(Constants.AppSecCategory)]
     public class AppSecBodyBenchmark
     {

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -24,6 +24,7 @@ namespace Benchmarks.Trace.Asm
 {
     [MemoryDiagnoser]
     [BenchmarkAgent2]
+    [BenchmarkCategory(Constants.AppSecCategory)]
     public class AppSecBodyBenchmark
     {
         private static readonly Security _security;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -17,6 +17,7 @@ namespace Benchmarks.Trace.Asm;
 
 [MemoryDiagnoser]
 [BenchmarkAgent7]
+[BenchmarkCategory(Constants.AppSecCategory)]
 public class AppSecWafBenchmark
 {
     private const int TimeoutMicroSeconds = 1_000_000;

--- a/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -18,7 +18,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent1]    
-    [BenchmarkCategory("tracer")]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class AspNetCoreBenchmark
     {
         private static readonly HttpClient Client;

--- a/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AspNetCoreBenchmark.cs
@@ -17,7 +17,8 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
-    [BenchmarkAgent1]
+    [BenchmarkAgent1]    
+    [BenchmarkCategory("tracer")]
     public class AspNetCoreBenchmark
     {
         private static readonly HttpClient Client;

--- a/tracer/test/benchmarks/Benchmarks.Trace/CIVisibilityProtocolWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/CIVisibilityProtocolWriterBenchmark.cs
@@ -10,6 +10,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent1]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class CIVisibilityProtocolWriterBenchmark
     {
         private const int SpanCount = 1000;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Constants.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Constants.cs
@@ -1,0 +1,7 @@
+namespace Benchmarks.Trace;
+
+public class Constants
+{
+    public const string TracerCategory = "tracer";
+    public const string AppSecCategory = "appsec";
+}

--- a/tracer/test/benchmarks/Benchmarks.Trace/DbCommandBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/DbCommandBenchmark.cs
@@ -9,6 +9,8 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent1]
+    [BenchmarkCategory(Constants.TracerCategory)]
+
     public class DbCommandBenchmark
     {
         private static readonly CustomDbCommand CustomCommand = new CustomDbCommand();

--- a/tracer/test/benchmarks/Benchmarks.Trace/ElasticsearchBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ElasticsearchBenchmark.cs
@@ -11,6 +11,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent5]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class ElasticsearchBenchmark
     {
         private static readonly RequestPipeline Pipeline = new RequestPipeline();

--- a/tracer/test/benchmarks/Benchmarks.Trace/GraphQLBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/GraphQLBenchmark.cs
@@ -10,6 +10,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent3]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class GraphQLBenchmark
     {
         private static readonly Task<ExecutionResult> Result = Task.FromResult(new ExecutionResult { Value = 42 });

--- a/tracer/test/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/HttpClientBenchmark.cs
@@ -11,6 +11,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent3]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class HttpClientBenchmark
     {
         private static readonly HttpRequestMessage HttpRequest = new HttpRequestMessage { RequestUri = new Uri("http://datadoghq.com") };

--- a/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ILoggerBenchmark.cs
@@ -13,6 +13,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent4]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class ILoggerBenchmark
     {
         private static readonly Tracer LogInjectionTracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -19,6 +19,7 @@ namespace Benchmarks.Trace.Iast;
 
 [MemoryDiagnoser]
 [BenchmarkAgent7]
+[BenchmarkCategory(Constants.AppSecCategory)]
 public class StringAspectsBenchmark
 {
     private const int TimeoutMicroSeconds = 1_000_000;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Log4netBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Log4netBenchmark.cs
@@ -14,6 +14,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent4]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class Log4netBenchmark
     {
         private static readonly Tracer LogInjectionTracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/NLogBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/NLogBenchmark.cs
@@ -11,6 +11,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent3]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class NLogBenchmark
     {
         private static readonly Tracer LogInjectionTracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/RedisBenchmark.cs
@@ -11,6 +11,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent4]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class RedisBenchmark
     {
         private static readonly RedisNativeClient Client = new RedisNativeClient();

--- a/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/SerilogBenchmark.cs
@@ -17,6 +17,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent5]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class SerilogBenchmark
     {
         private static readonly Logger Logger;

--- a/tracer/test/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/SpanBenchmark.cs
@@ -11,6 +11,7 @@ namespace Benchmarks.Trace
     /// </summary>
     [MemoryDiagnoser]
     [BenchmarkAgent6]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class SpanBenchmark
     {
         private static readonly Tracer Tracer;

--- a/tracer/test/benchmarks/Benchmarks.Trace/TraceAnnotationsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/TraceAnnotationsBenchmark.cs
@@ -9,6 +9,7 @@ namespace Benchmarks.Trace
 {
     [MemoryDiagnoser]
     [BenchmarkAgent6]
+    [BenchmarkCategory(Constants.TracerCategory)]
     public class TraceAnnotationsBenchmark
     {
         private static readonly RuntimeMethodHandle MethodHandle;


### PR DESCRIPTION
## Summary of changes

Only play appsec benchmarks when appsec file is changed or a variable is forced. 

## Reason for change
appsec benchmarks can take a long time to play and are not necessary when changes don't relate with it 

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
