### PR TITLE
Revert "[CI Visibility] - Include GAC installation feature to fix compatibility with .NET Framework"

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetFramework.cs
@@ -31,16 +31,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
         private static Assembly AssemblyResolve_ManagedProfilerDependencies(object sender, ResolveEventArgs args)
         {
-            try
-            {
-                return ResolveAssembly(args.Name);
-            }
-            catch (Exception ex)
-            {
-                StartupLogger.Log(ex, "Error resolving assembly: {0}", args.Name);
-            }
-
-            return null;
+            return ResolveAssembly(args.Name);
         }
 
         private static Assembly ResolveAssembly(string name)
@@ -52,31 +43,29 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             // in its satellite assemblies. Exit early so we don't cause
             // infinite recursion.
             if (string.Equals(assemblyName.Name, "mscorlib.resources", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase) ||
-                string.Equals(assemblyName.Name, "vstest.console.resources", StringComparison.OrdinalIgnoreCase))
+                string.Equals(assemblyName.Name, "System.Net.Http", StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
 
             // WARNING: Logs must not be added _before_ we check for the above bail-out conditions
-            var path = string.IsNullOrEmpty(ManagedProfilerDirectory) ? $"{assemblyName.Name}.dll" : Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
-            StartupLogger.Debug("  Looking for: '{0}'", path);
+            StartupLogger.Debug("Assembly Resolve event received for: {0}", name);
+            var path = Path.Combine(ManagedProfilerDirectory, $"{assemblyName.Name}.dll");
+            StartupLogger.Debug("Looking for: {0}", path);
 
             if (File.Exists(path))
             {
                 if (name.StartsWith("Datadog.Trace, Version=") && name != AssemblyName)
                 {
-                    StartupLogger.Debug("  Trying to load '{0}' which does not match the expected version ('{1}'). [Path={2}]", name, AssemblyName, path);
+                    StartupLogger.Debug("Trying to load {0} which does not match the expected version ({1}). [Path={2}]", name, AssemblyName, path);
                     return null;
                 }
 
-                StartupLogger.Debug("  Resolving '{0}', loading '{1}'", name, path);
-                var assembly = Assembly.LoadFrom(path);
-                StartupLogger.Debug("Assembly '{0}' loaded.", assembly?.FullName ?? "(null)");
-                return assembly;
+                StartupLogger.Debug("Resolving {0}, loading {1}", name, path);
+                return Assembly.LoadFrom(path);
             }
 
-            StartupLogger.Debug("Assembly not found in path: '{0}'", path);
+            StartupLogger.Debug("Assembly not found in path: {0}", path);
             return null;
         }
     }

--- a/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using Datadog.Trace.Ci;
 using Spectre.Console;
 
 namespace Datadog.Trace.Tools.Runner
@@ -63,8 +62,7 @@ namespace Datadog.Trace.Tools.Runner
                 _applicationContext.RunnerFolder,
                 _applicationContext.Platform,
                 _tracerSettings,
