### PR TITLE
[WIP] Add simple log statement at serialization to get SamplingPriority

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -159,29 +159,6 @@ namespace Datadog.Trace.Agent
                     new object[] { span.Context.RawSpanId, span.Context.ParentIdInternal, span.Context.RawTraceId, span.ServiceName, span.ResourceName, span.OperationName, traceContext.SamplingPriority, span.Tags, traceContext.Tags, span.ToString() });
         }
 
-        private string GetSpanInfoForDebugLog(Span span)
-        {
-            var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-            sb.AppendLine($"TraceId64: {span.Context.TraceId128.Lower}");
-            sb.AppendLine($"TraceId128: {span.Context.TraceId128}");
-            sb.AppendLine($"RawTraceId: {span.Context.RawTraceId}");
-            sb.AppendLine($"ParentId: {span.Context.ParentIdInternal}");
-            sb.AppendLine($"SpanId: {span.Context.SpanId}");
-            sb.AppendLine($"RawSpanId: {span.Context.RawSpanId}");
-            sb.AppendLine($"Origin: {span.Context.Origin}");
-            sb.AppendLine($"ServiceName: {span.ServiceName}");
-            sb.AppendLine($"OperationName: {span.OperationName}");
-            sb.AppendLine($"Resource: {span.ResourceName}");
-            sb.AppendLine($"Type: {span.Type}");
-            sb.AppendLine($"Start: {span.StartTime.ToString("O")}");
-            sb.AppendLine($"Duration: {span.Duration}");
-            sb.AppendLine($"End: {span.StartTime.Add(span.Duration).ToString("O")}");
-            sb.AppendLine($"Error: {span.Error}");
-            sb.AppendLine($"Meta: {span.Tags}");
-
-            return StringBuilderCache.GetStringAndRelease(sb);
-        }
-
         public async Task FlushAndCloseAsync()
         {
             if (!_processExit.TrySetResult(true))

--- a/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
+++ b/tracer/src/Datadog.Trace/Agent/AgentWriter.cs
@@ -494,7 +494,6 @@ namespace Datadog.Trace.Agent
             }
 
             // Add the current keep rate to the root span
-            var traceContext = spans.Array![spans.Offset].Context.TraceContext;
             var rootSpan = spans.Array![spans.Offset].Context.TraceContext?.RootSpan;
 
             if (rootSpan is not null)
@@ -512,6 +511,7 @@ namespace Datadog.Trace.Agent
 
                 if (IsLogLevelDebugEnabled)
                 {
+                    var traceContext = spans.Array![spans.Offset].Context.TraceContext;
                     // foreach span write out the enhanced debug information
                     LogRootSpanDebugInformation(traceContext, rootSpan);
                     LogSpanDebugInformation(traceContext, spans);


### PR DESCRIPTION
## Summary of changes

Just adding logging statements closer toward serialization to try and get SamplingPriority.

## Reason for change

Sampling priority doesn't get logged out and could be helpful for investigations where we seem to be missing spans.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
