### PR TITLE
[Dynamic Instrumentation] Scrub stacktrace value in probe tests snapshots

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnWithExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTaskReturnWithExceptionTest.verified.txt
@@ -81,10 +81,7 @@
                     "type": "String",
                     "value": "System.Linq"
                   },
-                  "StackTrace": {
-                    "type": "String",
-                    "value": "   at System.Linq.ThrowHelper.ThrowNoMatchException()\r\n   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source, Func`2 predicate)\r\n   at Samples.Probes.TestRuns.SmokeTests.AsyncTaskReturnWithExceptionTest.GetRoomById(String id) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\AsyncTaskReturnWithExceptionTest.cs:line 28\r\n   at Samples.Probes.TestRuns.SmokeTests.AsyncTaskReturnWithExceptionTest.Method(String caller) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\AsyncTaskReturnWithExceptionTest.cs:line 24"
-                  }
+                  "StackTrace": "ScrubbedValue"
                 },
                 "type": "InvalidOperationException",
                 "value": "InvalidOperationException"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncThrowException.verified.txt
@@ -45,10 +45,7 @@
                     "type": "String",
                     "value": "Samples.Probes.TestRuns"
                   },
-                  "StackTrace": {
-                    "type": "String",
-                    "value": "   at Samples.Probes.TestRuns.SmokeTests.AsyncThrowException.Method(String caller) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\AsyncThrowException.cs:line 19"
-                  }
+                  "StackTrace": "ScrubbedValue"
                 },
                 "type": "InvalidOperationException",
                 "value": "InvalidOperationException"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericRefReturnTest.verified.txt
@@ -23,6 +23,33 @@
               }
             },
             "locals": {
+              "@exception": {
+                "fields": {
+                  "HelpLink": {
+                    "isNull": "true",
+                    "type": "String"
+                  },
+                  "HResult": {
+                    "type": "Int32",
+                    "value": "-2147467261"
+                  },
+                  "InnerException": {
+                    "isNull": "true",
+                    "type": "Exception"
+                  },
+                  "Message": {
+                    "type": "String",
+                    "value": "Object reference not set to an instance of an object."
+                  },
+                  "Source": {
+                    "type": "String",
+                    "value": "Samples.Probes.TestRuns"
+                  },
+                  "StackTrace": "ScrubbedValue"
+                },
+                "type": "NullReferenceException",
+                "value": "NullReferenceException"
+              },
               "whatever": {
                 "fields": {
                   "City": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
@@ -65,10 +65,7 @@
                     "type": "String",
                     "value": "Samples.Probes.TestRuns"
                   },
-                  "StackTrace": {
-                    "type": "String",
-                    "value": "   at Samples.Probes.TestRuns.SmokeTests.MethodThrowExceptionTest.Method(Int32 toSet) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\MethodThrowExceptionTest.cs:line 29\r\n   at Samples.Probes.TestRuns.SmokeTests.MethodThrowExceptionTest.Run() in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\MethodThrowExceptionTest.cs:line 14\r\n   at Program.RunTest(Object instance, String testClassName) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\Samples.Probes\\Program.cs:line 61"
-                  }
+                  "StackTrace": "ScrubbedValue"
                 },
                 "type": "InvalidOperationException",
                 "value": "InvalidOperationException"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.OverloadAndSimpleNameTest_#1..verified.txt
@@ -38,6 +38,35 @@
                 "value": "OverloadAndSimpleNameTest"
               }
             },
