### PR TITLE
Fix instrumentation definitions source generator IDE performance

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/DiagnosticInfo.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/DiagnosticInfo.cs
@@ -10,6 +10,11 @@ namespace Datadog.Trace.SourceGenerators.Helpers;
 internal sealed record DiagnosticInfo
 {
     public DiagnosticInfo(DiagnosticDescriptor descriptor, Location? location)
+        : this(descriptor, location is not null ? LocationInfo.CreateFrom(location) : null)
+    {
+    }
+
+    public DiagnosticInfo(DiagnosticDescriptor descriptor, LocationInfo? location)
     {
         Descriptor = descriptor;
         Location = location;
@@ -17,5 +22,5 @@ internal sealed record DiagnosticInfo
 
     public DiagnosticDescriptor Descriptor { get; }
 
-    public Location? Location { get; }
+    public LocationInfo? Location { get; }
 }

--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/DiagnosticsExtensions.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/DiagnosticsExtensions.cs
@@ -25,7 +25,7 @@ internal static class DiagnosticsExtensions
             diagnostics,
             static (context, info) =>
             {
-                context.ReportDiagnostic(Diagnostic.Create(info.Descriptor, info.Location));
+                context.ReportDiagnostic(Diagnostic.Create(info.Descriptor, info.Location?.ToLocation()));
             });
     }
 }

--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/LocationInfo.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/LocationInfo.cs
@@ -1,0 +1,48 @@
+// <copyright file="LocationInfo.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Datadog.Trace.SourceGenerators.Helpers;
+
+internal record LocationInfo
+{
+    private LocationInfo(string filePath, TextSpan textSpan, LinePositionSpan lineSpan)
+    {
+        FilePath = filePath;
+        TextSpan = textSpan;
+        LineSpan = lineSpan;
+    }
+
+    public string FilePath { get; }
+
+    public TextSpan TextSpan { get; }
+
+    public LinePositionSpan LineSpan { get; }
+
+    public Location ToLocation()
+        => Location.Create(FilePath, TextSpan, LineSpan);
+
+    public static LocationInfo? CreateFrom(SyntaxNode? node)
+        => CreateFrom(node?.GetLocation());
+
+    public static LocationInfo? CreateFrom(Location? location)
+    {
+        if (location?.SourceTree is null)
+        {
+            return null;
+        }
+
+        return new LocationInfo(location.SourceTree.FilePath, location.SourceSpan, location.GetLineSpan().Span);
+    }
+
+    public void Deconstruct(out string filePath, out TextSpan textSpan, out LinePositionSpan lineSpan)
+    {
+        filePath = FilePath;
+        textSpan = TextSpan;
+        lineSpan = LineSpan;
+    }
+}

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/AdoNetSignature.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/AdoNetSignature.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.SourceGenerators.Helpers;
+
 namespace Datadog.Trace.SourceGenerators.InstrumentationDefinitions;
 
 internal record AdoNetSignature
