### PR TITLE
[CI Visibility] - Add support for event proxy v4 endpoint (gzip support)

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -24,7 +24,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
         private const string SupportedConfigurationEndpoint = "v0.7/config";
         private const string SupportedStatsEndpoint = "v0.6/stats";
         private const string SupportedDataStreamsEndpoint = "v0.1/pipeline_stats";
-        private const string SupportedEventPlatformProxyEndpoint = "evp_proxy/v2";
+        private const string SupportedEventPlatformProxyEndpointV2 = "evp_proxy/v2";
+        private const string SupportedEventPlatformProxyEndpointV4 = "evp_proxy/v4";
         private const string SupportedTelemetryProxyEndpoint = "telemetry/proxy";
         private const string SupportedTracerFlareEndpoint = "tracer_flare/v1";
 
@@ -68,7 +69,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 SupportedConfigurationEndpoint,
                 SupportedStatsEndpoint,
                 SupportedDataStreamsEndpoint,
-                SupportedEventPlatformProxyEndpoint,
+                SupportedEventPlatformProxyEndpointV2,
+                SupportedEventPlatformProxyEndpointV4,
                 SupportedTelemetryProxyEndpoint,
                 SupportedTracerFlareEndpoint,
             };
@@ -255,7 +257,11 @@ namespace Datadog.Trace.Agent.DiscoveryService
                     {
                         dataStreamsMonitoringEndpoint = endpoint;
                     }
-                    else if (endpoint.Equals(SupportedEventPlatformProxyEndpoint, StringComparison.OrdinalIgnoreCase))
+                    else if (eventPlatformProxyEndpoint is null && endpoint.Equals(SupportedEventPlatformProxyEndpointV2, StringComparison.OrdinalIgnoreCase))
+                    {
+                        eventPlatformProxyEndpoint = endpoint;
+                    }
+                    else if (endpoint.Equals(SupportedEventPlatformProxyEndpointV4, StringComparison.OrdinalIgnoreCase))
                     {
                         eventPlatformProxyEndpoint = endpoint;
                     }

