### PR TITLE
[ASM] Prevent null references: harden ControllerExtensions integration

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -71,7 +71,6 @@ src/Datadog.Trace/AppSec/AddressesConstants.cs
 src/Datadog.Trace/AppSec/AppSecRateLimiter.cs
 src/Datadog.Trace/AppSec/BlockException.cs
 src/Datadog.Trace/AppSec/BlockingAction.cs
-src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
 src/Datadog.Trace/AppSec/CoreHttpContextStore.cs
 src/Datadog.Trace/AppSec/EventTrackingSdk.cs
 src/Datadog.Trace/AppSec/IDatadogSecurity.cs

--- a/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
@@ -3,80 +3,101 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 #if NETFRAMEWORK
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using Datadog.Trace.AspNet;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet;
-using Datadog.Trace.DuckTyping;
-using Datadog.Trace.Iast;
 
 namespace Datadog.Trace.AppSec
 {
     internal static class ControllerContextExtensions
     {
-        internal static void MonitorBodyAndPathParams(this IControllerContext controllerContext, IDictionary<string, object> parameters, string peekScopeKey)
+        internal static void MonitorBodyAndPathParams(this IControllerContext controllerContext, IDictionary<string, object>? parameters, string peekScopeKey)
         {
-            if (parameters == null || parameters.Count == 0)
+            if (parameters is null or { Count: 0 })
+            {
+                return;
+            }
+
+            var context = HttpContext.Current;
+            if (context is null)
+            {
+                return;
+            }
+
+            var scope = SharedItems.TryPeekScope(context, peekScopeKey);
+            if (scope == null)
             {
                 return;
             }
 
             var security = Security.Instance;
-            var context = HttpContext.Current;
-            var iastEnabled = Iast.Iast.Instance.Settings.Enabled;
-            Scope scope = null;
-            object requestBody = null;
-            Dictionary<string, object> pathParamsDic = null;
-
-            if (context != null)
+            var iastRequestContext = scope.Span?.Context?.TraceContext?.IastRequestContext;
+            var runIast = Iast.Iast.Instance.Settings.Enabled && iastRequestContext is not null;
+            // if neither iast or security is enabled leave
+            if (!security.Enabled && !runIast)
             {
-                if (security.Enabled || iastEnabled)
+                return;
+            }
+
+            var bodyDic = new Dictionary<string, object>();
+            var pathParamsDic = new Dictionary<string, object>();
+            foreach (var item in parameters)
+            {
+                if (controllerContext.RouteData?.Values?.ContainsKey(item.Key) ?? false)
                 {
-                    scope = SharedItems.TryPeekScope(context, peekScopeKey);
-
-                    var bodyDic = new Dictionary<string, object>(parameters.Count);
-                    pathParamsDic = new Dictionary<string, object>(parameters.Count);
-                    foreach (var item in parameters)
-                    {
-                        if (controllerContext.RouteData.Values.ContainsKey(item.Key))
-                        {
-                            pathParamsDic[item.Key] = item.Value;
-                        }
-                        else
-                        {
-                            // We exclude the query string params
-                            if (!context.Request.QueryString.AllKeys.Contains(item.Key))
-                            {
-                                bodyDic[item.Key] = item.Value;
-                            }
-                        }
-                    }
-
-                    requestBody = ObjectExtractor.Extract(bodyDic);
+                    pathParamsDic[item.Key] = item.Value;
                 }
-
-                if (security.Enabled)
+                else
                 {
-                    var securityTransport = new Coordinator.SecurityCoordinator(security, context, scope.Span);
-                    if (!securityTransport.IsBlocked)
+                    // We exclude the query string params
+                    if (!context.Request.QueryString?.AllKeys.Contains(item.Key) ?? false)
                     {
-                        var inputData = new Dictionary<string, object>
-                        {
-                            { AddressesConstants.RequestBody, requestBody },
-                            { AddressesConstants.RequestPathParams, ObjectExtractor.Extract(pathParamsDic) }
-                        };
-                        securityTransport.CheckAndBlock(inputData);
+                        bodyDic[item.Key] = item.Value;
                     }
                 }
+            }
 
-                if (iastEnabled)
+            object? requestBody = null;
+            if (bodyDic.Count > 0)
+            {
+                requestBody = ObjectExtractor.Extract(bodyDic);
+            }
+
+            if (security.Enabled)
+            {
+                var securityTransport = new Coordinator.SecurityCoordinator(security, context, scope.Span!);
+                if (!securityTransport.IsBlocked)
                 {
-                    var iastRequestContext = scope?.Span?.Context?.TraceContext?.IastRequestContext;
-                    iastRequestContext?.AddRequestData(context.Request, controllerContext.RouteData.Values);
-                    iastRequestContext?.AddRequestBody(null, requestBody);
+                    var inputData = new Dictionary<string, object>();
+                    if (requestBody is not null)
+                    {
+                        inputData.Add(AddressesConstants.RequestBody, requestBody);
+                    }
+
+                    if (pathParamsDic.Count > 0)
+                    {
+                        inputData.Add(AddressesConstants.RequestPathParams, ObjectExtractor.Extract(pathParamsDic));
+                    }
+
+                    securityTransport.CheckAndBlock(inputData);
+                }
+            }
+
+            if (runIast)
+            {
+                if (controllerContext.RouteData?.Values?.Count > 0)
+                {
+                    iastRequestContext!.AddRequestData(context.Request, controllerContext.RouteData.Values);
+                }
+
+                if (requestBody is not null)
+                {
+                    iastRequestContext!.AddRequestBody(null, requestBody);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Web;
 using Datadog.Trace.AspNet;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet;
+using Datadog.Trace.Iast;
 
 namespace Datadog.Trace.AppSec
 {
@@ -36,8 +37,14 @@ namespace Datadog.Trace.AppSec
             }
 
             var security = Security.Instance;
-            var iastRequestContext = scope.Span?.Context?.TraceContext?.IastRequestContext;
-            var runIast = Iast.Iast.Instance.Settings.Enabled && iastRequestContext is not null;
+            var runIast = Iast.Iast.Instance.Settings.Enabled;
+            IastRequestContext? iastRequestContext = null;
+            if (runIast)
+            {
+                iastRequestContext = scope.Span?.Context?.TraceContext?.IastRequestContext;
+                runIast = iastRequestContext is not null;
+            }
+
             // if neither iast or security is enabled leave
             if (!security.Enabled && !runIast)
             {

--- a/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetMvc5.TelemetryEnabled.Classic.enableIast=true.path=_Iast_GetFileContent-file=nonexisting.txt.verified.txt
@@ -52,7 +52,6 @@
       _dd.agent_psr: 1.0,
       _dd.iast.telemetry.executed.propagation: 2.0,
       _dd.iast.telemetry.executed.sink.path_traversal: 1.0,
-      _dd.iast.telemetry.executed.source.http_request_body: 1.0,
       _dd.iast.telemetry.executed.source.http_request_cookie_name: 1.0,
       _dd.iast.telemetry.executed.source.http_request_cookie_value: 1.0,
       _dd.iast.telemetry.executed.source.http_request_header: 1.0,


### PR DESCRIPTION
## Summary of changes

Harden guards to avoid null reference exception seen in some customers
## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
