### PR TITLE
[ASM] Fix building IAST instrumented tests on macOS + increase QoL on macOS

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSDKVersion)" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
     <PackageReference Include="xunit" Version="$(ApiVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(ApiVersion)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSDKVersion)" />
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
     <PackageReference Include="xunit" Version="$(ApiVersion)" />
     <PackageReference Include="xunit.runner.visualstudio" Version="$(ApiVersion)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -42,6 +41,10 @@
     <PackageReference Include="System.Data.OleDb" Version="4.7.1" />
     <PackageReference Include="MySql.Data" Version="8.0.28" />
     <PackageReference Include="Oracle.ManagedDataAccess.Core" Version="2.19.110" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='net8.0' OR '$(TargetFramework)'=='net7.0' OR '$(TargetFramework)'=='net6.0'">
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Properties/launchSettings.json
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Properties/launchSettings.json
@@ -33,6 +33,7 @@
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
         "CORECLR_PROFILER_PATH_32": "$(SolutionDir)\\shared\\bin\\monitoring-home\\win-x86\\Datadog.Tracer.Native.dll",
         "CORECLR_PROFILER_PATH_64": "$(SolutionDir)\\shared\\bin\\monitoring-home\\win-x64\\Datadog.Tracer.Native.dll",
+        "CORECLR_PROFILER_PATH_ARM64": "$(SolutionDir)\\shared\\bin\\monitoring-home\\win-arm64\\Datadog.Tracer.Native.dll",
         "DD_VERSION": "1.0.0",
         "DD_TRACE_HEADER_TAGS": "sample.correlation.identifier, Server",
         "DD_TRACE_DEBUG": "1",
@@ -58,12 +59,11 @@
       "use64Bit": false,
       "applicationUrl": "http://localhost:5458"
     },
-    "Samples.AspNetCore5.Linux": {
+    "Linux": {
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
-        "DD_ENABLE_SECURITY": "true",
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)tracer/bin/tracer-home",
         "CORECLR_ENABLE_PROFILING": "1",
         "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
@@ -77,6 +77,39 @@
           "Default": "Info",
           "Microsoft": "Info",
           "Microsoft.Hosting.Lifetime": "Info"
+        }
+      },
+      "nativeDebugging": true,
+      "use64Bit": true,
+      "applicationUrl": "http://localhost:5458"
+    },
+    "OSX": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared/bin/monitoring-home",
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared/bin/monitoring-home/osx/Datadog.Trace.ClrProfiler.Native.dylib",
+        "DD_VERSION": "1.0.0",
+        "DD_TRACE_HEADER_TAGS": "sample.correlation.identifier, Server",
+        "DD_TRACE_DEBUG": "1",
+        "DD_SERVICE" : "Samples.Security.AspNetCore5.OSX",
+        "DD_ENV": "asm-samples",
+        "DD_APPSEC_ENABLED": "true",
+        "DD_APPSEC_BLOCKING_ENABLED": "true",
+        "DD_IAST_ENABLED": "true",
+        "DD_IAST_DEDUPLICATION_ENABLED": "false",
+        "DD_IAST_VULNERABILITIES_PER_REQUEST": "100",
+        "DD_IAST_REQUEST_SAMPLING": "100",
+        "DD_IAST_MAX_CONCURRENT_REQUESTS": "1"
+      },
+      "Logging": {
+        "LogLevel": {
+          "Default": "Warning",
+          "Microsoft": "Warning",
+          "Microsoft.Hosting.Lifetime": "Warning"
         }
       },
       "nativeDebugging": true,

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugType>None</DebugType>
     <DebugSymbols>false</DebugSymbols>
   </PropertyGroup>


### PR DESCRIPTION
## Summary of changes

- Fix building of the IAST Instrumented unit tests (add macos arm64 compatible sqlite to fix building issues)
- Add a setting to launch the aspnetcore5 sample without changing the current settings for windows users
- Re-enable symbols for Debug for the aspnetcore5 sample (disabled due to the Location data for IAST, but can be safely re-enabled only for debug mode)

## Reason for change

Please I don't want to stash these files every time. 😆
