### PR TITLE
Enable debug logs in XUnitEvpTests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -32,6 +32,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             SetServiceName("mstest-tests-evp");
             SetServiceVersion("1.0.0");
+#pragma warning disable CS0618 // Type or member is obsolete
+            EnableDebugMode();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [SkippableTheory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -34,6 +34,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
         {
             SetServiceName("xunit-tests-evp");
             SetServiceVersion("1.0.0");
+#pragma warning disable CS0618 // Type or member is obsolete
+            EnableDebugMode();
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [SkippableTheory]


### PR DESCRIPTION
## Summary of changes

Enabling debug logs for XUnitEvpTests.

## Reason for change

Trying to understand why XunitEvp tests are randomly failing on ARM64.
