### PR TITLE
Fix failing GraphQL tests on .NET Core 2.1 on alpine

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
+++ b/tracer/test/test-applications/integrations/Samples.GraphQL/Samples.GraphQL.csproj
@@ -5,8 +5,7 @@
     <PackageReference Include="GraphQL.StarWars" Version="1.0.0" />
     <PackageReference Include="GraphQL.Server.Transports.AspNetCore" Version="3.4.0" />
     <PackageReference Include="GraphQL.Server.Ui.Playground" Version="3.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.7" />
   </ItemGroup>
 
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.HotChocolate/Samples.HotChocolate.csproj
+++ b/tracer/test/test-applications/integrations/Samples.HotChocolate/Samples.HotChocolate.csproj
@@ -16,7 +16,6 @@
   
   <ItemGroup>
     <PackageReference Include="HotChocolate.AspNetCore" Version="$(ApiVersion)" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary of changes

Bump the version of Microsoft.AspNetCore used to workaround a segfault in libuv

## Reason for change

When we increased the size of the CI runners we somehow inadvertently started triggering a segfault in libuv, which _only_ happened on .NET Core 2.1 no alpine, on the GraphQL2 tests

## Implementation details

Kevin identified it as a segfault in libuv but [the symbols aren't available](https://github.com/aspnet/libuv-build/issues/35), so we couldn't do much more. But then we noticed this is the only app running with 2.0.0, and bumping it fixed it so 🤷 

## Test coverage

This should fix it

## Other details
I noticed that HotChocolate also uses 2.0.0, although as that doesn't target .NET Core 2.1, I think it's a bug, so removed it entirely.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
