### PR TITLE
[ASM] Allow 0 values for iast regex timeout

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -10,6 +10,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Aspects.System;
 using Datadog.Trace.Iast.Propagation;
@@ -228,7 +229,14 @@ internal static class IastModule
 
     internal static EvidenceRedactor? CreateRedactor(IastSettings settings)
     {
-        return settings.RedactionEnabled ? new EvidenceRedactor(settings.RedactionKeysRegex, settings.RedactionValuesRegex, TimeSpan.FromMilliseconds(settings.RegexTimeout)) : null;
+        var timeout = TimeSpan.FromMilliseconds(settings.RegexTimeout);
+
+        if (timeout.TotalMilliseconds == 0)
+        {
+            timeout = Regex.InfiniteMatchTimeout;
+        }
+
+        return settings.RedactionEnabled ? new EvidenceRedactor(settings.RedactionKeysRegex, settings.RedactionValuesRegex, timeout) : null;
     }
 
     private static string BuildCommandInjectionEvidence(string file, string argumentLine, Collection<string>? argumentList)

--- a/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
@@ -63,7 +63,7 @@ internal class IastSettings
                                .AsString(DefaultRedactionValuesRegex);
         RegexTimeout = config
                                 .WithKeys(ConfigurationKeys.Iast.RegexTimeout)
-                                .AsDouble(200, val1 => val1 is > 0).Value;
+                                .AsDouble(200, val1 => val1 is >= 0).Value;
 
         IastTelemetryVerbosity = config
             .WithKeys(ConfigurationKeys.Iast.IastTelemetryVerbosity)


### PR DESCRIPTION
## Summary of changes

This PR allows IAST's regex to have an infinite timeout if a 0 value is set in config

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
