### PR TITLE
Force execute permissions on OSX

### DIFF
--- a/tracer/build.sh
+++ b/tracer/build.sh
@@ -32,4 +32,6 @@ echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 echo "dotnet build exited with code $?"
 ls -l "$SCRIPT_DIR/build/_build/bin/Debug/_build"
 
+# This shouldn't be needed, but the build randomly fails on OSX because the file doesn't have execute permissions
+chmod +x "$SCRIPT_DIR/build/_build/bin/Debug/_build"
 "$SCRIPT_DIR/build/_build/bin/Debug/_build" "$@"


### PR DESCRIPTION
## Summary of changes

Nuke randomly fails on OSX. In https://github.com/DataDog/dd-trace-dotnet/pull/5127 I added some commands to display more information and here is the result:

```
dotnet build exited with code 0
-rw-r--r--  1 runner  staff  132768 Feb  5 13:22 /Users/runner/work/1/s/tracer/build/_build/bin/Debug/_build
./tracer/build.sh: line 35: /Users/runner/work/1/s/tracer/build/_build/bin/Debug/_build: Permission denied
```

We can see that `dotnet build` completes successfully, yet the created file doesn't have execute permission.

In this PR, I add an explicit `chmod +x` to try to fix this problem.

## Reason for change

Flaky runs on OSX.
