### PR TITLE
[Dynamic Instrumentation] Remove async void in SymbolsUploader

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -702,7 +702,6 @@
       <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1" />
       <type fullname="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder" />
       <type fullname="System.Runtime.CompilerServices.AsyncValueTaskMethodBuilder`1" />
-      <type fullname="System.Runtime.CompilerServices.AsyncVoidMethodBuilder" />
       <type fullname="System.Runtime.CompilerServices.CallerFilePathAttribute" />
       <type fullname="System.Runtime.CompilerServices.CallerLineNumberAttribute" />
       <type fullname="System.Runtime.CompilerServices.CompilationRelaxationsAttribute" />
@@ -981,7 +980,6 @@
       <type fullname="System.OperationCanceledException" />
       <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder" />
       <type fullname="System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1" />
-      <type fullname="System.Runtime.CompilerServices.AsyncVoidMethodBuilder" />
       <type fullname="System.Runtime.CompilerServices.ConfiguredAsyncDisposable" />
       <type fullname="System.Threading.CancellationTokenSource" />
       <type fullname="System.Threading.Tasks.TaskAsyncEnumerableExtensions" />

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -136,9 +136,9 @@ namespace Datadog.Trace.Debugger.Symbols
             AppDomain.CurrentDomain.AssemblyLoad -= CurrentDomain_AssemblyLoad;
         }
 
-        private async void CurrentDomain_AssemblyLoad(object? sender, AssemblyLoadEventArgs args)
+        private void CurrentDomain_AssemblyLoad(object? sender, AssemblyLoadEventArgs args)
         {
-            await ProcessItemAsync(args.LoadedAssembly).ConfigureAwait(false);
+            _ = ProcessItemAsync(args.LoadedAssembly);
         }
 
         private async Task ProcessItemAsync(Assembly assembly)


### PR DESCRIPTION
## Summary of changes

Change `async void` method to a simple fire-and-forget.

## Reason for change

When an exception is thrown in an `async void` method, it's propagated to the synchronization context and it crashes the process. The caller can't await it anyway, so keeping it brings no benefits.