### PR TITLE
[CI Visibility] Small optimizations

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
+++ b/tracer/src/Datadog.Trace/Ci/Agent/CIVisibilityProtocolWriter.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Ci.Agent
      */
     internal sealed class CIVisibilityProtocolWriter : IEventWriter
     {
-        private const int DefaultBatchInterval = 1000;
+        private const int DefaultBatchInterval = 2500;
         private const int DefaultMaxItemsInQueue = 25000;
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<CIVisibilityProtocolWriter>();

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -44,6 +44,7 @@ namespace Datadog.Trace.Ci.Configuration
             CodeCoverageSnkFilePath = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverageSnkFile).AsString();
             CodeCoveragePath = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoveragePath).AsString();
             CodeCoverageEnableJitOptimizations = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverageEnableJitOptimizations).AsBool(true);
+            CodeCoverageMode = config.WithKeys(ConfigurationKeys.CIVisibility.CodeCoverageMode).AsString();
 
             // Git upload
             GitUploadEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.GitUploadEnabled).AsBool();
@@ -121,6 +122,11 @@ namespace Datadog.Trace.Ci.Configuration
         public bool CodeCoverageEnableJitOptimizations { get; }
 
         /// <summary>
+        /// Gets the code coverage mode
+        /// </summary>
+        public string? CodeCoverageMode { get; private set; }
+
+        /// <summary>
         /// Gets a value indicating whether the Git Upload metadata is going to be used.
         /// </summary>
         public bool? GitUploadEnabled { get; private set; }
@@ -170,6 +176,11 @@ namespace Datadog.Trace.Ci.Configuration
             Agentless = enabled;
             ApiKey = apiKey;
             AgentlessUrl = agentlessUrl;
+        }
+
+        internal void SetCodeCoverageMode(string? coverageMode)
+        {
+            CodeCoverageMode = coverageMode;
         }
 
         internal void SetDefaultManualInstrumentationSettings()

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -487,6 +487,11 @@ namespace Datadog.Trace.Configuration
             public const string CodeCoverageEnableJitOptimizations = "DD_CIVISIBILITY_CODE_COVERAGE_ENABLE_JIT_OPTIMIZATIONS";
 
             /// <summary>
+            /// Configuration key for selecting the code coverage mode LineExecution or LineCallCount
+            /// </summary>
+            public const string CodeCoverageMode = "DD_CIVISIBILITY_CODE_COVERAGE_MODE";
+
+            /// <summary>
             /// Configuration key for setting the code coverage jsons destination path.
             /// </summary>
             public const string CodeCoveragePath = "DD_CIVISIBILITY_CODE_COVERAGE_PATH";

