### PR TITLE
Add a fast developer loop option to the build project.

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -108,6 +108,10 @@
             "type": "string"
           }
         },
+        "FastDevLoop": {
+          "type": "boolean",
+          "description": "Enable or Disable fast developer loop"
+        },
         "Filter": {
           "type": "string",
           "description": "Override the default test filters for integration tests. (Optional)"

--- a/tracer/build/_build/Build.Shared.Steps.cs
+++ b/tracer/build/_build/Build.Shared.Steps.cs
@@ -126,8 +126,10 @@ partial class Build
         {
             DeleteDirectory(NativeLoaderProject.Directory / "bin");
 
+            var finalArchs = FastDevLoop ? new[]  { "arm64" } : OsxArchs;
+
             var lstNativeBinaries = new List<string>();
-            foreach (var arch in OsxArchs)
+            foreach (var arch in finalArchs)
             {
                 var buildDirectory = NativeBuildDirectory + "_" + arch;
                 EnsureExistingDirectory(buildDirectory);

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -212,6 +212,11 @@ partial class Build
         .Unlisted()
         .Executes(() =>
         {
+            if (FastDevLoop)
+            {
+                return;
+            }
+
             if (IsWin)
             {
                 NuGetTasks.NuGetRestore(s => s
@@ -278,8 +283,10 @@ partial class Build
         {
             DeleteDirectory(NativeTracerProject.Directory / "build");
 
+            var finalArchs = FastDevLoop ? new[]  { "arm64" } : OsxArchs;
+            
             var lstNativeBinaries = new List<string>();
-            foreach (var arch in OsxArchs)
+            foreach (var arch in finalArchs)
             {
                 var buildDirectory = NativeBuildDirectory + "_" + arch;
                 EnsureExistingDirectory(buildDirectory);

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -79,6 +79,9 @@ partial class Build : NukeBuild
     [Parameter("Enables code coverage")]
     readonly bool CodeCoverage;
 
+    [Parameter("Enable or Disable fast developer loop")]
+    readonly bool FastDevLoop;
+    
     [Parameter("The directory containing the tool .nupkg file")]
     readonly AbsolutePath ToolSource;
 


### PR DESCRIPTION
## Summary of changes

This PR adds an option to enable a fast developer loop when building the solution.

In this initial approach the option:

- Disables the Restore step just bypassing it
- Disables the multiplatform build on macos, and only building for arm64.

This reduces the warm build time to 17s from 30s.

<img width="750" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/cc09ccfd-0f54-4533-9e5f-32b96985e9a9">


