### PR TITLE
Test source generators for incrementality

### DIFF
--- a/tracer/src/Datadog.Trace.SourceGenerators/Helpers/TrackingNames.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/Helpers/TrackingNames.cs
@@ -1,0 +1,34 @@
+// <copyright file="TrackingNames.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.SourceGenerators.Helpers;
+
+internal class TrackingNames
+{
+    // General generator stages
+    public const string PostTransform = nameof(PostTransform);
+    public const string Diagnostics = nameof(Diagnostics);
+    public const string ValidValues = nameof(ValidValues);
+    public const string Collected = nameof(Collected);
+
+    // Tag generator
+    public const string TagResults = nameof(TagResults);
+    public const string MetricResults = nameof(MetricResults);
+    public const string TagDiagnostics = nameof(TagDiagnostics);
+    public const string MetricDiagnostics = nameof(MetricDiagnostics);
+    public const string AllTags = nameof(AllTags);
+    public const string AllMetrics = nameof(AllMetrics);
+    public const string AllProperties = nameof(AllProperties);
+
+    // Call target
+    public const string CallTargetDiagnostics = nameof(CallTargetDiagnostics);
+    public const string AdoNetDiagnostics = nameof(AdoNetDiagnostics);
+    public const string AssemblyDiagnostics = nameof(AssemblyDiagnostics);
+    public const string AdoNetMergeDiagnostics = nameof(AdoNetMergeDiagnostics);
+    public const string CallTargetDefinitionSource = nameof(CallTargetDefinitionSource);
+    public const string AssemblyCallTargetDefinitionSource = nameof(AssemblyCallTargetDefinitionSource);
+    public const string AdoNetCallTargetDefinitionSource = nameof(AdoNetCallTargetDefinitionSource);
+    public const string AdoNetSignatures = nameof(AdoNetSignatures);
+}

--- a/tracer/src/Datadog.Trace.SourceGenerators/PublicApi/PublicApiGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/PublicApi/PublicApiGenerator.cs
@@ -39,16 +39,19 @@ public class PublicApiGenerator : IIncrementalGenerator
                         GeneratePublicApiAttribute,
                         static (node, _) => node is PropertyDeclarationSyntax,
                         static (context, ct) => GetPublicApiProperties(context, ct))
-                   .Where(static m => m is not null)!;
+                   .Where(static m => m is not null)!
+                   .WithTrackingName(TrackingNames.PostTransform);
 
         context.ReportDiagnostics(
             properties
                .Where(static m => m.Errors.Count > 0)
-               .SelectMany(static (x, _) => x.Errors));
+               .SelectMany(static (x, _) => x.Errors)
+               .WithTrackingName(TrackingNames.Diagnostics));
 
         var allValidProperties = properties
                      .Where(static m => m.Value.IsValid)
                      .Select(static (x, _) => x.Value.PropertyTag)
+                     .WithTrackingName(TrackingNames.ValidValues)
                      .Collect();
 
         context.RegisterSourceOutput(allValidProperties, Execute);

--- a/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/TelemetryMetricGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TelemetryMetric/TelemetryMetricGenerator.cs
@@ -41,23 +41,26 @@ public class TelemetryMetricGenerator : IIncrementalGenerator
                         TelemetryMetricTypeAttributeFullName,
                         static (node, _) => node is EnumDeclarationSyntax,
                         static (context, ct) => GetTypeToGenerate(context, ct))
+                   .WithTrackingName(TrackingNames.PostTransform)
                    .Where(static m => m is not null)!;
 
         context.ReportDiagnostics(
             enums
                .Where(static m => m.Errors.Count > 0)
-               .SelectMany(static (x, _) => x.Errors));
+               .SelectMany(static (x, _) => x.Errors)
+               .WithTrackingName(TrackingNames.Diagnostics));
 
         var validEnums = enums
                         .Where(static m => m.Value.IsValid)
-                        .Select(static (x, _) => x.Value.EnumDetails);
+                        .Select(static (x, _) => x.Value.EnumDetails)
+                        .WithTrackingName(TrackingNames.ValidValues);
 
         context.RegisterSourceOutput(
             validEnums,
             static (spc, source) => GenerateEnumSpecificCollectors(in source, spc));
 
         context.RegisterSourceOutput(
-            validEnums.Collect(),
+            validEnums.Collect().WithTrackingName(TrackingNames.Collected),
             static (spc, source) => GenerateAggregateCollectors(in source, spc));
     }
 

