### PR TITLE
[ASM] Improved Unsafe Encoder readability

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.AppSec
             ApiSecurityEnabled = config.WithKeys(ConfigurationKeys.AppSec.ApiExperimentalSecurityEnabled)
                                        .AsBool(false);
             UseUnsafeEncoder = config.WithKeys(ConfigurationKeys.AppSec.UseUnsafeEncoder)
-                                     .AsBool(false);
+                                     .AsBool(true);
 
             // For now, RASP is disabled by default.
             RaspEnabled = config.WithKeys(ConfigurationKeys.AppSec.RaspEnabled)

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -70,6 +70,12 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
         // -----------------------------------
 
+        internal DdwafObjectStruct Encode<TInstance>(TInstance? o, List<IntPtr> argToFree, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true, UnmanagedMemoryPool? pool = null)
+        {
+            var context = new EncoderContext { ApplySafetyLimits = applySafetyLimits, Buffers = new List<IntPtr>(), Pool = Pool };
+            return Encode(ref context, remainingDepth, key, o);
+        }
+
         private static unsafe DdwafObjectStruct Encode<TInstance>(ref EncoderContext context, int remainingDepth, string? key, TInstance? o)
         {
             DdwafObjectStruct ddwafObjectStruct;

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -63,120 +63,335 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
         public IEncodeResult Encode<TInstance>(TInstance? o, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true)
         {
-            var lstPointers = new List<IntPtr>();
-            var pool = Pool;
-            return new EncodeResult(lstPointers, pool, Encode(o, lstPointers, remainingDepth, key, applySafetyLimits, pool: pool));
+            var context = new EncoderContext { ApplySafetyLimits = applySafetyLimits, Buffers = new List<IntPtr>(), Pool = Pool };
+            var result = Encode(ref context, remainingDepth, key, o);
+            return new EncodeResult(context.Buffers, context.Pool, result);
         }
 
-        public unsafe DdwafObjectStruct Encode<TInstance>(TInstance? o, List<IntPtr> argToFree, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true, UnmanagedMemoryPool? pool = null)
+        // -----------------------------------
+
+        private static unsafe DdwafObjectStruct Encode<TInstance>(ref EncoderContext context, int remainingDepth, string? key, TInstance? o)
         {
-            pool ??= Pool;
+            DdwafObjectStruct ddwafObjectStruct;
 
-            DdwafObjectStruct ProcessKeyValuePairs<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> enumerableDic, int count, delegate*<KeyValuePair<TKey, TValue>, string?> getKey, delegate*<KeyValuePair<TKey, TValue>, object?> getValue)
-                where TKey : notnull
+            switch (o)
             {
-                var ddWafObjectMap = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP };
-                if (!string.IsNullOrEmpty(key))
-                {
-                    var convertToUtf8 = ConvertToUtf8(key!, false);
-                    ddWafObjectMap.ParameterName = convertToUtf8.Item1;
-                    ddWafObjectMap.ParameterNameLength = (ulong)key!.Length;
-                }
-
-                if (applySafetyLimits)
-                {
-                    if (remainingDepth-- <= 0)
+                case string str:
+                    ddwafObjectStruct = GetStringObject(ref context, str);
+                    break;
+                case JValue:
+                    ddwafObjectStruct = GetStringObject(ref context, o?.ToString() ?? string.Empty);
+                    break;
+                case null:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_NULL };
+                    break;
+                case ulong u:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED, UintValue = u };
+                    break;
+                case uint u:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED, UintValue = u };
+                    break;
+                case int i:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED, IntValue = i };
+                    break;
+                case long u:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED, IntValue = u };
+                    break;
+                case decimal d:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = (double)d };
+                    break;
+                case double d:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = d };
+                    break;
+                case float d:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = d };
+                    break;
+                case bool b:
+                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_BOOL, ByteValue = b ? (byte)1 : (byte)0 };
+                    break;
+                case IEnumerable<KeyValuePair<string, object>> objDict:
                     {
-                        string GetItemsAsString()
-                        {
-                            var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-                            foreach (var x in enumerableDic)
-                            {
-                                sb.Append($"{getKey(x)}, {getValue(x)}, ");
-                            }
-
-                            if (sb.Length > 0)
-                            {
-                                sb.Remove(sb.Length - 2, 2);
-                            }
-
-                            return StringBuilderCache.GetStringAndRelease(sb);
-                        }
-
-                        Log.Warning("EncodeDictionary: object graph too deep, truncating nesting {Items}", GetItemsAsString());
-                        return ddWafObjectMap;
+                        var collectionDict = objDict as ICollection<KeyValuePair<string, object>> ?? objDict.ToList();
+                        ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey1, &GetValue1);
+                        static string GetKey1(KeyValuePair<string, object> item) => item.Key;
+                        static object GetValue1(KeyValuePair<string, object> item) => item.Value;
+                        break;
                     }
 