@@ -11,7 +13,7 @@ internal record AdoNetSignature
     {
         TargetMethodName = targetMethodName;
         TargetReturnType = targetReturnType;
-        TargetParameterTypes = targetParameterTypes;
+        TargetParameterTypes = new(targetParameterTypes);
         InstrumentationTypeName = instrumentationTypeName;
         CallTargetIntegrationKind = callTargetIntegrationKind;
         ReturnType = returnType;
@@ -21,7 +23,7 @@ internal record AdoNetSignature
 
     public string? TargetReturnType { get; }
 
-    public string[] TargetParameterTypes { get; }
+    public EquatableArray<string> TargetParameterTypes { get; }
 
     public string InstrumentationTypeName { get; }
 

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/AssemblyCallTargetDefinitionSource.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/AssemblyCallTargetDefinitionSource.cs
@@ -1,4 +1,4 @@
-// <copyright file="CallTargetDefinitionSource.cs" company="Datadog">
+// <copyright file="AssemblyCallTargetDefinitionSource.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -8,23 +8,24 @@ using Datadog.Trace.SourceGenerators.Helpers;
 
 namespace Datadog.Trace.SourceGenerators.InstrumentationDefinitions;
 
-internal record CallTargetDefinitionSource
+internal record AssemblyCallTargetDefinitionSource
 {
-    public CallTargetDefinitionSource(string integrationName, string assemblyName, string targetTypeName, string targetMethodName, string targetReturnType, string[] targetParameterTypes, (ushort Major, ushort Minor, ushort Patch) minimumVersion, (ushort Major, ushort Minor, ushort Patch) maximumVersion, string instrumentationTypeName, int integrationKind, bool isAdoNetIntegration, InstrumentationCategory instrumentationCategory)
+    public AssemblyCallTargetDefinitionSource(string signatureAttributeName, string integrationName, string assemblyName, string targetTypeName, (ushort Major, ushort Minor, ushort Patch) minimumVersion, (ushort Major, ushort Minor, ushort Patch) maximumVersion, bool isAdoNetIntegration, InstrumentationCategory instrumentationCategory, LocationInfo? location, string? dataReaderTypeName, string? dataReaderTaskTypeName)
     {
+        SignatureAttributeName = signatureAttributeName;
         IntegrationName = integrationName;
         AssemblyName = assemblyName;
         TargetTypeName = targetTypeName;
-        TargetMethodName = targetMethodName;
-        TargetReturnType = targetReturnType;
-        TargetParameterTypes = new EquatableArray<string>(targetParameterTypes);
         MinimumVersion = minimumVersion;
         MaximumVersion = maximumVersion;
-        InstrumentationTypeName = instrumentationTypeName;
-        IntegrationKind = integrationKind;
         IsAdoNetIntegration = isAdoNetIntegration;
         InstrumentationCategory = instrumentationCategory;
+        Location = location;
+        DataReaderTypeName = dataReaderTypeName;
+        DataReaderTaskTypeName = dataReaderTaskTypeName;
     }
+
+    public string SignatureAttributeName { get; }
 
     public string IntegrationName { get; }
 
@@ -32,21 +33,17 @@ internal record CallTargetDefinitionSource
 
     public string TargetTypeName { get; }
 
-    public string TargetMethodName { get; }
-
-    public string TargetReturnType { get; }
-
-    public EquatableArray<string> TargetParameterTypes { get; }
-
     public (ushort Major, ushort Minor, ushort Patch) MinimumVersion { get; }
 
     public (ushort Major, ushort Minor, ushort Patch) MaximumVersion { get; }
 
-    public string InstrumentationTypeName { get; }
-
-    public int IntegrationKind { get; }
-
     public bool IsAdoNetIntegration { get; }
 
     public InstrumentationCategory InstrumentationCategory { get; }
+
+    public LocationInfo? Location { get; }
+
+    public string? DataReaderTypeName { get; }
+
+    public string? DataReaderTaskTypeName { get; }
 }

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Diagnostics/InvalidVersionFormatDiagnostic.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Diagnostics/InvalidVersionFormatDiagnostic.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.SourceGenerators.Helpers;
 using Microsoft.CodeAnalysis;
 
 namespace Datadog.Trace.SourceGenerators.InstrumentationDefinitions.Diagnostics;
@@ -13,8 +14,8 @@ internal static class InvalidVersionFormatDiagnostic
     internal const string Id = "ID2";
     private const string Title = "Invalid version format";
 
-    public static Diagnostic Create(SyntaxNode? currentNode, string propertyName) =>
-        Diagnostic.Create(
+    public static DiagnosticInfo Create(SyntaxNode? currentNode, string propertyName) =>
+        new(
             new DiagnosticDescriptor(
                 Id,
                 Title,

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Diagnostics/MissingRequiredPropertyDiagnostic.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Diagnostics/MissingRequiredPropertyDiagnostic.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.SourceGenerators.Helpers;
 using Microsoft.CodeAnalysis;
 
 namespace Datadog.Trace.SourceGenerators.InstrumentationDefinitions.Diagnostics
@@ -13,14 +14,14 @@ namespace Datadog.Trace.SourceGenerators.InstrumentationDefinitions.Diagnostics
         internal const string Id = "ID1";
         private const string Title = "Missing required property";
 
-        public static Diagnostic Create(SyntaxNode? currentNode, string property, string otherProperty) =>
+        public static DiagnosticInfo Create(SyntaxNode? currentNode, string property, string otherProperty) =>
             Create(currentNode?.GetLocation(), $"You must set {property} or {otherProperty}");
 
-        public static Diagnostic Create(SyntaxNode? currentNode, string property) =>
+        public static DiagnosticInfo Create(SyntaxNode? currentNode, string property) =>
             Create(currentNode?.GetLocation(), $"You must set {property}");
 
-        private static Diagnostic Create(Location? location, string message) =>
-            Diagnostic.Create(
+        private static DiagnosticInfo Create(Location? location, string message) =>
+            new(
                 new DiagnosticDescriptor(
                     Id,
                     Title,

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Diagnostics/UnknownAdoNetSignatureNameDiagnostic.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Diagnostics/UnknownAdoNetSignatureNameDiagnostic.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.SourceGenerators.Helpers;
 using Microsoft.CodeAnalysis;
 
 namespace Datadog.Trace.SourceGenerators.InstrumentationDefinitions.Diagnostics;
@@ -13,8 +14,8 @@ internal static class UnknownAdoNetSignatureNameDiagnostic
     internal const string Id = "ID3";
     private const string Title = "Unknown AdoNetTargetSignatureAttribute";
 
-    public static Diagnostic Create(SyntaxNode? currentNode, string signatureName) =>
-        Diagnostic.Create(
+    public static DiagnosticInfo Create(LocationInfo? location, string signatureName) =>
+        new(
             new DiagnosticDescriptor(
                 Id,
                 Title,
@@ -22,5 +23,5 @@ internal static class UnknownAdoNetSignatureNameDiagnostic
                 category: SourceGenerators.Constants.Usage,
                 defaultSeverity: DiagnosticSeverity.Warning,
                 isEnabledByDefault: true),
-            currentNode?.GetLocation());
+            location);
 }

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/InstrumentationDefinitionsGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/InstrumentationDefinitionsGenerator.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using System.Text;
 using System.Threading;
 using Datadog.Trace.ClrProfiler;
+using Datadog.Trace.SourceGenerators.Helpers;
 using Datadog.Trace.SourceGenerators.InstrumentationDefinitions;
 using Datadog.Trace.SourceGenerators.InstrumentationDefinitions.Diagnostics;
 using Microsoft.CodeAnalysis;
@@ -22,150 +23,106 @@ using Microsoft.CodeAnalysis.Text;
 [Generator]
 public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
 {
+    private const string InstrumentedMethodAttribute = "Datadog.Trace.ClrProfiler.InstrumentMethodAttribute";
+    private const string AdoNetInstrumentAttribute = "Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.AdoNetClientInstrumentMethodsAttribute";
+    private const string AdoNetTargetSignatureAttribute = AdoNetInstrumentAttribute + ".AdoNetTargetSignatureAttribute";
+
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        // Register the attribute source
+        // Get all the [InstrumentMethod] instances on classes
+        IncrementalValuesProvider<Result<EquatableArray<CallTargetDefinitionSource>>> callTargetDefinitions =
+            context.SyntaxProvider.ForAttributeWithMetadataName(
+                InstrumentedMethodAttribute,
+                predicate: static (node, _) => node is ClassDeclarationSyntax,
+                transform: static (ctx, ct) => GetCallTargetDefinitionSources(ctx, ct));
 
-        IncrementalValuesProvider<ClassDeclarationSyntax> classDeclarations =
-            context.SyntaxProvider.CreateSyntaxProvider(
-                        static (node, token) => IsAttributedClass(node, token),
-                        static (syntaxContext, token) => GetPotentialClassesForGeneration(syntaxContext, token))
-                   .Where(static m => m is not null)!;
+        // Get all the `[AdoNetTargetSignature] attributes inside the AdoNetClientInstrumentMethodsAttribute type
+        IncrementalValuesProvider<Result<EquatableArray<(string ClassName, AdoNetSignature Signature)>>> adoNetSignatures =
+            context.SyntaxProvider.ForAttributeWithMetadataName(
+                        AdoNetInstrumentAttribute + "+AdoNetTargetSignatureAttribute", // metadata name uses `+`
+                        predicate: static (node, _) => node is ClassDeclarationSyntax,
+                        transform: static (ctx, ct) => GetAdoNetSignatures(ctx, ct));
 
-        IncrementalValuesProvider<AttributeData> assemblyAttributes =
-            context.CompilationProvider.SelectMany(static (compilation, _) => compilation.Assembly.GetAttributes());
+        // Get all the [AdoNetClientInstrumentMethods]  assembly attributes
+        IncrementalValuesProvider<Result<EquatableArray<AssemblyCallTargetDefinitionSource>>> assemblyCallTargetDefinitions =
+            context.SyntaxProvider.ForAttributeWithMetadataName(
+                        AdoNetInstrumentAttribute,
+                        predicate: static (node, _) => node is CompilationUnitSyntax,
+                        transform: static (ctx, ct) => GetAssemblyCallTargetDefinitionSources(ctx, ct));
 
-        IncrementalValuesProvider<AttributeData> adoNetAssemblyAttributes =
-            assemblyAttributes.Where(static a => IsAssemblyAttributeForGeneration(a));
+        // merge the adonet signatures
+        IncrementalValueProvider<ImmutableArray<(string ClassName, AdoNetSignature Signature)>> allSignatures =
+            adoNetSignatures
+               .SelectMany(static (result, _) => result.Value)
+               .Collect();
 
-        IncrementalValueProvider<((Compilation Left, ImmutableArray<ClassDeclarationSyntax> Right) Left, ImmutableArray<AttributeData> Right)> compilationAndClasses =
-            context.CompilationProvider
-                   .Combine(classDeclarations.Collect())
-                   .Combine(adoNetAssemblyAttributes.Collect());
+        IncrementalValuesProvider<Result<CallTargetDefinitionSource?>> adoNetCallTargetDefinitions =
+            assemblyCallTargetDefinitions
+               .SelectMany(static (result, _) => result.Value)
+               .Combine(allSignatures)
+               .Select((tuple, _) => MergeAdoNetAttributes(tuple.Left, tuple.Right));
 
-        IncrementalValueProvider<(IReadOnlyList<CallTargetDefinitionSource> Definitions, IReadOnlyList<Diagnostic> Diagnostics)> detailsToRender =
-            compilationAndClasses.Select(static (x, ct) => GetDefinitionToWrite(x.Left.Left, x.Left.Right, x.Right, ct));
+        context.ReportDiagnostics(
+            callTargetDefinitions
+               .Where(static m => m.Errors.Count > 0)
+               .SelectMany(static (x, _) => x.Errors));
 
-        context.RegisterSourceOutput(detailsToRender, static (spc, source) =>
-                                         Execute(source.Definitions, source.Diagnostics, spc));
+        context.ReportDiagnostics(
+            adoNetSignatures
+               .Where(static m => m.Errors.Count > 0)
+               .SelectMany(static (x, _) => x.Errors));
+
+        context.ReportDiagnostics(
+            assemblyCallTargetDefinitions
+               .Where(static m => m.Errors.Count > 0)
+               .SelectMany(static (x, _) => x.Errors));
+
+        context.ReportDiagnostics(
+            adoNetCallTargetDefinitions
+               .Where(static m => m.Errors.Count > 0)
+               .SelectMany(static (x, _) => x.Errors));
+
+        var allCallTargetDefinitions =
+            callTargetDefinitions
+               .SelectMany(static (x, _) => x.Value)
+               .Collect();
+
+        var allAdoNetDefinitions =
+            adoNetCallTargetDefinitions
+               .Where(x => x.Value is not null)
+               .Select((x, _) => x.Value!)
+               .Collect();
+
+        context.RegisterSourceOutput(
+            allCallTargetDefinitions.Combine(allAdoNetDefinitions),
+            static (spc, source) =>
+                Execute(source.Left, source.Right, spc));
     }
 
-    private static bool IsAttributedClass(SyntaxNode node, CancellationToken cancellationToken)
-        => node is ClassDeclarationSyntax c && c.AttributeLists.Count > 0;
-
-    private static ClassDeclarationSyntax? GetPotentialClassesForGeneration(GeneratorSyntaxContext context, CancellationToken cancellationToken)
+    private static Result<EquatableArray<CallTargetDefinitionSource>> GetCallTargetDefinitionSources(
+        GeneratorAttributeSyntaxContext ctx, CancellationToken ct)
     {
-        var classDeclarationSyntax = (ClassDeclarationSyntax)context.Node;
-
-        foreach (AttributeListSyntax attributeListSyntax in classDeclarationSyntax.AttributeLists)
-        {
-            foreach (AttributeSyntax attributeSyntax in attributeListSyntax.Attributes)
-            {
-                if (attributeSyntax.Name.ToString() is "InstrumentMethod" or "InstrumentMethodAttribute" or "AdoNetTargetSignatureAttribute" or "AdoNetTargetSignature")
-                {
-                    return classDeclarationSyntax;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private static bool IsAssemblyAttributeForGeneration(AttributeData attributeData)
-    {
-        return attributeData.AttributeClass?.ToDisplayString() == Constants.AdoNetInstrumentAttribute;
-    }
-
-    private static (IReadOnlyList<CallTargetDefinitionSource> Definitions, IReadOnlyList<Diagnostic> Diagnostics) GetDefinitionToWrite(
-        Compilation compilation,
-        ImmutableArray<ClassDeclarationSyntax> classes,
-        ImmutableArray<AttributeData> assemblyAttributes,
-        CancellationToken ct)
-    {
-        if (classes.IsDefaultOrEmpty)
-        {
-            // nothing to do yet
-            return (Array.Empty<CallTargetDefinitionSource>(), Array.Empty<Diagnostic>());
-        }
-
-        var (definitions, diagnostics) = GetCallTargetDefinitionSources(
-            compilation,
-            classes.Distinct(),
-            assemblyAttributes,
-            ct);
-
-        return (definitions, diagnostics);
-    }
-
-    private static void Execute(
-        IReadOnlyList<CallTargetDefinitionSource> definitions,
-        IReadOnlyList<Diagnostic> diagnostics,
-        SourceProductionContext context)
-    {
-        if (definitions.Count != 0)
-        {
-            string source = Sources.CreateCallTargetDefinitions(definitions);
-            context.AddSource("InstrumentationDefinitions.g.cs", SourceText.From(source, Encoding.UTF8));
-        }
-
-        foreach (var diagnostic in diagnostics)
-        {
-            context.ReportDiagnostic(diagnostic);
-        }
-    }
-
-    private static (IReadOnlyList<CallTargetDefinitionSource> Definitions, IReadOnlyList<Diagnostic> Diagnostics) GetCallTargetDefinitionSources(
-        Compilation compilation,
-        IEnumerable<ClassDeclarationSyntax> classes,
-        ImmutableArray<AttributeData> assemblyAttributes,
-        CancellationToken cancellationToken)
-    {
-        INamedTypeSymbol? instrumentAttribute = compilation.GetTypeByMetadataName(Constants.InstrumentAttribute);
-        if (instrumentAttribute is null)
+        INamedTypeSymbol? classSymbol = ctx.TargetSymbol as INamedTypeSymbol;
+        if (classSymbol is null)
         {
             // nothing to do if this type isn't available
-            return (Array.Empty<CallTargetDefinitionSource>(), Array.Empty<Diagnostic>());
+            return new Result<EquatableArray<CallTargetDefinitionSource>>(default, default);
         }
 
-        INamedTypeSymbol? adoNetSignatureAttribute = compilation.GetTypeByMetadataName(Constants.AdoNetTargetSignatureSymbolName);
-        if (adoNetSignatureAttribute is null && !assemblyAttributes.IsDefaultOrEmpty)
+        ct.ThrowIfCancellationRequested();
+
+        List<DiagnosticInfo>? diagnostics = null;
+        List<CallTargetDefinitionSource>? results = null;
+
+        // Process InstrumentMethodAttribute first
+        foreach (AttributeData attributeData in classSymbol!.GetAttributes())
         {
-            // nothing to do if this type isn't available
-            return (Array.Empty<CallTargetDefinitionSource>(), Array.Empty<Diagnostic>());
-        }
-
-        INamedTypeSymbol? adoNetInstrumentationAttribute = compilation.GetTypeByMetadataName(Constants.AdoNetInstrumentAttribute);
-        if (adoNetInstrumentationAttribute is null && !assemblyAttributes.IsDefaultOrEmpty)
-        {
-            // nothing to do if this type isn't available
-            return (Array.Empty<CallTargetDefinitionSource>(), Array.Empty<Diagnostic>());
-        }
-
-        var results = new List<CallTargetDefinitionSource>();
-        var signatures = assemblyAttributes.IsDefaultOrEmpty ? null : new Dictionary<string, AdoNetSignature>();
-        List<Diagnostic>? diagnostics = null;
-
-        foreach (ClassDeclarationSyntax classDec in classes)
-        {
-            // stop if we're asked to
-            cancellationToken.ThrowIfCancellationRequested();
-
-            SemanticModel sm = compilation.GetSemanticModel(classDec.SyntaxTree);
-            INamedTypeSymbol? classSymbol = sm.GetDeclaredSymbol(classDec, cancellationToken) as INamedTypeSymbol;
-            Debug.Assert(classSymbol is not null, "Instrumented class is not present");
-            var boundAttributes = classSymbol!.GetAttributes();
-
-            // Process InstrumentMethodAttribute first
-            foreach (AttributeData attributeData in boundAttributes)
+            if ((attributeData.AttributeClass?.Name == "InstrumentMethodAttribute" ||
+                 attributeData.AttributeClass?.Name == "InstrumentMethod")
+             && attributeData.AttributeClass.ToDisplayString() == InstrumentedMethodAttribute)
             {
                 var hasMisconfiguredInput = false;
-
-                if (!instrumentAttribute.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default))
-                {
-                    continue;
-                }
-
                 string? assemblyName = null;
                 string[]? assemblyNames = null;
                 string? integrationName = null;
@@ -248,7 +205,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 if (assemblyNames is null or { Length: 0 } && assemblyName is null)
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         MissingRequiredPropertyDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -259,7 +216,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 if (typeNames is null or { Length: 0 } && typeName is null)
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         MissingRequiredPropertyDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -270,7 +227,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 if (integrationName is null)
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         MissingRequiredPropertyDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -280,7 +237,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 if (methodName is null)
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         MissingRequiredPropertyDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -290,7 +247,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 if (returnTypeName is null)
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         MissingRequiredPropertyDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -302,7 +259,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 if (minimumVersion is null)
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         MissingRequiredPropertyDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -311,7 +268,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 else if (!TryGetVersion(minimumVersion, ushort.MinValue, out minVersion))
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         InvalidVersionFormatDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -321,7 +278,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 if (maximumVersion is null)
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         MissingRequiredPropertyDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -330,7 +287,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 else if (!TryGetVersion(maximumVersion, ushort.MaxValue, out maxVersion))
                 {
                     hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
+                    diagnostics ??= new();
                     diagnostics.Add(
                         InvalidVersionFormatDiagnostic.Create(
                             attributeData.ApplicationSyntaxReference?.GetSyntax(),
@@ -346,6 +303,7 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 {
                     foreach (var type in typeNames ?? new[] { typeName })
                     {
+                        results ??= new();
                         results.Add(
                             new CallTargetDefinitionSource(
                                 integrationName: integrationName!,
@@ -363,111 +321,132 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                     }
                 }
             }
+        }
 
-            // no need to extract signature attribute details, as we don't have any assembly attributes to use them
-            if (assemblyAttributes.IsDefaultOrEmpty)
+        var errors = diagnostics is { Count: > 0 }
+                         ? new EquatableArray<DiagnosticInfo>(diagnostics.ToArray())
+                         : default;
+
+        return new Result<EquatableArray<CallTargetDefinitionSource>>(results is null ? default : new(results.ToArray()), errors);
+    }
+
+    private static Result<EquatableArray<(string ClassName, AdoNetSignature Signature)>> GetAdoNetSignatures(
+        GeneratorAttributeSyntaxContext ctx, CancellationToken ct)
+    {
+        INamedTypeSymbol? classSymbol = ctx.TargetSymbol as INamedTypeSymbol;
+        if (classSymbol is null)
+        {
+            // nothing to do if this type isn't available
+            return new Result<EquatableArray<(string ClassName, AdoNetSignature Signature)>>(default, default);
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        List<DiagnosticInfo>? diagnostics = null;
+        List<(string ClassName, AdoNetSignature Signature)>? results = null;
+
+        // Process AdoNetSignatureAttribute next
+        foreach (AttributeData attributeData in classSymbol!.GetAttributes())
+        {
+            if ((attributeData.AttributeClass?.Name != "AdoNetTargetSignatureAttribute" &&
+                 attributeData.AttributeClass?.Name != "AdoNetTargetSignature")
+             || attributeData.AttributeClass.ToDisplayString() != AdoNetTargetSignatureAttribute)
             {
                 continue;
             }
 
-            // Process AdoNetSignatureAttribute next
-            foreach (AttributeData attributeData in boundAttributes)
-            {
-                var hasMisconfiguredInput = false;
+            var hasMisconfiguredInput = false;
 
-                if (!adoNetSignatureAttribute!.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default))
+            string? methodName = null;
+            string? returnTypeName = null;
+            string[]? parameterTypeNames = null;
+            int? integrationKind = null;
+            int? returnType = null;
+            string? callTargetType = null;
+
+            foreach (KeyValuePair<string, TypedConstant> namedArgument in attributeData.NamedArguments)
+            {
+                if (namedArgument.Value.Kind == TypedConstantKind.Error)
                 {
-                    continue;
+                    hasMisconfiguredInput = true;
+                    break;
                 }
 
-                string? methodName = null;
-                string? returnTypeName = null;
-                string[]? parameterTypeNames = null;
-                int? integrationKind = null;
-                int? returnType = null;
-                string? callTargetType = null;
-
-                foreach (KeyValuePair<string, TypedConstant> namedArgument in attributeData.NamedArguments)
+                switch (namedArgument.Key)
                 {
-                    if (namedArgument.Value.Kind == TypedConstantKind.Error)
-                    {
+                    case nameof(Constants.AdoNetSignatureAttributeProperties.MethodName):
+                        methodName = namedArgument.Value.Value?.ToString();
+                        break;
+                    case nameof(Constants.AdoNetSignatureAttributeProperties.ReturnTypeName):
+                        returnTypeName = namedArgument.Value.Value?.ToString();
+                        break;
+                    case nameof(Constants.AdoNetSignatureAttributeProperties.ParameterTypeNames):
+                        parameterTypeNames = GetStringArray(namedArgument.Value.Values);
+                        break;
+                    case nameof(Constants.AdoNetSignatureAttributeProperties.CallTargetType):
+                        callTargetType = (namedArgument.Value.Value as INamedTypeSymbol)?.ToDisplayString();
+                        break;
+                    case nameof(Constants.AdoNetSignatureAttributeProperties.CallTargetIntegrationKind):
+                        integrationKind = namedArgument.Value.Value as int?;
+                        break;
+                    case nameof(Constants.AdoNetSignatureAttributeProperties.ReturnType):
+                        returnType = namedArgument.Value.Value as int?;
+                        break;
+                    default:
                         hasMisconfiguredInput = true;
                         break;
-                    }
-
-                    switch (namedArgument.Key)
-                    {
-                        case nameof(Constants.AdoNetSignatureAttributeProperties.MethodName):
-                            methodName = namedArgument.Value.Value?.ToString();
-                            break;
-                        case nameof(Constants.AdoNetSignatureAttributeProperties.ReturnTypeName):
-                            returnTypeName = namedArgument.Value.Value?.ToString();
-                            break;
-                        case nameof(Constants.AdoNetSignatureAttributeProperties.ParameterTypeNames):
-                            parameterTypeNames = GetStringArray(namedArgument.Value.Values);
-                            break;
-                        case nameof(Constants.AdoNetSignatureAttributeProperties.CallTargetType):
-                            callTargetType = (namedArgument.Value.Value as INamedTypeSymbol)?.ToDisplayString();
-                            break;
-                        case nameof(Constants.AdoNetSignatureAttributeProperties.CallTargetIntegrationKind):
-                            integrationKind = namedArgument.Value.Value as int?;
-                            break;
-                        case nameof(Constants.AdoNetSignatureAttributeProperties.ReturnType):
-                            returnType = namedArgument.Value.Value as int?;
-                            break;
-                        default:
-                            hasMisconfiguredInput = true;
-                            break;
-                    }
-
-                    if (hasMisconfiguredInput)
-                    {
-                        break;
-                    }
                 }
 
                 if (hasMisconfiguredInput)
                 {
-                    continue;
+                    break;
                 }
+            }
 
-                if (methodName is null)
-                {
-                    hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
-                    diagnostics.Add(
-                        MissingRequiredPropertyDiagnostic.Create(
-                            attributeData.ApplicationSyntaxReference?.GetSyntax(),
-                            Constants.AdoNetSignatureAttributeProperties.MethodName));
-                }
+            if (hasMisconfiguredInput)
+            {
+                continue;
+            }
 
-                if (callTargetType is null)
-                {
-                    hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
-                    diagnostics.Add(
-                        MissingRequiredPropertyDiagnostic.Create(
-                            attributeData.ApplicationSyntaxReference?.GetSyntax(),
-                            Constants.AdoNetSignatureAttributeProperties.CallTargetType));
-                }
+            if (methodName is null)
+            {
+                hasMisconfiguredInput = true;
+                diagnostics ??= new();
+                diagnostics.Add(
+                    MissingRequiredPropertyDiagnostic.Create(
+                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        Constants.AdoNetSignatureAttributeProperties.MethodName));
+            }
 
-                if (returnType is 0 && returnTypeName is null)
-                {
-                    hasMisconfiguredInput = true;
-                    diagnostics ??= new List<Diagnostic>();
-                    diagnostics.Add(
-                        MissingRequiredPropertyDiagnostic.Create(
-                            attributeData.ApplicationSyntaxReference?.GetSyntax(),
-                            Constants.AdoNetSignatureAttributeProperties.ReturnTypeName,
-                            Constants.AdoNetSignatureAttributeProperties.ReturnType));
-                }
+            if (callTargetType is null)
+            {
+                hasMisconfiguredInput = true;
+                diagnostics ??= new();
+                diagnostics.Add(
+                    MissingRequiredPropertyDiagnostic.Create(
+                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        Constants.AdoNetSignatureAttributeProperties.CallTargetType));
+            }
 
-                if (hasMisconfiguredInput)
-                {
-                    continue;
-                }
+            if (returnType is 0 && returnTypeName is null)
+            {
+                hasMisconfiguredInput = true;
+                diagnostics ??= new();
+                diagnostics.Add(
+                    MissingRequiredPropertyDiagnostic.Create(
+                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        Constants.AdoNetSignatureAttributeProperties.ReturnTypeName,
+                        Constants.AdoNetSignatureAttributeProperties.ReturnType));
+            }
 
-                signatures!.Add(
+            if (hasMisconfiguredInput)
+            {
+                continue;
+            }
+
+            results ??= new();
+            results!.Add(
+                (
                     classSymbol.ToDisplayString(),
                     new AdoNetSignature(
                         targetMethodName: methodName!,
@@ -475,16 +454,34 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                         targetParameterTypes: parameterTypeNames ?? Array.Empty<string>(),
                         instrumentationTypeName: callTargetType!.ToString(),
                         callTargetIntegrationKind: integrationKind ?? 0,
-                        returnType: returnType ?? 0));
-            }
+                        returnType: returnType ?? 0)));
         }
+
+        var errors = diagnostics is { Count: > 0 }
+                         ? new EquatableArray<DiagnosticInfo>(diagnostics.ToArray())
+                         : default;
+
+        return new Result<EquatableArray<(string, AdoNetSignature)>>(results is null ? default : new(results.ToArray()), errors);
+    }
+
+    private static Result<EquatableArray<AssemblyCallTargetDefinitionSource>> GetAssemblyCallTargetDefinitionSources(
+        GeneratorAttributeSyntaxContext ctx, CancellationToken ct)
+    {
+        var assemblyAttributes = ctx.TargetSymbol.GetAttributes();
+
+        ct.ThrowIfCancellationRequested();
+
+        List<DiagnosticInfo>? diagnostics = null;
+        List<AssemblyCallTargetDefinitionSource>? results = null;
 
         // Now build the adonet references
         foreach (AttributeData attributeData in assemblyAttributes)
         {
             var hasMisconfiguredInput = false;
 
-            if (!adoNetInstrumentationAttribute!.Equals(attributeData.AttributeClass, SymbolEqualityComparer.Default))
+            if ((attributeData.AttributeClass?.Name != "AdoNetClientInstrumentMethodsAttribute" &&
+                 attributeData.AttributeClass?.Name != "AdoNetClientInstrumentMethods")
+             || attributeData.AttributeClass.ToDisplayString() != AdoNetInstrumentAttribute)
             {
                 continue;
             }
@@ -548,33 +545,35 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
                 continue;
             }
 
+            var syntaxNode = attributeData.ApplicationSyntaxReference?.GetSyntax();
+
             if (string.IsNullOrEmpty(assemblyName))
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.AssemblyName));
             }
 
             if (string.IsNullOrEmpty(typeName))
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.TypeName));
             }
 
             if (integrationName is null)
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.IntegrationName));
             }
 
@@ -583,68 +582,68 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
             if (minimumVersion is null)
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.MinimumVersion));
             }
             else if (!TryGetVersion(minimumVersion, ushort.MinValue, out minVersion))
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     InvalidVersionFormatDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.MinimumVersion));
             }
 
             if (maximumVersion is null)
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.MaximumVersion));
             }
             else if (!TryGetVersion(maximumVersion, ushort.MaxValue, out maxVersion))
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     InvalidVersionFormatDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.MaximumVersion));
             }
 
             if (dataReaderTypeName is null)
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.DataReaderType));
             }
 
             if (dataReaderTaskTypeName is null)
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.DataReaderTaskType));
             }
 
             if (signatureAttributeTypes is null or { Length: 0 })
             {
                 hasMisconfiguredInput = true;
-                diagnostics ??= new List<Diagnostic>();
+                diagnostics ??= new();
                 diagnostics.Add(
                     MissingRequiredPropertyDiagnostic.Create(
-                        attributeData.ApplicationSyntaxReference?.GetSyntax(),
+                        syntaxNode,
                         Constants.AdoNetInstrumentAttributeProperties.TargetMethodAttributes));
             }
 
