### PR TITLE
[Dynamic Instrumentation] Skip dynamic modules when instrumenting all

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
@@ -114,7 +114,7 @@ void DebuggerProbesInstrumentationRequester::PerformInstrumentAllIfNeeded(const 
     const auto& module_info = GetModuleInfo(m_corProfiler->info_, module_id);
     const auto assembly_name = module_info.assembly.name;
 
-    if (!IsCoreLibOr3rdParty(assembly_name))
+    if (!IsCoreLibOr3rdParty(assembly_name) && !module_info.IsDynamic())
     {
         ComPtr<IUnknown> metadataInterfaces;
         auto hr = m_corProfiler->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,


### PR DESCRIPTION
## Summary of changes

When all instrumentation is enabled, we try to instrument dynamic modules but they can't be rejitted (https://learn.microsoft.com/en-us/dotnet/framework/unmanaged-api/profiling/icorprofilercallback4-rejiterror-method#status-hresults)

## Reason for change

Just cleaning up some rejit errors.