-                    if (count > WafConstants.MaxContainerSize)
+                case IEnumerable<KeyValuePair<string, bool>> objDict:
+                    {
+                        var collectionDict = objDict as ICollection<KeyValuePair<string, bool>> ?? objDict.ToList();
+                        ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey1, &GetValue1);
+                        static string GetKey1(KeyValuePair<string, bool> item) => item.Key;
+                        static object GetValue1(KeyValuePair<string, bool> item) => item.Value;
+                        break;
+                    }
+
+                case IEnumerable<KeyValuePair<string, string>> objDict:
+                    {
+                        var collectionDict = objDict as ICollection<KeyValuePair<string, string>> ?? objDict.ToList();
+                        ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey2, &GetValue2);
+                        static string GetKey2(KeyValuePair<string, string> item) => item.Key;
+                        static object GetValue2(KeyValuePair<string, string> item) => item.Value;
+                        break;
+                    }
+
+                case IEnumerable<KeyValuePair<string, JToken>> objDict:
+                    {
+                        var collectionDict = objDict as ICollection<KeyValuePair<string, JToken>> ?? objDict.ToList();
+                        ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey3, &GetValue3);
+                        static string GetKey3(KeyValuePair<string, JToken> item) => item.Key;
+                        static object GetValue3(KeyValuePair<string, JToken> item) => item.Value;
+                        break;
+                    }
+
+                case IEnumerable<KeyValuePair<string, string[]>> objDict:
+                    {
+                        var collectionDict = objDict as ICollection<KeyValuePair<string, string[]>> ?? objDict.ToList();
+                        ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey4, &GetValue4);
+                        static string GetKey4(KeyValuePair<string, string[]> item) => item.Key;
+                        static object GetValue4(KeyValuePair<string, string[]> item) => item.Value;
+                        break;
+                    }
+
+                case IEnumerable<KeyValuePair<string, List<string>>> objDict:
+                    {
+                        var collectionDict = objDict as ICollection<KeyValuePair<string, List<string>>> ?? objDict.ToList();
+                        ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey5, &GetValue5);
+                        static string GetKey5(KeyValuePair<string, List<string>> item) => item.Key;
+                        static object GetValue5(KeyValuePair<string, List<string>> item) => item.Value;
+                        break;
+                    }
+
+                case IEnumerable enumerable:
+                    {
+                        ddwafObjectStruct = ProcessIEnumerable(ref context, remainingDepth, enumerable);
+                        break;
+                    }
+
+                default:
+                    if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
+                    {
+                        Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+                    }
+
+                    ddwafObjectStruct = GetStringObject(ref context, string.Empty);
+                    break;
+            }
+
+            if (!string.IsNullOrEmpty(key))
+            {
+                ddwafObjectStruct.ParameterName = ConvertToUtf8(ref context, key!, false).Item1;
+                ddwafObjectStruct.ParameterNameLength = (ulong)key!.Length;
+            }
+
+            return ddwafObjectStruct;
+        }
+
+        private static unsafe DdwafObjectStruct ProcessIEnumerable(ref EncoderContext context, int remainingDepth, IEnumerable enumerable)
+        {
+            var ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_ARRAY };
+
+            if (context.ApplySafetyLimits && remainingDepth-- <= 0)
+            {
+                Log.Warning("EncodeList: object graph too deep, truncating nesting {Items}", string.Join(", ", enumerable));
+                return ddwafObjectStruct;
+            }
+
+            if (enumerable is IList { Count: var count } listInstance)
+            {
+                if (context.ApplySafetyLimits && count > WafConstants.MaxContainerSize)
+                {
+                    Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                }
+
+                var childrenCount = !context.ApplySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
+                var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
+                var childrenData = childrenFromPool ? context.Pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
+
+                // Avoid boxing of known values types from the switch above
+                switch (listInstance)
+                {
+                    case IList<bool> boolCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, boolCollection);
+                        break;
+                    case IList<decimal> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection);
+                        break;
+                    case IList<double> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection);
+                        break;
+                    case IList<float> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection);
+                        break;
+                    case IList<int> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection);
+                        break;
+                    case IList<uint> uintCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, uintCollection);
+                        break;
+                    case IList<long> longCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, longCollection);
+                        break;
+                    case IList<ulong> ulongCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, ulongCollection);
+                        break;
+                    default:
+                        EnumerateAndEncodeIList(ref context, remainingDepth, listInstance);
+                        break;
+                }
+
+                ddwafObjectStruct.Array = childrenData;
+                ddwafObjectStruct.NbEntries = (ulong)childrenCount;
+                context.Buffers.Add(childrenData);
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void EnumerateAndEncode<T>(ref EncoderContext context, int remainingDepth, IList<T> lstInstance)
+                {
+                    var itemData = childrenData;
+                    for (var idx = 0; idx < childrenCount; idx++)
+                    {
+                        *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, null, lstInstance[idx]);
+                        itemData += ObjectStructSize;
+                    }
+                }
+
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void EnumerateAndEncodeIList(ref EncoderContext context, int remainingDepth, IList lstInstance)
+                {
+                    var itemData = childrenData;
+                    for (var idx = 0; idx < childrenCount; idx++)
+                    {
+                        *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, null, lstInstance[idx]);
+                        itemData += ObjectStructSize;
+                    }
+                }
+            }
+            else
+            {
+                var childrenCount = 0;
+                // Let's enumerate first.
+                foreach (var val in enumerable)
+                {
+                    childrenCount++;
+                    if (context.ApplySafetyLimits && childrenCount == WafConstants.MaxContainerSize)
                     {
                         Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                        return ddwafObjectStruct;
                     }
                 }
 
-                var childrenCount = !applySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
-                var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
-                var childrenData = childrenFromPool ? pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
-
-                if (enumerableDic is IDictionary)
+                if (childrenCount > 0)
                 {
-                    var typeKVP = typeof(KeyValuePair<TKey, TValue>);
-                    if (typeKVP == typeof(KeyValuePair<string, string>))
+                    var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
+                    var childrenData = childrenFromPool ? context.Pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
+                    var itemData = childrenData;
+                    var idx = 0;
+                    foreach (var val in enumerable)
                     {
-                        EnumerateItems<string, string>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, object>))
-                    {
-                        EnumerateItems<string, object>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, string[]>))
-                    {
-                        EnumerateItems<string, string[]>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, List<string>>))
-                    {
-                        EnumerateItems<string, List<string>>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, JToken>))
-                    {
-                        EnumerateItems<string, JToken>();
-                    }
-                    else
-                    {
-                        EnumerateItems<TKey, TValue>();
-                    }
-
-                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    void EnumerateItems<TKeySource, TValueSource>()
-                        where TKeySource : notnull
-                    {
-                        var itemData = childrenData;
-                        var dic = (Dictionary<TKeySource, TValueSource>)enumerableDic;
-                        var maxChildrenCount = childrenCount;
-                        for (var i = 0; i < maxChildrenCount; i++)
+                        if (idx > childrenCount)
                         {
-                            var originalKeyValue = dic.ElementAt(i);
-                            var keyValue = VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.As<KeyValuePair<TKeySource, TValueSource>, KeyValuePair<TKey, TValue>>(ref originalKeyValue);
-                            var key = getKey(keyValue);
-                            if (string.IsNullOrEmpty(key))
-                            {
-                                childrenCount--;
-                                Log.Warning("EncodeDictionary: ignoring dictionary member with null name");
-                                continue;
-                            }
-
-                            *(DdwafObjectStruct*)itemData = Encode(getValue(keyValue!), argToFree, applySafetyLimits: applySafetyLimits, key: key, remainingDepth: remainingDepth, pool: pool);
-                            itemData += ObjectStructSize;
+                            return ddwafObjectStruct;
                         }
+
+                        *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, null, val);
+                        itemData += ObjectStructSize;
+                        idx++;
                     }
