### PR TITLE
[ASM][IAST] Fix Tests Location 

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.Deduplication/Samples.Deduplication.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Deduplication/Samples.Deduplication.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <!-- Disable symbols generation for consistant vulnerabilities Location data -->
+    <!-- Disable symbols generation for consistent vulnerabilities Location data -->
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/Samples.Deduplication/Samples.Deduplication.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Deduplication/Samples.Deduplication.csproj
@@ -4,5 +4,9 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <!-- Disable symbols generation for consistant vulnerabilities Location data -->
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.WeakCipher/Samples.WeakCipher.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WeakCipher/Samples.WeakCipher.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
 
-    <!-- Disable symbols generation for consistant vulnerabilities Location data -->
+    <!-- Disable symbols generation for consistent vulnerabilities Location data -->
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>

--- a/tracer/test/test-applications/integrations/Samples.WeakCipher/Samples.WeakCipher.csproj
+++ b/tracer/test/test-applications/integrations/Samples.WeakCipher/Samples.WeakCipher.csproj
@@ -4,5 +4,9 @@
     <!-- Required to build multiple projects with the same Configuration|Platform -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+
+    <!-- Disable symbols generation for consistant vulnerabilities Location data -->
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes

Disabling symbols generation on Samples for `WeakCipher` and `Deduplication`

## Reason for change

Forgot to disable symbols on some samples used by IAST.
Failing tests on the CI.
