### PR TITLE
[APM] Move common files ownership on tracer folder to APM group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,11 @@
 # Tracer
 /tracer/                                  @DataDog/tracing-dotnet
 
+# Common Files
+Datadog.Trace.Trimming.xml                @DataDog/apm-dotnet
+missing-nullability-files.csv             @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace/Datadog.Trace.csproj  @DataDog/apm-dotnet
+
 # CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,6 @@
 # Common Files
 Datadog.Trace.Trimming.xml                @DataDog/apm-dotnet
 missing-nullability-files.csv             @DataDog/apm-dotnet
-/tracer/src/Datadog.Trace/Datadog.Trace.csproj  @DataDog/apm-dotnet
 
 # CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,8 @@
 # Common Files
 Datadog.Trace.Trimming.xml                @DataDog/apm-dotnet
 missing-nullability-files.csv             @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace/Generated/      @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace/Configuration/IntegrationId.cs @DataDog/apm-dotnet
 
 # CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet


### PR DESCRIPTION
## Summary of changes
Move common files inside the tracer folder to APM team, so anyone can modify them freely.

## Reason for change
Most of the PRs end up needing the approval of a Tracing team member because these files (null file, trimming, datadog.tracer.csproj) are usually modified.

## Implementation details
Changed ownership of these files to APM group