@@ -655,41 +654,88 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
 
             foreach (var signatureAttributeName in signatureAttributeTypes!)
             {
-                if (!signatures!.TryGetValue(signatureAttributeName, out var signatureAttribute))
-                {
-                    diagnostics ??= new List<Diagnostic>();
-                    diagnostics.Add(
-                        UnknownAdoNetSignatureNameDiagnostic.Create(
-                            attributeData.ApplicationSyntaxReference?.GetSyntax(),
-                            signatureAttributeName));
-                    continue;
-                }
-
-                var returnTypeName = signatureAttribute.ReturnType switch
-                {
-                    1 => dataReaderTypeName,
-                    2 => dataReaderTaskTypeName,
-                    _ => signatureAttribute.TargetReturnType
-                };
-
+                results ??= new();
                 results.Add(
-                    new CallTargetDefinitionSource(
+                    new AssemblyCallTargetDefinitionSource(
+                        signatureAttributeName: signatureAttributeName,
                         integrationName: integrationName!,
                         assemblyName: assemblyName!,
                         targetTypeName: typeName!,
-                        targetMethodName: signatureAttribute.TargetMethodName,
-                        targetReturnType: returnTypeName!,
-                        targetParameterTypes: signatureAttribute.TargetParameterTypes,
                         minimumVersion: minVersion,
                         maximumVersion: maxVersion,
-                        instrumentationTypeName: signatureAttribute.InstrumentationTypeName,
-                        integrationKind: signatureAttribute.CallTargetIntegrationKind,
                         isAdoNetIntegration: true,
-                        instrumentationCategory: InstrumentationCategory.Tracing));
+                        instrumentationCategory: InstrumentationCategory.Tracing,
+                        location: LocationInfo.CreateFrom(syntaxNode),
+                        dataReaderTypeName,
+                        dataReaderTaskTypeName));
             }
         }
 
