### PR TITLE
[Profiler] Refactor to optimize samples collection

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -130,7 +130,7 @@ public:
 
     std::unique_ptr<SamplesEnumerator> GetSamples() override
     {
-        return std::make_unique<SamplesEnumeratorImpl>(_collectedSamples.FetchRawSamples(), this);
+        return std::make_unique<SamplesEnumeratorImpl>(_collectedSamples.Move(), this);
     }
 
 protected:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -20,7 +20,7 @@
 #include "IThreadsCpuManager.h"
 #include "ProviderBase.h"
 #include "RawSample.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 #include "SampleValueTypeProvider.h"
 
 #include "shared/src/native-src/string.h"
@@ -128,9 +128,9 @@ public:
         return sample;
     }
 
-    std::unique_ptr<SampleEnumerator> GetSamples() override
+    std::unique_ptr<SamplesEnumerator> GetSamples() override
     {
-        return std::make_unique<SampleEnumeratorImpl>(FetchRawSamples(), this);
+        return std::make_unique<SamplesEnumeratorImpl>(FetchRawSamples(), this);
     }
 
 protected:
@@ -145,16 +145,16 @@ protected:
     }
 
 private:
-    class SampleEnumeratorImpl : public SampleEnumerator
+    class SamplesEnumeratorImpl : public SamplesEnumerator
     {
     public:
-        SampleEnumeratorImpl(std::list<TRawSample> rawSamples, CollectorBase<TRawSample>* collector) :
+        SamplesEnumeratorImpl(std::list<TRawSample> rawSamples, CollectorBase<TRawSample>* collector) :
             _rawSamples{std::move(rawSamples)}, _collector{collector}
         {
             _currentRawSample = _rawSamples.begin();
         }
 
-        // Inherited via SampleEnumerator
+        // Inherited via SamplesEnumerator
         std::size_t size() const override
         {
             return _rawSamples.size();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -246,6 +246,7 @@
     <ClInclude Include="ExporterBuilder.h" />
     <ClInclude Include="FileHelper.h" />
     <ClInclude Include="FrameworkThreadInfo.h" />
+    <ClInclude Include="SampleEnumerator.h" />
     <ClInclude Include="Success.h" />
     <ClInclude Include="Exception.h" />
     <ClInclude Include="Exporter.h" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -246,7 +246,7 @@
     <ClInclude Include="ExporterBuilder.h" />
     <ClInclude Include="FileHelper.h" />
     <ClInclude Include="FrameworkThreadInfo.h" />
-    <ClInclude Include="SampleEnumerator.h" />
+    <ClInclude Include="SamplesEnumerator.h" />
     <ClInclude Include="Success.h" />
     <ClInclude Include="Exception.h" />
     <ClInclude Include="Exporter.h" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -246,6 +246,7 @@
     <ClInclude Include="ExporterBuilder.h" />
     <ClInclude Include="FileHelper.h" />
     <ClInclude Include="FrameworkThreadInfo.h" />
+    <ClInclude Include="RawSamples.hpp" />
     <ClInclude Include="SamplesEnumerator.h" />
     <ClInclude Include="Success.h" />
     <ClInclude Include="Exception.h" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -431,6 +431,9 @@
     <ClInclude Include="FrameworkThreadInfo.h">
       <Filter>Threads</Filter>
     </ClInclude>
+    <ClInclude Include="SampleEnumerator.h">
+      <Filter>Utils</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="OpSysTools.cpp">

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ISamplesProvider.h
@@ -6,12 +6,12 @@
 #include <memory>
 
 // forward declarations
-class SampleEnumerator;
+class SamplesEnumerator;
 
 class ISamplesProvider
 {
 public:
     virtual ~ISamplesProvider() = default;
-    virtual std::unique_ptr<SampleEnumerator> GetSamples() = 0;
+    virtual std::unique_ptr<SamplesEnumerator> GetSamples() = 0;
     virtual const char* GetName() = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -9,7 +9,7 @@
 #include "LiveObjectsProvider.h"
 #include "OpSysTools.h"
 #include "Sample.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 #include "SampleValueTypeProvider.h"
 
 std::vector<SampleValueType> LiveObjectsProvider::SampleTypeDefinitions(
@@ -99,7 +99,7 @@ void LiveObjectsProvider::OnGarbageCollectionEnd(
     });
 }
 
-class LiveObjectsEnumerator : public SampleEnumerator
+class LiveObjectsEnumerator : public SamplesEnumerator
 {
 public:
     LiveObjectsEnumerator(std::size_t size) :
@@ -113,7 +113,7 @@ public:
         _samples.push_back(std::move(sample));
     }
 
-    // Inherited via SampleEnumerator
+    // Inherited via SamplesEnumerator
     std::size_t size() const override
     {
         return _samples.size();
@@ -132,7 +132,7 @@ public:
     std::size_t _currentPos;
 };
 
-std::unique_ptr<SampleEnumerator> LiveObjectsProvider::GetSamples()
+std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
 {
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -147,11 +147,12 @@ std::unique_ptr<SamplesEnumerator> LiveObjectsProvider::GetSamples()
         // gen2 objects are candidates for leaking however collections could be rare and only gen1 objects
         // are available for live heap profiling
         auto sample = info.GetSample();
-        samples->Add(sample);
 
         // update samples lifetime
         sample->ReplaceLabel(Label{Sample::ObjectLifetimeLabel, std::to_string(sample->GetTimeStamp() - currentTimestamp)});
         sample->ReplaceLabel(Label{Sample::ObjectGenerationLabel, info.IsGen2() ? Gen2 : Gen1});
+
+        samples->Add(sample);
     }
 
     return samples;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -9,6 +9,7 @@
 #include "LiveObjectsProvider.h"
 #include "OpSysTools.h"
 #include "Sample.h"
+#include "SampleEnumerator.h"
 #include "SampleValueTypeProvider.h"
 
 std::vector<SampleValueType> LiveObjectsProvider::SampleTypeDefinitions(
@@ -21,7 +22,6 @@ const uint32_t MAX_LIVE_OBJECTS = 1024;
 
 const std::string LiveObjectsProvider::Gen1("1");
 const std::string LiveObjectsProvider::Gen2("2");
-
 
 LiveObjectsProvider::LiveObjectsProvider(
     SampleValueTypeProvider& valueTypeProvider,
@@ -64,7 +64,7 @@ void LiveObjectsProvider::OnGarbageCollectionStart(
     uint32_t generation,
     GCReason reason,
     GCType type
-    )
+)
 {
     // The address provided during AllocationTick event is not pointing to real object
     // so we tried to wait for the next garbage collection to create a wrapping weak handle.
@@ -80,8 +80,7 @@ void LiveObjectsProvider::OnGarbageCollectionEnd(
     bool isCompacting,
     uint64_t pauseDuration,
     uint64_t totalDuration,
-    uint64_t endTimestamp
-    )
+    uint64_t endTimestamp)
 {
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 
@@ -100,30 +99,62 @@ void LiveObjectsProvider::OnGarbageCollectionEnd(
     });
 }
 
-std::list<std::shared_ptr<Sample>> LiveObjectsProvider::GetSamples()
+class LiveObjectsEnumerator : public SampleEnumerator
 {
-    // return the live object samples
-    std::list<std::shared_ptr<Sample>> liveObjectsSamples;
-
-    // limit lock scope
+public:
+    LiveObjectsEnumerator(std::size_t size) :
+        _currentPos{0}
     {
-        std::lock_guard<std::mutex> lock(_liveObjectsLock);
-
-        int64_t currentTimestamp = OpSysTools::GetHighPrecisionTimestamp();
-        for (auto const& info : _monitoredObjects)
-        {
-            // gen2 objects are candidates for leaking however collections could be rare and only gen1 objects
-            // are available for live heap profiling
-            auto sample = info.GetSample();
-            liveObjectsSamples.push_back(sample);
-
-            // update samples lifetime
-            sample->ReplaceLabel(Label{Sample::ObjectLifetimeLabel, std::to_string(sample->GetTimeStamp() - currentTimestamp)});
-            sample->ReplaceLabel(Label{Sample::ObjectGenerationLabel, info.IsGen2() ? Gen2 : Gen1});
-        }
+        _samples.reserve(size);
     }
 
-    return liveObjectsSamples;
+    void Add(std::shared_ptr<Sample> sample)
+    {
+        _samples.push_back(std::move(sample));
+    }
+
+    // Inherited via SampleEnumerator
+    std::size_t size() const override
+    {
+        return _samples.size();
+    }
+
+    bool MoveNext(std::shared_ptr<Sample>& sample) override
+    {
+        if (_currentPos >= _samples.size())
+            return false;
+
+        sample = _samples[_currentPos++];
+        return true;
+    }
+
+    std::vector<std::shared_ptr<Sample>> _samples;
+    std::size_t _currentPos;
+};
+
+std::unique_ptr<SampleEnumerator> LiveObjectsProvider::GetSamples()
+{
+    std::lock_guard<std::mutex> lock(_liveObjectsLock);
+
+    int64_t currentTimestamp = OpSysTools::GetHighPrecisionTimestamp();
+    std::size_t nbSamples = 0;
+
+    // OPTIM maybe use an allocator
+    auto samples = std::make_unique<LiveObjectsEnumerator>(_monitoredObjects.size());
+
+    for (auto const& info : _monitoredObjects)
+    {
+        // gen2 objects are candidates for leaking however collections could be rare and only gen1 objects
+        // are available for live heap profiling
+        auto sample = info.GetSample();
+        samples->Add(sample);
+
+        // update samples lifetime
+        sample->ReplaceLabel(Label{Sample::ObjectLifetimeLabel, std::to_string(sample->GetTimeStamp() - currentTimestamp)});
+        sample->ReplaceLabel(Label{Sample::ObjectGenerationLabel, info.IsGen2() ? Gen2 : Gen1});
+    }
+
+    return samples;
 }
 
 void LiveObjectsProvider::OnAllocation(RawAllocationSample& rawSample)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -48,7 +48,7 @@ public:
     bool Stop() override;
 
     // Inherited via IBatchedSamplesProvider
-    std::unique_ptr<SampleEnumerator> GetSamples() override;
+    std::unique_ptr<SamplesEnumerator> GetSamples() override;
 
     const char* GetName() override;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -48,7 +48,8 @@ public:
     bool Stop() override;
 
     // Inherited via IBatchedSamplesProvider
-    std::list<std::shared_ptr<Sample>> GetSamples() override;
+    std::unique_ptr<SampleEnumerator> GetSamples() override;
+
     const char* GetName() override;
 
     // Inherited via ISampledAllocationsListener

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -23,9 +23,12 @@ public:
     {
     }
 
+    CpuSampleEnumerator(CpuSampleEnumerator const&) = delete;
+    CpuSampleEnumerator& operator=(CpuSampleEnumerator const&) = delete;
+
     void Set(std::shared_ptr<Sample> sample)
     {
-        _sample = sample;
+        _sample = std::move(sample);
     }
 
     // Inherited via SamplesEnumerator
@@ -36,10 +39,11 @@ public:
 
     bool MoveNext(std::shared_ptr<Sample>& sample) override
     {
-        if (_alreadyCalled)
+        if (_sample == nullptr)
         {
             return false;
         }
+        // not thread-safe but ok since this enumerator will be consumed by only one thread (when exporting)
         sample = _sample;
         _sample.reset();
 
@@ -47,7 +51,6 @@ public:
     }
 
     std::shared_ptr<Sample> _sample;
-    bool _alreadyCalled;
 };
 
 std::unique_ptr<SamplesEnumerator> NativeThreadsCpuProviderBase::GetSamples()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -7,7 +7,7 @@
 #include "Log.h"
 #include "OsSpecificApi.h"
 #include "RawCpuSample.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 
 NativeThreadsCpuProviderBase::NativeThreadsCpuProviderBase(CpuTimeProvider* cpuTimeProvider) :
     _cpuTimeProvider{cpuTimeProvider},
@@ -15,7 +15,7 @@ NativeThreadsCpuProviderBase::NativeThreadsCpuProviderBase(CpuTimeProvider* cpuT
 {
 }
 
-class CpuSampleEnumerator : public SampleEnumerator
+class CpuSampleEnumerator : public SamplesEnumerator
 {
 public:
     CpuSampleEnumerator() :
@@ -28,7 +28,7 @@ public:
         _sample = sample;
     }
 
-    // Inherited via SampleEnumerator
+    // Inherited via SamplesEnumerator
     std::size_t size() const override
     {
         return _sample == nullptr ? 0 : 1;
@@ -50,7 +50,7 @@ public:
     bool _alreadyCalled;
 };
 
-std::unique_ptr<SampleEnumerator> NativeThreadsCpuProviderBase::GetSamples()
+std::unique_ptr<SamplesEnumerator> NativeThreadsCpuProviderBase::GetSamples()
 {
     std::uint64_t cpuTime = 0;
     for (auto const& thread : GetThreads())

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.cpp
@@ -7,6 +7,7 @@
 #include "Log.h"
 #include "OsSpecificApi.h"
 #include "RawCpuSample.h"
+#include "SampleEnumerator.h"
 
 NativeThreadsCpuProviderBase::NativeThreadsCpuProviderBase(CpuTimeProvider* cpuTimeProvider) :
     _cpuTimeProvider{cpuTimeProvider},
@@ -14,14 +15,48 @@ NativeThreadsCpuProviderBase::NativeThreadsCpuProviderBase(CpuTimeProvider* cpuT
 {
 }
 
-std::list<std::shared_ptr<Sample>> NativeThreadsCpuProviderBase::GetSamples()
+class CpuSampleEnumerator : public SampleEnumerator
+{
+public:
+    CpuSampleEnumerator() :
+        _sample{nullptr}
+    {
+    }
+
+    void Set(std::shared_ptr<Sample> sample)
+    {
+        _sample = sample;
+    }
+
+    // Inherited via SampleEnumerator
+    std::size_t size() const override
+    {
+        return _sample == nullptr ? 0 : 1;
+    }
+
+    bool MoveNext(std::shared_ptr<Sample>& sample) override
+    {
+        if (_alreadyCalled)
+        {
+            return false;
+        }
+        sample = _sample;
+        _sample.reset();
+
+        return true;
+    }
+
+    std::shared_ptr<Sample> _sample;
+    bool _alreadyCalled;
+};
+
+std::unique_ptr<SampleEnumerator> NativeThreadsCpuProviderBase::GetSamples()
 {
     std::uint64_t cpuTime = 0;
     for (auto const& thread : GetThreads())
     {
         cpuTime += OsSpecificApi::GetThreadCpuTime(thread.get());
     }
-
 
     auto currentTotalCpuTime = cpuTime;
     // There is a case where it's possible to have currentTotalCpuTime < _previousTotalCpuTime: native threads died in the meantime
@@ -32,11 +67,11 @@ std::list<std::shared_ptr<Sample>> NativeThreadsCpuProviderBase::GetSamples()
     // For native threads, we need to keep the last cpu time
     _previousTotalCpuTime = currentTotalCpuTime;
 
-    auto samples = std::list<std::shared_ptr<Sample>>();
+    auto enumerator = std::make_unique<CpuSampleEnumerator>();
     if (cpuTime == 0)
     {
         Log::Debug(GetName(), " CPU time sums up to 0. No sample will be created.");
-        return samples;
+        return enumerator;
     }
 
     RawCpuSample rawSample;
@@ -54,8 +89,9 @@ std::list<std::shared_ptr<Sample>> NativeThreadsCpuProviderBase::GetSamples()
         sample->AddFrame(frame);
     }
 
-    samples.push_back(sample);
-    return samples;
+    enumerator->Set(sample);
+
+    return enumerator;
 }
 
 void NativeThreadsCpuProviderBase::OnCpuDuration(std::uint64_t cpuTime)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
@@ -20,8 +20,8 @@ protected:
     virtual void OnCpuDuration(std::uint64_t cpuTime);
 
 private:
-    std::list<std::shared_ptr<Sample>> GetSamples() override;
 
+    std::unique_ptr<SampleEnumerator> GetSamples() override;
     virtual std::vector<FrameInfoView> GetFrames() = 0;
     virtual std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() = 0;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/NativeThreadsCpuProviderBase.h
@@ -21,7 +21,7 @@ protected:
 
 private:
 
-    std::unique_ptr<SampleEnumerator> GetSamples() override;
+    std::unique_ptr<SamplesEnumerator> GetSamples() override;
     virtual std::vector<FrameInfoView> GetFrames() = 0;
     virtual std::vector<std::shared_ptr<IThreadInfo>> const& GetThreads() = 0;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
@@ -21,7 +21,7 @@
 #include "OsSpecificApi.h"
 #include "Profile.h"
 #include "Sample.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 #include "ScopeFinalizer.h"
 #include "dd_profiler_version.h"
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
@@ -21,6 +21,7 @@
 #include "OsSpecificApi.h"
 #include "Profile.h"
 #include "Sample.h"
+#include "SampleEnumerator.h"
 #include "ScopeFinalizer.h"
 #include "dd_profiler_version.h"
 
@@ -425,9 +426,16 @@ void ProfileExporter::AddUpscalingRules(libdatadog::Profile* profile, std::vecto
 std::list<std::shared_ptr<Sample>> ProfileExporter::GetProcessSamples()
 {
     std::list<std::shared_ptr<Sample>> samples;
+
+    std::shared_ptr<Sample> sample(nullptr); // for process-level samples, we do not need to initialize
     for (auto const& provider : _processSamplesProviders)
     {
-        samples.splice(samples.end(), provider->GetSamples());
+        auto processedSamples = provider->GetSamples();
+
+        while (processedSamples->MoveNext(sample))
+        {
+            samples.push_back(sample);
+        }
     }
     return samples;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProviderBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProviderBase.h
@@ -13,7 +13,6 @@ class ProviderBase : public ISamplesProvider
 {
 public:
     ProviderBase(const char* name);
-    std::list<std::shared_ptr<Sample>> GetSamples() override = 0;
     const char* GetName() override;
 
 protected:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSamples.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSamples.hpp
@@ -1,0 +1,69 @@
+
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+#include <list>
+
+template <class TRawSample>
+class RawSamples
+{
+public:
+    using const_iterator = typename std::list<TRawSample>::const_iterator;
+
+    RawSamples() = default;
+
+    RawSamples(RawSamples&& other)
+    {
+        *this = std::move(other);
+    };
+
+    RawSamples& operator=(RawSamples&& other)
+    {
+        _samples = std::move(other._samples);
+        return *this;
+    }
+
+    RawSamples(RawSamples const&) = delete;
+    RawSamples& operator=(RawSamples const& other) = delete;
+
+    RawSamples<TRawSample> FetchRawSamples()
+    {
+        std::lock_guard<std::mutex> lock(_lock);
+
+        std::list<TRawSample> result;
+        _samples.swap(result);
+
+        return RawSamples(std::move(result));
+    }
+
+    void Add(TRawSample&& sample)
+    {
+        std::lock_guard<std::mutex> lock(_lock);
+        _samples.push_back(std::forward<TRawSample>(sample));
+    }
+
+    auto cbegin() const
+    {
+        return _samples.cbegin();
+    }
+
+    auto cend() const
+    {
+        return _samples.cend();
+    }
+
+    std::size_t size() const
+    {
+        return _samples.size();
+    }
+
+private:
+    RawSamples(std::list<TRawSample> samples) :
+        _samples{std::move(samples)}
+    {
+    }
+
+    std::mutex _lock;
+    std::list<TRawSample> _samples;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSamples.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawSamples.hpp
@@ -27,7 +27,7 @@ public:
     RawSamples(RawSamples const&) = delete;
     RawSamples& operator=(RawSamples const& other) = delete;
 
-    RawSamples<TRawSample> FetchRawSamples()
+    RawSamples<TRawSample> Move()
     {
         std::lock_guard<std::mutex> lock(_lock);
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.cpp
@@ -42,6 +42,8 @@ Sample::Sample(uint64_t timestamp, std::string_view runtimeId, size_t framesCoun
     _timestamp = timestamp;
     _runtimeId = runtimeId;
     _callstack.reserve(framesCount);
+    _labels.reserve(10);
+    _numericLabels.reserve(10);
 }
 
 Sample::Sample(std::string_view runtimeId) :

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Sample.h
@@ -22,10 +22,10 @@ struct SampleValueType
 
 typedef std::vector<int64_t> Values;
 typedef std::pair<std::string_view, std::string> Label;
-typedef std::list<Label> Labels;
+typedef std::vector<Label> Labels;
 typedef std::pair<std::string_view, int64_t> NumericLabel;
 typedef std::pair<std::string_view, uint64_t> SpanLabel;
-typedef std::list<NumericLabel> NumericLabels;
+typedef std::vector<NumericLabel> NumericLabels;
 typedef std::vector<FrameInfoView> CallStack;
 
 class Sample
@@ -34,13 +34,17 @@ public:
     static size_t ValuesCount;
 
 public:
-    Sample(std::string_view runtimeId); // only for tests
     Sample(uint64_t timestamp, std::string_view runtimeId, size_t framesCount);
+    Sample(std::string_view runtimeId); // only for tests
 
-    Sample(const Sample&) = delete;
-    Sample& operator=(const Sample& sample) = delete;
-    Sample(Sample&& sample) noexcept = delete;
-    Sample& operator=(Sample&& other) noexcept = delete;
+#ifndef DD_TEST
+private:
+#endif
+    // let compiler generating the move and copy ctors/assignment operators
+    Sample(const Sample&) = default;
+    Sample& operator=(const Sample& sample) = default;
+    Sample(Sample&& sample) noexcept = default;
+    Sample& operator=(Sample&& other) noexcept = default;
 
 public:
     uint64_t GetTimeStamp() const;
@@ -124,6 +128,25 @@ public:
         AddLabel(Label{ThreadNameLabel, std::forward<T>(name)});
     }
 
+    void SetTimestamp(std::uint64_t timestamp)
+    {
+        _timestamp = timestamp;
+    }
+
+    void SetRuntimeId(std::string_view runtimeId)
+    {
+        _runtimeId = runtimeId;
+    }
+
+    void Reset()
+    {
+        _timestamp = 0;
+        _callstack.clear();
+        _runtimeId = {};
+        _numericLabels.clear();
+        _labels.clear();
+        std::fill(_values.begin(), _values.end(), 0);
+    }
     // well known labels
 public:
     static const std::string ThreadIdLabel;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleEnumerator.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SampleEnumerator.h
@@ -2,16 +2,17 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #pragma once
-#include <list>
+
+#include <cstddef>
 #include <memory>
 
-// forward declarations
-class SampleEnumerator;
+class Sample;
 
-class ISamplesProvider
+class SampleEnumerator
 {
 public:
-    virtual ~ISamplesProvider() = default;
-    virtual std::unique_ptr<SampleEnumerator> GetSamples() = 0;
-    virtual const char* GetName() = 0;
+    virtual ~SampleEnumerator() = default;
+
+    virtual std::size_t size() const = 0;
+    virtual bool MoveNext(std::shared_ptr<Sample>& sample) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
@@ -5,6 +5,7 @@
 
 #include "Log.h"
 #include "OpSysTools.h"
+#include "SampleEnumerator.h"
 
 SamplesCollector::SamplesCollector(
     IConfiguration* configuration,
@@ -15,7 +16,8 @@ SamplesCollector::SamplesCollector(
     _mustStop{false},
     _pThreadsCpuManager{pThreadsCpuManager},
     _metricsSender{metricsSender},
-    _exporter{exporter}
+    _exporter{exporter},
+    _cachedSample{std::make_shared<Sample>(0, std::string_view{}, 2048)}
 {
 }
 
@@ -136,14 +138,14 @@ void SamplesCollector::CollectSamples(std::forward_list<std::pair<ISamplesProvid
         {
             std::lock_guard lock(_exportLock);
 
-            auto result = samplesProvider.first->GetSamples();
-            samplesProvider.second += result.size();
+            auto samples = samplesProvider.first->GetSamples();
+            samplesProvider.second += samples->size();
 
-            for (auto const& sample : result)
+            while (samples->MoveNext(_cachedSample))
             {
-                if (!sample->GetCallstack().empty())
+                if (!_cachedSample->GetCallstack().empty())
                 {
-                    _exporter->Add(sample);
+                    _exporter->Add(_cachedSample);
                 }
             }
         }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
@@ -5,7 +5,7 @@
 
 #include "Log.h"
 #include "OpSysTools.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 
 SamplesCollector::SamplesCollector(
     IConfiguration* configuration,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.h
@@ -60,4 +60,12 @@ private:
     std::promise<void> _workerThreadPromise;
     IMetricsSender* _metricsSender;
     IExporter* _exporter;
+
+    // OPTIM
+    // It safe to have only one cached sample with no synchronization
+    // This field is only used by one thread at a time:
+    // - worker thread responsible to collect and push samples in the profile
+    // - thread executing the Stop: at that time, the worker thread has stopped
+    //   and the thread will be the only one using this field to collect the last samples
+    std::shared_ptr<Sample> _cachedSample;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesEnumerator.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesEnumerator.h
@@ -8,10 +8,10 @@
 
 class Sample;
 
-class SampleEnumerator
+class SamplesEnumerator
 {
 public:
-    virtual ~SampleEnumerator() = default;
+    virtual ~SamplesEnumerator() = default;
 
     virtual std::size_t size() const = 0;
     virtual bool MoveNext(std::shared_ptr<Sample>& sample) = 0;

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -60,6 +60,7 @@
     <ClCompile Include="EnvironmentHelper.cpp" />
     <ClCompile Include="ErrorCodeTest.cpp" />
     <ClCompile Include="ExporterTest.cpp" />
+    <ClCompile Include="FakeSamples.cpp" />
     <ClCompile Include="FrameStoreHelper.cpp" />
     <ClCompile Include="IMetricsSenderFactoryTest.cpp" />
     <ClCompile Include="ProfileExporterTest.cpp" />
@@ -88,6 +89,7 @@
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\IMetricsSenderFactory.cpp" />
     <ClInclude Include="AppDomainStoreHelper.h" />
     <ClInclude Include="EnvironmentHelper.h" />
+    <ClInclude Include="FakeSamples.h" />
     <ClInclude Include="FrameStoreHelper.h" />
     <ClInclude Include="ProfilerMockedInterface.h" />
     <ClInclude Include="RuntimeIdStoreHelper.h" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -154,6 +154,9 @@
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\ETW\IpcServer.cpp" />
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\ETW\ProfilerLogger.cpp" />
     <ClCompile Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\SecurityDescriptorHelpers.cpp" />
+    <ClCompile Include="FakeSamples.cpp">
+      <Filter>Helpers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">
@@ -181,5 +184,8 @@
       <Filter>Helpers</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native.Windows\SecurityDescriptorHelpers.h" />
+    <ClInclude Include="FakeSamples.h">
+      <Filter>Helpers</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/profiler/test/Datadog.Profiler.Native.Tests/FakeSamples.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/FakeSamples.cpp
@@ -1,0 +1,36 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "FakeSamples.h"
+
+FakeSamples::FakeSamples()
+{
+    _currentPos = _samples.end();
+}
+
+FakeSamples::FakeSamples(std::shared_ptr<Sample> sample)
+{
+    _currentPos = _samples.begin();
+    _samples.push_back(sample);
+}
+
+FakeSamples::FakeSamples(std::list<std::shared_ptr<Sample>> samples) :
+    _samples{std::move(samples)}
+{
+    _currentPos = _samples.begin();
+}
+
+std::size_t FakeSamples::size() const
+{
+    return _samples.size();
+}
+
+bool FakeSamples::MoveNext(std::shared_ptr<Sample>& sample)
+{
+    if (_currentPos == _samples.end())
+        return false;
+
+    sample = *_currentPos;
+    _currentPos++;
+    return true;
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/FakeSamples.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/FakeSamples.h
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "SampleEnumerator.h"
+
+#include <list>
+#include <memory>
+
+class FakeSamples : public SampleEnumerator
+{
+public:
+    FakeSamples();
+    ~FakeSamples() = default;
+    FakeSamples(std::shared_ptr<Sample> sample);
+    FakeSamples(std::list<std::shared_ptr<Sample>> samples);
+
+    // Inherited via SampleEnumerator
+    std::size_t size() const override;
+
+    bool MoveNext(std::shared_ptr<Sample>& sample) override;
+
+    std::list<std::shared_ptr<Sample>> _samples;
+    std::list<std::shared_ptr<Sample>>::iterator _currentPos;
+};

--- a/profiler/test/Datadog.Profiler.Native.Tests/FakeSamples.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/FakeSamples.h
@@ -3,12 +3,12 @@
 
 #pragma once
 
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 
 #include <list>
 #include <memory>
 
-class FakeSamples : public SampleEnumerator
+class FakeSamples : public SamplesEnumerator
 {
 public:
     FakeSamples();
@@ -16,7 +16,7 @@ public:
     FakeSamples(std::shared_ptr<Sample> sample);
     FakeSamples(std::list<std::shared_ptr<Sample>> samples);
 
-    // Inherited via SampleEnumerator
+    // Inherited via SamplesEnumerator
     std::size_t size() const override;
 
     bool MoveNext(std::shared_ptr<Sample>& sample) override;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
@@ -13,7 +13,7 @@
 #include "MetricsRegistry.h"
 #include "ProfilerMockedInterface.h"
 #include "RuntimeInfoHelper.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 
 #include "shared/src/native-src/dd_filesystem.hpp"
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfileExporterTest.cpp
@@ -5,13 +5,15 @@
 #include "gtest/gtest.h"
 
 #include "EnabledProfilers.h"
-#include "ProfileExporter.h"
 #include "OpSysTools.h"
+#include "ProfileExporter.h"
 
+#include "FakeSamples.h"
+#include "IMetadataProvider.h"
 #include "MetricsRegistry.h"
 #include "ProfilerMockedInterface.h"
 #include "RuntimeInfoHelper.h"
-#include "IMetadataProvider.h"
+#include "SampleEnumerator.h"
 
 #include "shared/src/native-src/dd_filesystem.hpp"
 
@@ -79,8 +81,7 @@ TEST(ProfileExporterTest, CheckProfileIsWrittenToDisk)
     IAllocationsRecorder* allocRecorder = nullptr;
     IMetadataProvider* metadataProvider = nullptr;
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo,
-                                      &enabledProfilers, metricsRegistry, metadataProvider, allocRecorder);
-
+                                    &enabledProfilers, metricsRegistry, metadataProvider, allocRecorder);
 
     // Add samples to only one application
     auto callstack1 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
@@ -130,7 +131,6 @@ TEST(ProfileExporterTest, CheckProfileIsWrittenToDisk)
 
     fs::remove_all(pprofTempDir);
 }
-
 
 // ----------------------------------------------------------------------------------------------
 // This test is done in 2 steps:
@@ -196,7 +196,7 @@ TEST(ProfileExporterTest, EnsureOnlyProfileWithSamplesIsWrittenToDisk)
     IAllocationsRecorder* allocRecorder = nullptr;
     IMetadataProvider* metadataProvider = nullptr;
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers,
-                                      metricsRegistry, metadataProvider, allocRecorder);
+                                    metricsRegistry, metadataProvider, allocRecorder);
 
     auto callstack1 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
     auto labels1 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
@@ -251,7 +251,6 @@ TEST(ProfileExporterTest, EnsureOnlyProfileWithSamplesIsWrittenToDisk)
     fs::remove_all(pprofTempDir);
 }
 
-
 TEST(ProfileExporterTest, EnsureTwoPprofFilesAreWrittenToDiskForTwoApplications)
 {
     auto [configuration, mockConfiguration] = CreateConfiguration();
@@ -304,7 +303,7 @@ TEST(ProfileExporterTest, EnsureTwoPprofFilesAreWrittenToDiskForTwoApplications)
     IAllocationsRecorder* allocRecorder = nullptr;
     IMetadataProvider* metadataProvider = nullptr;
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers,
-                                      metricsRegistry, metadataProvider, allocRecorder);
+                                    metricsRegistry, metadataProvider, allocRecorder);
 
     auto callstack1 = std::vector<std::pair<std::string, std::string>>({{"module", "frame1"}, {"module", "frame2"}, {"module", "frame3"}});
     auto labels1 = std::vector<std::pair<std::string, std::string>>{{"label1", "value1"}, {"label2", "value2"}};
@@ -396,7 +395,7 @@ TEST(ProfileExporterTest, MustCreateAgentBasedExporterIfAgentUrlIsSet)
     IAllocationsRecorder* allocRecorder = nullptr;
     IMetadataProvider* metadataProvider = nullptr;
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers,
-                                      metricsRegistry, metadataProvider, allocRecorder);
+                                    metricsRegistry, metadataProvider, allocRecorder);
 }
 
 TEST(ProfileExporterTest, MustCreateAgentBasedExporterIfAgentUrlIsNotSet)
@@ -441,7 +440,7 @@ TEST(ProfileExporterTest, MustCreateAgentBasedExporterIfAgentUrlIsNotSet)
     IAllocationsRecorder* allocRecorder = nullptr;
     IMetadataProvider* metadataProvider = nullptr;
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers,
-                                      metricsRegistry, metadataProvider, allocRecorder);
+                                    metricsRegistry, metadataProvider, allocRecorder);
 }
 
 TEST(ProfileExporterTest, MustCreateAgentLessExporterIfAgentless)
@@ -479,7 +478,7 @@ TEST(ProfileExporterTest, MustCreateAgentLessExporterIfAgentless)
     IAllocationsRecorder* allocRecorder = nullptr;
     IMetadataProvider* metadataProvider = nullptr;
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers,
-                                      metricsRegistry, metadataProvider, allocRecorder);
+                                    metricsRegistry, metadataProvider, allocRecorder);
 }
 
 TEST(ProfileExporterTest, MustCollectSamplesFromProcessProvider)
