### PR TITLE
[Tracing] Support configuring `DD_TRACE_ENABLED` remotely

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
@@ -17,6 +17,7 @@ namespace Datadog.Trace.Configuration.ConfigurationSources
     {
         private static readonly IReadOnlyDictionary<string, string> Mapping = new Dictionary<string, string>
         {
+            { ConfigurationKeys.TraceEnabled, "tracing_enabled" },
             // { ConfigurationKeys.DebugEnabled, "tracing_debug" },
             // { ConfigurationKeys.RuntimeMetricsEnabled, "runtime_metrics_enabled" },
             { ConfigurationKeys.HeaderTags, "tracing_header_tags" },

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -72,6 +72,7 @@ namespace Datadog.Trace.Configuration
 
             var dynamicSettings = new ImmutableDynamicSettings
             {
+                TraceEnabled = settings.WithKeys(ConfigurationKeys.TraceEnabled).AsBool(),
                 // RuntimeMetricsEnabled = settings.WithKeys(ConfigurationKeys.RuntimeMetricsEnabled).AsBool(),
                 // DataStreamsMonitoringEnabled = settings.WithKeys(ConfigurationKeys.DataStreamsMonitoring.Enabled).AsBool(),
                 // CustomSamplingRules = settings.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString(),

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -45,6 +45,7 @@ namespace Datadog.Trace.Configuration
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingHttpHeaderTags, true);
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingLogsInjection, true);
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingSampleRate, true);
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingEnabled, true);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Configuration
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingHttpHeaderTags, true);
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingLogsInjection, true);
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingSampleRate, true);
-                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingEnabled, true);
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingTracingEnabled, true);
             }
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
@@ -12,6 +12,8 @@ namespace Datadog.Trace.Configuration
 {
     internal class ImmutableDynamicSettings : IEquatable<ImmutableDynamicSettings>
     {
+        public bool? TraceEnabled { get; init; }
+
         public bool? RuntimeMetricsEnabled { get; init; }
 
         public bool? DataStreamsMonitoringEnabled { get; init; }
@@ -41,7 +43,8 @@ namespace Datadog.Trace.Configuration
             }
 
             return
-                RuntimeMetricsEnabled == other.RuntimeMetricsEnabled
+                TraceEnabled == other.TraceEnabled
+             && RuntimeMetricsEnabled == other.RuntimeMetricsEnabled
              && DataStreamsMonitoringEnabled == other.DataStreamsMonitoringEnabled
              && Nullable.Equals(GlobalSamplingRate, other.GlobalSamplingRate)
              && SpanSamplingRules == other.SpanSamplingRules
@@ -73,7 +76,13 @@ namespace Datadog.Trace.Configuration
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(RuntimeMetricsEnabled, DataStreamsMonitoringEnabled, GlobalSamplingRate, SpanSamplingRules, LogsInjectionEnabled);
+            return HashCode.Combine(
+                TraceEnabled,
+                RuntimeMetricsEnabled,
+                DataStreamsMonitoringEnabled,
+                GlobalSamplingRate,
+                SpanSamplingRules,
+                LogsInjectionEnabled);
         }
 
         private static bool AreEqual(IReadOnlyDictionary<string, string>? dictionary1, IReadOnlyDictionary<string, string>? dictionary2)

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -243,7 +243,7 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets a value indicating whether we should tag every telemetry event with git metadata.
-        /// Defaul value is true (enabled).
+        /// Default value is true (enabled).
         /// </summary>
         /// <seealso cref="ConfigurationKeys.GitMetadataEnabled"/>
         internal bool GitMetadataEnabled { get; }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -28,6 +28,7 @@ namespace Datadog.Trace.Configuration
     /// </summary>
     public partial record ImmutableTracerSettings
     {
+        private readonly bool _traceEnabled;
         private readonly DomainMetadata _domainMetadata;
         private readonly bool _isDataStreamsMonitoringEnabled;
         private readonly bool _logsInjectionEnabled;
@@ -90,7 +91,7 @@ namespace Datadog.Trace.Configuration
 
             GitMetadataEnabled = settings.GitMetadataEnabled;
             ServiceNameInternal = settings.ServiceNameInternal;
-            TraceEnabledInternal = settings.TraceEnabledInternal;
+            _traceEnabled = settings.TraceEnabledInternal;
             ExporterInternal = new ImmutableExporterSettings(settings.ExporterInternal, true);
 #pragma warning disable 618 // App analytics is deprecated, but still used
             AnalyticsEnabledInternal = settings.AnalyticsEnabledInternal;
@@ -253,7 +254,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.TraceEnabled"/>
         [GeneratePublicApi(PublicApiUsage.ImmutableTracerSettings_TraceEnabled_Get)]
-        internal bool TraceEnabledInternal { get; }
+        internal bool TraceEnabledInternal => DynamicSettings.TraceEnabled ?? _traceEnabled;
 
         /// <summary>
         /// Gets the exporter settings that dictate how the tracer exports data.

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
@@ -45,6 +45,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public static readonly BigInteger AsmCustomDataScanners = Create(17);
 
+        public static readonly BigInteger AsmExclusionData = Create(18);
+
         public static readonly BigInteger ApmTracingEnabled = Create(19);
 
         private static BigInteger Create(int index) => new(1UL << index);

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
@@ -45,6 +45,8 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public static readonly BigInteger AsmCustomDataScanners = Create(17);
 
+        public static readonly BigInteger ApmTracingEnabled = Create(19);
+
         private static BigInteger Create(int index) => new(1UL << index);
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public static readonly BigInteger AsmExclusionData = Create(18);
 
-        public static readonly BigInteger ApmTracingEnabled = Create(19);
+        public static readonly BigInteger ApmTracingTracingEnabled = Create(19);
 
         private static BigInteger Create(int index) => new(1UL << index);
     }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Tests.Configuration
 
             TracerManager.Instance.DirectLogSubmission.Formatter.Tags.Should().Be("key1:value1");
 