--- a/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIWriterHttpSender.cs
@@ -196,9 +196,8 @@ namespace Datadog.Trace.Ci.Agent
             MemoryStream agentlessMemoryStream = null;
             try
             {
-                if (!payload.UseEvpProxy)
+                if (payload.UseGZip)
                 {
-                    // If we are in agentless mode (no EVP Proxy) then we use gzip compression, supported by the intake
                     agentlessMemoryStream = new MemoryStream();
                     int uncompressedSize;
                     using (var gzipStream = new GZipStream(agentlessMemoryStream, CompressionLevel.Fastest, true))
@@ -226,7 +225,7 @@ namespace Datadog.Trace.Ci.Agent
 
                 await SendPayloadAsync(
                         payload,
-                        static (request, payload, payloadBytes) => request.PostAsync(payloadBytes, MimeTypes.MsgPack, payload.UseEvpProxy ? null : "gzip"),
+                        static (request, payload, payloadBytes) => request.PostAsync(payloadBytes, MimeTypes.MsgPack, payload.UseGZip ? "gzip" : null),
                         payloadArraySegment)
                    .ConfigureAwait(false);
             }
@@ -255,7 +254,7 @@ namespace Datadog.Trace.Ci.Agent
                 {
                     if (request is IMultipartApiRequest multipartRequest)
                     {
-                        return multipartRequest.PostAsync(payloadArray, payload.UseEvpProxy ? MultipartCompression.None : MultipartCompression.GZip);
+                        return multipartRequest.PostAsync(payloadArray, payload.UseGZip ? MultipartCompression.GZip : MultipartCompression.None);
                     }
 
                     MultipartApiRequestNotSupported.Throw();

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/CICodeCoveragePayload.cs
@@ -45,7 +45,6 @@ namespace Datadog.Trace.Ci.Agent.Payloads
 
         protected override MultipartFormItem CreateMultipartFormItem(EventsBuffer<IEvent> eventsBuffer)
         {
-            var totalEvents = eventsBuffer.Count;
             var index = Count;
             var eventInBytes = MessagePackSerializer.Serialize(new CoveragePayload(eventsBuffer), _formatterResolver);
             CIVisibility.Log.Debug<int, int>("CICodeCoveragePayload: Serialized {Count} test code coverage as a single multipart item with {Size} bytes.", eventsBuffer.Count, eventInBytes.Length);

--- a/tracer/src/Datadog.Trace/Ci/Agent/Payloads/EventPlatformPayload.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/Payloads/EventPlatformPayload.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.Ci.Agent.Payloads
     internal abstract class EventPlatformPayload
     {
         private readonly CIVisibilitySettings _settings;
+        private bool? _useGzip;
         private Uri _url;
 
         protected EventPlatformPayload(CIVisibilitySettings settings)
@@ -26,6 +27,7 @@ namespace Datadog.Trace.Ci.Agent.Payloads
             }
 
             _settings = settings;
+            _useGzip = null;
             UseEvpProxy = !settings.Agentless;
         }
 
@@ -51,39 +53,12 @@ namespace Datadog.Trace.Ci.Agent.Payloads
         {
             get
             {
-                if (_url is { } url)
+                if (_url is null)
                 {
-                    return url;
+                    EnsureUrl();
                 }
 
-                UriBuilder builder;
-                if (_settings.Agentless)
-                {
-                    var agentlessUrl = _settings.AgentlessUrl;
-                    if (!string.IsNullOrWhiteSpace(agentlessUrl))
-                    {
-                        builder = new UriBuilder(agentlessUrl);
-                        builder.Path = EventPlatformPath;
-                    }
-                    else
-                    {
-                        builder = new UriBuilder(
-                            scheme: "https",
-                            host: $"{EventPlatformSubdomain}.{_settings.Site}",
-                            port: 443,
-                            pathValue: EventPlatformPath);
-                    }
-                }
-                else
-                {
-                    // Use Agent EVP Proxy
-                    builder = new UriBuilder(_settings.TracerSettings.ExporterInternal.AgentUriInternal);
-                    builder.Path = $"/evp_proxy/v2/{EventPlatformPath}";
-                }
-
-                url = builder.Uri;
-                _url = url;
-                return url;
+                return _url;
             }
 
             set
@@ -96,6 +71,22 @@ namespace Datadog.Trace.Ci.Agent.Payloads
         /// Gets a value indicating whether the payload is configured to use the agent proxy
         /// </summary>
         public virtual bool UseEvpProxy { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the payload need to be gzipped
+        /// </summary>
+        public virtual bool UseGZip
+        {
+            get
+            {
+                if (_useGzip is null)
+                {
+                    EnsureUrl();
+                }
+
+                return _useGzip ?? false;
+            }
+        }
 
         /// <summary>
         /// Gets a value indicating whether the payload contains events or not
@@ -125,5 +116,46 @@ namespace Datadog.Trace.Ci.Agent.Payloads
         /// Resets payload buffer
         /// </summary>
         public abstract void Reset();
+
+        private void EnsureUrl()
+        {
+            UriBuilder builder;
+            if (_settings.Agentless)
+            {
+                var agentlessUrl = _settings.AgentlessUrl;
+                if (!string.IsNullOrWhiteSpace(agentlessUrl))
+                {
+                    builder = new UriBuilder(agentlessUrl);
+                    builder.Path = EventPlatformPath;
+                }
+                else
+                {
+                    builder = new UriBuilder(
+                        scheme: "https",
+                        host: $"{EventPlatformSubdomain}.{_settings.Site}",
+                        port: 443,
+                        pathValue: EventPlatformPath);
+                }
+
+                _useGzip = true;
+            }
+            else
+            {
+                // Use Agent EVP Proxy
+                builder = new UriBuilder(_settings.TracerSettings.ExporterInternal.AgentUriInternal);
+                if (CIVisibility.EventPlatformProxySupport == EventPlatformProxySupport.V4)
+                {
+                    builder.Path = $"/evp_proxy/v4/{EventPlatformPath}";
+                    _useGzip = true;
+                }
+                else if (CIVisibility.EventPlatformProxySupport == EventPlatformProxySupport.V2)
+                {
+                    builder.Path = $"/evp_proxy/v2/{EventPlatformPath}";
+                    _useGzip = false;
+                }
+            }
+
+            _url = builder.Uri;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/EventPlatformProxySupport.cs
+++ b/tracer/src/Datadog.Trace/Ci/EventPlatformProxySupport.cs
@@ -1,0 +1,13 @@
+// <copyright file="EventPlatformProxySupport.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+namespace Datadog.Trace.Ci;
+
+internal enum EventPlatformProxySupport
+{
+    None,
+    V2,
+    V4
+}

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2EvpTests.cs
@@ -64,19 +64,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/libraries/tests/services/setting")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/libraries/tests/services/setting"))
                         {
                             e.Value.Response = new MockTracerResponse("{\"data\":{\"id\":\"b5a855bffe6c0b2ae5d150fb6ad674363464c816\",\"type\":\"ci_app_tracers_test_service_settings\",\"attributes\":{\"code_coverage\":false,\"efd_enabled\":false,\"flaky_test_retries_enabled\":false,\"itr_enabled\":true,\"require_git\":false,\"tests_skipping\":true}}} ", 200);
                             return;
                         }
 
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/ci/tests/skippable")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/ci/tests/skippable"))
                         {
                             e.Value.Response = new MockTracerResponse($"{{\"data\":[],\"meta\":{{\"correlation_id\":\"{correlationId}\"}}}}", 200);
                             return;
                         }
 
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/citestcycle")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/citestcycle"))
                         {
                             var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
                             if (payload.Events?.Length > 0)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/MsTestV2Tests.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
-                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2")).ToArray();
+                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
                     using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         spans = agent.WaitForSpans(expectedSpanCount)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -88,19 +88,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/libraries/tests/services/setting")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/libraries/tests/services/setting"))
                         {
                             e.Value.Response = new MockTracerResponse("{\"data\":{\"id\":\"b5a855bffe6c0b2ae5d150fb6ad674363464c816\",\"type\":\"ci_app_tracers_test_service_settings\",\"attributes\":{\"code_coverage\":false,\"efd_enabled\":false,\"flaky_test_retries_enabled\":false,\"itr_enabled\":true,\"require_git\":false,\"tests_skipping\":true}}} ", 200);
                             return;
                         }
 
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/ci/tests/skippable")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/ci/tests/skippable"))
                         {
                             e.Value.Response = new MockTracerResponse($"{{\"data\":[],\"meta\":{{\"correlation_id\":\"{correlationId}\"}}}}", 200);
                             return;
                         }
 
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/citestcycle")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/citestcycle"))
                         {
                             var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
                             if (payload.Events?.Length > 0)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitEvpTests.cs
@@ -50,11 +50,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             SetServiceVersion("1.0.0");
         }
 
