### PR TITLE
[Dynamic Instrumentation] Reduce allocations in probe processing

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryExtensions.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
 
 namespace Datadog.Trace.Debugger.Helpers

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryExtensions.cs
@@ -1,0 +1,34 @@
+// <copyright file="MemoryExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+
+namespace Datadog.Trace.Debugger.Helpers
+{
+    internal static class MemoryExtensions
+    {
+        /// <summary>
+        /// Return a new IMemoryOwner of size 'currentSize * 2' and dispose the old one
+        /// </summary>
+        internal static IMemoryOwner<T> EnlargeBuffer<T>(this IMemoryOwner<T> memoryOwner, int currentSize)
+        {
+            var newMemory = ArrayMemoryPool<T>.Shared.Rent(currentSize * 2);
+            memoryOwner.Memory.Span.CopyTo(newMemory.Memory.Span);
+            memoryOwner.Dispose();
+            return newMemory;
+        }
+
+        /// <summary>
+        /// Return a new array of size 'currentSize * 2' from the pool and return the old one to the pool
+        /// </summary>
+        internal static T[] EnlargeBuffer<T>(this T[] array, int currentSize)
+        {
+            var newArray = ArrayPool<T>.Shared.Rent(currentSize * 2);
+            array.CopyTo(newArray, 0);
+            ArrayPool<T>.Shared.Return(array, !typeof(T).IsValueType);
+            return newArray;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -18,7 +18,6 @@ using Datadog.Trace.Debugger.Helpers;
 using Datadog.Trace.Debugger.Models;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
-using ProbeInfo = Datadog.Trace.Debugger.Expressions.ProbeInfo;
 using ProbeLocation = Datadog.Trace.Debugger.Expressions.ProbeLocation;
 
 namespace Datadog.Trace.Debugger.Snapshots
@@ -575,7 +574,7 @@ namespace Datadog.Trace.Debugger.Snapshots
                         break;
                     case MethodState.ExitEndAsync:
                         CaptureExitMethodStartMarker(ref captureInfo);
-                        CaptureScopeMembers(MethodScopeMembers.Members.Where(member => member.ElementType == ScopeMemberKind.Local).ToArray());
+                        CaptureScopeMembers(MethodScopeMembers.Members, ScopeMemberKind.Local);
                         return true;
                     case MethodState.EndLine:
                     case MethodState.EndLineAsync:
@@ -592,7 +591,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             return false;
         }
 
-        internal void CaptureScopeMembers(ScopeMember[] members)
+        internal void CaptureScopeMembers(ScopeMember[] members, ScopeMemberKind? kind = null)
         {
             foreach (var member in members)
             {
@@ -600,6 +599,11 @@ namespace Datadog.Trace.Debugger.Snapshots
                 {
                     // ArrayPool can allocate more items than we need, if "Type == null", this mean we can exit the loop because Type should never be null
                     break;
+                }
+
+                if (kind != null && kind.Value != member.ElementType)
+                {
+                    continue;
                 }
 
                 switch (member.ElementType)


### PR DESCRIPTION
## Summary of changes
Avoid creating unnecessary objects via lambda expression (`where` clause) and minimize the number of array allocations when processing probes.

## Reason for change
Probes are critical path because they are part of the customer code so we want to make it thin as possible.

## Implementation details
Using array pool for saving method scope members.

## Test coverage
All probes integration tests.
