### PR TITLE
[v3] Create a new Datadog.Trace.Manual project

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -563,6 +563,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LogsInjection.ILogger.Exten
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Samples.Yarp.DistributedTracing", "tracer\test\test-applications\integrations\Samples.Yarp.DistributedTracing\Samples.Yarp.DistributedTracing.csproj", "{E10243AE-34FC-47B5-B898-B5203C36920C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.Manual", "tracer\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj", "{D18A4340-268E-4EAA-8603-38EA998EBDF2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1347,6 +1349,10 @@ Global
 		{E10243AE-34FC-47B5-B898-B5203C36920C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E10243AE-34FC-47B5-B898-B5203C36920C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E10243AE-34FC-47B5-B898-B5203C36920C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D18A4340-268E-4EAA-8603-38EA998EBDF2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D18A4340-268E-4EAA-8603-38EA998EBDF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D18A4340-268E-4EAA-8603-38EA998EBDF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D18A4340-268E-4EAA-8603-38EA998EBDF2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1566,6 +1572,7 @@ Global
 		{F24EB026-65FB-4247-ABF8-942B11ADAB64} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{483A27EE-7682-417C-9FCA-C2171C13F693} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{E10243AE-34FC-47B5-B898-B5203C36920C} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{D18A4340-268E-4EAA-8603-38EA998EBDF2} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -447,6 +447,7 @@ partial class Build
                 "tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj",
                 "tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj",
                 "tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs",
+                "tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj",
                 "tracer/src/Datadog.Tracer.Native/CMakeLists.txt",
                 "tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h",
                 "tracer/src/Datadog.Tracer.Native/Resource.rc",

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -156,7 +156,7 @@ partial class Build
 
     IEnumerable<Project> ProjectsToPack => new[]
     {
-        Solution.GetProject(Projects.DatadogTrace),
+        Solution.GetProject(Projects.DatadogTraceManual),
         Solution.GetProject(Projects.DatadogTraceOpenTracing),
         Solution.GetProject(Projects.DatadogTraceAnnotations),
         Solution.GetProject(Projects.DatadogTraceTrimming),

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -266,6 +266,10 @@ namespace PrepareRelease
                     NugetVersionReplace);
 
                 SynchronizeVersion(
+                    "src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj",
+                    NugetVersionReplace);
+
+                SynchronizeVersion(
                     "src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj",
                     NugetVersionReplace);
 

--- a/tracer/build/_build/Projects.cs
+++ b/tracer/build/_build/Projects.cs
@@ -1,6 +1,7 @@
 public static class Projects
 {
     public const string DatadogTrace = "Datadog.Trace";
+    public const string DatadogTraceManual = "Datadog.Trace.Manual";
     public const string ManagedLoader = "Datadog.Trace.ClrProfiler.Managed.Loader";
     public const string DatadogTraceAnnotations = "Datadog.Trace.Annotations";
     public const string DatadogTraceAspNet = "Datadog.Trace.AspNet";

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- NuGet -->
+    <Version>3.0.0-prerelease</Version>
+    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <PackageId>Datadog.Trace</PackageId>
+    <Title>Datadog APM</Title>
+    <Description>Instrumentation library for Datadog APM.</Description>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RootNamespace>Datadog.Trace</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\docs\Datadog.Trace\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+</Project>

--- a/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
+++ b/tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
@@ -22,3 +22,4 @@
   </ItemGroup>
 
 </Project>
+  


### PR DESCRIPTION
## Summary of changes

- Adds a new project Datadog.Trace.Manual which provides the public API surface in v3
- Update the build to use Datadog.Trace.Manual instead of Datadog.Trace in the Datadog.Trace NuGet
- Doesn't add any implementation to Datadog.Trace.Manual yet

## Reason for change

This is the initial pre-requisite work to start testing with Datadog.Trace.Manual. This potentially _shouldn't_ be in its own PR, I just wanted to separate the build and project faff from the actual implementation for reviewing purposes

> ~~What do we think about the name Datadog.Trace.Custom (i.e. custom instrumentation). The dll name won't be exposed to customers, so it's not a big deal, but we should try to agree on something 😅~~ Renamed to Datadog.Trace.Manual

## Implementation details

With the new design, the Datadog.Trace.Manual dll is packaged in the Datadog.Trace NuGet package. This naming is inconvenient in some ways, but it's just the way it is (as we have a lot of additional code tied to the Datadog.Trace name).

Datadog.Trace.Manual only targets 3 TFMs:
- `net461`
- `netstandard2.0`
- `netcoreapp3.1`

This maintains compatibility with our existing TFMs, but drops `net6.0` as unnecessary. 

> We will still have the net6.0 specialization in Datadog.Trace.dll, but there's no benefit to having it in Datadog.Trace.Custom.dll

Updated the Datadog.Trace.Bundle project to point to Datadog.Trace.Manual (so that the NuGet package references are maintained correctly).

## Test coverage

There's not really much to test here - I expect _something_ will break though 😅 The subsequent PR adds the implementation though, which should fix any issues

## Other details

The contents of the Datadog.Trace NuGet will look like this:

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/c9b5c450-993e-43b2-bb26-36f87768703f)

Stacked on
- https://github.com/DataDog/dd-trace-dotnet/pull/5065

Dependent of
- https://github.com/DataDog/dd-trace-dotnet/pull/5072
- https://github.com/DataDog/dd-trace-dotnet/pull/5073



<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