+        public static IEnumerable<object[]> GetData()
+        {
+            foreach (var version in PackageVersions.NUnit)
+            {
+                yield return version.Concat("evp_proxy/v2", true);
+                yield return version.Concat("evp_proxy/v4", false);
+            }
+        }
+
         [SkippableTheory]
-        [MemberData(nameof(PackageVersions.NUnit), MemberType = typeof(PackageVersions))]
+        [MemberData(nameof(GetData))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public async Task SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion, string evpVersionToRemove, bool expectedGzip)
         {
             if (new Version(FrameworkDescription.Instance.ProductVersion).Major >= 5)
             {
@@ -81,10 +90,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Enabled, "1");
-                SetEnvironmentVariable(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, "1");
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
+                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains(evpVersionToRemove)).ToArray();
+
                     const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
@@ -102,6 +112,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         if (e.Value.PathAndQuery.EndsWith("api/v2/citestcycle"))
                         {
+                            e.Value.Headers["Content-Encoding"].Should().Be(expectedGzip ? "gzip" : null);
+
                             var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
                             if (payload.Events?.Length > 0)
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/NUnitTests.cs
@@ -68,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
-                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2")).ToArray();
+                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
                     using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         spans = agent.WaitForSpans(ExpectedSpanCount)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -70,19 +70,19 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                     const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/libraries/tests/services/setting")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/libraries/tests/services/setting"))
                         {
                             e.Value.Response = new MockTracerResponse("{\"data\":{\"id\":\"b5a855bffe6c0b2ae5d150fb6ad674363464c816\",\"type\":\"ci_app_tracers_test_service_settings\",\"attributes\":{\"code_coverage\":false,\"efd_enabled\":false,\"flaky_test_retries_enabled\":false,\"itr_enabled\":true,\"require_git\":false,\"tests_skipping\":true}}} ", 200);
                             return;
                         }
 
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/ci/tests/skippable")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/ci/tests/skippable"))
                         {
                             e.Value.Response = new MockTracerResponse($"{{\"data\":[],\"meta\":{{\"correlation_id\":\"{correlationId}\"}}}}", 200);
                             return;
                         }
 
-                        if (e.Value.PathAndQuery == "/evp_proxy/v2/api/v2/citestcycle")
+                        if (e.Value.PathAndQuery.EndsWith("api/v2/citestcycle"))
                         {
                             var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
                             if (payload.Events?.Length > 0)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitEvpTests.cs
@@ -36,11 +36,20 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             SetServiceVersion("1.0.0");
         }
 
