### PR TITLE
[Dynamic Instrumentation] Fix number of locals in async method

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.SingleProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Instrumentation/AsyncMethodDebuggerInvoker.SingleProbe.cs
@@ -252,7 +252,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
             asyncState.MoveNextInvocationTarget = instance;
 
             var asyncCaptureInfo = new AsyncCaptureInfo(asyncState.MoveNextInvocationTarget, asyncState.KickoffInvocationTarget, asyncState.MethodMetadataInfo.KickoffInvocationTargetType, hoistedLocals: asyncState.MethodMetadataInfo.AsyncMethodHoistedLocals, hoistedArgs: asyncState.MethodMetadataInfo.AsyncMethodHoistedArguments);
-            var capture = new CaptureInfo<Exception>(asyncState.MethodMetadataIndex, value: exception, methodState: MethodState.ExitStartAsync, asyncCaptureInfo: asyncCaptureInfo, memberKind: ScopeMemberKind.Exception);
+            var capture = new CaptureInfo<Exception>(asyncState.MethodMetadataIndex, value: exception, methodState: MethodState.ExitStartAsync, localsCount: asyncState.MethodMetadataInfo.LocalVariableNames.Length, asyncCaptureInfo: asyncCaptureInfo, memberKind: ScopeMemberKind.Exception);
             var probeData = asyncState.ProbeData;
 
             if (!asyncState.ProbeData.Processor.Process(ref capture, asyncState.SnapshotCreator, in probeData))
@@ -291,7 +291,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
 
             if (exception != null)
             {
-                var captureInfo = new CaptureInfo<Exception>(asyncState.MethodMetadataIndex, value: exception, methodState: MethodState.ExitStartAsync, memberKind: ScopeMemberKind.Exception, asyncCaptureInfo: asyncCaptureInfo);
+                var captureInfo = new CaptureInfo<Exception>(asyncState.MethodMetadataIndex, value: exception, methodState: MethodState.ExitStartAsync, memberKind: ScopeMemberKind.Exception, localsCount: asyncState.MethodMetadataInfo.LocalVariableNames.Length, asyncCaptureInfo: asyncCaptureInfo);
                 if (!asyncState.ProbeData.Processor.Process(ref captureInfo, asyncState.SnapshotCreator, in probeData))
                 {
                     asyncState.IsActive = false;
@@ -299,7 +299,7 @@ namespace Datadog.Trace.Debugger.Instrumentation
             }
             else if (returnValue != null)
             {
-                var captureInfo = new CaptureInfo<TReturn>(asyncState.MethodMetadataIndex, value: returnValue, name: "@return", methodState: MethodState.ExitStartAsync, memberKind: ScopeMemberKind.Return, asyncCaptureInfo: asyncCaptureInfo);
+                var captureInfo = new CaptureInfo<TReturn>(asyncState.MethodMetadataIndex, value: returnValue, name: "@return", methodState: MethodState.ExitStartAsync, memberKind: ScopeMemberKind.Return, localsCount: asyncState.MethodMetadataInfo.LocalVariableNames.Length, asyncCaptureInfo: asyncCaptureInfo);
                 if (!asyncState.ProbeData.Processor.Process(ref captureInfo, asyncState.SnapshotCreator, in probeData))
                 {
                     asyncState.IsActive = false;

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncNoHoistedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncNoHoistedLocal.verified.txt
@@ -1,0 +1,70 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "ddtags": "Unknown",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "this": {
+                "type": "AsyncNoHoistedLocal",
+                "value": "AsyncNoHoistedLocal"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "this": {
+                "type": "AsyncNoHoistedLocal",
+                "value": "AsyncNoHoistedLocal"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "String",
+                "value": "Method"
+              },
+              "iii": {
+                "isNull": "true",
+                "type": "Object"
+              },
+              "input": {
+                "isNull": "true",
+                "type": "String"
+              },
+              "rrr": {
+                "isNull": "true",
+                "type": "String"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Method",
+            "type": "Samples.Probes.TestRuns.SmokeTests.AsyncNoHoistedLocal"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Method",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncNoHoistedLocal",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncNoHoistedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncNoHoistedLocal.verified.txt
@@ -3,7 +3,6 @@
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
     "ddsource": "dd_debugger",
-    "ddtags": "Unknown",
     "debugger": {
       "snapshot": {
         "captures": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncNoHoistedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncNoHoistedLocal.verified.txt
@@ -1,0 +1,16 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "INSTALLED"
+      }
+    },
+    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/AsyncNoHoistedLocal.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/AsyncNoHoistedLocal.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    public class AsyncNoHoistedLocal : IAsyncRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public async Task RunAsync()
+        {
+            await Method();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData]
+        public async Task<string> Method()
+        {
+            var input = nameof(Method) + "f";
+            var iii = M(input);
+            var rrr = M(iii) + input;
+            var sss = M(rrr);
+            await Task.Delay(20);
+            return nameof(Method);
+        }
+
+        private object M(object input)
+        {
+            return input;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
This PR fix the incorrect number of locals in async method that has "real" locals - i.e. locals that aren't hoisted (because they are not in use between awaits).

## Test coverage
AsyncMethodNoHoisted
