### PR TITLE
[Profiler] Optimize AppDomainStore

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AppDomainStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AppDomainStore.h
@@ -1,4 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
 #pragma once
+
+#include <mutex>
+#include <unordered_map>
 
 #include "IAppDomainStore.h"
 
@@ -13,4 +19,7 @@ public:
 
 private:
     ICorProfilerInfo4* _pProfilerInfo;
+
+    std::mutex _lock;
+    std::unordered_map<AppDomainID, std::pair<ProcessID, std::string>> _appDomainToInfo;
 };


### PR DESCRIPTION
## Summary of changes

Cache AppDomain info.

## Reason for change

For each sample, we retrieve the AppDomain's thread infos: pid and name. To get those information we call into the ICorprofilerInfo API.
But this comes as a cost.

## Implementation details

Cache the AppDomain information (pid and name) in a `unordered_map`. 

## Test coverage

Current tests should work.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