-                reducePathLength: true,
-                ciVisibilityOptions: new(CIVisibility.Settings.InstallDatadogTraceInGac, true));
+                reducePathLength: true);
 
             if (profilerEnvironmentVariables == null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
@@ -41,8 +41,7 @@ namespace Datadog.Trace.Tools.Runner
                 ApplicationContext.RunnerFolder,
                 ApplicationContext.Platform,
                 _legacySettings,
-                reducePathLength: false,
-                ciVisibilityOptions: Utils.CIVisibilityOptions.None);
+                reducePathLength: false);
 
             if (profilerEnvironmentVariables is null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -46,14 +46,12 @@ namespace Datadog.Trace.Tools.Runner
         private async Task ExecuteAsync(InvocationContext context)
         {
             // CI Visibility mode is enabled.
-            var ciVisibilitySettings = CIVisibility.Settings;
-
             var args = _runSettings.Command.GetValue(context);
             var program = args[0];
             var arguments = args.Length > 1 ? Utils.GetArgumentsAsString(args.Skip(1)) : string.Empty;
 
             // Get profiler environment variables
-            if (!RunHelper.TryGetEnvironmentVariables(_applicationContext, context, _runSettings, new Utils.CIVisibilityOptions(ciVisibilitySettings.InstallDatadogTraceInGac, true), out var profilerEnvironmentVariables))
+            if (!RunHelper.TryGetEnvironmentVariables(_applicationContext, context, _runSettings, out var profilerEnvironmentVariables))
             {
                 context.ExitCode = 1;
                 return;
@@ -63,6 +61,7 @@ namespace Datadog.Trace.Tools.Runner
             profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.Enabled] = "1";
 
             // We check the settings and merge with the command settings options
+            var ciVisibilitySettings = CIVisibility.Settings;
             var agentless = ciVisibilitySettings.Agentless;
             var apiKey = ciVisibilitySettings.ApiKey;
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunHelper.cs
@@ -12,18 +12,12 @@ namespace Datadog.Trace.Tools.Runner
     {
         public static bool TryGetEnvironmentVariables(ApplicationContext applicationContext, InvocationContext invocationContext, RunSettings settings, out Dictionary<string, string> profilerEnvironmentVariables)
         {
-            return TryGetEnvironmentVariables(applicationContext, invocationContext, settings, Utils.CIVisibilityOptions.None, out profilerEnvironmentVariables);
-        }
-
-        public static bool TryGetEnvironmentVariables(ApplicationContext applicationContext, InvocationContext invocationContext, RunSettings settings, Utils.CIVisibilityOptions ciVisibilityOptions, out Dictionary<string, string> profilerEnvironmentVariables)
-        {
             profilerEnvironmentVariables = Utils.GetProfilerEnvironmentVariables(
                 invocationContext,
                 applicationContext.RunnerFolder,
                 applicationContext.Platform,
                 settings,
-                reducePathLength: false,
-                ciVisibilityOptions: ciVisibilityOptions);
+                reducePathLength: false);
 
             if (profilerEnvironmentVariables is null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -14,11 +14,9 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
-using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 using Spectre.Console;
 
@@ -27,8 +25,6 @@ namespace Datadog.Trace.Tools.Runner
     internal class Utils
     {
         public const string Profilerid = "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}";
-
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(Utils));
 
         public static string GetHomePath(string runnerFolder)
         {
@@ -42,11 +38,11 @@ namespace Datadog.Trace.Tools.Runner
             return DirectoryExists("Home", Path.Combine(runnerFolder, "..", "..", "..", "home"), Path.Combine(runnerFolder, "home"));
         }
 
-        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, CommonTracerSettings options, bool reducePathLength, CIVisibilityOptions ciVisibilityOptions)
+        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, CommonTracerSettings options, bool reducePathLength)
         {
             var tracerHomeFolder = options.TracerHome.GetValue(context);
 
-            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, tracerHomeFolder, reducePathLength, ciVisibilityOptions);
+            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, tracerHomeFolder, reducePathLength);
 
             var environment = options.Environment.GetValue(context);
 
@@ -79,9 +75,9 @@ namespace Datadog.Trace.Tools.Runner
             return envVars;
         }
 
-        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, LegacySettings options, bool reducePathLength, CIVisibilityOptions ciVisibilityOptions)
+        public static Dictionary<string, string> GetProfilerEnvironmentVariables(InvocationContext context, string runnerFolder, Platform platform, LegacySettings options, bool reducePathLength)
         {
-            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, options.TracerHomeFolderOption.GetValue(context), reducePathLength, ciVisibilityOptions);
+            var envVars = GetBaseProfilerEnvironmentVariables(runnerFolder, platform, options.TracerHomeFolderOption.GetValue(context), reducePathLength);
 
             var environment = options.EnvironmentOption.GetValue(context);
 
@@ -411,7 +407,7 @@ namespace Datadog.Trace.Tools.Runner
             return false;
         }
 