+        public static IEnumerable<object[]> GetData()
+        {
+            foreach (var version in PackageVersions.XUnit)
+            {
+                yield return version.Concat("evp_proxy/v2", true);
+                yield return version.Concat("evp_proxy/v4", false);
+            }
+        }
+
         [SkippableTheory]
-        [MemberData(nameof(PackageVersions.XUnit), MemberType = typeof(PackageVersions))]
+        [MemberData(nameof(GetData))]
         [Trait("Category", "EndToEnd")]
         [Trait("Category", "TestIntegrations")]
-        public async Task SubmitTraces(string packageVersion)
+        public async Task SubmitTraces(string packageVersion, string evpVersionToRemove, bool expectedGzip)
         {
             var tests = new List<MockCIVisibilityTest>();
             var testSuites = new List<MockCIVisibilityTestSuite>();
@@ -59,7 +68,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
             try
             {
                 SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Enabled, "1");
-                SetEnvironmentVariable(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, "1");
 
                 using var logsIntake = new MockLogsIntakeForCiVisibility();
                 EnableDirectLogSubmission(logsIntake.Port, nameof(IntegrationId.XUnit), nameof(XUnitTests));
@@ -67,6 +75,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
+                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains(evpVersionToRemove)).ToArray();
+
                     const string correlationId = "2e8a36bda770b683345957cc6c15baf9";
                     agent.EventPlatformProxyPayloadReceived += (sender, e) =>
                     {
@@ -84,6 +94,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
 
                         if (e.Value.PathAndQuery.EndsWith("api/v2/citestcycle"))
                         {
+                            e.Value.Headers["Content-Encoding"].Should().Be(expectedGzip ? "gzip" : null);
+
                             var payload = JsonConvert.DeserializeObject<MockCIVisibilityProtocol>(e.Value.BodyInJson);
                             if (payload.Events?.Length > 0)
                             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/XUnitTests.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.CI
                 using (var agent = EnvironmentHelper.GetMockAgent())
                 {
                     // We remove the evp_proxy endpoint to force the APM protocol compatibility
-                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2")).ToArray();
+                    agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
                     using (ProcessResult processResult = await RunDotnetTestSampleAndWaitForExit(agent, packageVersion: packageVersion))
                     {
                         spans = agent.WaitForSpans(ExpectedSpanCount)

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -47,6 +47,7 @@ public class DiscoveryServiceTests
         AgentConfiguration config = null;
         var clientDropP0s = true;
         var version = "1.26.3";
+        var evpProxyEndpoint = "evp_proxy/v4";
         var mutex = new ManualResetEventSlim();
         var factory = new TestRequestFactory(
             x => new TestApiRequest(x, responseContent: GetConfig(clientDropP0s, version)));
@@ -68,6 +69,7 @@ public class DiscoveryServiceTests
         config.ClientDropP0s.Should().Be(clientDropP0s);
         config.StatsEndpoint.Should().NotBeNullOrEmpty();
         config.DataStreamsMonitoringEndpoint.Should().NotBeNullOrEmpty();
+        config.EventPlatformProxyEndpoint.Should().Be(evpProxyEndpoint);
         await ds.DisposeAsync();
     }
 

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/BaseRunCommandTests.cs
@@ -159,7 +159,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
         {
             var agent = MockTracerAgent.Create(null, TcpPortProvider.GetOpenPort());
             // We remove the evp_proxy endpoint to force the APM protocol compatibility
-            agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2")).ToArray();
+            agent.Configuration.Endpoints = agent.Configuration.Endpoints.Where(e => !e.Contains("evp_proxy/v2") && !e.Contains("evp_proxy/v4")).ToArray();
             return agent;
         }
     }


### PR DESCRIPTION
## Summary of changes

This PR adds support for the new Event Platform Proxy v4 endpoint which enables gzip data redirection.

https://github.com/DataDog/datadog-agent/pull/22090

## Reason for change

v2 version of the endpoint is missing the header redirection for gzip content, this is solved in the v4 of the endpoint.

## Implementation details

Because the version depends on the installed agent, we need to keep compatibility with the v2, so a refactor was made to support both version, enabling gzip compression on v4.

## Test coverage

All Evp tests were updated to support both v2 and v4 versions. Also, CI Visibility test-environment is going to be updated to test this scenario.

## Other details

Confluence page with the endpoint's gzip support in CI Visibility: https://datadoghq.atlassian.net/wiki/spaces/CIAPP/pages/3391033809/GZip+support

Note: There's no current release of the agent with the endpoint, in order to test it manually you have to download a development build.