+
+                    ddwafObjectStruct.Array = childrenData;
+                    ddwafObjectStruct.NbEntries = (ulong)childrenCount;
+                    context.Buffers.Add(childrenData);
+                }
+            }
+
+            return ddwafObjectStruct;
+        }
+
+        private static unsafe DdwafObjectStruct ProcessKeyValuePairs<TKey, TValue>(ref EncoderContext context, int remainingDepth, string? key, IEnumerable<KeyValuePair<TKey, TValue>> enumerableDic, int count, delegate*<KeyValuePair<TKey, TValue>, string?> getKey, delegate*<KeyValuePair<TKey, TValue>, object?> getValue)
+            where TKey : notnull
+        {
+            var ddWafObjectMap = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP };
+            if (!string.IsNullOrEmpty(key))
+            {
+                var convertToUtf8 = ConvertToUtf8(ref context, key!, false);
+                ddWafObjectMap.ParameterName = convertToUtf8.Item1;
+                ddWafObjectMap.ParameterNameLength = (ulong)key!.Length;
+            }
+
+            if (context.ApplySafetyLimits)
+            {
+                if (remainingDepth-- <= 0)
+                {
+                    string GetItemsAsString()
+                    {
+                        var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+                        foreach (var x in enumerableDic)
+                        {
+                            sb.Append($"{getKey(x)}, {getValue(x)}, ");
+                        }
+
+                        if (sb.Length > 0)
+                        {
+                            sb.Remove(sb.Length - 2, 2);
+                        }
+
+                        return StringBuilderCache.GetStringAndRelease(sb);
+                    }
+
+                    Log.Warning("EncodeDictionary: object graph too deep, truncating nesting {Items}", GetItemsAsString());
+                    return ddWafObjectMap;
+                }
+
+                if (count > WafConstants.MaxContainerSize)
+                {
+                    Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                }
+            }
+
+            var childrenCount = !context.ApplySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
+            var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
+            var childrenData = childrenFromPool ? context.Pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
+
+            if (enumerableDic is IDictionary)
+            {
+                var typeKVP = typeof(KeyValuePair<TKey, TValue>);
+                if (typeKVP == typeof(KeyValuePair<string, string>))
+                {
+                    EnumerateIDictionaryItems<string, string>(ref context, remainingDepth);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, object>))
+                {
+                    EnumerateIDictionaryItems<string, object>(ref context, remainingDepth);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, string[]>))
+                {
+                    EnumerateIDictionaryItems<string, string[]>(ref context, remainingDepth);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, List<string>>))
+                {
+                    EnumerateIDictionaryItems<string, List<string>>(ref context, remainingDepth);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, JToken>))
+                {
+                    EnumerateIDictionaryItems<string, JToken>(ref context, remainingDepth);
                 }
                 else
                 {
-                    var itemData = childrenData;
-                    var maxChildrenCount = childrenCount;
+                    EnumerateIDictionaryItems<TKey, TValue>(ref context, remainingDepth);
+                }
 
