### PR TITLE
Stop rebuilding dddotnet

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -890,7 +890,7 @@ partial class Build
     Target ZipMonitoringHomeLinux => _ => _
         .Unlisted()
         .After(BuildTracerHome, BuildProfilerHome, BuildNativeLoader)
-        .DependsOn(PrepareMonitoringHomeLinux, BuildDdDotnet)
+        .DependsOn(PrepareMonitoringHomeLinux)
         .OnlyWhenStatic(() => IsLinux)
         .Requires(() => Version)
         .Executes(() =>


### PR DESCRIPTION
## Summary of changes

Stop rebuilding dd-dotnet in `ZipMonitoringHomeLinux`

## Reason for change

Noticed we were building it again when it's already built in a separate stage

## Implementation details

Removed from `DependsOn`

## Test coverage

Will manually check the packages to make sure we're still bundling the pre-built version, but the tests should catch any issues

## Other details
That's 40s shaved off the hot-path 😅 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
