### PR TITLE
[v3] Stop producing the 32-bit MSI installer

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -720,10 +720,6 @@ stages:
         displayName: Publish tracer-home.zip
         artifact: windows-tracer-home.zip
 
-      - publish: $(artifacts)/x86/en-us
-        displayName: Publish Windows x86 MSI
-        artifact: windows-msi-x86
-
       - publish: $(artifacts)/x64/en-us
         displayName: Publish Windows x64 MSI
         artifact: windows-msi-x64
@@ -3707,12 +3703,6 @@ stages:
             artifact: windows-msi-x64
             path: $(Build.ArtifactStagingDirectory)
 
-        - task: DownloadPipelineArtifact@2
-          displayName: Download x86 MSI
-          inputs:
-            artifact: windows-msi-x86
-            path: $(Build.ArtifactStagingDirectory)
-
         - bash: |
             az storage blob upload-batch \
               --destination "$(AZURE_STORAGE_CONTAINER_NAME)" \
@@ -5624,11 +5614,8 @@ stages:
         - task: DownloadPipelineArtifact@2
           displayName: Download MSI to temp directory
           inputs:
-#            artifact: windows-msi-$(targetPlatform)
-#            patterns: '**/*-$(targetPlatform).msi'
-            # I give up, I can't get x86 to work in the docker file
-            artifact: windows-msi-x64
-            patterns: '**/*-x64.msi'
+            artifact: windows-msi-$(targetPlatform)
+            patterns: '**/*-$(targetPlatform).msi'
             path: $(Agent.TempDirectory)
 
         - powershell: |

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -693,6 +693,9 @@ partial class Build
         .OnlyWhenStatic(() => IsWin)
         .Executes(() =>
         {
+            // We don't produce an x86-only MSI any more
+            var architectures = ArchitecturesForPlatformForTracer.Where(x => x != MSBuildTargetPlatform.x86);
+            
             MSBuild(s => s
                     .SetTargetPath(SharedDirectory / "src" / "msi-installer" / "WindowsInstaller.wixproj")
                     .SetConfiguration(BuildConfiguration)
@@ -700,7 +703,7 @@ partial class Build
                     .AddProperty("RunWixToolsOutOfProc", true)
                     .SetProperty("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetMaxCpuCount(null)
-                    .CombineWith(ArchitecturesForPlatformForTracer, (o, arch) => o
+                    .CombineWith(architectures, (o, arch) => o
                         .SetProperty("MsiOutputPath", ArtifactsDirectory / arch.ToString())
                         .SetTargetPlatform(arch)),
                 degreeOfParallelism: 2);

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -208,15 +208,17 @@ partial class Build : NukeBuild
 
             void GenerateIntegrationTestsWindowsMsiMatrix(params TargetFramework[] targetFrameworks)
             {
-                var targetPlatforms = new[] { "x86", "x64" };
+                var targetPlatforms = new[] { 
+                    (targetPlaform: "x64", enable32Bit: false),
+                    (targetPlaform: "x64", enable32Bit: true),
+                };
 
                 var matrix = new Dictionary<string, object>();
                 foreach (var framework in targetFrameworks)
                 {
-                    foreach (var targetPlatform in targetPlatforms)
+                    foreach (var (targetPlatform, enable32Bit) in targetPlatforms)
                     {
-                        var enable32bit = targetPlatform == "x86";
-                        matrix.Add($"{targetPlatform}_{framework}", new { framework = framework, targetPlatform = targetPlatform, enable32bit = enable32bit });
+                        matrix.Add($"{targetPlatform}_{(enable32Bit ? "32bit" : "64bit")}_{framework}", new { framework = framework, targetPlatform = targetPlatform, enable32bit = enable32Bit });
                     }
                 }
 
@@ -1022,7 +1024,6 @@ partial class Build : NukeBuild
                     var platforms = new(MSBuildTargetPlatform platform, bool enable32Bit)[] {
                         (MSBuildTargetPlatform.x64, false),
                         (MSBuildTargetPlatform.x64, true),
-                        (MSBuildTargetPlatform.x86, true)
                     };
                     var runtimeImages = new (string publishFramework, string runtimeTag)[]
                     {


### PR DESCRIPTION
## Summary of changes

Stop producing the 32-bit (only) MSI installer

## Reason for change

The 32-bit MSI installer should only be used on 32-bit versions of Windows; the 64-bit MSI should normally be used, and allows tracing both 32-bit and 64-bit processes.

Windows Server 2008 was the last version of Windows Server to support 32-bit operating systems, and [was announced EOL by Microsoft in 2020](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-server-eos-faq/end-of-support-windows-server-2008-2008r2).

We are removing the 32-bit MSI to reduce confusion so that customers don't install the wrong version.

## Implementation details

Just removed the x86 switches from the build for now. Left all of the machinery for testing multiple platforms in case we support arm64 on Windows.

## Test coverage

Removed testing of the x86-only installer, but still test

## Other details
Confirmed it works in GitLab too and that we only produce the 64bit compiler

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