+            "locals": {
+              "@exception": {
+                "fields": {
+                  "HelpLink": {
+                    "isNull": "true",
+                    "type": "String"
+                  },
+                  "HResult": {
+                    "type": "Int32",
+                    "value": "-2147467263"
+                  },
+                  "InnerException": {
+                    "isNull": "true",
+                    "type": "Exception"
+                  },
+                  "Message": {
+                    "type": "String",
+                    "value": "The method or operation is not implemented."
+                  },
+                  "Source": {
+                    "type": "String",
+                    "value": "Samples.Probes.TestRuns"
+                  },
+                  "StackTrace": "ScrubbedValue"
+                },
+                "type": "NotImplementedException",
+                "value": "NotImplementedException"
+              }
+            },
             "throwable": {
               "message": "The method or operation is not implemented.",
               "stacktrace": [
@@ -104,6 +133,35 @@
               "this": {
                 "type": "OverloadAndSimpleNameTest",
                 "value": "OverloadAndSimpleNameTest"
+              }
+            },
+            "locals": {
+              "@exception": {
+                "fields": {
+                  "HelpLink": {
+                    "isNull": "true",
+                    "type": "String"
+                  },
+                  "HResult": {
+                    "type": "Int32",
+                    "value": "-2147467263"
+                  },
+                  "InnerException": {
+                    "isNull": "true",
+                    "type": "Exception"
+                  },
+                  "Message": {
+                    "type": "String",
+                    "value": "The method or operation is not implemented."
+                  },
+                  "Source": {
+                    "type": "String",
+                    "value": "Samples.Probes.TestRuns"
+                  },
+                  "StackTrace": "ScrubbedValue"
+                },
+                "type": "NotImplementedException",
+                "value": "NotImplementedException"
               }
             },
             "throwable": {
@@ -861,6 +919,33 @@
               }
             },
             "locals": {
+              "@exception": {
+                "fields": {
+                  "HelpLink": {
+                    "isNull": "true",
+                    "type": "String"
+                  },
+                  "HResult": {
+                    "type": "Int32",
+                    "value": "-2147467263"
+                  },
+                  "InnerException": {
+                    "isNull": "true",
+                    "type": "Exception"
+                  },
+                  "Message": {
+                    "type": "String",
+                    "value": "The method or operation is not implemented."
+                  },
+                  "Source": {
+                    "type": "String",
+                    "value": "Samples.Probes.TestRuns"
+                  },
+                  "StackTrace": "ScrubbedValue"
+                },
+                "type": "NotImplementedException",
+                "value": "NotImplementedException"
+              },
               "local": {
                 "type": "String",
                 "value": "Method@"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameInGlobalNamespaceTest.verified.txt
@@ -31,6 +31,33 @@
               }
             },
             "locals": {
+              "@exception": {
+                "fields": {
+                  "HelpLink": {
+                    "isNull": "true",
+                    "type": "String"
+                  },
+                  "HResult": {
+                    "type": "Int32",
+                    "value": "-2146233088"
+                  },
+                  "InnerException": {
+                    "isNull": "true",
+                    "type": "Exception"
+                  },
+                  "Message": {
+                    "type": "String",
+                    "value": "Same length."
+                  },
+                  "Source": {
+                    "type": "String",
+                    "value": "Samples.Probes.TestRuns"
+                  },
+                  "StackTrace": "ScrubbedValue"
+                },
+                "type": "IntentionalDebuggerException",
+                "value": "IntentionalDebuggerException"
+              },
               "arr": {
                 "elements": [
                   {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleNestedTypeNameTest.verified.txt
@@ -53,10 +53,7 @@
                     "type": "String",
                     "value": "Samples.Probes.TestRuns"
                   },
-                  "StackTrace": {
-                    "type": "String",
-                    "value": "   at Samples.Probes.TestRuns.SmokeTests.SimpleNestedTypeNameTest.NestedType.MethodToInstrument(String callerName) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\SimpleNestedTypeNameTest.cs:line 24\r\n   at Samples.Probes.TestRuns.SmokeTests.SimpleNestedTypeNameTest.Run() in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\SimpleNestedTypeNameTest.cs:line 10\r\n   at Program.RunTest(Object instance, String testClassName) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\Samples.Probes\\Program.cs:line 61"
-                  }
+                  "StackTrace": "ScrubbedValue"
                 },
                 "type": "IntentionalDebuggerException",
                 "value": "IntentionalDebuggerException"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameInGlobalNamespaceTest.verified.txt
@@ -31,6 +31,33 @@
               }
             },
             "locals": {
+              "@exception": {
+                "fields": {
+                  "HelpLink": {
+                    "isNull": "true",
+                    "type": "String"
+                  },
+                  "HResult": {
+                    "type": "Int32",
+                    "value": "-2146233088"
+                  },
+                  "InnerException": {
+                    "isNull": "true",
+                    "type": "Exception"
+                  },
+                  "Message": {
+                    "type": "String",
+                    "value": "Same length."
+                  },
+                  "Source": {
+                    "type": "String",
+                    "value": "Samples.Probes.TestRuns"
+                  },
+                  "StackTrace": "ScrubbedValue"
+                },
+                "type": "IntentionalDebuggerException",
+                "value": "IntentionalDebuggerException"
+              },
               "arr": {
                 "elements": [
                   {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SimpleTypeNameTest.verified.txt
@@ -53,10 +53,7 @@
                     "type": "String",
                     "value": "Samples.Probes.TestRuns"
                   },
-                  "StackTrace": {
-                    "type": "String",
-                    "value": "   at Samples.Probes.TestRuns.SmokeTests.SimpleTypeNameTest.MethodToInstrument(String callerName) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\SimpleTypeNameTest.cs:line 22\r\n   at Samples.Probes.TestRuns.SmokeTests.SimpleTypeNameTest.Run() in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\SmokeTests\\SimpleTypeNameTest.cs:line 10\r\n   at Program.RunTest(Object instance, String testClassName) in C:\\dev\\Datadog\\dd-trace-dotnet\\tracer\\test\\test-applications\\debugger\\Samples.Probes\\Program.cs:line 61"
-                  }
+                  "StackTrace": "ScrubbedValue"
                 },
                 "type": "IntentionalDebuggerException",
                 "value": "IntentionalDebuggerException"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateExceptionValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateExceptionValue.verified.txt
@@ -7,6 +7,12 @@
     "debugger": {
       "snapshot": {
         "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "this.@exceptions",
+            "message": "ScrubbedValue"
+          }
+        ],
         "id": "ScrubbedValue",
         "language": "dotnet",
         "probe": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateNoException.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TemplateNoException.verified.txt
@@ -7,6 +7,12 @@
     "debugger": {
       "snapshot": {
         "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "this.@exceptions",
+            "message": "ScrubbedValue"
+          }
+        ],
         "id": "ScrubbedValue",
         "language": "dotnet",
         "probe": {

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ProbesTests.cs
@@ -892,6 +892,14 @@ public class ProbesTests : TestHelper
                                 }
 
                                 break;
+
+                            case "StackTrace":
+                                if (IsParentName(item, parentName: ".@exception.fields"))
+                                {
+                                    item.Value.Replace("ScrubbedValue");
+                                }
+
+                                break;
                         }
                     }
                     catch (Exception)


### PR DESCRIPTION
## Summary of changes
Remove stacktrace property in snapshots of debugger tests to avoid windows\linux paths differences