@@ -517,9 +516,9 @@ TEST(ProfileExporterTest, MustCollectSamplesFromProcessProvider)
     IAllocationsRecorder* allocRecorder = nullptr;
     MockProcessSamplesProvider processSamplesProvider;
     IMetadataProvider* metadataProvider = nullptr;
-    EXPECT_CALL(processSamplesProvider, GetSamples()).Times(1).WillOnce(Return(std::list<std::shared_ptr<Sample>>()));
+    EXPECT_CALL(processSamplesProvider, GetSamples()).Times(1).WillOnce(Return(::testing::ByMove(std::make_unique<FakeSamples>())));
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers,
-                                      metricsRegistry, metadataProvider, allocRecorder);
+                                    metricsRegistry, metadataProvider, allocRecorder);
 
     exporter.RegisterProcessSamplesProvider(static_cast<ISamplesProvider*>(&processSamplesProvider));
 
@@ -562,7 +561,7 @@ TEST(ProfileExporterTest, MakeSureNoCrashForReallyLongCallstack)
     IAllocationsRecorder* allocRecorder = nullptr;
     IMetadataProvider* metadataProvider = nullptr;
     auto exporter = ProfileExporter(std::move(sampleTypeDefinitions), &mockConfiguration, &applicationStore, runtimeInfo, &enabledProfilers,
-                                      metricsRegistry, metadataProvider, allocRecorder);
+                                    metricsRegistry, metadataProvider, allocRecorder);
 
     std::string runtimeId = "MyRid";
     auto callstack = CreateCallstack(2048);
