### PR TITLE
[CI Visibility] - Add configure jenkins command in dd-trace ci

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/ConfigureCiCommand.cs
@@ -17,7 +17,8 @@ namespace Datadog.Trace.Tools.Runner
         private static readonly IReadOnlyDictionary<string, CIName> CiNamesMapping
             = new Dictionary<string, CIName>(StringComparer.OrdinalIgnoreCase)
             {
-                ["azp"] = CIName.AzurePipelines
+                ["azp"] = CIName.AzurePipelines,
+                ["jenkins"] = CIName.Jenkins
             };
 
         private readonly ApplicationContext _applicationContext;
@@ -33,6 +34,7 @@ namespace Datadog.Trace.Tools.Runner
             AddArgument(_nameArgument);
 
             AddExample("dd-trace ci configure azp");
+            AddExample("dd-trace ci configure jenkins");
 
             this.SetHandler(Execute);
         }


### PR DESCRIPTION
## Summary of changes

This PR adds the `dd-trace ci configure jenkins` command to print the environment variables to setup civisibility into the jenkins job.
