### PR TITLE
Avoid using dotnet run in nuke

### DIFF
--- a/tracer/build.sh
+++ b/tracer/build.sh
@@ -28,4 +28,8 @@ export NUKE_TELEMETRY_OPTOUT=1
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+
+echo "dotnet build exited with code $?"
+ls -l "$SCRIPT_DIR/build/_build/bin/Debug/_build"
+
 "$SCRIPT_DIR/build/_build/bin/Debug/_build" "$@"

--- a/tracer/build.sh
+++ b/tracer/build.sh
@@ -28,4 +28,4 @@ export NUKE_TELEMETRY_OPTOUT=1
 echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
-"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+"$SCRIPT_DIR/build/_build/bin/Debug/_build" "$@"


### PR DESCRIPTION
## Summary of changes

Nuke randomly fails on OSX when calling `dotnet run`:

```
Unhandled exception: System.ComponentModel.Win32Exception (13): An error occurred trying to start process '/Users/runner/work/1/s/tracer/build/_build/bin/Debug/_build' with working directory '/Users/runner/work/1/s'. Permission denied
   at System.Diagnostics.Process.ForkAndExecProcess(ProcessStartInfo startInfo, String resolvedFilename, String[] argv, String[] envp, String cwd, Boolean setCredentials, UInt32 userId, UInt32 groupId, UInt32[] groups, Int32& stdinFd, Int32& stdoutFd, Int32& stderrFd, Boolean usesTerminal, Boolean throwOnNoExec)
   at System.Diagnostics.Process.StartCore(ProcessStartInfo startInfo)
   at Microsoft.DotNet.Cli.Utils.Command.Execute(Action`1 processStarted)
   at Microsoft.DotNet.Tools.Run.RunCommand.Execute()
   at System.CommandLine.Invocation.InvocationPipeline.Invoke(ParseResult parseResult)
   at Microsoft.DotNet.Cli.Program.ProcessArgs(String[] args, TimeSpan startupTime, ITelemetry telemetryClient)
```

Since the issue is happening when `dotnet run` forks to run `_build`, we can try to skip the middle-man and directly invoke it ourselves.

## Reason for change

Too many failures in the CI.
