### PR TITLE
[Build] Fix dd-trace-dotnet:latest_snapshot image for system-tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3753,7 +3753,7 @@ stages:
 
 # Only run these on merges to master etc
 - stage: upload_container_images
-  condition: and(succeeded(), eq(variables.isMainRepository, true))
+  condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true), eq(variables.isMainOrReleaseBranch, true))
   dependsOn: [upload_to_azure]
   jobs:
     - job: upload

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3753,7 +3753,7 @@ stages:
 
 # Only run these on merges to master etc
 - stage: upload_container_images
-  condition: and(succeeded(), eq(variables['Build.Reason'], 'IndividualCI'), eq(variables.isMainRepository, true), eq(variables.isMainOrReleaseBranch, true))
+  condition: and(succeeded(), eq(variables.isMainRepository, true))
   dependsOn: [upload_to_azure]
   jobs:
     - job: upload

--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -47,7 +47,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot_test
+        tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot
         platforms: 'linux/amd64,linux/arm64'
         context: ${{inputs.artifacts_path}}
         file: ${{inputs.artifacts_path}}/system-tests.dockerfile

--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -47,7 +47,7 @@ runs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot
+        tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot_test
         platforms: 'linux/amd64,linux/arm64'
         context: ${{inputs.artifacts_path}}
         file: ${{inputs.artifacts_path}}/system-tests.dockerfile

--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -22,14 +22,6 @@ inputs:
     description: 'Github token for pushing images to ghcr.io Docker repository'
     required: true
 
-  architecture:
-    description: 'The architecture of the image being built'
-    required: true
-
-  architecture_tag:
-    description: 'The tag for the architecture of the image being built'
-    required: true
-
 runs:
   using: "composite"
   steps:
@@ -56,11 +48,11 @@ runs:
       with:
         push: true
         tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot
-        platforms: linux/${{inputs.architecture}}
+        platforms: 'linux/amd64' 
         context: ${{inputs.artifacts_path}}
         file: ${{inputs.artifacts_path}}/system-tests.dockerfile
         build-args: |
-          LINUX_PACKAGE=datadog-dotnet-apm-${{inputs.package_version}}${{inputs.architecture_tag}}.tar.gz
+          LINUX_PACKAGE=datadog-dotnet-apm-${{inputs.package_version}}.tar.gz
           LIBRARY_VERSION=${{inputs.package_version}}
           LIBDDWAF_VERSION=${{inputs.lib_waf_version}}
           APPSEC_EVENT_RULES_VERSION=${{inputs.waf_rules_version}}

--- a/.github/actions/create-system-test-docker-base-images/action.yml
+++ b/.github/actions/create-system-test-docker-base-images/action.yml
@@ -43,16 +43,17 @@ runs:
       shell: bash
       run: docker login -u publisher -p ${{ inputs.github_token }} ghcr.io
 
-    - name: Docker Build linux-x64 image
+    - name: Docker Build linux-x64 and linux-arm64 images
       uses: docker/build-push-action@v3
       with:
         push: true
         tags: ghcr.io/datadog/dd-trace-dotnet/dd-trace-dotnet:latest_snapshot
-        platforms: 'linux/amd64' 
+        platforms: 'linux/amd64,linux/arm64'
         context: ${{inputs.artifacts_path}}
         file: ${{inputs.artifacts_path}}/system-tests.dockerfile
         build-args: |
-          LINUX_PACKAGE=datadog-dotnet-apm-${{inputs.package_version}}.tar.gz
+          LINUX_AMD64_PACKAGE=datadog-dotnet-apm-${{inputs.package_version}}.tar.gz
+          LINUX_ARM64_PACKAGE=datadog-dotnet-apm-${{inputs.package_version}}.arm64.tar.gz
           LIBRARY_VERSION=${{inputs.package_version}}
           LIBDDWAF_VERSION=${{inputs.lib_waf_version}}
           APPSEC_EVENT_RULES_VERSION=${{inputs.waf_rules_version}}

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -42,23 +42,10 @@ jobs:
         AzureDevopsBuildId: "${{ github.event.inputs.azdo_build_id }}"
 
     - uses: ./.github/actions/create-system-test-docker-base-images