-        return (results, diagnostics as IReadOnlyList<Diagnostic> ?? Array.Empty<Diagnostic>());
+        var errors = diagnostics is { Count: > 0 }
+                         ? new EquatableArray<DiagnosticInfo>(diagnostics.ToArray())
+                         : default;
+
+        return new Result<EquatableArray<AssemblyCallTargetDefinitionSource>>(results is null ? default : new(results.ToArray()), errors);
+    }
+
+    private static Result<CallTargetDefinitionSource?> MergeAdoNetAttributes(
+        AssemblyCallTargetDefinitionSource attribute, ImmutableArray<(string ClassName, AdoNetSignature Signature)> signatures)
+    {
+        foreach (var signature in signatures)
+        {
+            if (signature.ClassName == attribute.SignatureAttributeName)
+            {
+                // found it
+
+                var returnTypeName = signature.Signature.ReturnType switch
+                {
+                    1 => attribute.DataReaderTypeName,
+                    2 => attribute.DataReaderTaskTypeName,
+                    _ => signature.Signature.TargetReturnType
+                };
+
+                var callTargetSource =
+                    new CallTargetDefinitionSource(
+                        integrationName: attribute.IntegrationName!,
+                        assemblyName: attribute.AssemblyName!,
+                        targetTypeName: attribute.TargetTypeName!,
+                        targetMethodName: signature.Signature.TargetMethodName,
+                        targetReturnType: returnTypeName!,
+                        targetParameterTypes: signature.Signature.TargetParameterTypes.AsArray() ?? [],
+                        minimumVersion: attribute.MinimumVersion,
+                        maximumVersion: attribute.MaximumVersion,
+                        instrumentationTypeName: signature.Signature.InstrumentationTypeName,
+                        integrationKind: signature.Signature.CallTargetIntegrationKind,
+                        isAdoNetIntegration: true,
+                        instrumentationCategory: InstrumentationCategory.Tracing);
+
+                return new Result<CallTargetDefinitionSource?>(callTargetSource, default);
+            }
+        }
+
+        var diagnostic = UnknownAdoNetSignatureNameDiagnostic.Create(
+            attribute.Location,
+            attribute.SignatureAttributeName);
+
+        return new Result<CallTargetDefinitionSource?>(null, new([diagnostic]));
+    }
+
+    private static void Execute(
+        ImmutableArray<CallTargetDefinitionSource> definitions,
+        ImmutableArray<CallTargetDefinitionSource> adoNetDefinitions,
+        SourceProductionContext context)
+    {
+        if (definitions.IsDefaultOrEmpty && adoNetDefinitions.IsDefaultOrEmpty)
+        {
+            return;
+        }
+
+        var allDefinitions = definitions.IsDefaultOrEmpty
+                                 ? adoNetDefinitions
+                                 : (adoNetDefinitions.IsDefaultOrEmpty ? definitions : definitions.AddRange(adoNetDefinitions));
+
+        string source = Sources.CreateCallTargetDefinitions(allDefinitions);
+        context.AddSource("InstrumentationDefinitions.g.cs", SourceText.From(source, Encoding.UTF8));
     }
 
     private static bool TryGetVersion(string version, ushort defaultValue, out (ushort Major, ushort Minor, ushort Patch) parsedVersion)

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/InstrumentationDefinitionsGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/InstrumentationDefinitionsGenerator.cs
@@ -116,7 +116,8 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
         List<CallTargetDefinitionSource>? results = null;
 
         // Process InstrumentMethodAttribute first
