### PR TITLE
Trace context propagation on SQS receive

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsCommon.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
         internal const string IntegrationName = nameof(Configuration.IntegrationId.AwsSqs);
         internal const IntegrationId IntegrationId = Configuration.IntegrationId.AwsSqs;
 
-        public static Scope? CreateScope(Tracer tracer, string operation, out AwsSqsTags? tags, ISpanContext? parentContext = null, string spanKind = SpanKinds.Client)
+        public static Scope? CreateScope(Tracer tracer, string operation, out AwsSqsTags? tags, ISpanContext? parentContext = null, string spanKind = SpanKinds.Client, DateTimeOffset? startTime = null)
         {
             tags = null;
 
@@ -41,7 +41,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS
                 tags = tracer.CurrentTraceSettings.Schema.Messaging.CreateAwsSqsTags(spanKind);
                 string serviceName = tracer.CurrentTraceSettings.GetServiceName(tracer, DatadogAwsSqsServiceName);
                 string operationName = GetOperationName(tracer, spanKind);
-                scope = tracer.StartActiveInternal(operationName, parent: parentContext, tags: tags, serviceName: serviceName);
+                scope = tracer.StartActiveInternal(operationName, parentContext, tags: tags, serviceName: serviceName, startTime: startTime);
                 var span = scope.Span;
 
                 span.Type = SpanTypes.Http;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsHandlerCommon.cs
@@ -6,9 +6,12 @@
 #nullable enable
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.Propagators;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Utilities;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SQS;
@@ -108,29 +111,36 @@ internal static class AwsSqsHandlerCommon
             return CallTargetState.GetDefault();
         }
 
-        var queueName = AwsSqsCommon.GetQueueName(request.QueueUrl);
-        var scope = AwsSqsCommon.CreateScope(Tracer.Instance, "ReceiveMessage", out var tags, spanKind: SpanKinds.Consumer);
-        if (tags is not null && request.QueueUrl is not null)
-        {
-            tags.QueueUrl = request.QueueUrl;
-            tags.QueueName = queueName;
-        }
-
         // request the message attributes that a datadog instrumentation might have set when sending
         request.MessageAttributeNames.AddDistinct(ContextPropagation.SqsKey);
         request.AttributeNames.AddDistinct("SentTimestamp");
 
-        return new CallTargetState(scope, queueName);
+        return new CallTargetState(scope: null, request.QueueUrl, DateTimeOffset.UtcNow);
     }
 
     internal static TResponse AfterReceive<TResponse>(TResponse response, Exception? exception, in CallTargetState state)
         where TResponse : IReceiveMessageResponse
     {
-        if (response.Instance != null && response.Messages != null && response.Messages.Count > 0 && state.State != null)
+        const string spanOperationName = "ReceiveMessage";
+        if (state.State is string queueUrl)
         {
-            var dataStreamsManager = Tracer.Instance.TracerManager.DataStreamsManager;
-            if (dataStreamsManager != null && dataStreamsManager.IsEnabled)
+            var queueName = AwsSqsCommon.GetQueueName(queueUrl);
+
+            if (response.Instance == null || response.Messages == null || response.Messages.Count <= 0)
             {
+                // nothing consumed, create scope starting in the past (at the time of the method beginning), and close it immediately.
+                var scope = AwsSqsCommon.CreateScope(Tracer.Instance, spanOperationName, out var tags, spanKind: SpanKinds.Consumer, startTime: state.StartTime);
+                if (tags is not null)
+                {
+                    tags.QueueUrl = queueUrl;
+                    tags.QueueName = queueName;
+                }
+
+                scope.DisposeWithException(exception);
+            }
+            else
+            {
+                var dataStreamsManager = Tracer.Instance.TracerManager.DataStreamsManager;
                 var edgeTags = new[] { "direction:in", $"topic:{(string)state.State}", "type:sqs" };
                 foreach (var o in response.Messages)
                 {
@@ -140,20 +150,35 @@ internal static class AwsSqsHandlerCommon
                         continue; // should not happen
                     }
 
-                    var sentTime = 0;
-                    if (message.Attributes != null && message.Attributes.TryGetValue("SentTimestamp", out var sentTimeStr) && sentTimeStr != null)
-                    {
-                        int.TryParse(sentTimeStr, out sentTime);
-                    }
-
+                    // open a new consume span that starts in the past at the time of beginning of the receive method,
+                    // with the context read from the message as parent (if present)
                     var adapter = AwsSqsHeadersAdapters.GetExtractionAdapter(message.MessageAttributes);
-                    var parentPathway = dataStreamsManager.ExtractPathwayContext(adapter);
-                    state.Scope.Span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Consume, edgeTags, payloadSizeBytes: 0, sentTime, parentPathway);
+                    var traceContext = SpanContextPropagator.Instance.Extract(adapter, AwsSqsHeadersAdapters.MessageAttributesAdapter.GetValue);
+                    using (var scope = AwsSqsCommon.CreateScope(Tracer.Instance, spanOperationName, out var tags, traceContext, SpanKinds.Consumer, state.StartTime))
+                    {
+                        if (tags is not null)
+                        {
+                            tags.QueueUrl = queueUrl;
+                            tags.QueueName = queueName;
+                        }
+
+                        // then send data streams monitoring metrics
+                        if (dataStreamsManager != null && dataStreamsManager.IsEnabled && scope != null)
+                        {
+                            var sentTime = 0;
+                            if (message.Attributes != null && message.Attributes.TryGetValue("SentTimestamp", out var sentTimeStr) && sentTimeStr != null)
+                            {
+                                int.TryParse(sentTimeStr, out sentTime);
+                            }
+
+                            var parentPathway = dataStreamsManager.ExtractPathwayContext(adapter);
+                            scope.Span.SetDataStreamsCheckpoint(dataStreamsManager, CheckpointKind.Consume, edgeTags, payloadSizeBytes: 0, sentTime, parentPathway);
+                        }
+                    }
                 }
             }
         }
 
-        state.Scope.DisposeWithException(exception);
         return response;
     }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/ContextPropagation.cs
@@ -7,10 +7,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Datadog.Trace.DataStreamsMonitoring;
 using Datadog.Trace.DuckTyping;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using Datadog.Trace.Vendors.Newtonsoft.Json;


### PR DESCRIPTION
## Summary of changes

In the SQS instrumentation, we were injecting the trace context in the headers, but we didn't read it on receive.
A span was created at the beginning of the receive method, and closed at the end. We cannot keep this behavior with trace propagation, because:
- we need one span per message, because one span cannot have several parents
- we need to keep the span open so that it covers any processing (and an eventual produce) that happens afterwards, otherwise the trace propagation is useless since it'll only show the consume span alone.

As such, this is a breaking change because it replaces a single span with the duration of the consume call that stays in the consume trace, with a span that goes in the produce trace, and covers everything happening afterwards.

Also, since SQS allows consuming several messages at once, we don't have any good options there, and only the last consume span will carry the "processing" spans.

## Reason for change

bridging gaps in implementation

## Implementation details

took example on the [Kafka consume instrumentation](https://github.com/DataDog/dd-trace-dotnet/blob/7ae3e22f69fb343d5696db186ade245230ddba2e/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/KafkaConsumerConsumeIntegration.cs#L53-L89), we might want to use a setting to control whether the spans stay open or not (see [the doc](https://docs.datadoghq.com/tracing/guide/monitor-kafka-queues/?tab=net#special-use-cases))

## Test coverage

will do