### PR TITLE
Fix Debugger's snapshot tests

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.Spans.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.Spans.verified.txt
@@ -17,9 +17,7 @@ at Samples.Probes.TestRuns.SmokeTests.AsyncSpanOnMethodWithExceptionProbeTest.Ca
       error.type: System.InvalidOperationException,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.Spans.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.dynamic.span.verified.txt
@@ -13,9 +13,7 @@
       runtime-id: Guid_2,
       SpanDecorationArgsAndLocals: Run,
       version: 1.0.0,
-      _dd.di.SpanDecorationArgsAndLocals.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationArgsAndLocals.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationArgsAndLocals.with.trace.annotation.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -36,9 +34,7 @@
       language: dotnet,
       SpanDecorationArgsAndLocals: Run,
       version: 1.0.0,
-      _dd.di.SpanDecorationArgsAndLocals.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationArgsAndLocals.probe_id: Guid_3
     }
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationAsync.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationAsync.with.dynamic.span.verified.txt
@@ -13,9 +13,7 @@
       runtime-id: Guid_2,
       SpanDecorationAsync: RunAsync,
       version: 1.0.0,
-      _dd.di.SpanDecorationAsync.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationAsync.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationAsync.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationAsync.with.trace.annotation.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -36,9 +34,7 @@
       language: dotnet,
       SpanDecorationAsync: RunAsync,
       version: 1.0.0,
-      _dd.di.SpanDecorationAsync.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationAsync.probe_id: Guid_3
     }
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.dynamic.span.verified.txt
@@ -14,9 +14,7 @@
       SpanDecorationError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
       _dd.di.SpanDecorationError.evaluation_error: EvaluationError { Expression = this.error },
-      _dd.di.SpanDecorationError.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationError.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationError.with.trace.annotation.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -37,9 +35,7 @@
       SpanDecorationError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
       _dd.di.SpanDecorationError.evaluation_error: EvaluationError { Expression = this.error },
-      _dd.di.SpanDecorationError.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationError.probe_id: Guid_3
     }
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationErrorInWhen.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationErrorInWhen.with.dynamic.span.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.dynamic.span.verified.txt
@@ -13,9 +13,7 @@
       runtime-id: Guid_2,
       SpanDecorationSameTags: 3,
       version: 1.0.0,
-      _dd.di.SpanDecorationSameTags.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationSameTags.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTags.with.trace.annotation.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -36,9 +34,7 @@
       language: dotnet,
       SpanDecorationSameTags: 3,
       version: 1.0.0,
-      _dd.di.SpanDecorationSameTags.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationSameTags.probe_id: Guid_3
     }
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.dynamic.span.verified.txt
@@ -13,9 +13,7 @@
       runtime-id: Guid_2,
       SpanDecorationSameTagsFirstError: Run,
       version: 1.0.0,
-      _dd.di.SpanDecorationSameTagsFirstError.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationSameTagsFirstError.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstError.with.trace.annotation.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -36,9 +34,7 @@
       language: dotnet,
       SpanDecorationSameTagsFirstError: Run,
       version: 1.0.0,
-      _dd.di.SpanDecorationSameTagsFirstError.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationSameTagsFirstError.probe_id: Guid_3
     }
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstErrorAsync.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsFirstErrorAsync.with.dynamic.span.verified.txt
@@ -13,9 +13,7 @@
       runtime-id: Guid_2,
       SpanDecorationSameTagsFirstErrorAsync: RunAsync,
       version: 1.0.0,
-      _dd.di.SpanDecorationSameTagsFirstErrorAsync.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationSameTagsFirstErrorAsync.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.dynamic.span.verified.txt
@@ -14,9 +14,7 @@
       SpanDecorationSameTagsSecondError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
       _dd.di.SpanDecorationSameTagsSecondError.evaluation_error: EvaluationError { Expression = this.error },
-      _dd.di.SpanDecorationSameTagsSecondError.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationSameTagsSecondError.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationSameTagsSecondError.with.trace.annotation.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -37,9 +35,7 @@
       SpanDecorationSameTagsSecondError: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValue,
       version: 1.0.0,
       _dd.di.SpanDecorationSameTagsSecondError.evaluation_error: EvaluationError { Expression = this.error },
-      _dd.di.SpanDecorationSameTagsSecondError.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationSameTagsSecondError.probe_id: Guid_3
     }
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoSegmentsWithError.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoSegmentsWithError.with.dynamic.span.verified.txt
@@ -14,9 +14,7 @@
       SpanDecorationTwoSegments: Instance=Datadog.Trace.Debugger.Expressions.UndefinedValueRun,
       version: 1.0.0,
       _dd.di.SpanDecorationTwoSegments.evaluation_error: EvaluationError { Expression = this.Arg =  },
-      _dd.di.SpanDecorationTwoSegments.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationTwoSegments.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.dynamic.span.verified.txt
@@ -15,9 +15,7 @@
       SpanDecorationTwoTags2: 3,
       version: 1.0.0,
       _dd.di.SpanDecorationTwoTags.probe_id: Guid_3,
-      _dd.di.SpanDecorationTwoTags2.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationTwoTags2.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.trace.annotation.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationTwoTags.with.trace.annotation.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,
@@ -38,9 +36,7 @@
       SpanDecorationTwoTags2: 3,
       version: 1.0.0,
       _dd.di.SpanDecorationTwoTags.probe_id: Guid_3,
-      _dd.di.SpanDecorationTwoTags2.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationTwoTags2.probe_id: Guid_3
     }
   }
 ]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWitLiteralWhen.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWitLiteralWhen.with.dynamic.span.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWithoutWhen.with.dynamic.span.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanDecorationWithoutWhen.with.dynamic.span.verified.txt
@@ -13,9 +13,7 @@
       runtime-id: Guid_2,
       SpanDecorationWithoutWhen: Run,
       version: 1.0.0,
-      _dd.di.SpanDecorationWithoutWhen.probe_id: Guid_3,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      _dd.di.SpanDecorationWithoutWhen.probe_id: Guid_3
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.Spans.verified.txt
@@ -11,9 +11,7 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.Spans.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.Spans.verified.txt
@@ -17,9 +17,7 @@ at Samples.Probes.TestRuns.SmokeTests.SpanOnMethodWithExceptionProbeTest.Calcula
       error.type: System.InvalidOperationException,
       language: dotnet,
       runtime-id: Guid_2,
-      version: 1.0.0,
-      _dd.git.commit.sha: aaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbb,
-      _dd.git.repository_url: https://github.com/DataDog/dd-trace-dotnet
+      version: 1.0.0
     },
     Metrics: {
       process_id: 0,


### PR DESCRIPTION
## Summary of changes

This PR fixes the debugger's snapshot tests broken by the SCI git metadata changes.

## Reason for change

Fix tests