+                [MethodImpl(MethodImplOptions.AggressiveInlining)]
+                void EnumerateIDictionaryItems<TKeySource, TValueSource>(ref EncoderContext context, int remainingDepth)
+                    where TKeySource : notnull
+                {
+                    var itemData = childrenData;
+                    var dic = (Dictionary<TKeySource, TValueSource>)enumerableDic;
+                    var maxChildrenCount = childrenCount;
                     for (var i = 0; i < maxChildrenCount; i++)
                     {
-                        var keyValue = enumerableDic.ElementAt(i);
+                        var originalKeyValue = dic.ElementAt(i);
+                        var keyValue = VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.As<KeyValuePair<TKeySource, TValueSource>, KeyValuePair<TKey, TValue>>(ref originalKeyValue);
                         var key = getKey(keyValue);
                         if (string.IsNullOrEmpty(key))
                         {
@@ -185,320 +400,74 @@ namespace Datadog.Trace.AppSec.WafEncoding
                             continue;
                         }
 
-                        *(DdwafObjectStruct*)itemData = Encode(getValue(keyValue), argToFree, applySafetyLimits: applySafetyLimits, key: key, remainingDepth: remainingDepth, pool: pool);
+                        *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, key, getValue(keyValue!));
                         itemData += ObjectStructSize;
                     }
                 }