-      name: 'Create system test docker images x64 (amd64)'
+      name: 'Create system test docker images'
       with:
         artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
         package_version: "${{steps.versions.outputs.version}}"
         lib_waf_version: "${{steps.versions.outputs.lib_waf_version}}"
         waf_rules_version: "${{steps.versions.outputs.waf_rules_version}}"
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        architecture: 'amd64'
-        architecture_tag: '' # No tag is needed for x64 (it will keep the unnamed tar.gz)
-
-    - uses: ./.github/actions/create-system-test-docker-base-images
-      name: 'Create system test docker images arm64'
-      with:
-        artifacts_path: "${{steps.assets.outputs.artifacts_path}}"
-        package_version: "${{steps.versions.outputs.version}}"
-        lib_waf_version: "${{steps.versions.outputs.lib_waf_version}}"
-        waf_rules_version: "${{steps.versions.outputs.waf_rules_version}}"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        architecture: 'arm64'
-        architecture_tag: '.arm64' # Correctly select the arm64 tag.gz file

--- a/tracer/build/_build/docker/system-tests.dockerfile
+++ b/tracer/build/_build/docker/system-tests.dockerfile
@@ -1,14 +1,19 @@
 FROM busybox as collect
-ARG LINUX_PACKAGE
+ARG LINUX_AMD64_PACKAGE
+ARG LINUX_ARM64_PACKAGE
 ARG LIBRARY_VERSION
 ARG APPSEC_EVENT_RULES_VERSION
 ARG LIBDDWAF_VERSION
+ARG TARGETARCH
 
 RUN mkdir /binaries \
   && echo ${LIBRARY_VERSION} | cat > /binaries/LIBRARY_VERSION \
   && echo ${LIBDDWAF_VERSION} | cat > /binaries/LIBDDWAF_VERSION \
   && echo ${APPSEC_EVENT_RULES_VERSION} | cat > /binaries/APPSEC_EVENT_RULES_VERSION
-COPY ${LINUX_PACKAGE} /binaries/datadog-dotnet-apm.tar.gz
+COPY ${LINUX_AMD64_PACKAGE} /binaries/amd64/datadog-dotnet-apm.tar.gz
+COPY ${LINUX_ARM64_PACKAGE} /binaries/arm64/datadog-dotnet-apm.tar.gz
+RUN echo "TARGETARCH=${TARGETARCH}"
+RUN if [[ "${TARGETARCH}" == "amd64" ]] ; then mv /binaries/amd64/datadog-dotnet-apm.tar.gz /binaries/datadog-dotnet-apm.tar.gz ; else mv /binaries/arm64/datadog-dotnet-apm.tar.gz /binaries/datadog-dotnet-apm.tar.gz ; fi
 
 FROM scratch
 COPY --from=collect /binaries/* /


### PR DESCRIPTION
## Summary of changes
Combines the build of the `latest_snapshot` tag into one `docker buildx build` command so that the published image is a multi-platform image with platforms `linux/amd64,linux/arm64`

## Reason for change
The `dev` system-tests are currently broken as the current `latest_snapshot` tag only has an arm64 image. The arm64 image was added in https://github.com/DataDog/dd-trace-dotnet/pull/5170 by adding another `docker buildx build --push` command to publish an arm64 image with the `latest_snapshot` tag, however the subsequent command overwrote the manifest so the `latest_snapshot` tag only pointed to arm64 image. This then caused issues when the `latest_snapshot` image was pulled down and its files extracted because it was assumed to be a multi-platform image when it was actually only the arm64 image.

## Implementation details
Removes the `LINUX_PACKAGE` dockerfile build arg and replaces it with the build args `LINUX_AMD64_PACKAGE` and `LINUX_ARM64_PACKAGE` so that we can run one `docker buildx build` command to generate the multi-platform image for x64 and arm64.

## Test coverage
See the test output: https://github.com/datadog/dd-trace-dotnet/pkgs/container/dd-trace-dotnet%2Fdd-trace-dotnet/178002555?tag=latest_snapshot_test

I also confirmed manually by pulling down the resulting images and extracting the layers to verify that the linux/amd64 image has the linux-x64 tracer binaries and the linux/arm64 image has the linux-arm64 tracer binaries.

## Other details
N/A