### PR TITLE
[v3] [Tracing] Change default value of `DD_TRACE_SAMPLING_RULES_FORMAT`

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -205,7 +205,7 @@ namespace Datadog.Trace.Configuration
 
             CustomSamplingRulesFormat = config.WithKeys(ConfigurationKeys.CustomSamplingRulesFormat)
                                               .GetAs(
-                                                   getDefaultValue: () => new DefaultResult<string>(SamplingRulesFormat.Regex, "regex"),
+                                                   getDefaultValue: () => new DefaultResult<string>(SamplingRulesFormat.Glob, "glob"),
                                                    converter: value =>
                                                    {
                                                        // We intentionally report invalid values as "valid" in the converter,

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -464,7 +464,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("1", SamplingRulesFormat.Unknown)]     // invalid
         [InlineData("", SamplingRulesFormat.Unknown)]      // empty is invalid
         [InlineData("  ", SamplingRulesFormat.Unknown)]    // whitespace is invalid
-        [InlineData(null, SamplingRulesFormat.Regex)]      // null defaults to regex
+        [InlineData(null, SamplingRulesFormat.Glob)]       // null defaults to glob
         public void CustomSamplingRulesFormat(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CustomSamplingRulesFormat, value));
@@ -493,7 +493,7 @@ namespace Datadog.Trace.Tests.Configuration
                 {
                     case ConfigurationOrigins.Default:
                         // setting not specified, so the default value is used
-                        entry.StringValue.Should().Be(SamplingRulesFormat.Regex);
+                        entry.StringValue.Should().Be(SamplingRulesFormat.Glob);
                         break;
                     case ConfigurationOrigins.Code:
                         // original setting


### PR DESCRIPTION
## Summary of changes

Change the default value of `DD_TRACE_SAMPLING_RULES_FORMAT` from `regex` to `glob`. This is a potential breaking change, so it is going into release v3 and users can revert to previous behavior by setting `DD_TRACE_SAMPLING_RULES_FORMAT=regex`.

## Reason for change

Dictated by spec/RFC for consistency across client libraries (aka tracers).

## Implementation details

Change the default value.

## Test coverage

Update tests to assert the default value.