-            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_tags", "['key2:value2']")));
+            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_tags", "[\"key2:value2\"]")));
 
             TracerManager.Instance.DirectLogSubmission.Formatter.Tags.Should().Be("key2:value2");
         }
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Tests.Configuration
 
             TracerManager.Instance.DirectLogSubmission.Formatter.Tags.Should().Be("key1:value1");
 
-            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_tags", "['key3:value3']")));
+            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_tags", "[\"key3:value3\"]")));
 
             TracerManager.Instance.DirectLogSubmission.Formatter.Tags.Should().Be("key1:value1");
         }
@@ -110,15 +110,15 @@ namespace Datadog.Trace.Tests.Configuration
             var jsonBuilder = new StringBuilder();
 
             jsonBuilder.AppendLine("{");
-            jsonBuilder.AppendLine("\"lib_config\":");
-            jsonBuilder.AppendLine("{");
+            jsonBuilder.AppendLine("    \"lib_config\":");
+            jsonBuilder.AppendLine("    {");
 
             foreach (var (key, value) in settings)
             {
-                jsonBuilder.AppendLine($"\"{key}\": \"{value}\",");
+                jsonBuilder.AppendLine($"        \"{key}\": {value},");
             }
 
-            jsonBuilder.AppendLine("}");
+            jsonBuilder.AppendLine("    }");
             jsonBuilder.AppendLine("}");
 
             var configurationSource = new DynamicConfigConfigurationSource(jsonBuilder.ToString(), ConfigurationOrigins.RemoteConfig);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -93,11 +93,14 @@ namespace Datadog.Trace.Tests.Configuration
             var tracerSettings = new TracerSettings();
             TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings), TracerManagerFactory.Instance);
 
+            // tracing is enabled by default
             TracerManager.Instance.Settings.TraceEnabled.Should().BeTrue();
 
+            // disable "remotely"
             DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_enabled", "false")));
             TracerManager.Instance.Settings.TraceEnabled.Should().BeFalse();
 
+            // re-enable "remotely"
             DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_enabled", "true")));
             TracerManager.Instance.Settings.TraceEnabled.Should().BeTrue();
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -87,25 +87,38 @@ namespace Datadog.Trace.Tests.Configuration
             TracerManager.Instance.DirectLogSubmission.Formatter.Tags.Should().Be("key1:value1");
         }
 
+        [Fact]
+        public void EnableTracing()
+        {
+            var tracerSettings = new TracerSettings();
+            TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings), TracerManagerFactory.Instance);
+
+            TracerManager.Instance.Settings.TraceEnabled.Should().BeTrue();
+
+            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_enabled", "false")));
+            TracerManager.Instance.Settings.TraceEnabled.Should().BeFalse();
+
+            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_enabled", "true")));
+            TracerManager.Instance.Settings.TraceEnabled.Should().BeTrue();
+        }
+
         private static ConfigurationBuilder CreateConfig(params (string Key, string Value)[] settings)
         {
             var jsonBuilder = new StringBuilder();
 
             jsonBuilder.AppendLine("{");
-
-            jsonBuilder.AppendLine("'lib_config':");
-
+            jsonBuilder.AppendLine("\"lib_config\":");
             jsonBuilder.AppendLine("{");
+
             foreach (var (key, value) in settings)
             {
-                jsonBuilder.AppendLine($"\"{key}\": {value},");
+                jsonBuilder.AppendLine($"\"{key}\": \"{value}\",");
             }
 
             jsonBuilder.AppendLine("}");
             jsonBuilder.AppendLine("}");
 
             var configurationSource = new DynamicConfigConfigurationSource(jsonBuilder.ToString(), ConfigurationOrigins.RemoteConfig);
-
             return new ConfigurationBuilder(configurationSource, Mock.Of<IConfigurationTelemetry>());
         }
     }


### PR DESCRIPTION
## Summary of changes

Allow users to remotely disable tracing through the Datadog UI (aka "remote disablement").

## Reason for change

New feature across all tracing libraries to improve onboarding experience.

## Implementation details

Map the RCM setting to `DD_TRACE_ENABLE`, which all (probably all) instrumentations already check via `TracerSettings.TraceEnabled`.

## Test coverage

- Tested manually.
- Added `DD_TRACE_ENABLE` to existing unit and integration tests.
- Covered by existing shared tests. See https://github.com/DataDog/system-tests/pull/2039 and https://github.com/DataDog/system-tests/pull/2131.

## Other details
[AIT-9648](https://datadoghq.atlassian.net/browse/AIT-9648)


[AIT-9648]: https://datadoghq.atlassian.net/browse/AIT-9648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