### PR TITLE
Add more async in tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -59,7 +59,7 @@ public abstract class AzureFunctionsTests : TestHelper
 
         using var helper = new ProcessHelper(process);
 
-        return WaitForProcessResult(helper, expectedExitCode);
+        return await WaitForProcessResult(helper, expectedExitCode);
     }
 
     protected async Task AssertInProcessSpans(IImmutableList<MockSpan> spans)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/LoaderOptimizationStartup.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/LoaderOptimizationStartup.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.IIS
                     break;
                 }
 
-                Thread.Sleep(intervalMilliseconds);
+                await Task.Delay(intervalMilliseconds);
             }
 
             // Server is ready to receive requests

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/SmokeTestBase.cs
@@ -85,7 +85,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
                 {
                     using var helper = new ProcessHelper(process);
 
-                    var ranToCompletion = process.WaitForExit(MaxTestRunMilliseconds) && helper.Drain(MaxTestRunMilliseconds / 2);
+                    var ranToCompletion = await process.WaitForExitAsync(MaxTestRunMilliseconds) && await helper.Drain(MaxTestRunMilliseconds / 2);
                     var standardOutput = helper.StandardOutput;
                     standardError = helper.ErrorOutput;
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerSampleProcessHelper.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerSampleProcessHelper.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Debugger.IntegrationTests.Helpers
         {
             using var httpWebResponse = await WebRequest.CreateHttp(_stopUrl).GetResponseAsync();
             var timeout = 10_000;
-            var isExited = Process.WaitForExit(timeout);
+            var isExited = await Process.WaitForExitAsync(timeout);
 
             if (!isExited)
             {

--- a/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/DiagnosticListeners/AspNetCoreDiagnosticObserverTests.cs
@@ -459,15 +459,15 @@ namespace Datadog.Trace.IntegrationTests.DiagnosticListeners
                 // This gives time for the Stop event to run and to be flushed to the writer
                 const int timeoutInMilliseconds = 30_000;
 
-                var deadline = DateTime.Now.AddMilliseconds(timeoutInMilliseconds);
-                while (DateTime.Now < deadline)
+                var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
+                while (DateTime.UtcNow < deadline)
                 {
                     if (writer.Traces.Count > 0)
                     {
                         break;
                     }
 
-                    Thread.Sleep(200);
+                    await Task.Delay(200);
                 }
             }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -123,7 +123,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             // tracing module and mvc actions
             await TestRateLimiter(_enableSecurity, url, _iisFixture.Agent, _traceRateLimit.GetValueOrDefault(100), totalRequests, 2);
             // have to wait a second for the rate limiter to reset (or restart iis express completely)
-            Thread.Sleep(1000);
+            await Task.Delay(1000);
         }
 
         public async Task InitializeAsync()

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/AspNetCoreTestFixture.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace.TestHelpers
                 WriteToOutput($"Starting aspnetcore sample, agentPort: {Agent.Port}");
                 Process = await helper.StartSample(Agent, arguments: null, packageVersion: packageVersion, aspNetCorePort: 0, enableSecurity: enableSecurity, externalRulesFile: externalRulesFile);
 
-                var mutex = new ManualResetEventSlim();
+                var mutex = new AsyncMutex();
 
                 int? port = null;
 
@@ -120,7 +120,7 @@ namespace Datadog.Trace.TestHelpers
                 Process.BeginOutputReadLine();
                 Process.BeginErrorReadLine();
 
-                if (!mutex.Wait(TimeSpan.FromSeconds(60)))
+                if (!await mutex.WaitAsync(TimeSpan.FromSeconds(60)))
                 {
                     WriteToOutput("Timeout while waiting for the proces to start");
                 }

--- a/tracer/test/Datadog.Trace.TestHelpers/AsyncMutex.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/AsyncMutex.cs
@@ -1,0 +1,41 @@
+// <copyright file="AsyncMutex.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.TestHelpers;
+
+/// <summary>
+/// Simple wrapper around TaskCompletionSource
+/// </summary>
+public class AsyncMutex
+{
+    private readonly TaskCompletionSource<bool> _tcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public void Set() => _tcs.TrySetResult(true);
+
+    public Task WaitAsync() => WaitAsync(Timeout.InfiniteTimeSpan);
+
+    public async Task<bool> WaitAsync(TimeSpan timeout)
+    {
+        if (timeout == Timeout.InfiniteTimeSpan)
+        {
+            await _tcs.Task;
+            return true;
+        }
+
+#if NET8_0_OR_GREATER
+        await _tcs.Task.WaitAsync(timeout);
+        return _tcs.Task.IsCompleted;
+#else
+        var delay = Task.Delay(timeout);
+        var completedTask = await Task.WhenAny(_tcs.Task, delay);
+
+        return completedTask == _tcs.Task;
+#endif
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/ProcessExtensions.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProcessExtensions.cs
@@ -1,0 +1,31 @@
+// <copyright file="ProcessExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.TestHelpers;
+
+public static class ProcessExtensions
+{
+    public static async Task<bool> WaitForExitAsync(this Process process, int milliseconds = Timeout.Infinite)
+    {
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        process.Exited += (_, _) => tcs.TrySetResult(true);
+        process.EnableRaisingEvents = true;
+
+        if (milliseconds == Timeout.Infinite)
+        {
+            await tcs.Task;
+            return true;
+        }
+
+        var completedTask = await Task.WhenAny(tcs.Task, Task.Delay(milliseconds));
+
+        return completedTask == tcs.Task;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.TestHelpers
              && Path.GetExtension(executable) == ".exe"
              && !ExesToExcludeFromCorflags.Contains(Path.GetFileNameWithoutExtension(executable)))
             {
-                SetCorFlags(executable, agent.Output, !EnvironmentTools.IsTestTarget64BitProcess());
+                await SetCorFlags(executable, agent.Output, !EnvironmentTools.IsTestTarget64BitProcess());
             }
 
             var startInfo = new ProcessStartInfo(executable, $"{arguments ?? string.Empty}");
@@ -87,7 +87,7 @@ namespace Datadog.Trace.TestHelpers
             return Process.Start(startInfo);
         }
 
-        public static void SetCorFlags(string executable, ITestOutputHelper output, bool require32Bit)
+        public static async Task SetCorFlags(string executable, ITestOutputHelper output, bool require32Bit)
         {
             var corFlagsExe = _corFlagsExe;
             var setBit = require32Bit ? "/32BITREQ+" : "/32BITREQ-";
@@ -131,7 +131,7 @@ namespace Datadog.Trace.TestHelpers
                 UseShellExecute = false
             };
 
-            var executedSuccessfully = Process.Start(opts).WaitForExit(20_000);
+            var executedSuccessfully = await Process.Start(opts).WaitForExitAsync(20_000);
 
             if (!executedSuccessfully)
             {

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/CheckCommandTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -12,12 +13,12 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests;
 public class CheckCommandTests : RunnerTests
 {
     [SkippableFact]
-    public void Help()
+    public async Task Help()
     {
         using var helper = StartProcess("check");
 
-        helper.Process.WaitForExit();
-        helper.Drain();
+        await helper.Process.WaitForExitAsync();
+        await helper.Drain();
 
         helper.Process.ExitCode.Should().Be(1);
         helper.StandardOutput.Should().Contain("dd-trace check [command] [options]");
@@ -25,15 +26,15 @@ public class CheckCommandTests : RunnerTests
     }
 
     [SkippableFact]
-    public void MultipleArguments()
+    public async Task MultipleArguments()
     {
         // Currently we can only test this one Windows.
         // The only command that accepts a space is "check iis" and it's not available on Linux.
         SkipOn.Platform(SkipOn.PlatformValue.Linux);
         using var helper = StartProcess("check iis \"hello world\"");
 
-        helper.Process.WaitForExit();
-        helper.Drain();
+        await helper.Process.WaitForExitAsync();
+        await helper.Drain();
 
         helper.Process.ExitCode.Should().Be(1);
         helper.StandardOutput.Should().Contain("Could not find IIS application \"hello world/\".");

--- a/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.ArtifactTests/LegacyCommandLineArgumentsTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -19,14 +20,14 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
     public class LegacyCommandLineArgumentsTests : RunnerTests
     {
         [Fact]
-        public void InvalidArgument()
+        public async Task InvalidArgument()
         {
             // This test makes sure that wrong arguments will return a non-zero exit code
 
             using var helper = StartProcess("--dummy-wrong-argument");
 
-            helper.Process.WaitForExit();
-            helper.Drain();
+            await helper.Process.WaitForExitAsync();
+            await helper.Drain();
 
             using var scope = StartAssertionScope(helper);
 
@@ -36,14 +37,14 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
         [Theory]
         [InlineData(' ')]
         [InlineData('=')]
-        public void SetCi(char separator)
+        public async Task SetCi(char separator)
         {
             var commandLine = $"--set-ci --dd-env{separator}TestEnv --dd-service{separator}TestService --dd-version{separator}TestVersion --tracer-home{separator}TestTracerHome --agent-url{separator}TestAgentUrl --env-vars{separator}VAR1=A,VAR2=B";
 
             using var helper = StartProcess(commandLine, ("TF_BUILD", "1"));
 
-            helper.Process.WaitForExit();
-            helper.Drain();
+            await helper.Process.WaitForExitAsync();
+            await helper.Drain();
 
             helper.Process.ExitCode.Should().Be(0);
 
@@ -70,14 +71,14 @@ namespace Datadog.Trace.Tools.Runner.ArtifactTests
         }
 
         [Fact]
-        public void LocateTracerHome()
+        public async Task LocateTracerHome()
         {
             var commandLine = "--set-ci";
 
             using var helper = StartProcess(commandLine, ("TF_BUILD", "1"));
 
-            helper.Process.WaitForExit();
-            helper.Drain();
+            await helper.Process.WaitForExitAsync();
+            await helper.Drain();
 
             helper.Process.ExitCode.Should().Be(0);
             helper.StandardOutput.Should().NotContainEquivalentOf("error");

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -26,7 +26,7 @@ public abstract class ConsoleTestHelper : ToolTestHelper
         return StartConsole(EnvironmentHelper, enableProfiler, environmentVariables);
     }
 
-    protected (string Executable, string Args) PrepareSampleApp(EnvironmentHelper environmentHelper)
+    protected async Task<(string Executable, string Args)> PrepareSampleApp(EnvironmentHelper environmentHelper)
     {
         var sampleAppPath = environmentHelper.GetSampleApplicationPath();
         var executable = EnvironmentHelper.IsCoreClr() ? environmentHelper.GetSampleExecutionSource() : sampleAppPath;
@@ -38,7 +38,7 @@ public abstract class ConsoleTestHelper : ToolTestHelper
          && !EnvironmentHelper.IsCoreClr()
          && !EnvironmentTools.IsTestTarget64BitProcess())
         {
-            ProfilerHelper.SetCorFlags(executable, Output, !EnvironmentTools.IsTestTarget64BitProcess());
+            await ProfilerHelper.SetCorFlags(executable, Output, !EnvironmentTools.IsTestTarget64BitProcess());
         }
 
         return (executable, args);
@@ -46,7 +46,7 @@ public abstract class ConsoleTestHelper : ToolTestHelper
 
     protected async Task<ProcessHelper> StartConsole(EnvironmentHelper environmentHelper, bool enableProfiler, params (string Key, string Value)[] environmentVariables)
     {
-        var (executable, args) = PrepareSampleApp(environmentHelper);
+        var (executable, args) = await PrepareSampleApp(environmentHelper);
 
         args += " wait";
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -103,7 +103,7 @@ public abstract class ConsoleTestHelper : ToolTestHelper
         }
 
         // Try to capture a memory dump before giving up
-        if (MemoryDumpHelper.CaptureMemoryDump(helper.Process, new Progress<string>(Output.WriteLine)))
+        if (await MemoryDumpHelper.CaptureMemoryDump(helper.Process, new Progress<string>(Output.WriteLine)))
         {
             Output.WriteLine("Successfully captured a memory dump");
         }


### PR DESCRIPTION
## Summary of changes

Convert more parts of the integration tests to async.

## Reason for change

Reducing the pressure on the threadpool, with the hope of reducing flakiness.

