### PR TITLE
[CI Visibility] - Add netcoreapp2.x support for dd-trace GAC commands

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Gac/AdministratorHelper.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Gac/AdministratorHelper.cs
@@ -51,9 +51,17 @@ internal static class AdministratorHelper
             }
 
             var process = Process.Start(processInfo);
-            process?.WaitForExit();
-            Console.WriteLine("Returned: {0}", process?.ExitCode);
-            Environment.Exit(process?.ExitCode ?? 0);
+            if (process is null)
+            {
+                Console.WriteLine("Process cannot be executed.");
+                Environment.Exit(1);
+            }
+            else
+            {
+                process.WaitForExit();
+                Console.WriteLine("Returned: {0}", process.ExitCode);
+                Environment.Exit(process.ExitCode);
+            }
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/Gac/AssemblyCacheContainer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Gac/AssemblyCacheContainer.cs
@@ -8,8 +8,6 @@ using System.Runtime.InteropServices;
 
 namespace Datadog.Trace.Tools.Runner.Gac;
 
-#if NETCOREAPP3_0_OR_GREATER
-
 internal sealed class AssemblyCacheContainer : IDisposable
 {
     private readonly IntPtr _libPointer;
@@ -30,5 +28,3 @@ internal sealed class AssemblyCacheContainer : IDisposable
         }
     }
 }
-
-#endif

--- a/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeLibrary.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeLibrary.cs
@@ -1,0 +1,61 @@
+﻿// <copyright file="NativeLibrary.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Datadog.Trace.Tools.Runner.Gac;
+
+#if !NETCOREAPP3_0_OR_GREATER
+
+internal sealed class NativeLibrary
+{
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    private static extern IntPtr LoadLibrary(string libName);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+    private static extern bool FreeLibrary(IntPtr hModule);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Ansi, SetLastError = true)]
+    private static extern IntPtr GetProcAddress(IntPtr hModule, string lpProcName);
+
+    public static IntPtr Load(string libraryPath)
+    {
+        var value = LoadLibrary(libraryPath);
+        if (value != IntPtr.Zero)
+        {
+            return value;
+        }
+
+        var errorCode = Marshal.GetLastWin32Error();
+        var hr = Marshal.GetHRForLastWin32Error();
+        throw new Exception($"Failed to load library (ErrorCode: {errorCode}, HR: {hr})");
+    }
+
+    public static IntPtr GetExport(IntPtr handle, string name)
+    {
+        var value = GetProcAddress(handle, name);
+        if (value != IntPtr.Zero)
+        {
+            return value;
+        }
+
+        var errorCode = Marshal.GetLastWin32Error();
+        var hr = Marshal.GetHRForLastWin32Error();
+        throw new Exception($"Failed to get the Export (ErrorCode: {errorCode}, HR: {hr})");
+    }
+
+    public static void Free(IntPtr handle)
+    {
+        if (handle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        FreeLibrary(handle);
+    }
+}
+
+#endif

--- a/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeMethods.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeMethods.cs
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-#if NETCOREAPP3_0_OR_GREATER
-
 using System;
 using System.IO;
 using System.Reflection;
@@ -54,5 +52,3 @@ internal sealed class NativeMethods
         return new AssemblyCacheContainer(libPointer, ppAsmCache);
     }
 }
-
-#endif

--- a/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeMethods.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeMethods.cs
@@ -21,7 +21,7 @@ internal sealed class NativeMethods
     private const string NetFrameworkSubKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
 
     private delegate int CreateAssemblyCacheDelegate(out IAssemblyCache ppAsmCache, int reserved);
