### PR TITLE
[v3] Add additional fields to linux packages

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -828,8 +828,6 @@ partial class Build
         .Requires(() => Version)
         .Executes(() =>
         {
-            var fpm = Fpm.Value;
-            var gzip = GZip.Value;
             var chmod = Chmod.Value;
 
             // For legacy back-compat reasons, we _must_ add certain files to their expected locations
@@ -910,6 +908,11 @@ partial class Build
                     $"--chdir {assetsDirectory}",
                     $"--after-install {BuildDirectory / "artifacts" / FileNames.AfterInstallScript}",
                     $"--after-remove {BuildDirectory / "artifacts" / FileNames.AfterRemoveScript}",
+                    "--license \"Apache License 2.0\"",
+                    "--description \"Datadog APM client library for .NET\"",
+                    "--url \"https://github.com/DataDog/dd-trace-dotnet\"",
+                    "--vendor \"Datadog <package@datadoghq.com>\"",
+                    "--maintainer \"Datadog Packages <package@datadoghq.com>\"",
                     "createLogPath.sh",
                     "dd-dotnet.sh",
                     "netstandard2.0/",


### PR DESCRIPTION
## Summary of changes

Adds additional fields to the linux packages we produce 

## Reason for change

Original intention was to remove the need for the repacking step in GitLab, but as they need a different folder structure anyway, repacking seems inevitable. Nevertheless, adding the extra fields seems like a good practice.

## Implementation details

Passed extra values to `fpm`

## Test coverage

Tested that the package is produced as expected. Comparing the fields using `dpkg-deb -I ./datadog-dotnet-apm_3.0.0_amd64.deb` gives:

```bash
 Package: datadog-dotnet-apm
 Version: 3.0.0
 License: Apache License 2.0
 Vendor: Datadog <package@datadoghq.com>
 Architecture: amd64
 Maintainer: Datadog Packages <package@datadoghq.com>
 Installed-Size: 69796
 Section: default
 Priority: extra
 Homepage: https://github.com/DataDog/dd-trace-dotnet
 Description: Datadog APM client library for .NET
```

Whereas in v2 we have:

```bash
 Package: datadog-dotnet-apm
 Version: 2.46.0
 License: unknown
 Vendor: none
 Architecture: amd64
 Maintainer: <@c5fb5e039735>
 Installed-Size: 69809
 Section: default
 Priority: extra
 Homepage: http://example.com/no-uri-given
 Description: no description given
```

## Other details

The repackaged `datadog-apm-library-dotnet` version we produce for single-step has the following:

```bash
 Package: datadog-apm-library-dotnet
 Version: 2.46.0-1
 License: Apache License 2.0
 Vendor: Datadog <package@datadoghq.com>
 Architecture: amd64
 Maintainer: Datadog Packages <package@datadoghq.com>
 Installed-Size: 69809
 Recommends: datadog-signing-keys (>= 1.3.1)
 Section: default
 Priority: optional
 Homepage: https://github.com/DataDog/dd-trace-dotnet
 Description: Datadog APM client library for .NET
```

I chose to use the same values for consistency (and they seem like good options)


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
