### PR TITLE
[ASM] when appsec rules files is not found, dont continue init process and log confusing messages

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -57,7 +57,7 @@ namespace Datadog.Trace.AppSec.Waf
         /// <param name="setupWafSchemaExtraction">should we read the config file for schema extraction</param>
         /// <param name="useUnsafeEncoder">use legacy encoder</param>
         /// <returns>the waf wrapper around waf native</returns>
-        internal static unsafe InitResult Create(WafLibraryInvoker wafLibraryInvoker, string obfuscationParameterKeyRegex, string obfuscationParameterValueRegex, string? embeddedRulesetPath = null, JToken? rulesFromRcm = null, bool setupWafSchemaExtraction = false, bool useUnsafeEncoder = false)
+        internal static InitResult Create(WafLibraryInvoker wafLibraryInvoker, string obfuscationParameterKeyRegex, string obfuscationParameterValueRegex, string? embeddedRulesetPath = null, JToken? rulesFromRcm = null, bool setupWafSchemaExtraction = false, bool useUnsafeEncoder = false)
         {
             var wafConfigurator = new WafConfigurator(wafLibraryInvoker);
 
@@ -65,6 +65,10 @@ namespace Datadog.Trace.AppSec.Waf
             wafLibraryInvoker.SetupLogging(GlobalSettings.Instance.DebugEnabledInternal);
 
             var jtokenRoot = rulesFromRcm ?? WafConfigurator.DeserializeEmbeddedOrStaticRules(embeddedRulesetPath)!;
+            if (jtokenRoot is null)
+            {
+                return InitResult.FromUnusableRuleFile();
+            }
 
             IntPtr rulesObj;
             DdwafConfigStruct configWafStruct = default;

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafErrorsTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafErrorsTests.cs
@@ -55,9 +55,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             initResult.Success.Should().BeFalse();
             initResult.FailedToLoadRules.Should().Be(0);
             initResult.LoadedRules.Should().Be(0);
-            initResult.Errors.Should().Equal(new Dictionary<string, object> { { "diagnostics-error", "Waf could not provide diagnostics on rules or diagnostic format is incorrect" } });
-            initResult.HasErrors.Should().BeTrue();
-            initResult.ErrorMessage.Should().Be("{\"diagnostics-error\":\"Waf could not provide diagnostics on rules or diagnostic format is incorrect\"}");
+            initResult.UnusableRuleFile.Should().BeTrue();
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

small refactoring avoiding that init continues after appsec rules havent been found

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
