### PR TITLE
Fix trimming file

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -961,6 +961,7 @@
       <type fullname="System.Text.RegularExpressions.Match" />
       <type fullname="System.Text.RegularExpressions.MatchCollection" />
       <type fullname="System.Text.RegularExpressions.Regex" />
+      <type fullname="System.Text.RegularExpressions.RegexMatchTimeoutException" />
       <type fullname="System.Text.RegularExpressions.RegexOptions" />
    </assembly>
    <assembly fullname="System.Threading">


### PR DESCRIPTION
## Summary of changes

Adds missing entry in trimming file

## Reason for change

I suspect this was missed in the IAST headers PR

## Implementation details

Added the missing line

## Test coverage

This is the test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