--- a/tracer/src/Datadog.Trace.SourceGenerators/TracerSettingsSnapshot/TracerSettingsSnapshotGenerator.cs
+++ b/tracer/src/Datadog.Trace.SourceGenerators/TracerSettingsSnapshot/TracerSettingsSnapshotGenerator.cs
@@ -34,16 +34,19 @@ public class TracerSettingsSnapshotGenerator : IIncrementalGenerator
                         GenerateSnapshotFullName,
                         static (node, _) => node is ClassDeclarationSyntax,
                         static (context, ct) => GetSettableProperties(context, ct))
+                   .WithTrackingName(TrackingNames.PostTransform)
                    .Where(static m => m is not null)!;
 
         context.ReportDiagnostics(
             classesToGenerate
                .Where(static m => m.Errors.Count > 0)
-               .SelectMany(static (x, _) => x.Errors));
+               .SelectMany(static (x, _) => x.Errors)
+               .WithTrackingName(TrackingNames.Diagnostics));
 
         var validClasses = classesToGenerate
                           .Where(static m => m.Value.IsValid)
-                          .Select(static (x, _) => x.Value.ClassToGenerate);
+                          .Select(static (x, _) => x.Value.ClassToGenerate)
+                          .WithTrackingName(TrackingNames.ValidValues);
 
         context.RegisterSourceOutput(
             validClasses,

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/InstrumentationDefinitionsGeneratorTests.cs
@@ -23,7 +23,8 @@ namespace MyTests
     }
 }";
 
-            var (diagnostics, output) = TestHelpers.GetGeneratedOutput<InstrumentationDefinitionsGenerator>(input);
+            // No tracked steps execute, so have to disable the tracked step assertions
+            var (diagnostics, output) = TestHelpers.GetGeneratedTrees<InstrumentationDefinitionsGenerator>([input], assertOutput: false);
             Assert.Empty(output);
             Assert.Empty(diagnostics);
         }

--- a/tracer/test/Datadog.Trace.SourceGenerators.Tests/TestHelpers.cs
+++ b/tracer/test/Datadog.Trace.SourceGenerators.Tests/TestHelpers.cs
@@ -4,9 +4,13 @@
 // </copyright>
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
-using Datadog.Trace.SourceGenerators.TagsListGenerator;
+using System.Reflection;
+using Datadog.Trace.SourceGenerators.Helpers;
+using FluentAssertions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -17,33 +21,212 @@ namespace Datadog.Trace.SourceGenerators.Tests
         public static (ImmutableArray<Diagnostic> Diagnostics, string Output) GetGeneratedOutput<T>(params string[] source)
             where T : IIncrementalGenerator, new()
         {
-            var (diagnostics, trees) = GetGeneratedTrees<T>(source);
+            var (diagnostics, trees) = GetGeneratedTrees<T, TrackingNames>(source);
             return (diagnostics, trees.LastOrDefault() ?? string.Empty);
         }
 