--- a/tracer/src/Datadog.Trace/Util/AsyncManualResetEvent.cs
+++ b/tracer/src/Datadog.Trace/Util/AsyncManualResetEvent.cs
@@ -54,13 +54,7 @@ internal class AsyncManualResetEvent
     {
         var waitTask = WaitAsync();
 
-        return waitTask.IsCompleted ? InternalCompletedWaitAsync(waitTask) : InternalWaitAsync(waitTask, millisecondTimeout);
-
-        static async Task<bool> InternalCompletedWaitAsync(Task task)
-        {
-            await task.ConfigureAwait(false);
-            return true;
-        }
+        return waitTask.IsCompleted ? Task.FromResult(true) : InternalWaitAsync(waitTask, millisecondTimeout);
 
         static async Task<bool> InternalWaitAsync(Task task, int timeout)
         {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
@@ -43,6 +43,7 @@ public class ConfigurationTests
         "DD_PIPELINE_EXECUTION_ID",
         "DD_TESTSESSION_COMMAND",
         "DD_TESTSESSION_WORKINGDIRECTORY",
+        "DD_CIVISIBILITY_CODE_COVERAGE_MODE",
         // Internal env vars that we only ever read from environment
         "DD_INTERNAL_TRACE_NATIVE_ENGINE_PATH",
         "DD_DOTNET_TRACER_HOME",

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyAttribute.LineCallCount.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyAttribute.LineCallCount.verified.txt
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyAttribute.LineExecution.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyAttribute.LineExecution.verified.txt
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyType.LineCallCount.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyType.LineCallCount.verified.txt
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyType.LineExecution.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAssemblyType.LineExecution.verified.txt
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAttribute.LineCallCount.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAttribute.LineCallCount.verified.txt
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Ci.Coverage.Attributes;
+using Datadog.Trace.Ci.Coverage.Metadata.Target;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: AssemblyCompany("CoverageRewriterAssembly")]
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyProduct("CoverageRewriterAssembly")]
+[assembly: AssemblyTitle("CoverageRewriterAssembly")]
+[assembly: CoveredAssembly]
+[assembly: AssemblyVersion("1.0.0.0")]
+namespace CoverageRewriterAssembly
+{
+	public class Class1
+	{
+		public string MyProperty { get; set; }
+
+		public void Main()
+		{
+			int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(0);
+			_ = counters[10];
+			counters[0]++;
+			counters[1]++;
+			Console.WriteLine("Main Method");
+			counters[2]++;
+			int num = 0;
+			while (true)
+			{
+				counters[7]++;
+				if (num >= 100)
+				{
+					break;
+				}
+				counters[3]++;
+				counters[4]++;
+				Console.WriteLine(num);
+				counters[5]++;
+				counters[6]++;
+				num++;
+			}
+			counters[8]++;
+			MyProperty = "Value";
+			counters[9]++;
+			Console.WriteLine(MyProperty);
+			counters[10]++;
+		}
+
+		public async Task MainAsync()
+		{
+			await Task.Delay(100);
+		}
+	}
+}
+namespace Datadog.Trace.Ci.Coverage.Metadata.Target
+{
+	internal sealed class ModuleCoverage : ModuleCoverageMetadata
+	{
+		public ModuleCoverage()
+		{
+			SequencePoints = new int[1];
+			SequencePoints[0] = 11;
+			Metadata = new long[1];
+			Metadata[0] = 4294967298L;
+			TotalInstructions = 11L;
+		}
+	}
+}

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAttribute.LineExecution.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterByAttribute.LineExecution.verified.txt
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Ci.Coverage.Attributes;
+using Datadog.Trace.Ci.Coverage.Metadata.Target;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: AssemblyCompany("CoverageRewriterAssembly")]
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyProduct("CoverageRewriterAssembly")]
+[assembly: AssemblyTitle("CoverageRewriterAssembly")]
+[assembly: CoveredAssembly]
+[assembly: AssemblyVersion("1.0.0.0")]
+namespace CoverageRewriterAssembly
+{
+	public class Class1
+	{
+		public string MyProperty { get; set; }
+
+		public void Main()
+		{
+			int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(0);
+			_ = counters[10];
+			counters[0] = 1;
+			counters[1] = 1;
+			Console.WriteLine("Main Method");
+			counters[2] = 1;
+			int num = 0;
+			while (true)
+			{
+				counters[7] = 1;
+				if (num >= 100)
+				{
+					break;
+				}
+				counters[3] = 1;
+				counters[4] = 1;
+				Console.WriteLine(num);
+				counters[5] = 1;
+				counters[6] = 1;
+				num++;
+			}
+			counters[8] = 1;
+			MyProperty = "Value";
+			counters[9] = 1;
+			Console.WriteLine(MyProperty);
+			counters[10] = 1;
+		}
+
+		public async Task MainAsync()
+		{
+			await Task.Delay(100);
+		}
+	}
+}
+namespace Datadog.Trace.Ci.Coverage.Metadata.Target
+{
+	internal sealed class ModuleCoverage : ModuleCoverageMetadata
+	{
+		public ModuleCoverage()
+		{
+			SequencePoints = new int[1];
+			SequencePoints[0] = 11;
+			Metadata = new long[1];
+			Metadata[0] = 4294967298L;
+			TotalInstructions = 11L;
+		}
+	}
+}

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterBySourceFile.LineCallCount.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterBySourceFile.LineCallCount.verified.txt
@@ -1,16 +1,13 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using Datadog.Trace.Ci.Coverage;
-using Datadog.Trace.Ci.Coverage.Attributes;
-using Datadog.Trace.Ci.Coverage.Metadata.Target;
 
 [assembly: CompilationRelaxations(8)]
 [assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations | DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints | DebuggableAttribute.DebuggingModes.EnableEditAndContinue)]
 [assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
 [assembly: AssemblyCompany("CoverageRewriterAssembly")]
 [assembly: AssemblyConfiguration("Debug")]
@@ -18,7 +15,6 @@ using Datadog.Trace.Ci.Coverage.Metadata.Target;
 [assembly: AssemblyInformationalVersion("1.0.0")]
 [assembly: AssemblyProduct("CoverageRewriterAssembly")]
 [assembly: AssemblyTitle("CoverageRewriterAssembly")]
-[assembly: CoveredAssembly]
 [assembly: AssemblyVersion("1.0.0.0")]
 namespace CoverageRewriterAssembly
 {
@@ -28,51 +24,18 @@ namespace CoverageRewriterAssembly
 
 		public void Main()
 		{
-			int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(0);
-			_ = counters[10];
-			counters[0]++;
-			counters[1]++;
 			Console.WriteLine("Main Method");
-			counters[2]++;
-			int num = 0;
-			while (true)
+			for (int i = 0; i < 100; i++)
 			{
-				counters[7]++;
-				if (num >= 100)
-				{
-					break;
-				}
-				counters[3]++;
-				counters[4]++;
-				Console.WriteLine(num);
-				counters[5]++;
-				counters[6]++;
-				num++;
+				Console.WriteLine(i);
 			}
-			counters[8]++;
 			MyProperty = "Value";
-			counters[9]++;
 			Console.WriteLine(MyProperty);
-			counters[10]++;
 		}
 
 		public async Task MainAsync()
 		{
 			await Task.Delay(100);
-		}
-	}
-}
-namespace Datadog.Trace.Ci.Coverage.Metadata.Target
-{
-	internal sealed class ModuleCoverage : ModuleCoverageMetadata
-	{
-		public ModuleCoverage()
-		{
-			SequencePoints = new int[1];
-			SequencePoints[0] = 11;
-			Metadata = new long[1];
-			Metadata[0] = 4294967298L;
-			TotalInstructions = 11L;
 		}
 	}
 }

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterBySourceFile.LineExecution.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.CoverletFilterBySourceFile.LineExecution.verified.txt
@@ -1,16 +1,13 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Versioning;
 using System.Threading.Tasks;