@@ -756,7 +755,7 @@ TEST(ProfileExporterTest, CheckHeapIsDisabledWhenNoEvents)
     EXPECT_CALL(mockConfiguration, IsWallTimeProfilingEnabled()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(mockConfiguration, IsCpuProfilingEnabled()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(mockConfiguration, IsExceptionProfilingEnabled()).Times(1).WillOnce(Return(false));
-    EnabledProfilers enabledProfilers(configuration.get(), false, true);  // this should never happen but test it anyway
+    EnabledProfilers enabledProfilers(configuration.get(), false, true); // this should never happen but test it anyway
 
     std::string tag = ProfileExporter::GetEnabledProfilersTag(&enabledProfilers);
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -13,6 +13,7 @@
 #include "ISamplesCollector.h"
 #include "ISamplesProvider.h"
 #include "Sample.h"
+#include "SampleEnumerator.h"
 #include "TagsHelper.h"
 
 #include <memory>
@@ -93,7 +94,7 @@ public:
 class MockSampleProvider : public ISamplesProvider
 {
 public:
-    MOCK_METHOD(std::list<std::shared_ptr<Sample>>, GetSamples, (), (override));
+    MOCK_METHOD(std::unique_ptr<SampleEnumerator>, GetSamples, (), (override));
     MOCK_METHOD(const char*, GetName, (), (override));
 };
 
@@ -148,7 +149,7 @@ public:
 class MockProcessSamplesProvider : public ISamplesProvider
 {
 public:
-    MOCK_METHOD(std::list<std::shared_ptr<Sample>>, GetSamples, (), (override));
+    MOCK_METHOD(std::unique_ptr<SampleEnumerator>, GetSamples, (), (override));
     MOCK_METHOD(const char*, GetName, (), (override));
 };
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -13,7 +13,7 @@
 #include "ISamplesCollector.h"
 #include "ISamplesProvider.h"
 #include "Sample.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 #include "TagsHelper.h"
 
 #include <memory>
@@ -94,7 +94,7 @@ public:
 class MockSampleProvider : public ISamplesProvider
 {
 public:
-    MOCK_METHOD(std::unique_ptr<SampleEnumerator>, GetSamples, (), (override));
+    MOCK_METHOD(std::unique_ptr<SamplesEnumerator>, GetSamples, (), (override));
     MOCK_METHOD(const char*, GetName, (), (override));
 };
 
@@ -149,7 +149,7 @@ public:
 class MockProcessSamplesProvider : public ISamplesProvider
 {
 public:
-    MOCK_METHOD(std::unique_ptr<SampleEnumerator>, GetSamples, (), (override));
+    MOCK_METHOD(std::unique_ptr<SamplesEnumerator>, GetSamples, (), (override));
     MOCK_METHOD(const char*, GetName, (), (override));
 };
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
@@ -12,7 +12,7 @@
 #include "ISamplesProvider.h"
 #include "ProfilerMockedInterface.h"
 #include "Sample.h"
-#include "SampleEnumerator.h"
+#include "SamplesEnumerator.h"
 #include "ThreadsCpuManagerHelper.h"
 
 #include <chrono>
@@ -58,7 +58,7 @@ public:
     {
     }
 
-    std::unique_ptr<SampleEnumerator> GetSamples() override
+    std::unique_ptr<SamplesEnumerator> GetSamples() override
     {
         _calls++;
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/SamplesCollectorTest.cpp
@@ -7,10 +7,12 @@
 #include "gtest/gtest.h"
 
 #include "Configuration.h"
+#include "FakeSamples.h"
 #include "IExporter.h"
 #include "ISamplesProvider.h"
 #include "ProfilerMockedInterface.h"
 #include "Sample.h"
+#include "SampleEnumerator.h"
 #include "ThreadsCpuManagerHelper.h"
 
 #include <chrono>
@@ -56,10 +58,11 @@ public:
     {
     }
 
-    std::list<std::shared_ptr<Sample>> GetSamples() override
+    std::unique_ptr<SampleEnumerator> GetSamples() override
     {
         _calls++;
-        return CreateSamples(_runtimeId, _nbSamples);
+
+        return std::make_unique<FakeSamples>(CreateSamples(_runtimeId, _nbSamples));
     }
 
     int GetNbCalls()
@@ -99,7 +102,6 @@ private:
     int _nbSamples;
     int _calls;
 };
-
 
 TEST(SamplesCollectorTest, MustCollectSamplesFromTwoProviders)
 {
@@ -197,7 +199,7 @@ TEST(SamplesCollectorTest, MustCollectSamplesFromProviderAndBatchedProvider)
     collector.Stop();
 
     auto exportsCount = samplesProvider.GetNbCalls();
-    ASSERT_EQ(exportsCount, 2);  // 1 at work time + 1 at stop time
+    ASSERT_EQ(exportsCount, 2); // 1 at work time + 1 at stop time
     auto exportsCount2 = batchedSamplesProvider.GetNbCalls();
     ASSERT_EQ(exportsCount2, 1); // 1 at export time
 
@@ -228,7 +230,7 @@ TEST(SamplesCollectorTest, MustCollectSamplesFromProviderAndBatchedProvider)
 
     collector.Export();
 
-    ASSERT_EQ(exportedSamples.size(), 2);  // the BatchedSamplesProvider is called once in export
+    ASSERT_EQ(exportedSamples.size(), 2); // the BatchedSamplesProvider is called once in export
     ASSERT_EQ(pendingSamples.size(), 0);
 }
 
@@ -360,13 +362,11 @@ TEST(SamplesCollectorTest, MustdNotAddSampleInExporterIfEmptyCallstack)
 
     EXPECT_CALL(mockSamplesProvider, GetSamples())
         .Times(AtLeast(1))
-        .WillRepeatedly(InvokeWithoutArgs([runtimeId] {
-            std::list<std::shared_ptr<Sample>> samples;
-
-            // add sample with empty callstack
-            samples.push_back(std::make_shared<Sample>(runtimeId.c_str()));
-            return samples;
-        }));
+        .WillRepeatedly(
+            [runtimeId]() {
+                // process sample with empty callstack
+                return std::make_unique<FakeSamples>(std::make_shared<Sample>(runtimeId.c_str()));
+            });
 
     EXPECT_CALL(mockSamplesProvider, GetName())
         .Times(AtLeast(1))


### PR DESCRIPTION
## Summary of changes

Optimization RawSample to Sample transformation

## Reason for change

When transforming `RawSample` to `Sample`, we allocate/deallocate a lot of memory (mainly for the frames). This allocation/deallocation has a  non-negligible CPU cost (~8-10%).

## Implementation details

- Add `SamplesEnumerator` class responsible to store the RawSamples objects. Provide a `MoveNext` method to iterate over the `Sample`. This allows us to reuse the same sample object at every iteration.
- Change CollectorBase to handle the same Sample object (add `SetTimestamp`, `SetRuntimeId` and `Clear`)
- Propagate the changes to children classes.
- `Sample` class now use `std::vector` for the labels instead of `std::list` : allows reuse of memory
 
## Test coverage

The current tests should still work.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
