### PR TITLE
Update PublishAotCompressed and enable LZMA compression

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -34,9 +34,7 @@
 
     <StripSymbols>true</StripSymbols>
 
-    <!-- Don't enable LZMA on Linux because it randomly crashes with exit code 127
-         We should check the UPX changelog whenever we upgrade to see if there's any relevant fix -->
-    <PublishLzmaCompressed Condition="'$(RuntimeIdentifier)' == 'win-x64'">true</PublishLzmaCompressed>    
+    <PublishLzmaCompressed>true</PublishLzmaCompressed>    
 
   </PropertyGroup>
 
@@ -71,7 +69,7 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="PublishAotCompressed" Version="1.0.2" />
+    <PackageReference Include="PublishAotCompressed" Version="1.0.3" />
     <PackageReference Include="StrongNamer" Version="0.2.5" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of changes

Update PublishAotCompressed and enable LZMA compression for dd-dotnet.

## Reason for change

We had to disable LZMA compression on Linux because of a bug in UPX. It should be fixed now: https://github.com/upx/upx/issues/717
