### PR TITLE
Ignore TestPlatform SDK assembly resolve error from CI CheckBuildLogs

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2375,6 +2375,9 @@ partial class Build
                new (@".*DD_GIT_COMMIT_SHA must be a full-length git SHA.*", RegexOptions.Compiled),
                new (@".*Timeout occurred when flushing spans.*", RegexOptions.Compiled),
                new (@".*ITR: .*", RegexOptions.Compiled),
+               // Error caused for race condition on TestPlatform SDK triggered by CI Visibility
+               // https://github.com/microsoft/vstest/blob/v16.7.1/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs#L67-L70
+               new (@".*Error detecting and reconfiguring git repository for shallow clone. System.IO.FileLoadException: Could not load file or assembly.*", RegexOptions.Compiled),
                // This one is annoying but we _think_ due to a dodgy named pipes implementation, so ignoring for now
                new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\trace-.*The operation has timed out.*", RegexOptions.Compiled),
                new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\metrics-.*The operation has timed out.*", RegexOptions.Compiled),


### PR DESCRIPTION
## Summary of changes

This PR removes an error entry in the logs caused by a race condition in the TestPlatform SDK Assembly resolver triggered by CI Visibility due to an early rewrite of the Process.Start() method.

## Reason for change

CI is failing randomly on some jobs due to:

```
╬════════════════════════════
║ CheckBuildLogsForErrors
╬═══════════════════
​
15:17:04 [WRN] Found the following problems in log files:
15:17:04 [INF] 
15:17:04 [ERR] Found errors in log file '/project/tracer/build_data/logs/XUnitEvpTestsLogs/dotnet-tracer-managed-dotnet-20240115.log':
15:17:04 [ERR] 03:09:04 [Error] Error detecting and reconfiguring git repository for shallow clone. System.IO.FileLoadException: Could not load file or assembly 'Datadog.Trace, Version=2.46.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb'. Error 2147500035 (0x80004003 (E_POINTER))
File name: 'Datadog.Trace, Version=2.46.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb'
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformAssemblyResolver.AssemblyResolverEvent(Object sender, Object eventArgs)
   at System.Runtime.Loader.AssemblyLoadContext.GetFirstResolvedAssemblyFromResolvingEvent(AssemblyName assemblyName)
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingEvent(AssemblyName assemblyName)
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingResolvingEvent(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
   at System.Diagnostics.Process.Start()
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at Datadog.Trace.Util.ProcessHelpers.RunCommandAsync(Command command, String input) in /project/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs:line 70
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.RunGitCommandAsync(String arguments, CIVisibilityCommands ciVisibilityCommand, String input) in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 949
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.UploadRepositoryChangesAsync() in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 197
 { MachineName: ".", Process: "[6335 dotnet]", AppDomain: "[1 testhost]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.46.0.0" }

```

After an investigation it appears that the error happens due to a race condition in the TestPlatform Assembly resolver.

https://github.com/microsoft/vstest/blob/v16.7.1/src/Microsoft.TestPlatform.Common/Utilities/AssemblyResolver.cs#L67-L70

The `PlatformAssemblyResolver` is created but the AssemblyResolver is set after. We are hitting the case when we are resolving an assembly and the resolver is still null. 

https://github.com/microsoft/vstest/blob/v16.7.1/src/Microsoft.TestPlatform.PlatformAbstractions/netcore/Runtime/PlatformAssemblyResolver.cs#L76

## Implementation details

For now we are ignoring this error so we don't break CI, the race condition on the TestPlatform sdk was solved in v17.9.0 and we are not crashing the application just logging the error.

I'll run some test with an alternative approach and avoid the error.