-
-                ddWafObjectMap.Array = childrenData;
-                ddWafObjectMap.NbEntries = (ulong)childrenCount;
-                argToFree.Add(childrenData);
-                return ddWafObjectMap;
             }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            Tuple<IntPtr, int> ConvertToUtf8(string s, bool applySafety)
+            else
             {
-                IntPtr unmanagedMemory;
-                int writtenBytes;
-                var length = s.Length;
-                if (applySafety || length <= WafConstants.MaxStringLength)
-                {
-                    length = Math.Min(length, WafConstants.MaxStringLength);
-                    unmanagedMemory = pool.Rent();
-                    fixed (char* chrPtr = s)
-                    {
-                        writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, MaxBytesForMaxStringLength);
-                    }
-                }
-                else
-                {
-                    var bytesCount = System.Text.Encoding.UTF8.GetMaxByteCount(length) + 1;
-                    unmanagedMemory = Marshal.AllocCoTaskMem(bytesCount);
-                    fixed (char* chrPtr = s)
-                    {
-                        writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, bytesCount);
-                    }
-                }
+                var itemData = childrenData;
+                var maxChildrenCount = childrenCount;
 
-                Marshal.WriteByte(unmanagedMemory, writtenBytes, (byte)'\0');
-                argToFree.Add(unmanagedMemory);
-                return new Tuple<IntPtr, int>(unmanagedMemory, length);
+                for (var i = 0; i < maxChildrenCount; i++)
+                {
+                    var element = enumerableDic.ElementAt(i);
+                    var elementKey = getKey(element);
+                    if (string.IsNullOrEmpty(elementKey))
+                    {
+                        childrenCount--;
+                        Log.Warning("EncodeDictionary: ignoring dictionary member with null name");
+                        continue;
+                    }
+
+                    *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, elementKey, getValue(element));
+                    itemData += ObjectStructSize;
+                }
             }
 
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            DdwafObjectStruct GetStringObject(string value)
+            ddWafObjectMap.Array = childrenData;
+            ddWafObjectMap.NbEntries = (ulong)childrenCount;
+            context.Buffers.Add(childrenData);
+            return ddWafObjectMap;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Tuple<IntPtr, int> ConvertToUtf8(ref EncoderContext context, string s, bool applySafety)
+        {
+            IntPtr unmanagedMemory;
+            int writtenBytes;
+            var length = s.Length;
+            if (applySafety || length <= WafConstants.MaxStringLength)
             {
-                var convertToUtf8 = ConvertToUtf8(value, applySafetyLimits);
-                var ddWafObject = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_STRING, Array = convertToUtf8.Item1, NbEntries = (ulong)convertToUtf8.Item2 };
-                return ddWafObject;
+                length = Math.Min(length, WafConstants.MaxStringLength);
+                unmanagedMemory = context.Pool.Rent();
+                fixed (char* chrPtr = s)
+                {
+                    writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, MaxBytesForMaxStringLength);
+                }
             }
-
-            DdwafObjectStruct ddwafObjectStruct;
-
-            switch (o)
+            else
             {
-                case string str:
+                var bytesCount = System.Text.Encoding.UTF8.GetMaxByteCount(length) + 1;
+                unmanagedMemory = Marshal.AllocCoTaskMem(bytesCount);
+                fixed (char* chrPtr = s)
                 {
-                    ddwafObjectStruct = GetStringObject(str);
-                    break;
+                    writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, bytesCount);
                 }