-        public static (ImmutableArray<Diagnostic> Diagnostics, string[] Output) GetGeneratedTrees<T>(params string[] source)
+        public static (ImmutableArray<Diagnostic> Diagnostics, string[] Output) GetGeneratedTrees<TGenerator>(params string[] source)
+            where TGenerator : IIncrementalGenerator, new()
+            => GetGeneratedTrees<TGenerator, TrackingNames>(source);
+
+        public static (ImmutableArray<Diagnostic> Diagnostics, string[] Output) GetGeneratedTrees<TGenerator>(string[] source, bool assertOutput)
+            where TGenerator : IIncrementalGenerator, new()
+            => GetGeneratedTrees<TGenerator, TrackingNames>(source, assertOutput);
+
+        public static (ImmutableArray<Diagnostic> Diagnostics, string[] Output) GetGeneratedTrees<TGenerator, TTrackingNames>(params string[] sources)
+            where TGenerator : IIncrementalGenerator, new()
+            => GetGeneratedTrees<TGenerator, TTrackingNames>(sources, assertOutput: true);
+
+        public static (ImmutableArray<Diagnostic> Diagnostics, string[] Output) GetGeneratedTrees<TGenerator, TTrackingNames>(string[] sources, bool assertOutput)
+            where TGenerator : IIncrementalGenerator, new()
+        {
+            // get all the const string fields
+            var trackingNames = typeof(TTrackingNames)
+                               .GetFields()
+                               .Where(fi => fi.IsLiteral && !fi.IsInitOnly && fi.FieldType == typeof(string))
+                               .Select(x => (string)x.GetRawConstantValue())
+                               .Where(x => !string.IsNullOrEmpty(x))
+                               .ToArray();
+
+            return GetGeneratedTrees<TGenerator>(sources, trackingNames, assertOutput);
+        }
+
+        public static (ImmutableArray<Diagnostic> Diagnostics, string[] Output) GetGeneratedTrees<T>(string[] source, string[] stages, bool assertOutput = true)
             where T : IIncrementalGenerator, new()
         {
-            var syntaxTrees = source.Select(static x => CSharpSyntaxTree.ParseText(x));
+            IEnumerable<SyntaxTree> syntaxTrees = source.Select(static x => CSharpSyntaxTree.ParseText(x));
             var references = AppDomain.CurrentDomain.GetAssemblies()
                                       .Where(_ => !_.IsDynamic && !string.IsNullOrWhiteSpace(_.Location))
                                       .Select(_ => MetadataReference.CreateFromFile(_.Location))
                                       .Concat(new[] { MetadataReference.CreateFromFile(typeof(T).Assembly.Location) });
-            var compilation = CSharpCompilation.Create(
+
+            CSharpCompilation compilation = CSharpCompilation.Create(
                 "Datadog.Trace.Generated",
                 syntaxTrees,
                 references,
                 new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-            var originalTreeCount = compilation.SyntaxTrees.Length;
-            var generator = new T();
+            GeneratorDriverRunResult runResult = RunGeneratorAndAssertOutput<T>(compilation, stages, assertOutput);
 
-            var driver = CSharpGeneratorDriver.Create(generator);
-            driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out var diagnostics);
+            return (runResult.Diagnostics, runResult.GeneratedTrees.Select(x => x.ToString()).ToArray());
+        }
 
-            var trees = outputCompilation.SyntaxTrees.ToList();
+        private static GeneratorDriverRunResult RunGeneratorAndAssertOutput<T>(CSharpCompilation compilation, string[] trackingNames, bool assertOutput = true)
+            where T : IIncrementalGenerator, new()
+        {
+            ISourceGenerator generator = new T().AsSourceGenerator();
 
-            return (diagnostics, trees.Skip(originalTreeCount).Select(x => x.ToString()).ToArray());
+            var opts = new GeneratorDriverOptions(
+                disabledOutputs: IncrementalGeneratorOutputKind.None,
+                trackIncrementalGeneratorSteps: true);
+
+            GeneratorDriver driver = CSharpGeneratorDriver.Create([generator], driverOptions: opts);
+
+            var clone = compilation.Clone();
+            // Run twice, once with a clone of the compilation
+            // Note that we store the returned drive value, as it contains cached previous outputs
+            driver = driver.RunGenerators(compilation);
+            GeneratorDriverRunResult runResult = driver.GetRunResult();
+
+            if (assertOutput)
+            {
+                // Run with a clone of the compilation
+                GeneratorDriverRunResult runResult2 = driver
+                                                     .RunGenerators(clone)
+                                                     .GetRunResult();
+
+                AssertRunsEqual(runResult, runResult2, trackingNames);
+
+                // verify the second run only generated cached source outputs
+                runResult2.Results[0]
+                          .TrackedOutputSteps
+                          .SelectMany(x => x.Value) // step executions
+                          .SelectMany(x => x.Outputs) // execution results
+                          .Should()
+                          .OnlyContain(x => x.Reason == IncrementalStepRunReason.Cached);
+            }
+
+            return runResult;
+        }
+
+        private static void AssertRunsEqual(GeneratorDriverRunResult runResult1, GeneratorDriverRunResult runResult2, string[] trackingNames)
+        {
+            // We're given all the tracking names, but not all the stages have necessarily executed so filter
+            Dictionary<string, ImmutableArray<IncrementalGeneratorRunStep>> trackedSteps1 = GetTrackedSteps(runResult1, trackingNames);
+            Dictionary<string, ImmutableArray<IncrementalGeneratorRunStep>> trackedSteps2 = GetTrackedSteps(runResult2, trackingNames);
+
+            // These should be the same
+            trackedSteps1.Should()
+                         .NotBeEmpty()
+                         .And.HaveSameCount(trackedSteps2)
+                         .And.ContainKeys(trackedSteps2.Keys);
+
+            foreach (var trackedStep in trackedSteps1)
+            {
+                var trackingName = trackedStep.Key;
+                var runSteps1 = trackedStep.Value;
+                var runSteps2 = trackedSteps2[trackingName];
+                AssertEqual(runSteps1, runSteps2, trackingName);
+            }
+
+            return;
+
+            static Dictionary<string, ImmutableArray<IncrementalGeneratorRunStep>> GetTrackedSteps(
+                GeneratorDriverRunResult runResult, string[] trackingNames) =>
+                runResult.Results[0]
+                         .TrackedSteps
+                         .Where(step => trackingNames.Contains(step.Key))
+                         .ToDictionary(x => x.Key, x => x.Value);
+        }
+
+        private static void AssertEqual(
+            ImmutableArray<IncrementalGeneratorRunStep> runSteps1,
+            ImmutableArray<IncrementalGeneratorRunStep> runSteps2,
+            string stepName)
+        {
+            runSteps1.Should().HaveSameCount(runSteps2);
+
+            for (var i = 0; i < runSteps1.Length; i++)
+            {
+                var runStep1 = runSteps1[i];
+                var runStep2 = runSteps2[i];
+
+                // The outputs should be equal between different runs
+                IEnumerable<object> outputs1 = runStep1.Outputs.Select(x => x.Value);
+                IEnumerable<object> outputs2 = runStep2.Outputs.Select(x => x.Value);
+
+                outputs1.Should()
+                        .Equal(outputs2, $"because {stepName} should produce cacheable outputs");
+
+                // Therefore, on the second run the results should always be cached or unchanged!
+                // - Unchanged is when the _input_ has changed, but the output hasn't
+                // - Cached is when the the input has not changed, so the cached output is used
+                runStep2.Outputs.Should()
+                        .OnlyContain(
+                             x => x.Reason == IncrementalStepRunReason.Cached || x.Reason == IncrementalStepRunReason.Unchanged,
+                             $"{stepName} expected to have reason {IncrementalStepRunReason.Cached} or {IncrementalStepRunReason.Unchanged}");
+
+                // Make sure we're not using anything we shouldn't
+                // TODO this causes _weird_ stack overflow issues with EquatableArray
+                // AssertObjectGraph(runStep1, stepName);
+                // AssertObjectGraph(runStep2, stepName);
+            }
+
+#pragma warning disable CS8321 // Local function is declared but never used
+            static void AssertObjectGraph(IncrementalGeneratorRunStep runStep, string stepName)
+#pragma warning restore CS8321 // Local function is declared but never used
+            {
+                var because = $"{stepName} shouldn't contain banned symbols";
+                var visited = new HashSet<object>();
+                var queue = new Queue<object>();
+
+                // Populate queue
+                foreach (var (obj, _) in runStep.Outputs)
+                {
+                    Visit(obj);
+                }
+
+                // drain queue
+                while (queue.Count > 0)
+                {
+                    Visit(queue.Dequeue());
+                }
+
+                void Visit(object node)
+                {
+                    if (node is null || !visited.Add(node))
+                    {
+                        return;
+                    }
+
+                    node.Should()
+                       .NotBeOfType<Compilation>(because)
+                       .And.NotBeOfType<ISymbol>(because)
+                       .And.NotBeOfType<SyntaxNode>(because);
+
+                    Type type = node.GetType();
+                    if (type.IsPrimitive || type.IsEnum || type == typeof(string))
+                    {
+                        return;
+                    }
+
+                    if (node is IEnumerable collection and not string)
+                    {
+                        foreach (object element in collection)
+                        {
+                            queue.Enqueue(element);
+                        }
+
+                        return;
+                    }
+
+                    foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+                    {
+                        object fieldValue = field.GetValue(node);
+                        queue.Enqueue(fieldValue);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Adds unit tests that confirm the source generators are caching outputs correctly

## Reason for change

It was guess-work and eyeballing before, these tests confirm the generators are _actually_ doing what we expect.

## Implementation details

- Add `WithTrackingName` to important stages in the generators
- Run the generator twice
  - Confirm that the second run re-uses the cached generated files (it doesn't write them again)
  - Confirm that the intermediate steps are all cached/unchanged
  - Confirm that the outputs are considered `Equal()`

I wanted to also loop through all the types to assert we're not using `Compilation`, `ISymbol`, or `SyntaxNode`, but this ran into weird stack overflow issues calling `x is EquatableArray<T>` for some `T`. It's not critical, as the caching is the important thing, so can look into it at a later point.

If you'd prefer a more thorough description, [I wrote this all up as a blog post](https://andrewlock.net/creating-a-source-generator-part-10-testing-your-incremental-generator-pipeline-outputs-are-cacheable/).

## Test coverage

This adds more!

## Other details
Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/5108

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
