### PR TITLE
Swap default propagation styles from `tracecontext,Datadog` to `Datadog,tracecontext`

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4554,7 +4554,7 @@ stages:
             versionSpec: '3.9'
         displayName: Install python 3.9
 
-      - script: git clone --depth 1 --branch steven/dotnet-w3c https://github.com/DataDog/system-tests.git
+      - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo
 
       - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4554,7 +4554,7 @@ stages:
             versionSpec: '3.9'
         displayName: Install python 3.9
 
-      - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
+      - script: git clone --depth 1 --branch steven/dotnet-w3c https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo
 
       - task: DownloadPipelineArtifact@2

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -312,8 +312,8 @@ namespace Datadog.Trace.Configuration
                                     .WithKeys(ConfigurationKeys.PropagationStyleInject, "DD_PROPAGATION_STYLE_INJECT", ConfigurationKeys.PropagationStyle)
                                     .GetAs(
                                          getDefaultValue: () => new DefaultResult<string[]>(
-                                             new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog },
-                                             $"{ContextPropagationHeaderStyle.W3CTraceContext},{ContextPropagationHeaderStyle.Datadog}"),
+                                             new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext },
+                                             $"{ContextPropagationHeaderStyle.Datadog},{ContextPropagationHeaderStyle.W3CTraceContext}"),
                                          validator: styles => styles is { Length: > 0 }, // invalid individual values are rejected later
                                          converter: style => TrimSplitString(style, commaSeparator));
 
@@ -321,8 +321,8 @@ namespace Datadog.Trace.Configuration
                                      .WithKeys(ConfigurationKeys.PropagationStyleExtract, "DD_PROPAGATION_STYLE_EXTRACT", ConfigurationKeys.PropagationStyle)
                                      .GetAs(
                                           getDefaultValue: () => new DefaultResult<string[]>(
-                                              new[] { ContextPropagationHeaderStyle.W3CTraceContext, ContextPropagationHeaderStyle.Datadog },
-                                              $"{ContextPropagationHeaderStyle.W3CTraceContext},{ContextPropagationHeaderStyle.Datadog}"),
+                                              new[] { ContextPropagationHeaderStyle.Datadog, ContextPropagationHeaderStyle.W3CTraceContext },
+                                              $"{ContextPropagationHeaderStyle.Datadog},{ContextPropagationHeaderStyle.W3CTraceContext}"),
                                           validator: styles => styles is { Length: > 0 }, // invalid individual values are rejected later
                                           converter: style => TrimSplitString(style, commaSeparator));
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs
@@ -68,8 +68,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             telemetry.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             telemetry.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
-            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "tracecontext,Datadog");
-            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "tracecontext,Datadog");
+            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext");
+            telemetry.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext");
 
             AssertService(telemetry, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(telemetry, enableDependencies);
@@ -100,8 +100,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             agent.AssertIntegrationEnabled(IntegrationId.HttpMessageHandler);
             agent.AssertConfiguration(ConfigTelemetryData.NativeTracerVersion, TracerConstants.ThreePartVersion);
-            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "tracecontext,Datadog");
-            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "tracecontext,Datadog");
+            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext");
+            agent.AssertConfiguration(ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext");
 
             AssertService(agent, "Samples.Telemetry", ServiceVersion);
             AssertDependencies(agent, enableDependencies);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -80,8 +80,8 @@ namespace Datadog.Trace.Tests.Configuration
             yield return (CreateFunc(s => s.MaxTracesSubmittedPerSecond), 100);
             yield return (CreateFunc(s => s.TracerMetricsEnabled), false);
             yield return (CreateFunc(s => s.Exporter.DogStatsdPort), 8125);
-            yield return (CreateFunc(s => s.PropagationStyleInject), new[] { "tracecontext", "Datadog" });
-            yield return (CreateFunc(s => s.PropagationStyleExtract), new[] { "tracecontext", "Datadog" });
+            yield return (CreateFunc(s => s.PropagationStyleInject), new[] { "Datadog", "tracecontext" });
+            yield return (CreateFunc(s => s.PropagationStyleExtract), new[] { "Datadog", "tracecontext" });
             yield return (CreateFunc(s => s.ServiceNameMappings), null);
 
             yield return (CreateFunc(s => s.TraceId128BitGenerationEnabled), true);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -696,10 +696,10 @@ namespace Datadog.Trace.Tests.Configuration
 
         [Theory]
         [InlineData("test1,, ,test2", "test3,, ,test4", "test5,, ,test6", new[] { "test1", "test2" })]
-        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "tracecontext", "Datadog" })]
+        [InlineData("", "test3,, ,test4", "test5,, ,test6", new[] { "Datadog", "tracecontext" })]
         [InlineData(null, "test3,, ,test4", "test5,, ,test6", new[] { "test3", "test4" })]
         [InlineData(null, null, "test5,, ,test6", new[] { "test5", "test6" })]
-        [InlineData(null, null, null, new[] { "tracecontext", "Datadog" })]
+        [InlineData(null, null, null, new[] { "Datadog", "tracecontext" })]
         public void PropagationStyleInject(string value, string legacyValue, string fallbackValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_INJECT";

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -200,14 +200,14 @@ public class ConfigurationTelemetryCollectorTests
         {
             (not null, _) => (ConfigurationKeys.PropagationStyleExtract, propagationStyleExtract),
             (null, not null) => (ConfigurationKeys.PropagationStyle, propagationStyle),
-            (null, null) => (ConfigurationKeys.PropagationStyleExtract, "tracecontext,Datadog"),
+            (null, null) => (ConfigurationKeys.PropagationStyleExtract, "Datadog,tracecontext"),
         };
 
         var (injectKey, injectValue) = (propagationStyleInject, propagationStyle) switch
         {
             (not null, _) => (ConfigurationKeys.PropagationStyleInject, propagationStyleInject),
             (null, not null) => (ConfigurationKeys.PropagationStyle, propagationStyle),
-            (null, null) => (ConfigurationKeys.PropagationStyleInject, "tracecontext,Datadog"),
+            (null, null) => (ConfigurationKeys.PropagationStyleInject, "Datadog,tracecontext"),
         };
 
         GetLatestValueFromConfig(data, extractKey).Should().Be(extractValue);


### PR DESCRIPTION
## Summary of changes

Swaps the default propagation style to `Datadog,tracecontext` from `tracecontext,Datadog`. Affects the settings:
```
DD_TRACE_PROPAGATION_STYLE
DD_TRACE_PROPAGATION_STYLE_INJECT
DD_TRACE_PROPAGATION_STYLE_EXTRACT
```

## Reason for change

`tracecontext,Datadog` caused us to be inconsistent with the other tracing libraries.

## Implementation details

Swap `tracecontext,Datadog` to `Datadog,tracecontext`

## Test coverage

- Updated tests
- Updated and ran system tests
  - Enabled `test_headers_precedence_propagationstyle_default_datadog_tracecontext`
  - Disabled `test_headers_precedence_propagationstyle_tracecontext_datadog` 

## Other details

System tests PR: https://github.com/DataDog/system-tests/pull/2085

Note that the stage fails here, but I ran it with that above PR branch and it passes (fails on system tests until this is merged)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
