### PR TITLE
Bump FluentAssertions and add analyzers

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -183,7 +183,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Origin = null,
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -233,7 +234,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Origin = null,
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -146,7 +146,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Origin = null,
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -181,7 +182,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Origin = null,
                           SamplingPriority = samplingPriority,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -229,7 +229,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = SamplingPriority,
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -259,7 +260,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = SamplingPriority,
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -288,7 +290,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = SamplingPriority,
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -325,7 +328,8 @@ namespace Datadog.Trace.Tests.Propagators
                           RawSpanId = "0000000000000000",
                           PropagatedTags = EmptyPropagatedTags,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -397,7 +401,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = SamplingPriority,
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -437,7 +442,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = expectedSamplingPriority,
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -365,7 +365,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Origin = null,
                           SamplingPriority = SamplingPriorityValues.AutoKeep,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -397,7 +398,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Origin = null,
                           SamplingPriority = SamplingPriorityValues.AutoKeep,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -432,7 +434,8 @@ namespace Datadog.Trace.Tests.Propagators
                           PropagatedTags = EmptyPropagatedTags,
                           IsRemote = true,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -473,7 +476,8 @@ namespace Datadog.Trace.Tests.Propagators
                           ParentId = null,
                           IsRemote = true,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -518,7 +522,8 @@ namespace Datadog.Trace.Tests.Propagators
                           SamplingPriority = SamplingPriorityValues.AutoKeep,
                           PropagatedTags = PropagatedTagsCollection,
                           IsRemote = true,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -680,7 +685,8 @@ namespace Datadog.Trace.Tests.Propagators
                           ParentId = null,
                           IsRemote = true,
                           LastParentId = w3CHeaderFirst ? "0123456789abcdef" : null, // if we have Datadog headers don't use p
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Theory]
@@ -734,7 +740,8 @@ namespace Datadog.Trace.Tests.Propagators
                           ParentId = null,
                           IsRemote = true,
                           LastParentId = w3CHeaderFirst ? "0123456789abcdef" : null, // if we have Datadog headers don't use p
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Theory]
@@ -788,7 +795,8 @@ namespace Datadog.Trace.Tests.Propagators
                           ParentId = null,
                           IsRemote = true,
                           LastParentId = w3CHeaderFirst ? ZeroLastParentId : null,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Theory]
@@ -844,7 +852,8 @@ namespace Datadog.Trace.Tests.Propagators
                           ParentId = null,
                           IsRemote = true,
                           LastParentId = expectW3cParentIds ? "0123456789abcdef" : null,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Theory]
@@ -902,7 +911,8 @@ namespace Datadog.Trace.Tests.Propagators
                           ParentId = null,
                           IsRemote = true,
                           LastParentId = w3CHeaderFirst ? ZeroLastParentId : null,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeEquivalentTo(new Baggage([new KeyValuePair<string, string>("usr", "customer")]));
         }

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -370,7 +370,8 @@ namespace Datadog.Trace.Tests.Propagators
                            Parent = null,
                            ParentId = null,
                            LastParentId = ZeroLastParentId,
-                       });
+                       },
+                       opts => opts.ExcludingMissingMembers());
         }
 
         [Theory]
@@ -417,7 +418,8 @@ namespace Datadog.Trace.Tests.Propagators
                            Parent = null,
                            ParentId = null,
                            LastParentId = ZeroLastParentId,
-                       });
+                       },
+                       opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -456,7 +458,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
 
             result.Baggage.Should().BeNull();
         }
@@ -531,7 +534,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = "0123456789abcdef",
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -570,7 +574,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -707,7 +712,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Theory]
@@ -749,7 +755,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -793,7 +800,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -837,7 +845,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -876,7 +885,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -915,7 +925,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -954,7 +965,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
 
         [Fact]
@@ -993,7 +1005,8 @@ namespace Datadog.Trace.Tests.Propagators
                           Parent = null,
                           ParentId = null,
                           LastParentId = ZeroLastParentId,
-                      });
+                      },
+                      opts => opts.ExcludingMissingMembers());
         }
     }
 }

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -18,7 +18,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="FluentAssertions.Analyzers" Version="0.34.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
@@ -31,7 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="DelegateDecompiler" Version="0.32.0" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSDKVersion)" />


### PR DESCRIPTION
## Summary of changes

- Update fluent assertions library from 6.4.0 => 7.0.0
- Add FluentAssertions.Analyzers for best practices

## Reason for change

I hate seeing `Assert.Equals()` in the logs and trying to work out what it was referring to 😅 

## Implementation details

Bump some versions

## Test coverage

Pretty well covered

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
