### PR TITLE
[Dynamic Instrumentation] Replace @exceptions with @exception in template tests

### DIFF
--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/TemplateExceptionValue.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/TemplateExceptionValue.cs
@@ -7,7 +7,7 @@ namespace Samples.Probes.TestRuns.ExpressionTests
     internal class TemplateExceptionValue : IRun
     {
         private const string Json = @"{
-        ""ref"": ""@exceptions""
+        ""ref"": ""@exception""
 }";
 
         [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/TemplateNoExceptionValue.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/ExpressionTests/TemplateNoExceptionValue.cs
@@ -7,7 +7,7 @@ namespace Samples.Probes.TestRuns.ExpressionTests
     internal class TemplateNoException : IRun
     {
         private const string Json = @"{
-        ""ref"": ""@exceptions""
+        ""ref"": ""@exception""
 }";
 
         [MethodImpl(MethodImplOptions.NoInlining)]


### PR DESCRIPTION
## Summary of changes
Replace @exceptions with @exception in template tests

## Test coverage
TemplateExceptionValue
TemplateNoException