-using Datadog.Trace.Ci.Coverage;
-using Datadog.Trace.Ci.Coverage.Attributes;
-using Datadog.Trace.Ci.Coverage.Metadata.Target;
 
 [assembly: CompilationRelaxations(8)]
 [assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
-[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations | DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints | DebuggableAttribute.DebuggingModes.EnableEditAndContinue)]
 [assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
 [assembly: AssemblyCompany("CoverageRewriterAssembly")]
 [assembly: AssemblyConfiguration("Debug")]
@@ -18,7 +15,6 @@ using Datadog.Trace.Ci.Coverage.Metadata.Target;
 [assembly: AssemblyInformationalVersion("1.0.0")]
 [assembly: AssemblyProduct("CoverageRewriterAssembly")]
 [assembly: AssemblyTitle("CoverageRewriterAssembly")]
-[assembly: CoveredAssembly]
 [assembly: AssemblyVersion("1.0.0.0")]
 namespace CoverageRewriterAssembly
 {
@@ -28,51 +24,18 @@ namespace CoverageRewriterAssembly
 
 		public void Main()
 		{
-			int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(0);
-			_ = counters[10];
-			counters[0]++;
-			counters[1]++;
 			Console.WriteLine("Main Method");
-			counters[2]++;
-			int num = 0;
-			while (true)
+			for (int i = 0; i < 100; i++)
 			{
-				counters[7]++;
-				if (num >= 100)
-				{
-					break;
-				}
-				counters[3]++;
-				counters[4]++;
-				Console.WriteLine(num);
-				counters[5]++;
-				counters[6]++;
-				num++;
+				Console.WriteLine(i);
 			}
-			counters[8]++;
 			MyProperty = "Value";
-			counters[9]++;
 			Console.WriteLine(MyProperty);
-			counters[10]++;
 		}
 
 		public async Task MainAsync()
 		{
 			await Task.Delay(100);
-		}
-	}
-}
-namespace Datadog.Trace.Ci.Coverage.Metadata.Target
-{
-	internal sealed class ModuleCoverage : ModuleCoverageMetadata
-	{
-		public ModuleCoverage()
-		{
-			SequencePoints = new int[1];
-			SequencePoints[0] = 11;
-			Metadata = new long[1];
-			Metadata[0] = 4294967298L;
-			TotalInstructions = 11L;
 		}
 	}
 }

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.LineCallCount.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.LineCallCount.verified.txt
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.LineExecution.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.LineExecution.verified.txt
@@ -1,0 +1,107 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Ci.Coverage.Attributes;
+using Datadog.Trace.Ci.Coverage.Metadata.Target;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: AssemblyCompany("CoverageRewriterAssembly")]
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyProduct("CoverageRewriterAssembly")]
+[assembly: AssemblyTitle("CoverageRewriterAssembly")]
+[assembly: CoveredAssembly]
+[assembly: AssemblyVersion("1.0.0.0")]
+namespace CoverageRewriterAssembly
+{
+	public class Class1
+	{
+		public string MyProperty
+		{
+			[CompilerGenerated]
+			get
+			{
+				int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(0);
+				counters[0] = 1;
+				return <MyProperty>k__BackingField;
+			}
+			[CompilerGenerated]
+			set
+			{
+				int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(1);
+				counters[0] = 1;
+				<MyProperty>k__BackingField = value;
+			}
+		}
+
+		public void Main()
+		{
+			int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(2);
+			_ = counters[10];
+			counters[0] = 1;
+			counters[1] = 1;
+			Console.WriteLine("Main Method");
+			counters[2] = 1;
+			int num = 0;
+			while (true)
+			{
+				counters[7] = 1;
+				if (num >= 100)
+				{
+					break;
+				}
+				counters[3] = 1;
+				counters[4] = 1;
+				Console.WriteLine(num);
+				counters[5] = 1;
+				counters[6] = 1;
+				num++;
+			}
+			counters[8] = 1;
+			MyProperty = "Value";
+			counters[9] = 1;
+			Console.WriteLine(MyProperty);
+			counters[10] = 1;
+		}
+
+		[AsyncStateMachine(typeof(<MainAsync>d__5))]
+		[DebuggerStepThrough]
+		public Task MainAsync()
+		{
+			<MainAsync>d__5 stateMachine = new <MainAsync>d__5();
+			stateMachine.<>t__builder = AsyncTaskMethodBuilder.Create();
+			stateMachine.<>4__this = this;
+			stateMachine.<>1__state = -1;
+			stateMachine.<>t__builder.Start(ref stateMachine);
+			return stateMachine.<>t__builder.Task;
+		}
+	}
+}
+namespace Datadog.Trace.Ci.Coverage.Metadata.Target
+{
+	internal sealed class ModuleCoverage : ModuleCoverageMetadata
+	{
+		public ModuleCoverage()
+		{
+			SequencePoints = new int[4];
+			SequencePoints[0] = 1;
+			SequencePoints[1] = 1;
+			SequencePoints[2] = 11;
+			SequencePoints[3] = 3;
+			Metadata = new long[4];
+			Metadata[0] = 4294967296L;
+			Metadata[1] = 4294967297L;
+			Metadata[2] = 4294967298L;
+			Metadata[3] = 8589934593L;
+			TotalInstructions = 16L;
+		}
+	}
+}

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterByAttribute.LineCallCount.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterByAttribute.LineCallCount.verified.txt
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Ci.Coverage.Attributes;
+using Datadog.Trace.Ci.Coverage.Metadata.Target;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: AssemblyCompany("CoverageRewriterAssembly")]
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyProduct("CoverageRewriterAssembly")]
+[assembly: AssemblyTitle("CoverageRewriterAssembly")]
+[assembly: CoveredAssembly]
+[assembly: AssemblyVersion("1.0.0.0")]
+namespace CoverageRewriterAssembly
+{
+	public class Class1
+	{
+		public string MyProperty { get; set; }
+
+		public void Main()
+		{
+			int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(0);
+			_ = counters[10];
+			counters[0]++;
+			counters[1]++;
+			Console.WriteLine("Main Method");
+			counters[2]++;
+			int num = 0;
+			while (true)
+			{
+				counters[7]++;
+				if (num >= 100)
+				{
+					break;
+				}
+				counters[3]++;
+				counters[4]++;
+				Console.WriteLine(num);
+				counters[5]++;
+				counters[6]++;
+				num++;
+			}
+			counters[8]++;
+			MyProperty = "Value";
+			counters[9]++;
+			Console.WriteLine(MyProperty);
+			counters[10]++;
+		}
+
+		public async Task MainAsync()
+		{
+			await Task.Delay(100);
+		}
+	}
+}
+namespace Datadog.Trace.Ci.Coverage.Metadata.Target
+{
+	internal sealed class ModuleCoverage : ModuleCoverageMetadata
+	{
+		public ModuleCoverage()
+		{
+			SequencePoints = new int[1];
+			SequencePoints[0] = 11;
+			Metadata = new long[1];
+			Metadata[0] = 4294967298L;
+			TotalInstructions = 11L;
+		}
+	}
+}

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterByAttribute.LineExecution.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterByAttribute.LineExecution.verified.txt
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+using Datadog.Trace.Ci.Coverage;
+using Datadog.Trace.Ci.Coverage.Attributes;
+using Datadog.Trace.Ci.Coverage.Metadata.Target;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: AssemblyCompany("CoverageRewriterAssembly")]
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyProduct("CoverageRewriterAssembly")]
+[assembly: AssemblyTitle("CoverageRewriterAssembly")]
+[assembly: CoveredAssembly]
+[assembly: AssemblyVersion("1.0.0.0")]
+namespace CoverageRewriterAssembly
+{
+	public class Class1
+	{
+		public string MyProperty { get; set; }
+
+		public void Main()
+		{
+			int[] counters = CoverageReporter<ModuleCoverage>.GetCounters(0);
+			_ = counters[10];
+			counters[0] = 1;
+			counters[1] = 1;
+			Console.WriteLine("Main Method");
+			counters[2] = 1;
+			int num = 0;
+			while (true)
+			{
+				counters[7] = 1;
+				if (num >= 100)
+				{
+					break;
+				}
+				counters[3] = 1;
+				counters[4] = 1;
+				Console.WriteLine(num);
+				counters[5] = 1;
+				counters[6] = 1;
+				num++;
+			}
+			counters[8] = 1;
+			MyProperty = "Value";
+			counters[9] = 1;
+			Console.WriteLine(MyProperty);
+			counters[10] = 1;
+		}
+
+		public async Task MainAsync()
+		{
+			await Task.Delay(100);
+		}
+	}
+}
+namespace Datadog.Trace.Ci.Coverage.Metadata.Target
+{
+	internal sealed class ModuleCoverage : ModuleCoverageMetadata
+	{
+		public ModuleCoverage()
+		{
+			SequencePoints = new int[1];
+			SequencePoints[0] = 11;
+			Metadata = new long[1];
+			Metadata[0] = 4294967298L;
+			TotalInstructions = 11L;
+		}
+	}
+}

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterBySourceFile.LineCallCount.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterBySourceFile.LineCallCount.verified.txt
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations | DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints | DebuggableAttribute.DebuggingModes.EnableEditAndContinue)]
+[assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: AssemblyCompany("CoverageRewriterAssembly")]
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyProduct("CoverageRewriterAssembly")]
+[assembly: AssemblyTitle("CoverageRewriterAssembly")]
+[assembly: AssemblyVersion("1.0.0.0")]
+namespace CoverageRewriterAssembly
+{
+	public class Class1
+	{
+		public string MyProperty { get; set; }
+
+		public void Main()
+		{
+			Console.WriteLine("Main Method");
+			for (int i = 0; i < 100; i++)
+			{
+				Console.WriteLine(i);
+			}
+			MyProperty = "Value";
+			Console.WriteLine(MyProperty);
+		}
+
+		public async Task MainAsync()
+		{
+			await Task.Delay(100);
+		}
+	}
+}

