### PR TITLE
Fix the issue of not having branch name when azure pipeline works with a detached HEAD

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1283,7 +1283,7 @@ partial class Build : NukeBuild
                     }
                 }
             }
-            catch (Exception ex)
+            catch
             {
                 // .
             }

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1251,29 +1251,8 @@ partial class Build : NukeBuild
         {
             branch = Environment.GetEnvironmentVariable(AzureBuildSourceBranchName);
         }
-
-        try
-        {
-            // Clean branch name
-            var regex = new Regex(@"^refs\/heads\/tags\/(.*)|refs\/heads\/(.*)|refs\/tags\/(.*)|refs\/(.*)|origin\/tags\/(.*)|origin\/(.*)$");
-            if (!string.IsNullOrEmpty(branch))
-            {
-                var match = regex.Match(branch);
-                if (match.Success && match.Groups.Count == 7)
-                {
-                    branch =
-                        !string.IsNullOrWhiteSpace(match.Groups[2].Value) ? match.Groups[2].Value :
-                        !string.IsNullOrWhiteSpace(match.Groups[4].Value) ? match.Groups[4].Value :
-                                                                            match.Groups[6].Value;
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            // .
-        }
         
-        if (string.Equals(branch, baseBranch, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(CleanBranchName(branch), CleanBranchName(baseBranch), StringComparison.OrdinalIgnoreCase))
         {
             return true;
         }
@@ -1285,6 +1264,32 @@ partial class Build : NukeBuild
             GitTasks.Git("rev-parse --abbrev-ref HEAD").First().Text,
             baseBranch,
             StringComparison.OrdinalIgnoreCase);
+
+        static string CleanBranchName(string branchName)
+        {
+            try
+            {
+                // Clean branch name
+                var regex = new Regex(@"^refs\/heads\/tags\/(.*)|refs\/heads\/(.*)|refs\/tags\/(.*)|refs\/(.*)|origin\/tags\/(.*)|origin\/(.*)$");
+                if (!string.IsNullOrEmpty(branchName))
+                {
+                    var match = regex.Match(branchName);
+                    if (match.Success && match.Groups.Count == 7)
+                    {
+                        branchName =
+                            !string.IsNullOrWhiteSpace(match.Groups[2].Value) ? match.Groups[2].Value :
+                            !string.IsNullOrWhiteSpace(match.Groups[4].Value) ? match.Groups[4].Value :
+                                                                                match.Groups[6].Value;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                // .
+            }
+
+            return branchName;
+        }
     }
 
     static string[] GetGitChangedFiles(string baseBranch)

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Nuke.Common;
 using Nuke.Common.CI.AzurePipelines;
@@ -1234,10 +1235,57 @@ partial class Build : NukeBuild
        });
 
     static bool IsGitBaseBranch(string baseBranch)
-        => string.Equals(
+    {
+        // *****
+        // First we try to find the base branch in the Azure Pipelines environment variables.
+        // This code is a simplified version of Datadog.Trace/CI/CIEnvironmentValues.cs file
+        // to only extract the branch name from Azure Pipelines
+        // *****
+        const string AzureSystemPullRequestSourceBranch = "SYSTEM_PULLREQUEST_SOURCEBRANCH";
+        const string AzureBuildSourceBranch = "BUILD_SOURCEBRANCH";
+        const string AzureBuildSourceBranchName = "BUILD_SOURCEBRANCHNAME";
+
+        var prBranch = Environment.GetEnvironmentVariable(AzureSystemPullRequestSourceBranch);
+        var branch = !string.IsNullOrWhiteSpace(prBranch) ? prBranch : Environment.GetEnvironmentVariable(AzureBuildSourceBranch);
+        if (string.IsNullOrWhiteSpace(branch))
+        {
+            branch = Environment.GetEnvironmentVariable(AzureBuildSourceBranchName);
+        }
+
+        try
+        {
+            // Clean branch name
+            var regex = new Regex(@"^refs\/heads\/tags\/(.*)|refs\/heads\/(.*)|refs\/tags\/(.*)|refs\/(.*)|origin\/tags\/(.*)|origin\/(.*)$");
+            if (!string.IsNullOrEmpty(branch))
+            {
+                var match = regex.Match(branch);
+                if (match.Success && match.Groups.Count == 7)
+                {
+                    branch =
+                        !string.IsNullOrWhiteSpace(match.Groups[2].Value) ? match.Groups[2].Value :
+                        !string.IsNullOrWhiteSpace(match.Groups[4].Value) ? match.Groups[4].Value :
+                                                                            match.Groups[6].Value;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // .
+        }
+        
+        if (string.Equals(branch, baseBranch, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        // *****
+        // In case we cannot find the baseBranch we fallback to the git command
+        // *****
+        return string.Equals(
             GitTasks.Git("rev-parse --abbrev-ref HEAD").First().Text,
             baseBranch,
             StringComparison.OrdinalIgnoreCase);
+    }
 
     static string[] GetGitChangedFiles(string baseBranch)
     {


### PR DESCRIPTION
## Summary of changes

This PR tries to fix the issue of not having a branch name at build time due to azure pipeline working with a detached HEAD

## Reason for change

We are seeing some cases where we are working on master but with a detached HEAD not being properly indetified as the master branch.

## Implementation details

Copied part of the code from the CI Visibility code to the build project.

## Test coverage

We need to check once it gets merged 🤷🏻 