-        private static Dictionary<string, string> GetBaseProfilerEnvironmentVariables(string runnerFolder, Platform platform, string tracerHomeFolder, bool reducePathLength, CIVisibilityOptions ciVisibilityOptions = null)
+        private static Dictionary<string, string> GetBaseProfilerEnvironmentVariables(string runnerFolder, Platform platform, string tracerHomeFolder, bool reducePathLength)
         {
             string tracerHome = null;
             if (!string.IsNullOrEmpty(tracerHomeFolder))
@@ -455,35 +451,12 @@ namespace Datadog.Trace.Tools.Runner
             string tracerProfiler64 = string.Empty;
             string tracerProfilerArm64 = null;
             string ldPreload = string.Empty;
-            string devPath = string.Empty;
 
             if (platform == Platform.Windows)
             {
                 tracerProfiler32 = FileExists(Path.Combine(tracerHome, "win-x86", "Datadog.Trace.ClrProfiler.Native.dll"));
                 tracerProfiler64 = FileExists(Path.Combine(tracerHome, "win-x64", "Datadog.Trace.ClrProfiler.Native.dll"));
                 tracerProfilerArm64 = FileExistsOrNull(Path.Combine(tracerHome, "win-ARM64EC", "Datadog.Trace.ClrProfiler.Native.dll"));
-
-                if (ciVisibilityOptions is not null)
-                {
-                    // For full compatibility with .NET Framework we need to either install Datadog.Trace.dll to the GAC or enable Development mode for vstest.console
-                    // This is a best effort approach by:
-                    //   1. Check if `Datadog.Trace` is installed in the gac using `gacutil`, if not, we try to install it.
-                    //   2. If that doesn't work we try to locate `vstest.console.exe.config` to enable debug mode on this
-                    //      command so we can inject the DevPath environment variable
-                    var installedInGac = false;
-                    if (ciVisibilityOptions.EnableGacInstallation)
-                    {
-                        installedInGac = EnsureDatadogTraceIsInTheGac(tracerHome);
-                    }
-
-                    if (!installedInGac && ciVisibilityOptions.EnableVsTestConsoleConfigModification)
-                    {
-                        if (EnsureNETFrameworkVSTestConsoleDevPathSupport())
-                        {
-                            devPath = Path.Combine(tracerHome, "net461");
-                        }
-                    }
-                }
             }
             else if (platform == Platform.Linux)
             {
@@ -536,162 +509,7 @@ namespace Datadog.Trace.Tools.Runner
                 envVars["COR_PROFILER_PATH_ARM64"] = tracerProfilerArm64;
             }
 
-            if (!string.IsNullOrEmpty(devPath))
-            {
-                envVars["DEVPATH"] = devPath;
-            }
-
             return envVars;
-        }
-
-        private static bool EnsureDatadogTraceIsInTheGac(string tracerHome)
-        {
-            // We try to ensure Datadog.Trace.dll is installed in the gac for compatibility with .NET Framework fusion class loader
-            // Let's find gacutil, because CI Visibility runs with the SDK / CI environments it's probable that's available.
-            var cmdResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command("where", "gacutil"));
-            if (cmdResponse?.ExitCode == 0 &&
-                cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&
-                outputLines[0] is { Length: > 0 } gacPath)
-            {
-                Log.Debug("EnsureDatadogTraceIsInTheGac: gacutil was found.");
-                var cmdGacListResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command(gacPath, "/l"));
-                if (cmdGacListResponse?.ExitCode == 0)
-                {
-                    if (cmdGacListResponse.Output?.Contains(typeof(TracerConstants).Assembly.FullName!, StringComparison.OrdinalIgnoreCase) != true)
-                    {
-                        // Datadog.Trace is not in the GAC, let's try to install it.
-                        // We run the gacutil /i command using runas verb to elevate privileges
-                        Log.Warning("EnsureDatadogTraceIsInTheGac: Datadog.Trace is not in the GAC, let's try to install it.");
-                        WriteInfo("Datadog.Trace is not installed in the GAC, the installation will require Administrator permissions. Installing...");
-                        if (FileExistsOrNull(Path.Combine(tracerHome, "net461", "Datadog.Trace.dll")) is { } datadogTraceDllPath &&
-                            ProcessHelpers.RunCommand(new ProcessHelpers.Command(gacPath, $"/if {datadogTraceDllPath}", verb: "runas")) is { } cmdGacInstallResponse)
-                        {
-                            if (cmdGacInstallResponse.ExitCode == 0)
-                            {
-                                // gacutil install was successful.
-                                Log.Information("EnsureDatadogTraceIsInTheGac: Datadog.Trace was installed in the gac.");
-                                WriteInfo("Datadog.Trace was installed in the GAC.");
-                                return true;
-                            }
-
-                            Log.Warning("EnsureDatadogTraceIsInTheGac: gacutil returned an error, Datadog.Trace was not installed in the gac.");
-                            WriteInfo("Datadog.Trace was not installed in the GAC.");
-                            return false;
-                        }
-                    }
-                    else
-                    {
-                        // Datadog.Trace is in the GAC, do nothing
-                        Log.Information("EnsureDatadogTraceIsInTheGac: Datadog.Trace is already installed in the gac.");
-                        return true;
-                    }
-                }
-                else
-                {
-                    // `gacutil /l` failed
-                    Log.Warning("EnsureDatadogTraceIsInTheGac: Call to `gacutil /l` failed.");
-                }
-            }
-            else
-            {
-                // `gacutil` cannot be found
-                Log.Warning("EnsureDatadogTraceIsInTheGac: gacutil cannot be found.");
-            }
-
-            return false;
-        }
-
-        private static bool EnsureNETFrameworkVSTestConsoleDevPathSupport()
-        {
-            // As a final workaround for .NET Framework compatibility we can use the DevPath approach.
-            // https://learn.microsoft.com/en-us/dotnet/framework/configure-apps/how-to-locate-assemblies-by-using-devpath
-            // .NET Framework tests runs using `vstest.console.exe` console app. So we need to locate this file and modify
-            // the configuration `vstest.console.exe.config` file to add:
-            /*
-                <configuration>
-                  <runtime>
-                    <developmentMode developerInstallation="true"/>
-                  </runtime>
-                </configuration>
-             */
-
-            Log.Debug("EnsureNETFrameworkVSTestConsoleDevPathSupport: Looking for vstest.console");
-            var cmdResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command("where", "vstest.console"));
-            if (cmdResponse?.ExitCode == 0 &&
-                cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&
-                outputLines[0] is { Length: > 0 } vstestConsolePath)
-            {
-                Log.Debug("EnsureNETFrameworkVSTestConsoleDevPathSupport: vstest.console was found.");
-                var configPath = $"{vstestConsolePath.Trim()}.config";
-                if (File.Exists(configPath))
-                {
-                    try
-                    {
-                        Log.Debug("EnsureNETFrameworkVSTestConsoleDevPathSupport: vstest.console configuration file was found.");
-                        var configContent = File.ReadAllText(configPath);
-                        var xmlDocument = new XmlDocument();
-                        xmlDocument.LoadXml(configContent);
-                        var xmlDoc = xmlDocument.DocumentElement!;
-                        var isDirty = false;
-                        var runtimeNode = xmlDoc["runtime"];
-                        if (runtimeNode is null)
-                        {
-                            runtimeNode = (XmlElement)xmlDoc.AppendChild(xmlDocument.CreateElement("runtime"))!;
-                            isDirty = true;
-                        }
-
-                        var developmentModeNode = runtimeNode["developmentMode"];
-                        if (developmentModeNode is null)
-                        {
-                            developmentModeNode = (XmlElement)runtimeNode.AppendChild(xmlDocument.CreateElement("developmentMode"))!;
-                            isDirty = true;
-                        }
-
-                        var developerInstallationAttribute = developmentModeNode.Attributes["developerInstallation"];
-                        if (developerInstallationAttribute is null)
-                        {
-                            developmentModeNode.SetAttribute("developerInstallation", "true");
-                            isDirty = true;
-                        }
-                        else if (developerInstallationAttribute.Value != "true")
-                        {
-                            developerInstallationAttribute.Value = "true";
-                            isDirty = true;
-                        }
-
-                        if (isDirty)
-                        {
-                            try
-                            {
-                                var outerXml = xmlDocument.OuterXml;
-                                Log.Debug("EnsureNETFrameworkVSTestConsoleDevPathSupport: vstest.console configuration file content: {Content}", outerXml);
-                                File.WriteAllText(configPath, outerXml);
-                                Log.Information("EnsureNETFrameworkVSTestConsoleDevPathSupport: vstest.console configuration file has been configured as developer mode.");
-                            }
-                            catch (Exception ex)
-                            {
-                                Log.Error(ex, "EnsureNETFrameworkVSTestConsoleDevPathSupport: Error writing the vstest.console configuration file.");
-                                return false;
-                            }
-                        }
-                        else
-                        {
-                            Log.Information("EnsureNETFrameworkVSTestConsoleDevPathSupport: vstest.console configuration file was already configured as developer mode.");
-                        }
-
-                        return true;
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "EnsureNETFrameworkVSTestConsoleDevPathSupport: Error writing the vstest.console configuration file.");
-                        return false;
-                    }
-                }
-
-                Log.Warning("EnsureNETFrameworkVSTestConsoleDevPathSupport: vstest.console configuration file was not found.");
-            }
-
-            return false;
         }
 
         /// <summary>