-
-                case JValue:
-                {
-                    ddwafObjectStruct = GetStringObject(o?.ToString() ?? string.Empty);
-                    break;
-                }
-
-                case null:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_NULL };
-                    break;
-                }
-
-                case ulong u:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED, UintValue = u };
-                    break;
-                }
-
-                case uint u:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED, UintValue = u };
-                    break;
-                }
-
-                case int i:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED, IntValue = i };
-                    break;
-                }
-
-                case long u:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED, IntValue = u };
-                    break;
-                }
-
-                case decimal d:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = (double)d };
-                    break;
-                }
-
-                case double d:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = d };
-                    break;
-                }
-
-                case float d:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = d };
-                    break;
-                }
-
-                case bool b:
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_BOOL, ByteValue = b ? (byte)1 : (byte)0 };
-                    break;
-
-                case IEnumerable<KeyValuePair<string, object>> objDict:
-                {
-                    var collectionDict = objDict as ICollection<KeyValuePair<string, object>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey1, &GetValue1);
-                    static string GetKey1(KeyValuePair<string, object> item) => item.Key;
-                    static object GetValue1(KeyValuePair<string, object> item) => item.Value;
-                    break;
-                }
-
-                case IEnumerable<KeyValuePair<string, bool>> objDict:
-                {
-                    var collectionDict = objDict as ICollection<KeyValuePair<string, bool>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey1, &GetValue1);
-                    static string GetKey1(KeyValuePair<string, bool> item) => item.Key;
-                    static object GetValue1(KeyValuePair<string, bool> item) => item.Value;
-                    break;
-                }
-
-                case IEnumerable<KeyValuePair<string, string>> objDict:
-                {
-                    var collectionDict = objDict as ICollection<KeyValuePair<string, string>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey2, &GetValue2);
-                    static string GetKey2(KeyValuePair<string, string> item) => item.Key;
-                    static object GetValue2(KeyValuePair<string, string> item) => item.Value;
-                    break;
-                }
-
-                case IEnumerable<KeyValuePair<string, JToken>> objDict:
-                {
-                    var collectionDict = objDict as ICollection<KeyValuePair<string, JToken>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey3, &GetValue3);
-                    static string GetKey3(KeyValuePair<string, JToken> item) => item.Key;
-                    static object GetValue3(KeyValuePair<string, JToken> item) => item.Value;
-                    break;
-                }
-
-                case IEnumerable<KeyValuePair<string, string[]>> objDict:
-                {
-                    var collectionDict = objDict as ICollection<KeyValuePair<string, string[]>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey4, &GetValue4);
-                    static string GetKey4(KeyValuePair<string, string[]> item) => item.Key;
-                    static object GetValue4(KeyValuePair<string, string[]> item) => item.Value;
-                    break;
-                }
-
-                case IEnumerable<KeyValuePair<string, List<string>>> objDict:
-                {
-                    var collectionDict = objDict as ICollection<KeyValuePair<string, List<string>>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey5, &GetValue5);
-                    static string GetKey5(KeyValuePair<string, List<string>> item) => item.Key;
-                    static object GetValue5(KeyValuePair<string, List<string>> item) => item.Value;
-                    break;
-                }
-
-                case IEnumerable enumerable:
-                {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_ARRAY };
-
-                    if (applySafetyLimits && remainingDepth-- <= 0)
-                    {
-                        Log.Warning("EncodeList: object graph too deep, truncating nesting {Items}", string.Join(", ", enumerable));
-                        break;
-                    }
-
-                    if (enumerable is IList { Count: var count } listInstance)
-                    {
-                        if (applySafetyLimits && count > WafConstants.MaxContainerSize)
-                        {
-                            Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
-                        }
-
-                        var childrenCount = !applySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
-                        var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
-                        var childrenData = childrenFromPool ? pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
-
-                        // Avoid boxing of known values types from the switch above
-                        switch (listInstance)
-                        {
-                            case IList<bool> boolCollection:
-                                EnumerateAndEncode(boolCollection);
-                                break;
-                            case IList<decimal> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<double> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<float> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<int> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<uint> uintCollection:
-                                EnumerateAndEncode(uintCollection);
-                                break;
-                            case IList<long> longCollection:
-                                EnumerateAndEncode(longCollection);
-                                break;
-                            case IList<ulong> ulongCollection:
-                                EnumerateAndEncode(ulongCollection);
-                                break;
-                            default:
-                                EnumerateAndEncodeIList(listInstance);
-                                break;
-                        }
-
-                        ddwafObjectStruct.Array = childrenData;
-                        ddwafObjectStruct.NbEntries = (ulong)childrenCount;
-                        argToFree.Add(childrenData);
-
-                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                        void EnumerateAndEncode<T>(IList<T> lstInstance)
-                        {
-                            var itemData = childrenData;
-                            for (var idx = 0; idx < childrenCount; idx++)
-                            {
-                                *(DdwafObjectStruct*)itemData = Encode(lstInstance[idx], argToFree, applySafetyLimits: applySafetyLimits, remainingDepth: remainingDepth, pool: pool);
-                                itemData += ObjectStructSize;
-                            }
-                        }
-
-                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                        void EnumerateAndEncodeIList(IList lstInstance)
-                        {
-                            var itemData = childrenData;
-                            for (var idx = 0; idx < childrenCount; idx++)
-                            {
-                                *(DdwafObjectStruct*)itemData = Encode(lstInstance[idx], argToFree, applySafetyLimits: applySafetyLimits, remainingDepth: remainingDepth, pool: pool);
-                                itemData += ObjectStructSize;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        var childrenCount = 0;
-                        // Let's enumerate first.
-                        foreach (var val in enumerable)
-                        {
-                            childrenCount++;
-                            if (applySafetyLimits && childrenCount == WafConstants.MaxContainerSize)
-                            {
-                                Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
-                                break;
-                            }
-                        }
-
-                        if (childrenCount > 0)
-                        {
-                            var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
-                            var childrenData = childrenFromPool ? pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
-                            var itemData = childrenData;
-                            var idx = 0;
-                            foreach (var val in enumerable)
-                            {
-                                if (idx > childrenCount)
-                                {
-                                    break;
-                                }
-
-                                *(DdwafObjectStruct*)itemData = Encode(val, argToFree, applySafetyLimits: applySafetyLimits, remainingDepth: remainingDepth, pool: pool);
-                                itemData += ObjectStructSize;
-                                idx++;
-                            }
-
-                            ddwafObjectStruct.Array = childrenData;
-                            ddwafObjectStruct.NbEntries = (ulong)childrenCount;
-                            argToFree.Add(childrenData);
-                        }
-                    }
-
-                    break;
-                }
-
-                default:
-                    if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
-                    {
-                        Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
-                    }
-
-                    ddwafObjectStruct = GetStringObject(string.Empty);
-                    break;
             }
 