-    
+
     internal static AssemblyCacheContainer CreateAssemblyCache()
     {
         string fusionFullPath;

--- a/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeMethods.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Gac/NativeMethods.cs
@@ -20,7 +20,9 @@ internal sealed class NativeMethods
 {
     private const string NetFrameworkSubKey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
 
-    internal static unsafe AssemblyCacheContainer CreateAssemblyCache()
+    private delegate int CreateAssemblyCacheDelegate(out IAssemblyCache ppAsmCache, int reserved);
+    
+    internal static AssemblyCacheContainer CreateAssemblyCache()
     {
         string fusionFullPath;
         using (var ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, Environment.Is64BitProcess ? RegistryView.Registry64 : RegistryView.Registry32).OpenSubKey(NetFrameworkSubKey))
@@ -41,8 +43,8 @@ internal sealed class NativeMethods
 
         var libPointer = NativeLibrary.Load(fusionFullPath);
         var createAssemblyCachePointer = NativeLibrary.GetExport(libPointer, nameof(CreateAssemblyCache));
-        var functionPointer = (delegate* unmanaged[Stdcall]<out IAssemblyCache, uint, int>)createAssemblyCachePointer;
-        var hr = functionPointer(out var ppAsmCache, 0);
+        var createAssemblyCache = Marshal.GetDelegateForFunctionPointer<CreateAssemblyCacheDelegate>(createAssemblyCachePointer);
+        var hr = createAssemblyCache(out var ppAsmCache, 0);
         if (hr != 0)
         {
             NativeLibrary.Free(libPointer);

--- a/tracer/src/Datadog.Trace.Tools.Runner/GacGetCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/GacGetCommand.cs
@@ -6,15 +6,11 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.IO;
-using System.Reflection;
 using System.Runtime.Versioning;
 using Datadog.Trace.Tools.Runner.Gac;
 using Spectre.Console;
 
 namespace Datadog.Trace.Tools.Runner;
-
-#if NETCOREAPP3_0_OR_GREATER
 
 #if NET5_0_OR_GREATER
 [SupportedOSPlatform("windows")]
@@ -62,5 +58,3 @@ internal class GacGetCommand : CommandWithExamples
         context.ExitCode = hr;
     }
 }
-
-#endif

--- a/tracer/src/Datadog.Trace.Tools.Runner/GacInstallCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/GacInstallCommand.cs
@@ -12,8 +12,6 @@ using Datadog.Trace.Tools.Runner.Gac;
 
 namespace Datadog.Trace.Tools.Runner;
 
-#if NETCOREAPP3_0_OR_GREATER
-
 #if NET5_0_OR_GREATER
 [SupportedOSPlatform("windows")]
 #endif
@@ -62,5 +60,3 @@ internal class GacInstallCommand : CommandWithExamples
         context.ExitCode = hr;
     }
 }
-
-#endif

--- a/tracer/src/Datadog.Trace.Tools.Runner/GacUninstallCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/GacUninstallCommand.cs
@@ -6,14 +6,10 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.IO;
-using System.Reflection;
 using System.Runtime.Versioning;
 using Datadog.Trace.Tools.Runner.Gac;
 
 namespace Datadog.Trace.Tools.Runner;
-
-#if NETCOREAPP3_0_OR_GREATER
 
 #if NET5_0_OR_GREATER
 [SupportedOSPlatform("windows")]
@@ -74,5 +70,3 @@ internal class GacUninstallCommand : CommandWithExamples
         context.ExitCode = hr;
     }
 }
-
-#endif

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -109,7 +109,6 @@ namespace Datadog.Trace.Tools.Runner
             builder.Command.AddCommand(new AnalyzeInstrumentationErrorsCommand { IsHidden = true });
             builder.Command.AddCommand(new CoverageMergerCommand { IsHidden = true });
 
-#if NETCOREAPP3_0_OR_GREATER
             if (applicationContext.Platform == Platform.Windows)
             {
                 var gacCommand = new Command("gac", "Install or Uninstall a .NET Framework assembly to the GAC");
@@ -121,7 +120,6 @@ namespace Datadog.Trace.Tools.Runner
                 gacCommand.AddCommand(new GacUninstallCommand());
 #pragma warning restore CA1416
             }
-#endif
 
             var parser = builder.Build();
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -548,7 +548,6 @@ namespace Datadog.Trace.Tools.Runner
         {
             var datadogTraceDllPath = FileExistsOrNull(Path.Combine(tracerHome, "net461", "Datadog.Trace.dll"));
 
-#if NETCOREAPP3_0_OR_GREATER
             try
             {
                 // Let's try to execute the built-in GAC installer to avoid the gacutil dependency
@@ -604,7 +603,6 @@ namespace Datadog.Trace.Tools.Runner
             {
                 Log.Error(ex, "Error using the built-in gac installer.");
             }
-#endif
 
             // We try to ensure Datadog.Trace.dll is installed in the gac for compatibility with .NET Framework fusion class loader
             // Let's find gacutil, because CI Visibility runs with the SDK / CI environments it's probable that's available.

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/GacCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/GacCommandTests.cs
@@ -10,8 +10,6 @@ using Xunit;
 
 namespace Datadog.Trace.Tools.Runner.IntegrationTests;
 
-#if NETCOREAPP3_0_OR_GREATER
-
 #if NET5_0_OR_GREATER
 [SupportedOSPlatform("windows")]
 #endif
@@ -106,5 +104,3 @@ public class GacCommandTests
         }
     }
 }
-
-#endif


### PR DESCRIPTION
## Summary of changes

This PR is a continuation for #5167 that add support for `netcoreapp2.1` and `netcoreapp2.2` runtimes by creating a shim to the missing `NativeLibrary` class.

## Reason for change

These runtimes were missing in the first implementation.

## Implementation details

1. Removed all `NETCOREAPP3_0_OR_GREATER` conditionals.
2. Added a `NativeLibrary` polifill for that missing class on netcoreapp2.x runtimes.

## Test coverage

Removed `NETCOREAPP3_0_OR_GREATER` conditional in the `GacCommandTests` test suite.