### PR TITLE
Suppress build warnings we don't care about

### DIFF
--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -10,6 +10,7 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <!-- Stop NuGet from complaining about vulnerable packages -->
     <NuGetAudit>false</NuGetAudit>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 
     <!-- WebClient is obsolete -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->

--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -20,6 +20,7 @@
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <!-- Stop NuGet from complaining about vulnerable packages -->
     <NuGetAudit>false</NuGetAudit>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
 
     <!-- WebClient is obsolete -->
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->


### PR DESCRIPTION
## Summary of changes

Adds `<SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>` to test projects to avoid warnings

## Reason for change

The warnings are annoying and pointless

## Implementation details

Added `SuppressTfmSupportBuildWarnings` to a couple of Directory.Build.props files

## Test coverage

No change

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