-        foreach (AttributeData attributeData in classSymbol!.GetAttributes())
+        // Iterate over the GeneratorAttributeSyntaxContext.Attributes property which is pre-populated with the targeted attributes
+        foreach (AttributeData attributeData in ctx.Attributes)
         {
             if ((attributeData.AttributeClass?.Name == "InstrumentMethodAttribute" ||
                  attributeData.AttributeClass?.Name == "InstrumentMethod")
@@ -346,15 +347,9 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
         List<(string ClassName, AdoNetSignature Signature)>? results = null;
 
         // Process AdoNetSignatureAttribute next
-        foreach (AttributeData attributeData in classSymbol!.GetAttributes())
+        // Iterate over the GeneratorAttributeSyntaxContext.Attributes property which is pre-populated with the targeted attributes
+        foreach (AttributeData attributeData in ctx.Attributes)
         {
-            if ((attributeData.AttributeClass?.Name != "AdoNetTargetSignatureAttribute" &&
-                 attributeData.AttributeClass?.Name != "AdoNetTargetSignature")
-             || attributeData.AttributeClass.ToDisplayString() != AdoNetTargetSignatureAttribute)
-            {
-                continue;
-            }
-
             var hasMisconfiguredInput = false;
 
             string? methodName = null;
@@ -467,24 +462,16 @@ public class InstrumentationDefinitionsGenerator : IIncrementalGenerator
     private static Result<EquatableArray<AssemblyCallTargetDefinitionSource>> GetAssemblyCallTargetDefinitionSources(
         GeneratorAttributeSyntaxContext ctx, CancellationToken ct)
     {
-        var assemblyAttributes = ctx.TargetSymbol.GetAttributes();
-
         ct.ThrowIfCancellationRequested();
 
         List<DiagnosticInfo>? diagnostics = null;
         List<AssemblyCallTargetDefinitionSource>? results = null;
 
         // Now build the adonet references
-        foreach (AttributeData attributeData in assemblyAttributes)
+        // Iterate over the GeneratorAttributeSyntaxContext.Attributes property which is pre-populated with the targeted attributes
+        foreach (AttributeData attributeData in ctx.Attributes)
         {
             var hasMisconfiguredInput = false;
-
-            if ((attributeData.AttributeClass?.Name != "AdoNetClientInstrumentMethodsAttribute" &&
-                 attributeData.AttributeClass?.Name != "AdoNetClientInstrumentMethods")
-             || attributeData.AttributeClass.ToDisplayString() != AdoNetInstrumentAttribute)
-            {
-                continue;
-            }
 
             string? assemblyName = null;
             string? integrationName = null;

--- a/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Sources.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/InstrumentationDefinitions/Sources.cs
@@ -305,7 +305,7 @@ namespace Datadog.Trace.ClrProfiler
               .Append(definition.TargetMethodName)
               .Append(@"""), ");
 
-            var paramLengths = (definition.TargetParameterTypes?.Length ?? 0) + 1;
+            var paramLengths = (definition.TargetParameterTypes.Count) + 1;
             if (paramLengths > 9)
             {
                 sb.Append(@"NativeCallTargetUnmanagedMemoryHelper.AllocateAndWriteUtf16StringArray(new[] { """)
@@ -329,7 +329,7 @@ namespace Datadog.Trace.ClrProfiler
                   .Append(definition.TargetReturnType)
                   .Append(@"""");
 
-                if (definition.TargetParameterTypes is { Length: > 0 } types)
+                if (definition.TargetParameterTypes is { Count: > 0 } types)
                 {
                     foreach (var parameterType in types)
                     {


### PR DESCRIPTION
## Summary of changes

Rewrote the instrumentation definition generator to use best practices

## Reason for change

It was previously _terribly_ written. Every key press in the IDE was causing complete full regeneration, and probably was caching huge amounts of extra data. The person who wrote it clearly didn't know what they were doing at the time. (Spoiler: it was me, I wrote it).

## Implementation details

- Use the `ForAttributeWithMetadataName` to reduce load
- Stop using `SyntaxNode` in outputs
- Fix cacheability of diagnostics

[Basically everything described here](https://andrewlock.net/creating-a-source-generator-part-9-avoiding-performance-pitfalls-in-incremental-generators/) 

## Test coverage

As long as the existing tests still pass, and there's no change in the generator _output_ then everything's good!