-            if (!string.IsNullOrEmpty(key))
-            {
-                ddwafObjectStruct.ParameterName = ConvertToUtf8(key!, false).Item1;
-                ddwafObjectStruct.ParameterNameLength = (ulong)key!.Length;
-            }
+            Marshal.WriteByte(unmanagedMemory, writtenBytes, (byte)'\0');
+            context.Buffers.Add(unmanagedMemory);
+            return new Tuple<IntPtr, int>(unmanagedMemory, length);
+        }
 
-            return ddwafObjectStruct;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe DdwafObjectStruct GetStringObject(ref EncoderContext context, string value)
+        {
+            var convertToUtf8 = ConvertToUtf8(ref context, value, context.ApplySafetyLimits);
+            var ddWafObject = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_STRING, Array = convertToUtf8.Item1, NbEntries = (ulong)convertToUtf8.Item2 };
+            return ddWafObject;
         }
 
         private static void FormatArgsInternal(object o, StringBuilder sb)
@@ -607,6 +576,13 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
             sb.Append(" ]");
             return sb;
+        }
+
+        private struct EncoderContext
+        {
+            public bool ApplySafetyLimits;
+            public UnmanagedMemoryPool Pool;
+            public List<IntPtr> Buffers;
         }
 
         public class EncodeResult : IEncodeResult

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/FuzzEncoder.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/FuzzEncoder.cs
@@ -37,7 +37,7 @@ public class FuzzEncoder : WafLibraryRequiredTest
     [Fact]
     public void LetsFuzz()
     {
-        // if we don't throw any exceptions and generate a valid object the the test is successful
+        // if we don't throw any exceptions and generate a valid object then the test is successful
 
         var jsonGenerator = new JsonGenerator();
 


### PR DESCRIPTION
## Summary of changes
Externalized all embedded functions in `Encoder`

## Reason for change
`Encoder` code was a bit difficult to read due to the long embedded functions it contained.

## Implementation details
Created a `EncoderContext `struct passed by ref to all calls.
Externalized all embedded functions passing previously captured data as arguments

