### PR TITLE
[CI Visibility] - Add intelligent test runner CorrelationId support

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -31,6 +31,12 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
         private readonly byte[] _durationBytes = StringEncoding.UTF8.GetBytes("duration");
         private readonly byte[] _parentIdBytes = StringEncoding.UTF8.GetBytes("parent_id");
         private readonly byte[] _errorBytes = StringEncoding.UTF8.GetBytes("error");
+        private readonly byte[] _itrCorrelationId = StringEncoding.UTF8.GetBytes("itr_correlation_id");
+
+        // SuiteId, ModuleId, SessionId tags
+        private readonly byte[] _testSuiteIdBytes = StringEncoding.UTF8.GetBytes(TestSuiteVisibilityTags.TestSuiteId);
+        private readonly byte[] _testModuleIdBytes = StringEncoding.UTF8.GetBytes(TestSuiteVisibilityTags.TestModuleId);
+        private readonly byte[] _testSessionIdBytes = StringEncoding.UTF8.GetBytes(TestSuiteVisibilityTags.TestSessionId);
 
         // string tags
         private readonly byte[] _metaBytes = StringEncoding.UTF8.GetBytes("meta");
@@ -61,13 +67,13 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
 
             // values begin at -1, so they are shifted by 1 from their array index: [-1, 0, 1, 2]
             // these must serialized as msgpack float64 (Double in .NET).
-            _samplingPriorityValueBytes = new[]
-                                          {
-                                              MessagePackSerializer.Serialize((double)SamplingPriorityValues.UserReject),
-                                              MessagePackSerializer.Serialize((double)SamplingPriorityValues.AutoReject),
-                                              MessagePackSerializer.Serialize((double)SamplingPriorityValues.AutoKeep),
-                                              MessagePackSerializer.Serialize((double)SamplingPriorityValues.UserKeep),
-                                          };
+            _samplingPriorityValueBytes =
+            [
+                MessagePackSerializer.Serialize((double)SamplingPriorityValues.UserReject),
+                MessagePackSerializer.Serialize((double)SamplingPriorityValues.AutoReject),
+                MessagePackSerializer.Serialize((double)SamplingPriorityValues.AutoKeep),
+                MessagePackSerializer.Serialize((double)SamplingPriorityValues.UserKeep)
+            ];
         }
 
         public int Serialize(ref byte[] bytes, int offset, Span value, IFormatterResolver formatterResolver)
@@ -113,6 +119,12 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
                 isSpan = true;
             }
 
+            var correlationId = value.Type == SpanTypes.Test ? CIVisibility.GetSkippableTestsCorrelationId() : null;
+            if (correlationId is not null)
+            {
+                len++;
+            }
+
             var originalOffset = offset;
 
             offset += MessagePackBinary.WriteMapHeader(ref bytes, offset, len);
@@ -153,20 +165,26 @@ namespace Datadog.Trace.Ci.Agent.MessagePack
 
             if (testSuiteTags is not null)
             {
-                offset += MessagePackBinary.WriteString(ref bytes, offset, TestSuiteVisibilityTags.TestSuiteId);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSuiteIdBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, testSuiteTags.SuiteId);
             }
 
             if (testModuleTags is not null)
             {
-                offset += MessagePackBinary.WriteString(ref bytes, offset, TestSuiteVisibilityTags.TestModuleId);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testModuleIdBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, testModuleTags.ModuleId);
             }
 
             if (testSessionTags is not null && testSessionTags.SessionId != 0)
             {
-                offset += MessagePackBinary.WriteString(ref bytes, offset, TestSuiteVisibilityTags.TestSessionId);
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _testSessionIdBytes);
                 offset += MessagePackBinary.WriteUInt64(ref bytes, offset, testSessionTags.SessionId);
+            }
+
+            if (correlationId is not null)
+            {
+                offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _itrCorrelationId);
+                offset += MessagePackBinary.WriteString(ref bytes, offset, correlationId);
             }
 
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _errorBytes);

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -388,7 +388,7 @@ internal class IntelligentTestRunnerClient
         }
     }
 
