### PR TITLE
[Build] Update the ubuntu Microsoft-hosted agents

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4498,7 +4498,7 @@ stages:
   - job: test
     timeoutInMinutes: 60
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3534,7 +3534,7 @@ stages:
     - job: upload
       timeoutInMinutes: 60 #default value
       pool:
-        vmImage: ubuntu-20.04
+        vmImage: ubuntu-latest
       steps:
         - template: steps/clone-repo.yml
           parameters:
@@ -3759,7 +3759,7 @@ stages:
     - job: upload
       timeoutInMinutes: 60 #default value
       pool:
-        vmImage: ubuntu-20.04
+        vmImage: ubuntu-latest
       steps:
       - checkout: none
       - bash: |
@@ -4498,7 +4498,7 @@ stages:
   - job: test
     timeoutInMinutes: 60
     pool:
-      vmImage: ubuntu-22.04
+      vmImage: ubuntu-latest
 
     strategy:
       matrix:
@@ -4611,7 +4611,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
 
     steps:
     - template: steps/clone-repo.yml
@@ -4695,7 +4695,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        vmImage: ubuntu-20.04
+        vmImage: ubuntu-latest
       
       steps:
         - template: steps/clone-repo.yml
@@ -4774,7 +4774,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
 
     steps:
     - template: steps/clone-repo.yml
@@ -4864,7 +4864,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
 
     steps:
     - template: steps/clone-repo.yml
@@ -4928,7 +4928,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
 
     steps:
     - template: steps/clone-repo.yml
@@ -5000,7 +5000,7 @@ stages:
       installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb"
       linuxArtifacts: "linux-packages-linux-x64"
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
 
     steps:
     - template: steps/clone-repo.yml
@@ -5750,7 +5750,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        vmImage: ubuntu-20.04
+        vmImage: ubuntu-latest
       
       steps:
         - template: steps/clone-repo.yml
@@ -5953,7 +5953,7 @@ stages:
     timeoutInMinutes: 60 #default value
 
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
 
     services:
       dd_agent: dd_agent
@@ -5981,7 +5981,7 @@ stages:
   - job: notify
     timeoutInMinutes: 10
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-latest
 
     steps:
     - checkout: none


### PR DESCRIPTION
## Summary of changes
Updates all stages from using `ubuntu-20.04` to using `ubuntu-latest`

## Reason for change
The system-test Test_LibraryHeaders.test_datadog_entity_id runs successfully in the DataDog/system-tests repo but fails when we run it in our CI. This test asserts that the proper container tagging headers are used when the container uses cgroupv2. The problem is that the Ubuntu hosted agent we are using to run the `system_tests` stage is `ubuntu-20.04` which (I think) uses cgroupv1, causing the test to fail. Updating the `system_tests` stage to use `ubuntu-latest` fixes the issue.

Since I was here, I figured a mass update would be appropriate.

## Implementation details
`ubuntu-20.04` => `ubuntu-latest`

## Test coverage
Runs all of the existing tests with the new hosted agent

## Other details
N/A