--- a/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterBySourceFile.LineExecution.verified.txt
+++ b/tracer/test/snapshots/CoverageRewriteTests.Rewritten.NetFrameworkSettingsFilterBySourceFile.LineExecution.verified.txt
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Versioning;
+using System.Threading.Tasks;
+
+[assembly: CompilationRelaxations(8)]
+[assembly: RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: Debuggable(DebuggableAttribute.DebuggingModes.Default | DebuggableAttribute.DebuggingModes.DisableOptimizations | DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints | DebuggableAttribute.DebuggingModes.EnableEditAndContinue)]
+[assembly: TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = "")]
+[assembly: AssemblyCompany("CoverageRewriterAssembly")]
+[assembly: AssemblyConfiguration("Debug")]
+[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyProduct("CoverageRewriterAssembly")]
+[assembly: AssemblyTitle("CoverageRewriterAssembly")]
+[assembly: AssemblyVersion("1.0.0.0")]
+namespace CoverageRewriterAssembly
+{
+	public class Class1
+	{
+		public string MyProperty { get; set; }
+
+		public void Main()
+		{
+			Console.WriteLine("Main Method");
+			for (int i = 0; i < 100; i++)
+			{
+				Console.WriteLine(i);
+			}
+			MyProperty = "Value";
+			Console.WriteLine(MyProperty);
+		}
+
+		public async Task MainAsync()
+		{
+			await Task.Delay(100);
+		}
+	}
+}


### PR DESCRIPTION
## Summary of changes

This PR contains the following small optimizations:

1. A new code coverage mode called `LineExecution` as default. In this mode we are not incrementing the counters but only setting to 1, reducing the asm generated code. This mode is totally compatible with all CI Visibility features
2. Increase the DefaultBatchInterval of the CIVisibilityProtocolWriter from 1seg to 2.5 seg. The reason for that is that we were seeing a lot of loop cycles with no events to send or with only a few events. This should reduce the cpu preasure on CI without loosing any data. (We still make a full flush before exiting)
3. Change the AsyncManualResetEvent to avoid awaiting (introduce the state machine) when we actually knows that the task was completed already.

## Reason for change

Small optimizations to improve performance.

## Test coverage

Test for the code coverage rewriting process were updated to support all modes.