@@ -809,11 +627,6 @@ namespace Datadog.Trace.Tools.Runner
             {
                 File.Copy(newPath, newPath.Replace(sourcePath, targetPath), true);
             }
-        }
-
-        public record CIVisibilityOptions(bool EnableGacInstallation, bool EnableVsTestConsoleConfigModification)
-        {
-            public static CIVisibilityOptions None { get; } = new(false, false);
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -212,7 +212,6 @@
       <type fullname="System.Diagnostics.Process" />
       <type fullname="System.Diagnostics.ProcessStartInfo" />
       <type fullname="System.Diagnostics.ProcessThreadCollection" />
-      <type fullname="System.Diagnostics.ProcessWindowStyle" />
    </assembly>
    <assembly fullname="System.Diagnostics.StackTrace">
       <type fullname="System.Diagnostics.StackFrame" />

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -50,9 +50,6 @@ namespace Datadog.Trace.Ci.Configuration
 
             // Force evp proxy
             ForceAgentsEvpProxy = config.WithKeys(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy).AsBool(false);
-
-            // Check if Datadog.Trace should be installed in the GAC
-            InstallDatadogTraceInGac = config.WithKeys(ConfigurationKeys.CIVisibility.InstallDatadogTraceInGac).AsBool(true);
         }
 
         /// <summary>