-    public async Task<SkippableTest[]> GetSkippableTestsAsync()
+    public async Task<SkippableTestsResponse> GetSkippableTestsAsync()
     {
         Log.Debug("ITR: Getting skippable tests...");
         var framework = FrameworkDescription.Instance;
@@ -397,7 +397,7 @@ internal class IntelligentTestRunnerClient
         if (currentShaCommand is null)
         {
             Log.Warning("ITR: 'git rev-parse HEAD' command is null");
-            return Array.Empty<SkippableTest>();
+            return new SkippableTestsResponse();
         }
 
         var currentSha = currentShaCommand.Output.Replace("\n", string.Empty);
@@ -426,7 +426,7 @@ internal class IntelligentTestRunnerClient
 
         return await WithRetries(InternalGetSkippableTestsAsync, jsonQueryBytes, MaxRetries).ConfigureAwait(false);
 
-        async Task<SkippableTest[]> InternalGetSkippableTestsAsync(byte[] state, bool finalTry)
+        async Task<SkippableTestsResponse> InternalGetSkippableTestsAsync(byte[] state, bool finalTry)
         {
             var sw = Stopwatch.StartNew();
             try
@@ -462,13 +462,13 @@ internal class IntelligentTestRunnerClient
                 Log.Debug("ITR: JSON RS = {Json}", responseContent);
                 if (string.IsNullOrEmpty(responseContent))
                 {
-                    return Array.Empty<SkippableTest>();
+                    return new SkippableTestsResponse();
                 }
 
                 var deserializedResult = JsonConvert.DeserializeObject<DataArrayEnvelope<Data<SkippableTest>>>(responseContent!);
                 if (deserializedResult.Data is null || deserializedResult.Data.Length == 0)
                 {
-                    return Array.Empty<SkippableTest>();
+                    return new SkippableTestsResponse(deserializedResult.Meta?.CorrelationId, Array.Empty<SkippableTest>());
                 }
 
                 var testAttributes = new List<SkippableTest>(deserializedResult.Data.Length);
@@ -508,7 +508,7 @@ internal class IntelligentTestRunnerClient
 
                 var totalSkippableTests = testAttributes.ToArray();
                 TelemetryFactory.Metrics.RecordCountCIVisibilityITRSkippableTestsResponseTests(totalSkippableTests.Length);
-                return totalSkippableTests;
+                return new SkippableTestsResponse(deserializedResult.Meta?.CorrelationId, totalSkippableTests);
             }
             finally
             {
@@ -1022,9 +1022,19 @@ internal class IntelligentTestRunnerClient
         [JsonProperty("repository_url")]
         public readonly string RepositoryUrl;
 
+        [JsonProperty("correlation_id")]
+        public readonly string? CorrelationId;
+
         public Metadata(string repositoryUrl)
         {
             RepositoryUrl = repositoryUrl;
+            CorrelationId = null;
+        }
+
+        public Metadata(string repositoryUrl, string? correlationId)
+        {
+            RepositoryUrl = repositoryUrl;
+            CorrelationId = correlationId;
         }
     }
 
@@ -1071,6 +1081,24 @@ internal class IntelligentTestRunnerClient
             RepositoryUrl = repositoryUrl;
             Sha = sha;
             Configurations = configurations;
+        }
+    }
+
+    public readonly struct SkippableTestsResponse
+    {
+        public readonly string? CorrelationId;
+        public readonly SkippableTest[] Tests;
+
+        public SkippableTestsResponse()
+        {
+            CorrelationId = null;
+            Tests = Array.Empty<SkippableTest>();
+        }
+
+        public SkippableTestsResponse(string? correlationId, SkippableTest[] tests)
+        {
+            CorrelationId = correlationId;
+            Tests = tests;
         }
     }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -61,29 +61,43 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
+                    const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
-                        if (e.Value.PathAndQuery != "/evp_proxy/v2/api/v2/citestcycle")
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/libraries/tests/services/setting")
                         {
+                            e.Value.Response = new MockTracerResponse("{\"data\":{\"id\":\"b5a855bffe6c0b2ae5d150fb6ad674363464c816\",\"type\":\"ci_app_tracers_test_service_settings\",\"attributes\":{\"code_coverage\":false,\"efd_enabled\":false,\"flaky_test_retries_enabled\":false,\"itr_enabled\":true,\"require_git\":false,\"tests_skipping\":true}}} ", 200);
                             return;
                         }
 
