### PR TITLE
Fix `Non-serializable data ('System.Object[]') found` in tests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/CallTarget/InstrumentationDefinitionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CallTarget/InstrumentationDefinitionsTests.cs
@@ -55,17 +55,24 @@ namespace Datadog.Trace.Tests.CallTarget
             info.Value.Should().Be(IntegrationId.MongoDb);
         }
 
-        [Theory]
-        [InlineData(typeof(System.Data.SqlClient.SqlCommand), (int)IntegrationId.SqlClient)]
-        [InlineData(typeof(System.Data.SQLite.SQLiteCommand), (int)IntegrationId.Sqlite)]
-        public void CanGetIntegrationIdForAdoNetAttribute(Type targetType, int expected)
+        [Fact]
+        public void CanGetIntegrationIdForAdoNetAttribute()
         {
-            var integrationType = typeof(CommandExecuteNonQueryIntegration).FullName;
+            var types = new[]
+            {
+                (typeof(System.Data.SqlClient.SqlCommand), (int)IntegrationId.SqlClient),
+                (typeof(System.Data.SQLite.SQLiteCommand), (int)IntegrationId.Sqlite),
+            };
 
-            var info = InstrumentationDefinitions.GetIntegrationId(integrationType, targetType);
+            foreach (var (targetType, expected) in types)
+            {
+                var integrationType = typeof(CommandExecuteNonQueryIntegration).FullName;
 
-            info.Should().NotBeNull();
-            info.Value.Should().Be((IntegrationId)expected);
+                var info = InstrumentationDefinitions.GetIntegrationId(integrationType, targetType);
+
+                info.Should().NotBeNull();
+                info.Value.Should().Be((IntegrationId)expected);
+            }
         }
 
         [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Logging/ExceptionRedactorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/ExceptionRedactorTests.cs
@@ -171,18 +171,18 @@ public class ExceptionRedactorTests
 
     public static class TestData
     {
-        public static TheoryData<object> MethodsToRedact() => new()
-        {
+        public static List<object> MethodsToRedact() =>
+        [
             typeof(AssertionExtensions).GetMethod(nameof(AssertionExtensions.Should), types: new[] { typeof(object) }),
             typeof(Xunit.Assert).GetMethod(nameof(Assert.False), types: new[] { typeof(bool) }),
             typeof(VerifyTests.VerifierSettings).GetMethod(nameof(VerifyTests.VerifierSettings.DisableClipboard)),
             typeof(VerifyTests.VerifierSettings).GetProperty(nameof(VerifyTests.VerifierSettings.StrictJson))?.GetMethod,
             typeof(VerifyTests.VerifierSettings).GetProperty(nameof(VerifyTests.VerifierSettings.StrictJson))?.SetMethod,
             typeof(VerifyTests.SerializationSettings).GetConstructor(Array.Empty<Type>()),
-        };
+        ];
 
-        public static TheoryData<object> MethodsToNotRedact() => new()
-        {
+        public static List<object> MethodsToNotRedact() =>
+        [
             typeof(ExceptionRedactorTests.TestData).GetMethod(nameof(NoParameters)),
             typeof(Datadog.Trace.Tracer).GetMethod(nameof(Tracer.UnsafeSetTracerInstance), BindingFlags.Static | BindingFlags.NonPublic),
             typeof(Datadog.Trace.Tracer).GetProperty(nameof(Tracer.Instance))?.GetMethod,
@@ -204,19 +204,19 @@ public class ExceptionRedactorTests
             typeof(Microsoft.CodeAnalysis.DiagnosticDescriptor).GetProperty(nameof(Microsoft.CodeAnalysis.DiagnosticDescriptor.Id))?.GetMethod,
             typeof(Microsoft.Extensions.DependencyInjection.ServiceCollection).GetMethod(nameof(Microsoft.Extensions.DependencyInjection.ServiceCollection.Contains), types: new[] { typeof(Microsoft.Extensions.DependencyInjection.ServiceDescriptor) }),
 #endif
-        };
+        ];
 
-        public static IEnumerable<(StackTrace StackTrace, string ExpectedToString)> ToStringTestData()
-        {
-            yield return (new StackTrace(InvokeException()), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.ThrowException()");
-            yield return (new StackTrace(new Exception()), string.Empty);
-            yield return (NoParameters(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.NoParameters()");
-            yield return (OneParameter(1), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.OneParameter(Int32 x)");
-            yield return (TwoParameters(1, null), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.TwoParameters(Int32 x, String y)");
-            yield return (Generic<int>(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.Generic[T]()");
-            yield return (Generic<int, string>(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.Generic[T1,T2]()");
-            yield return (new ClassWithConstructor().StackTrace, "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.ClassWithConstructor..ctor()");
-        }
+        public static List<(StackTrace StackTrace, string ExpectedToString)> ToStringTestData() =>
+        [
+            (new StackTrace(InvokeException()), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.ThrowException()"),
+            (new StackTrace(new Exception()), string.Empty),
+            (NoParameters(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.NoParameters()"),
+            (OneParameter(1), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.OneParameter(Int32 x)"),
+            (TwoParameters(1, null), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.TwoParameters(Int32 x, String y)"),
+            (Generic<int>(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.Generic[T]()"),
+            (Generic<int, string>(), "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.Generic[T1,T2]()"),
+            (new ClassWithConstructor().StackTrace, "Datadog.Trace.Tests.Logging.ExceptionRedactorTests.TestData.ClassWithConstructor..ctor()"),
+        ];
 
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         public static unsafe StackTrace FunctionPointerParameter(delegate*<void> x) => new();

--- a/tracer/test/Datadog.Trace.Tests/OpenTelemetryOperationNameMapperTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/OpenTelemetryOperationNameMapperTests.cs
@@ -140,14 +140,14 @@ namespace Datadog.Trace.Tests
 
                 ExpectedActivityKind = data[1]?.ToString() ?? string.Empty;
 
-                Tags = data[2] is null ? new Dictionary<string, string>() : (Dictionary<string, string>)data[2];
+                Tags = data[2] is null ? new SerializableDictionary() : (SerializableDictionary)data[2];
             }
 
             public string ExpectedOperationName { get; }
 
             public string ExpectedActivityKind { get; }
 
-            public Dictionary<string, string> Tags { get; }
+            public SerializableDictionary Tags { get; }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Fix cases where we had non-serializable data

## Reason for change

Spotted in the logs:

```
Datadog.Trace.Tests: Non-serializable data ('System.Object[]') found for 'Datadog.Trace.Tests.Logging.ExceptionRedactorTests.RedactStackTrace_DoesNotRedactBclAndDatadog'; falling back to single test case
```

It means we're not actually running all the test cases

## Implementation details

Use `SerializableDictionary` where possible, or where not possible, convert the `Theory` into a `Fact`

## Test coverage

Should be more now!

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
