### PR TITLE
Disable code coverage unless forced

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -111,8 +111,9 @@ variables:
   isMainBranch: $[in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main')]
   isMainOrReleaseBranch: $[or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))]
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
-  # Run code coverage on main branches only, on scheduled build only
-  runCodeCoverage: $[or(eq(variables['run_code_coverage'], 'true'), and(eq(variables['Build.Reason'], 'Schedule'), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hotfix/'))))]
+  # Only run code coverage when requested
+  # Coverlet relies on IL rewriting, which currently breaks tests which explictly check the IL
+  runCodeCoverage: $[eq(variables['run_code_coverage'], 'true')]
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages


### PR DESCRIPTION
## Summary of changes

Disables coverlet code coverage everywhere unless explicitly requested.

## Reason for change

The tests introduced in #4782 fail on `master`, because they verify the IL of some libraries, but coverlet rewrites the IL.

## Implementation details

Stop running code coverage on master. We already skip it on branches because it contributed significantly to flake, and I don't think _anyone_ checks the master results, so this will do for now.

We can do a fix for the IL comparison test to account for coverlet later, and then re-enable this if we wish.

## Test coverage

We'll never know now 🙈 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
