### PR TITLE
[Profiler] Remove unused statistics method in StackSamplerLoop

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -523,29 +523,8 @@ void StackSamplerLoop::CollectOneThreadStackSample(
 
     } // SemaphoreScope guardedLock(pThreadInfo->GetStackWalkLock())
 
-    UpdateStatistics(hrCollectStack, countCollectedStackFrames);
-
     // Store stack-walk results into the results buffer:
     PersistStackSnapshotResults(pStackSnapshotResult, pThreadInfo, profilingType);
-}
-
-void StackSamplerLoop::UpdateStatistics(HRESULT hrCollectStack, std::size_t countCollectedStackFrames)
-{
-    // Counts stats on how often we encounter certain results.
-    // For now we only print it to the debug log.
-    // However, summary statistics of this are a good candidate for global telemetry in the future.
-
-    // All of these counters will cycle over time, especially _totalStacksCollected.
-    // For current Debug Log purposes this does not matter.
-    // For future global telemetry we may need to find some way to put it in the context of overall runtime
-    // to interpret correctly.
-    uint64_t& encounteredStackSnapshotHrCount = _encounteredStackSnapshotHRs[hrCollectStack];
-    ++encounteredStackSnapshotHrCount;
-
-    uint64_t& encounteredStackSnapshotDepthCount = _encounteredStackSnapshotDepths[countCollectedStackFrames];
-    ++encounteredStackSnapshotDepthCount;
-
-    ++_totalStacksCollectedCount;
 }
 
 void StackSamplerLoop::UpdateSnapshotInfos(StackSnapshotResultBuffer* const pStackSnapshotResult, int64_t representedDurationNanosecs, time_t currentUnixTimestamp)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -89,11 +89,6 @@ private:
     int32_t _codeHotspotsThreadsThreshold;
 
 private:
-    std::unordered_map<HRESULT, uint64_t> _encounteredStackSnapshotHRs;
-    std::unordered_map<size_t, uint64_t> _encounteredStackSnapshotDepths;
-    uint64_t _totalStacksCollectedCount{0};
-    uint64_t _lastStackSnapshotResultsStats_LogTimestampNS{0};
-    std::unordered_map<shared::WSTRING, uint64_t> _encounteredStackCountsForDebug;
     std::chrono::nanoseconds _samplingPeriod;
     uint32_t _nbCores;
     bool _isWalltimeEnabled;


### PR DESCRIPTION
## Summary of changes

Clean up.

## Reason for change

This method wastes CPU time and the statistics are not used anymore.

## Implementation details

Remove code.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