@@ -139,11 +136,6 @@ namespace Datadog.Trace.Ci.Configuration
         /// Gets a value indicating whether EVP Proxy must be used.
         /// </summary>
         public bool ForceAgentsEvpProxy { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether we ensure Datadog.Trace GAC installation.
-        /// </summary>
-        public bool InstallDatadogTraceInGac { get; }
 
         /// <summary>
         /// Gets the tracer settings

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/AssemblyResolverCtorIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/AssemblyResolverCtorIntegration.cs
@@ -5,7 +5,6 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -30,7 +29,7 @@ public class AssemblyResolverCtorIntegration
 {
     private const string IntegrationName = "TestPlatformAssemblyResolver";
 
-    private static readonly List<Task> LstTasks = new();
+    private static TaskCompletionSource<bool>? _callHasBeenCompletedTaskCompletionSource;
 
     /// <summary>
     /// OnMethodBegin callback
@@ -43,13 +42,8 @@ public class AssemblyResolverCtorIntegration
     internal static CallTargetState OnMethodBegin<TTarget, TArg1>(TTarget instance, ref TArg1 directories)
     {
         Common.Log.Debug("Microsoft.VisualStudio.TestPlatform.Common.Utilities.AssemblyResolver.ctor started.");
-        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        lock (LstTasks)
-        {
-            LstTasks.Add(tcs.Task);
-        }
-
-        return new CallTargetState(null, tcs);
+        _callHasBeenCompletedTaskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        return CallTargetState.GetDefault();
     }
 
     /// <summary>
@@ -62,26 +56,30 @@ public class AssemblyResolverCtorIntegration
     /// <returns>A return value, in an async scenario will be T of Task of T</returns>
     internal static CallTargetReturn OnMethodEnd<TTarget>(TTarget instance, Exception? exception, in CallTargetState state)
     {
-        if (state.State is TaskCompletionSource<bool> tcs)
-        {
-            tcs.TrySetResult(exception is null);
-            Common.Log.Debug("Microsoft.VisualStudio.TestPlatform.Common.Utilities.AssemblyResolver.ctor finished.");
-        }
-
+        _callHasBeenCompletedTaskCompletionSource?.TrySetResult(exception is null);
+        Common.Log.Debug("Microsoft.VisualStudio.TestPlatform.Common.Utilities.AssemblyResolver.ctor finished.");
         return CallTargetReturn.GetDefault();
     }
 
     internal static Task WaitForCallToBeCompletedAsync()
     {
-        lock (LstTasks)
+        if (_callHasBeenCompletedTaskCompletionSource?.Task is { } callTask)
         {
-            var lstTasks = LstTasks;
-            return lstTasks.Count switch
+            if (!callTask.IsCompleted)
             {
-                0 => Task.CompletedTask,
-                1 => lstTasks[0],
-                _ => Task.WhenAll(LstTasks)
-            };
+                return InternalWaitForCallToBeCompletedAsync(callTask);
+            }
+
+            Common.Log.Debug("Microsoft.VisualStudio.TestPlatform.Common.Utilities.AssemblyResolver.ctor already ran.");
+        }
+
+        return Task.CompletedTask;
+
+        static async Task InternalWaitForCallToBeCompletedAsync(Task<bool> callTask)
+        {
+            Common.Log.Debug("Waiting for Microsoft.VisualStudio.TestPlatform.Common.Utilities.AssemblyResolver.ctor to be completed...");
+            await callTask.ConfigureAwait(false);
+            Common.Log.Debug("Call to Microsoft.VisualStudio.TestPlatform.Common.Utilities.AssemblyResolver.ctor is completed.");
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -517,11 +517,6 @@ namespace Datadog.Trace.Configuration
             /// Configuration key for setting the external code coverage file path
             /// </summary>
             public const string ExternalCodeCoveragePath = "DD_CIVISIBILITY_EXTERNAL_CODE_COVERAGE_PATH";
-
-            /// <summary>
-            /// Configuration key for enabling or disabling Datadog.Trace GAC installation
-            /// </summary>
-            public const string InstallDatadogTraceInGac = "DD_CIVISIBILITY_GAC_INSTALL_ENABLED";
         }
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs
@@ -85,20 +85,13 @@ namespace Datadog.Trace.Util
             var errorStringBuilder = new StringBuilder();
             while (!processInfo.HasExited)
             {
-                if (!processStartInfo.UseShellExecute)
-                {
-                    outputStringBuilder.Append(processInfo.StandardOutput.ReadToEnd());
-                    errorStringBuilder.Append(processInfo.StandardError.ReadToEnd());
-                }
-
+                outputStringBuilder.Append(processInfo.StandardOutput.ReadToEnd());
+                errorStringBuilder.Append(processInfo.StandardError.ReadToEnd());
                 Thread.Sleep(15);
             }
 
-            if (!processStartInfo.UseShellExecute)
-            {
-                outputStringBuilder.Append(processInfo.StandardOutput.ReadToEnd());
-                errorStringBuilder.Append(processInfo.StandardError.ReadToEnd());
-            }
+            outputStringBuilder.Append(processInfo.StandardOutput.ReadToEnd());
+            errorStringBuilder.Append(processInfo.StandardError.ReadToEnd());
 
             Log.Debug<int>("Process finished with exit code: {Value}.", processInfo.ExitCode);
             return new CommandOutput(outputStringBuilder.ToString(), errorStringBuilder.ToString(), processInfo.ExitCode);
@@ -136,20 +129,13 @@ namespace Datadog.Trace.Util
             var errorStringBuilder = new StringBuilder();
             while (!processInfo.HasExited)
             {
-                if (!processStartInfo.UseShellExecute)
-                {
-                    outputStringBuilder.Append(await processInfo.StandardOutput.ReadToEndAsync().ConfigureAwait(false));
-                    errorStringBuilder.Append(await processInfo.StandardError.ReadToEndAsync().ConfigureAwait(false));
-                }
-
+                outputStringBuilder.Append(await processInfo.StandardOutput.ReadToEndAsync().ConfigureAwait(false));
+                errorStringBuilder.Append(await processInfo.StandardError.ReadToEndAsync().ConfigureAwait(false));
                 await Task.Delay(15).ConfigureAwait(false);
             }
 
-            if (!processStartInfo.UseShellExecute)
-            {
-                outputStringBuilder.Append(await processInfo.StandardOutput.ReadToEndAsync().ConfigureAwait(false));
-                errorStringBuilder.Append(await processInfo.StandardError.ReadToEndAsync().ConfigureAwait(false));
-            }
+            outputStringBuilder.Append(await processInfo.StandardOutput.ReadToEndAsync().ConfigureAwait(false));
+            errorStringBuilder.Append(await processInfo.StandardError.ReadToEndAsync().ConfigureAwait(false));
 
             Log.Debug<int>("Process finished with exit code: {Value}.", processInfo.ExitCode);
             return new CommandOutput(outputStringBuilder.ToString(), errorStringBuilder.ToString(), processInfo.ExitCode);
@@ -161,18 +147,9 @@ namespace Datadog.Trace.Util
                                        new ProcessStartInfo(command.Cmd) :
                                        new ProcessStartInfo(command.Cmd, command.Arguments);
             processStartInfo.CreateNoWindow = true;
-            processStartInfo.WindowStyle = ProcessWindowStyle.Hidden;
-            processStartInfo.Verb = command.Verb;
-            if (command.Verb is null)
-            {
-                processStartInfo.UseShellExecute = false;
-                processStartInfo.RedirectStandardOutput = true;
-                processStartInfo.RedirectStandardError = true;
-            }
-            else
-            {
-                processStartInfo.UseShellExecute = true;
-            }
+            processStartInfo.UseShellExecute = false;
+            processStartInfo.RedirectStandardOutput = true;
+            processStartInfo.RedirectStandardError = true;
 
             if (command.WorkingDirectory is not null)
             {
@@ -187,14 +164,12 @@ namespace Datadog.Trace.Util
             public readonly string Cmd;
             public readonly string? Arguments;
             public readonly string? WorkingDirectory;
-            public readonly string? Verb;
 
-            public Command(string cmd, string? arguments = null, string? workingDirectory = null, string? verb = null)
+            public Command(string cmd, string? arguments = null, string? workingDirectory = null)
             {
                 Cmd = cmd;
                 Arguments = arguments;
                 WorkingDirectory = workingDirectory;
-                Verb = verb;
             }
         }
 

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -51,7 +51,6 @@ const shared::WSTRING skip_assembly_prefixes[]{
     WStr("System.Text"),
     WStr("System.Threading"),
     WStr("System.Xml"),
-    WStr("System.Numerics"),
 };
 
 const shared::WSTRING include_assemblies[]{

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -358,7 +358,6 @@
   "DD_CIVISIBILITY_ITR_ENABLED": "ci_visibility_intelligent_test_runner_enabled",
   "DD_CIVISIBILITY_FORCE_AGENT_EVP_PROXY": "ci_visibility_force_agent_evp_proxy_enabled",
   "DD_CIVISIBILITY_EXTERNAL_CODE_COVERAGE_PATH": "ci_visibility_code_coverage_external_path",
-  "DD_CIVISIBILITY_GAC_INSTALL_ENABLED": "ci_visibility_gac_install_enabled",
   "DD_PROXY_HTTPS": "proxy_https",
   "DD_PROXY_NO_PROXY": "proxy_no_proxy",
   "DD_TRACE_DEBUG_LOOKUP_MDTOKEN": "trace_lookup_mdtoken_enabled",


### PR DESCRIPTION
Reverts DataDog/dd-trace-dotnet#5129

Just checking if it fixes the debugger tests.