-                        var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
-                        if (payload.Events?.Length > 0)
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/ci/tests/skippable")
                         {
-                            foreach (var @event in payload.Events)
+                            e.Value.Response = new MockTracerResponse($"{{\"data\":[],\"meta\":{{\"correlation_id\":\"{correlationId}\"}}}}", 200);
+                            return;
+                        }
+
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/citestcycle")
+                        {
+                            var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
+                            if (payload.Events?.Length > 0)
                             {
-                                if (@event.Type == SpanTypes.Test)
+                                foreach (var @event in payload.Events)
                                 {
-                                    tests.Add(JsonConvert.DeserializeObject<MockCIVisibilityTest>(@event.Content.ToString()));
-                                }
-                                else if (@event.Type == SpanTypes.TestSuite)
-                                {
-                                    testSuites.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestSuite>(@event.Content.ToString()));
-                                }
-                                else if (@event.Type == SpanTypes.TestModule)
-                                {
-                                    testModules.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestModule>(@event.Content.ToString()));
+                                    if (@event.Content.ToString() is { } eventContent)
+                                    {
+                                        if (@event.Type == SpanTypes.Test)
+                                        {
+                                            tests.Add(JsonConvert.DeserializeObject<MockCIVisibilityTest>(eventContent));
+                                        }
+                                        else if (@event.Type == SpanTypes.TestSuite)
+                                        {
+                                            testSuites.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestSuite>(eventContent));
+                                        }
+                                        else if (@event.Type == SpanTypes.TestModule)
+                                        {
+                                            testModules.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestModule>(eventContent));
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -125,6 +139,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                             // check the name
                             Assert.Equal("mstestv2.test", targetTest.Name);
+
+                            // check correlationId
+                            Assert.Equal(correlationId, targetTest.CorrelationId);
 
                             // check the CIEnvironmentValues decoration.
                             CheckCIEnvironmentValuesDecoration(targetTest);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -85,35 +85,49 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
+                    const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
-                        if (e.Value.PathAndQuery != "/evp_proxy/v2/api/v2/citestcycle")
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/libraries/tests/services/setting")
                         {
+                            e.Value.Response = new MockTracerResponse("{\"data\":{\"id\":\"b5a855bffe6c0b2ae5d150fb6ad674363464c816\",\"type\":\"ci_app_tracers_test_service_settings\",\"attributes\":{\"code_coverage\":false,\"efd_enabled\":false,\"flaky_test_retries_enabled\":false,\"itr_enabled\":true,\"require_git\":false,\"tests_skipping\":true}}} ", 200);
                             return;
                         }
 
-                        var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
-                        if (payload.Events?.Length > 0)
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/ci/tests/skippable")
                         {
-                            foreach (var @event in payload.Events)
+                            e.Value.Response = new MockTracerResponse($"{{\"data\":[],\"meta\":{{\"correlation_id\":\"{correlationId}\"}}}}", 200);
+                            return;
+                        }
+
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/citestcycle")
+                        {
+                            var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
+                            if (payload.Events?.Length > 0)
                             {
-                                if (@event.Type == SpanTypes.Test)
+                                foreach (var @event in payload.Events)
                                 {
-                                    var testObject = JsonConvert.DeserializeObject<MockCIVisibilityTest>(@event.Content.ToString());
-                                    Output.WriteLine($"Test: {testObject.Meta[TestTags.Suite]}.{testObject.Meta[TestTags.Name]} | {testObject.Meta[TestTags.Status]}");
-                                    tests.Add(testObject);
-                                }
-                                else if (@event.Type == SpanTypes.TestSuite)
-                                {
-                                    var suiteObject = JsonConvert.DeserializeObject<MockCIVisibilityTestSuite>(@event.Content.ToString());
-                                    Output.WriteLine($"Suite: {suiteObject.Meta[TestTags.Suite]} | {suiteObject.Meta[TestTags.Status]}");
-                                    testSuites.Add(suiteObject);
-                                }
-                                else if (@event.Type == SpanTypes.TestModule)
-                                {
-                                    var moduleObject = JsonConvert.DeserializeObject<MockCIVisibilityTestModule>(@event.Content.ToString());
-                                    Output.WriteLine($"Module: {moduleObject.Meta[TestTags.Module]} | {moduleObject.Meta[TestTags.Status]}");
-                                    testModules.Add(moduleObject);
+                                    if (@event.Content.ToString() is { } eventContent)
+                                    {
+                                        if (@event.Type == SpanTypes.Test)
+                                        {
+                                            var testObject = JsonConvert.DeserializeObject<MockCIVisibilityTest>(eventContent);
+                                            Output.WriteLine($"Test: {testObject.Meta[TestTags.Suite]}.{testObject.Meta[TestTags.Name]} | {testObject.Meta[TestTags.Status]}");
+                                            tests.Add(testObject);
+                                        }
+                                        else if (@event.Type == SpanTypes.TestSuite)
+                                        {
+                                            var suiteObject = JsonConvert.DeserializeObject<MockCIVisibilityTestSuite>(eventContent);
+                                            Output.WriteLine($"Suite: {suiteObject.Meta[TestTags.Suite]} | {suiteObject.Meta[TestTags.Status]}");
+                                            testSuites.Add(suiteObject);
+                                        }
+                                        else if (@event.Type == SpanTypes.TestModule)
+                                        {
+                                            var moduleObject = JsonConvert.DeserializeObject<MockCIVisibilityTestModule>(eventContent);
+                                            Output.WriteLine($"Module: {moduleObject.Meta[TestTags.Module]} | {moduleObject.Meta[TestTags.Status]}");
+                                            testModules.Add(moduleObject);
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -171,6 +185,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                             // check the name
                             Assert.Equal("nunit.test", targetTest.Name);
+
+                            // check correlationId
+                            Assert.Equal(correlationId, targetTest.CorrelationId);
 
                             // check the CIEnvironmentValues decoration.
                             CheckCIEnvironmentValuesDecoration(targetTest);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -67,29 +67,43 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
+                    const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
-                        if (e.Value.PathAndQuery != "/evp_proxy/v2/api/v2/citestcycle")
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/libraries/tests/services/setting")
                         {
+                            e.Value.Response = new MockTracerResponse("{\"data\":{\"id\":\"b5a855bffe6c0b2ae5d150fb6ad674363464c816\",\"type\":\"ci_app_tracers_test_service_settings\",\"attributes\":{\"code_coverage\":false,\"efd_enabled\":false,\"flaky_test_retries_enabled\":false,\"itr_enabled\":true,\"require_git\":false,\"tests_skipping\":true}}} ", 200);
                             return;
                         }
 
-                        var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
-                        if (payload.Events?.Length > 0)
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/ci/tests/skippable")
                         {
-                            foreach (var @event in payload.Events)
+                            e.Value.Response = new MockTracerResponse($"{{\"data\":[],\"meta\":{{\"correlation_id\":\"{correlationId}\"}}}}", 200);
+                            return;
+                        }
+
+                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/citestcycle")
+                        {
+                            var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
+                            if (payload.Events?.Length > 0)
                             {
-                                if (@event.Type == SpanTypes.Test)
+                                foreach (var @event in payload.Events)
                                 {
-                                    tests.Add(JsonConvert.DeserializeObject<MockCIVisibilityTest>(@event.Content.ToString()));
-                                }
-                                else if (@event.Type == SpanTypes.TestSuite)
-                                {
-                                    testSuites.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestSuite>(@event.Content.ToString()));
-                                }
-                                else if (@event.Type == SpanTypes.TestModule)
-                                {
-                                    testModules.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestModule>(@event.Content.ToString()));
+                                    if (@event.Content.ToString() is { } eventContent)
+                                    {
+                                        if (@event.Type == SpanTypes.Test)
+                                        {
+                                            tests.Add(JsonConvert.DeserializeObject<MockCIVisibilityTest>(eventContent));
+                                        }
+                                        else if (@event.Type == SpanTypes.TestSuite)
+                                        {
+                                            testSuites.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestSuite>(eventContent));
+                                        }
+                                        else if (@event.Type == SpanTypes.TestModule)
+                                        {
+                                            testModules.Add(JsonConvert.DeserializeObject<MockCIVisibilityTestModule>(eventContent));
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -136,6 +150,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                             // check the name
                             Assert.Equal("xunit.test", targetTest.Name);
+
+                            // check correlationId
+                            Assert.Equal(correlationId, targetTest.CorrelationId);
 
                             // check the CIEnvironmentValues decoration.
                             CheckCIEnvironmentValuesDecoration(targetTest);

--- a/tracer/test/Datadog.Trace.TestHelpers/Ci/MockCIVisibilityTest.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/Ci/MockCIVisibilityTest.cs
@@ -43,6 +43,9 @@ namespace Datadog.Trace.TestHelpers.Ci
         [JsonProperty("test_session_id")]
         public ulong TestSessionId { get; set; }
 
+        [JsonProperty("itr_correlation_id")]
+        public string CorrelationId { get; set; }
+
         [JsonProperty("error")]
         public int Error { get; set; }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -509,7 +509,11 @@ namespace Datadog.Trace.TestHelpers
             }
             else if (request.PathAndQuery.StartsWith("/evp_proxy/v2/"))
             {
-                HandleEvpProxyPayload(request);
+                if (HandleEvpProxyPayload(request) is { } customResponse)
+                {
+                    return customResponse;
+                }
+
                 responseType = MockTracerResponseType.EvpProxy;
             }
             else if (request.PathAndQuery.StartsWith("/tracer_flare/v1"))
@@ -744,7 +748,7 @@ namespace Datadog.Trace.TestHelpers
             }
         }
 
-        private void HandleEvpProxyPayload(MockHttpParser.MockHttpRequest request)
+        private MockTracerResponse HandleEvpProxyPayload(MockHttpParser.MockHttpRequest request)
         {
             if (ShouldDeserializeTraces && request.ContentLength >= 1)
             {
@@ -764,7 +768,9 @@ namespace Datadog.Trace.TestHelpers
                         _ => Encoding.UTF8.GetString(body), // e.g. multipart form data, currently we don't do anything with this so meh
                     };
 
-                    EventPlatformProxyPayloadReceived?.Invoke(this, new EventArgs<EvpProxyPayload>(new EvpProxyPayload(request.PathAndQuery, headerCollection, bodyAsJson)));
+                    var evpProxyPayload = new EvpProxyPayload(request.PathAndQuery, headerCollection, bodyAsJson);
+                    EventPlatformProxyPayloadReceived?.Invoke(this, new EventArgs<EvpProxyPayload>(evpProxyPayload));
+                    return evpProxyPayload.Response;
                 }
                 catch (Exception ex)
                 {
@@ -774,12 +780,14 @@ namespace Datadog.Trace.TestHelpers
                     {
                         // Accept call is likely interrupted by a dispose
                         // Swallow the exception and let the test finish
-                        return;
+                        return null;
                     }
 
                     throw;
                 }
             }
+
+            return null;
         }
 
         private void HandleTracerFlarePayload(MockHttpParser.MockHttpRequest request)
@@ -960,18 +968,23 @@ namespace Datadog.Trace.TestHelpers
             Snapshots = Snapshots.AddRange(snapshots);
         }
 
-        public readonly struct EvpProxyPayload
+        public class EvpProxyPayload
         {
-            public readonly string PathAndQuery;
-            public readonly NameValueCollection Headers;
-            public readonly string BodyInJson;
-
             public EvpProxyPayload(string pathAndQuery, NameValueCollection headers, string bodyInJson)
             {
                 PathAndQuery = pathAndQuery;
                 Headers = headers;
                 BodyInJson = bodyInJson;
+                Response = null;
             }
+
+            public string PathAndQuery { get; }
+
+            public NameValueCollection Headers { get; }
+
+            public string BodyInJson { get; }
+
+            public MockTracerResponse Response { get; set; }
         }
 
         public class AgentConfiguration


### PR DESCRIPTION
## Summary of changes

This PR adds support for the new `CorrelationId` field in CI Visibility.

## Reason for change

This is part of an initiative to `explain why a test was skipped or not in Intelligent Test Runner` described here: https://docs.google.com/document/d/1uFmHI1tTLUcDPHXkak1MXKaebydI2Xe7poZSvIeGfDI/edit 

## Implementation details

- Modify data model for the transactions to get the correlation id.
- Modify the messagepack serializer to include the correlation id in all test spans.

## Test coverage

Current CIVisibility EVP tests were updated to mock and assert the correlation id field.
