### PR TITLE
[APM] Move common (more) files ownership on tracer folder to APM group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@ Datadog.Trace.Trimming.xml                @DataDog/apm-dotnet
 missing-nullability-files.csv             @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Generated/      @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Configuration/IntegrationId.cs @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs @DataDog/apm-dotnet
 
 # CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet


### PR DESCRIPTION
## Summary of changes
Move common files inside the tracer folder to APM team, so anyone can modify them freely.

## Reason for change
Most of the PRs end up needing the approval of a Tracing team member because these files (null file, trimming, datadog.tracer.csproj) are usually modified.

## Implementation details

