### PR TITLE
[v3] Update manual throughput tests 

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3815,12 +3815,20 @@ stages:
         artifact: linux-monitoring-home-linux-x64
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
 
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Datadog.Trace.Manual
+      inputs:
+        artifact: build-windows-working-directory
+        itemPattern: tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll
+        path: $(Agent.TempDirectory)
+
     - script: |
+        mkdir -p tracer/bin/netcoreapp3.1
+        cp $(Agent.TempDirectory)/tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll tracer/bin/netcoreapp3.1/
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-        mkdir -p tracer/bin/netcoreapp3.1
-        cp tracer/tracer-home-linux/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll 
+        test ! -s "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll" && echo "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll does not exist" && exit 1
         mkdir -p $(CrankDir)/results/logs
         cd $(CrankDir)
         chmod +x ./run.sh
@@ -3860,12 +3868,20 @@ stages:
         artifact: windows-tracer-home
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-win
 
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Datadog.Trace.Manual
+      inputs:
+        artifact: build-windows-working-directory
+        itemPattern: tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll
+        path: $(Agent.TempDirectory)
+
     - script: |
+        mkdir -p tracer/bin/netcoreapp3.1
+        cp $(Agent.TempDirectory)/tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll tracer/bin/netcoreapp3.1/
         test ! -s "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Trace.ClrProfiler.Native.dll (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll" && echo "tracer/tracer-home-win/win-x64/Datadog.Tracer.Native.dll does not exist" && exit 1
         test ! -s "tracer/tracer-home-win/win-x64/ddwaf.dll" && echo "tracer/tracer-home-win/win-x64/ddwaf.dll does not exist" && exit 1
-        mkdir -p tracer/bin/netcoreapp3.1
-        cp tracer/tracer-home-win/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll
+        test ! -s "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll" && echo "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll does not exist" && exit 1
         mkdir -p $(CrankDir)/results/logs
         cd $(CrankDir)
         chmod +x ./run.sh
@@ -3904,12 +3920,20 @@ stages:
         artifact: linux-monitoring-home-linux-arm64
         path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux-arm64
 
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Datadog.Trace.Manual
+      inputs:
+        artifact: build-windows-working-directory
+        itemPattern: tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll
+        path: $(Agent.TempDirectory)
+
     - script: |
+        mkdir -p tracer/bin/netcoreapp3.1
+        cp $(Agent.TempDirectory)/tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll tracer/bin/netcoreapp3.1/
         test ! -s "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux-arm64/linux-arm64/Datadog.Tracer.Native.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux-arm64/linux-arm64/libddwaf.so" && echo "tracer/tracer-home-linux-arm64/linux-arm64/libddwaf.so does not exist" && exit 1
-        mkdir -p tracer/bin/netcoreapp3.1
-        cp tracer/tracer-home-linux-arm64/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll
+        test ! -s "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll" && echo "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll does not exist" && exit 1
         mkdir -p $(CrankDir)/results
         cd $(System.DefaultWorkingDirectory)/tracer/build/crank
         chmod +x ./run.sh
@@ -3956,10 +3980,20 @@ stages:
           artifact: linux-monitoring-home-linux-x64
           path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
 
+      - task: DownloadPipelineArtifact@2
+        displayName: Download Datadog.Trace.Manual
+        inputs:
+          artifact: build-windows-working-directory
+          itemPattern: tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll
+          path: $(Agent.TempDirectory)
+
       - script: |
+          mkdir -p tracer/bin/netcoreapp3.1
+          cp $(Agent.TempDirectory)/tracer/src/Datadog.Trace.Manual/bin/Release/netcoreapp3.1/Datadog.Trace.Manual.dll tracer/bin/netcoreapp3.1/
           test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
           test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
           test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
+          test ! -s "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll" && echo "tracer/bin/netcoreapp3.1/Datadog.Trace.Manual.dll does not exist" && exit 1
           mkdir -p $(CrankDir)/results/logs
           cd $(CrankDir)
           chmod +x ./run-appsec.sh

--- a/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
+++ b/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
@@ -107,6 +107,7 @@ public class CompareThroughput
     {
         CrankScenario.Baseline => "Baseline",
         CrankScenario.AutomaticInstrumentation => "Automatic",
+        CrankScenario.ManualInstrumentation => "Manual",
         CrankScenario.ManualAndAutomaticInstrumentation => "Manual + Automatic",
         CrankScenario.TraceStats => "Trace stats",
         CrankScenario.NoAttack => "No attack",
@@ -126,6 +127,7 @@ public class CompareThroughput
                 ("baseline_linux.json", CrankScenario.Baseline),
                 ("calltarget_ngen_linux.json", CrankScenario.AutomaticInstrumentation),
                 ("trace_stats_linux.json", CrankScenario.TraceStats),
+                ("manual_only_linux.json", CrankScenario.ManualInstrumentation),
                 ("manual_and_automatic_linux.json", CrankScenario.ManualAndAutomaticInstrumentation),
             }
         ),
@@ -134,6 +136,7 @@ public class CompareThroughput
                 ("baseline_linux_arm64.json", CrankScenario.Baseline),
                 ("calltarget_ngen_linux_arm64.json", CrankScenario.AutomaticInstrumentation),
                 ("trace_stats_linux_arm64.json", CrankScenario.TraceStats),
+                ("manual_only_linux_arm64.json", CrankScenario.ManualInstrumentation),
                 ("manual_and_automatic_linux_arm64.json", CrankScenario.ManualAndAutomaticInstrumentation),
             }
         ),
@@ -142,6 +145,7 @@ public class CompareThroughput
                 ("baseline_windows.json", CrankScenario.Baseline),
                 ("calltarget_ngen_windows.json", CrankScenario.AutomaticInstrumentation),
                 ("trace_stats_windows.json", CrankScenario.TraceStats),
+                ("manual_only_windows.json", CrankScenario.ManualInstrumentation),
                 ("manual_and_automatic_windows.json", CrankScenario.ManualAndAutomaticInstrumentation),
             }
         ),
@@ -197,6 +201,7 @@ public class CompareThroughput
         Baseline,
         AutomaticInstrumentation,
         TraceStats,
+        ManualInstrumentation,
         ManualAndAutomaticInstrumentation,
         NoAttack,
         AttackNoBlocking,

--- a/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
+++ b/tracer/build/_build/ThroughputComparison/CompareThroughput.cs
@@ -78,7 +78,7 @@ public class CompareThroughput
     private static string GetCommentMarkdown(List<CrankResultSource> sources, IEnumerable<string> charts)
     {
         return $"""
-            ## Throughput/Crank Report:zap:
+            ## Throughput/Crank Report :zap:
 
             Throughput results for AspNetCoreSimpleController comparing the following branches/commits:
             {string.Join('\n', GetSourceMarkdown(sources))}
@@ -107,9 +107,7 @@ public class CompareThroughput
     {
         CrankScenario.Baseline => "Baseline",
         CrankScenario.AutomaticInstrumentation => "Automatic",
-        CrankScenario.ManualInstrumentation => "Manual",
         CrankScenario.ManualAndAutomaticInstrumentation => "Manual + Automatic",
-        CrankScenario.VersionConflict => "Version Conflict",
         CrankScenario.TraceStats => "Trace stats",
         CrankScenario.NoAttack => "No attack",
         CrankScenario.AttackNoBlocking => "Attack",
@@ -128,9 +126,7 @@ public class CompareThroughput
                 ("baseline_linux.json", CrankScenario.Baseline),
                 ("calltarget_ngen_linux.json", CrankScenario.AutomaticInstrumentation),
                 ("trace_stats_linux.json", CrankScenario.TraceStats),
-                ("manual_only_linux.json", CrankScenario.ManualInstrumentation),
                 ("manual_and_automatic_linux.json", CrankScenario.ManualAndAutomaticInstrumentation),
-                ("version_conflict_linux.json", CrankScenario.VersionConflict),
             }
         ),
         ("crank_linux_arm64_1", CrankTestSuite.LinuxArm64, new[]
@@ -138,9 +134,7 @@ public class CompareThroughput
                 ("baseline_linux_arm64.json", CrankScenario.Baseline),
                 ("calltarget_ngen_linux_arm64.json", CrankScenario.AutomaticInstrumentation),
                 ("trace_stats_linux_arm64.json", CrankScenario.TraceStats),
-                ("manual_only_linux_arm64.json", CrankScenario.ManualInstrumentation),
                 ("manual_and_automatic_linux_arm64.json", CrankScenario.ManualAndAutomaticInstrumentation),
-                ("version_conflict_linux_arm64.json", CrankScenario.VersionConflict),
             }
         ),
         ("crank_windows_x64_1", CrankTestSuite.WindowsX64, new[]
@@ -148,9 +142,7 @@ public class CompareThroughput
                 ("baseline_windows.json", CrankScenario.Baseline),
                 ("calltarget_ngen_windows.json", CrankScenario.AutomaticInstrumentation),
                 ("trace_stats_windows.json", CrankScenario.TraceStats),
-                ("manual_only_windows.json", CrankScenario.ManualInstrumentation),
                 ("manual_and_automatic_windows.json", CrankScenario.ManualAndAutomaticInstrumentation),
-                ("version_conflict_windows.json", CrankScenario.VersionConflict),
             }
         ),
         ("crank_linux_x64_asm_1", CrankTestSuite.ASMLinuxX64, new[]
@@ -205,9 +197,7 @@ public class CompareThroughput
         Baseline,
         AutomaticInstrumentation,
         TraceStats,
-        ManualInstrumentation,
         ManualAndAutomaticInstrumentation,
-        VersionConflict,
         NoAttack,
         AttackNoBlocking,
         AttackBlocking,

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -69,6 +69,30 @@ scenarios:
         serverPort: 5000
         path: /hello
 
+  manual_only:
+    application:
+      job: server
+      buildArguments: 
+      - "/p:MANUAL_INSTRUMENTATION=true"
+      - "/p:MANUAL_ONLY_INSTRUMENTATION=true"
+      environmentVariables:
+        COR_ENABLE_PROFILING: 0
+        CORECLR_ENABLE_PROFILING: 0
+      options:
+        buildFiles:
+        # Copy the dll to the project directory
+        - "../../bin/netcoreapp3.1/Datadog.Trace.Manual.dll"
+        outputFiles:
+        # Copy the dll to the publish directory
+        - "../../bin/netcoreapp3.1/Datadog.Trace.Manual.dll"
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello
+
   manual_and_automatic:
     application:
       job: server

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -69,29 +69,6 @@ scenarios:
         serverPort: 5000
         path: /hello
 
-  manual_only:
-    application:
-      job: server
-      buildArguments: 
-      - "/p:MANUAL_INSTRUMENTATION=true"
-      environmentVariables:
-        COR_ENABLE_PROFILING: 0
-        CORECLR_ENABLE_PROFILING: 0
-      options:
-        buildFiles:
-        # Copy the dll to the project directory
-        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
-        outputFiles:
-        # Copy the dll to the publish directory
-        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
-    load:
-      job: bombardier
-      variables:
-        warmup: 30
-        duration: 240
-        serverPort: 5000
-        path: /hello
-
   manual_and_automatic:
     application:
       job: server
@@ -103,27 +80,10 @@ scenarios:
       options:
         buildFiles:
         # Copy the dll to the project directory
-        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
+        - "../../bin/netcoreapp3.1/Datadog.Trace.Manual.dll"
         outputFiles:
         # Copy the dll to the publish directory
-        - "../../bin/netcoreapp3.1/Datadog.Trace.dll"
-    load:
-      job: bombardier
-      variables:
-        warmup: 30
-        duration: 240
-        serverPort: 5000
-        path: /hello
-
-  version_conflict:
-    application:
-      job: server
-      buildArguments: 
-      - "/p:MANUAL_INSTRUMENTATION=true"
-      - "/p:VERSION_MISMATCH=true"
-      environmentVariables:
-        COR_ENABLE_PROFILING: 1
-        CORECLR_ENABLE_PROFILING: 1
+        - "../../bin/netcoreapp3.1/Datadog.Trace.Manual.dll"
     load:
       job: bombardier
       variables:

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -32,9 +32,7 @@ if [ "$1" = "windows" ]; then
     rm -f baseline_windows.json
     rm -f calltarget_ngen_windows.json
     rm -f trace_stats_windows.json
-    rm -f manual_only_windows.json
     rm -f manual_and_automatic_windows.json
-    rm -f version_conflict_windows.json
     
     echo "Running windows throughput tests"
 
@@ -52,25 +50,15 @@ if [ "$1" = "windows" ]; then
 
     echo "Running manual instrumentation throughput tests"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile windows --json manual_only_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha 
-    dd-trace --crank-import="manual_only_windows.json"
-
     crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="manual_and_automatic_windows.json"
-
-    if [ "$2" = "True" ]; then
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile windows --json version_conflict_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-      dd-trace --crank-import="version_conflict_windows.json"
-    fi
 
 elif [ "$1" = "linux" ]; then
     echo "Cleaning previous results"
     rm -f baseline_linux.json
     rm -f calltarget_ngen_linux.json
     rm -f trace_stats_linux.json
-    rm -f manual_only_linux.json
     rm -f manual_and_automatic_linux.json
-    rm -f version_conflict_linux.json
 
     echo "Running Linux x64 throughput tests"
 
@@ -88,25 +76,15 @@ elif [ "$1" = "linux" ]; then
 
     echo "Running manual instrumentation throughput tests"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux --json manual_only_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_only_linux.json"
-
     crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="manual_and_automatic_linux.json"
-
-    if [ "$2" = "True" ]; then
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux --json version_conflict_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-      dd-trace --crank-import="version_conflict_linux.json"
-    fi
 
 elif [ "$1" = "linux_arm64" ]; then
     echo "Cleaning previous results"
     rm -f baseline_linux_arm64.json
     rm -f calltarget_ngen_linux_arm64.json
     rm -f trace_stats_linux_arm64.json
-    rm -f manual_only_linux_arm64.json
     rm -f manual_and_automatic_linux_arm64.json
-    rm -f version_conflict_linux_arm64.json
 
     echo "Running Linux arm64 throughput tests"
 
@@ -124,16 +102,9 @@ elif [ "$1" = "linux_arm64" ]; then
 
     echo "Running manual instrumentation throughput tests"
     
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux_arm64 --json manual_only_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_only_linux_arm64.json"
-
     crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="manual_and_automatic_linux_arm64.json"
 
-    if [ "$2" = "True" ]; then
-      crank --config Samples.AspNetCoreSimpleController.yml --scenario version_conflict --profile linux_arm64 --json version_conflict_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=version_conflict --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
-      dd-trace --crank-import="version_conflict_linux_arm64.json"
-    fi
 else
     echo "Unknown argument $1"
     exit 1

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -32,6 +32,7 @@ if [ "$1" = "windows" ]; then
     rm -f baseline_windows.json
     rm -f calltarget_ngen_windows.json
     rm -f trace_stats_windows.json
+    rm -f manual_only_windows.json
     rm -f manual_and_automatic_windows.json
     
     echo "Running windows throughput tests"
@@ -46,6 +47,11 @@ if [ "$1" = "windows" ]; then
       echo "Running throughput tests with stats enabled"
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile windows --json trace_stats_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_windows.json"
+      
+      echo "Running manual-only instrumentation throughput tests"
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile windows --json manual_only_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha 
+      dd-trace --crank-import="manual_only_windows.json"
+
     fi
 
     echo "Running manual instrumentation throughput tests"
@@ -58,6 +64,7 @@ elif [ "$1" = "linux" ]; then
     rm -f baseline_linux.json
     rm -f calltarget_ngen_linux.json
     rm -f trace_stats_linux.json
+    rm -f manual_only_linux.json
     rm -f manual_and_automatic_linux.json
 
     echo "Running Linux x64 throughput tests"
@@ -72,6 +79,11 @@ elif [ "$1" = "linux" ]; then
       echo "Running throughput tests with stats enabled"
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux --json trace_stats_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_linux.json"
+      
+      echo "Running manual-only instrumentation throughput tests"
+      crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux --json manual_only_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+      dd-trace --crank-import="manual_only_linux.json"
+
     fi
 
     echo "Running manual instrumentation throughput tests"
@@ -84,6 +96,7 @@ elif [ "$1" = "linux_arm64" ]; then
     rm -f baseline_linux_arm64.json
     rm -f calltarget_ngen_linux_arm64.json
     rm -f trace_stats_linux_arm64.json
+    rm -f manual_only_linux_arm64.json
     rm -f manual_and_automatic_linux_arm64.json
 
     echo "Running Linux arm64 throughput tests"
@@ -98,6 +111,11 @@ elif [ "$1" = "linux_arm64" ]; then
       echo "Running throughput tests with stats enabled"
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux_arm64 --json trace_stats_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_linux_arm64.json"
+      
+      echo "Running manual-only instrumentation throughput tests"
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_only --profile linux_arm64 --json manual_only_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_only --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_only_linux_arm64.json"
+
     fi
 
     echo "Running manual instrumentation throughput tests"

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -33,6 +33,11 @@ if [ "$1" = "windows" ]; then
     rm -f calltarget_ngen_windows.json
     rm -f trace_stats_windows.json
     rm -f manual_and_automatic_windows.json
+
+    echo "Running manual instrumentation throughput tests"
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_windows.json"
     
     echo "Running windows throughput tests"
 
@@ -48,17 +53,17 @@ if [ "$1" = "windows" ]; then
       dd-trace --crank-import="trace_stats_windows.json"
     fi
 
-    echo "Running manual instrumentation throughput tests"
-
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_and_automatic_windows.json"
-
 elif [ "$1" = "linux" ]; then
     echo "Cleaning previous results"
     rm -f baseline_linux.json
     rm -f calltarget_ngen_linux.json
     rm -f trace_stats_linux.json
     rm -f manual_and_automatic_linux.json
+
+    echo "Running manual instrumentation throughput tests"
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_linux.json"
 
     echo "Running Linux x64 throughput tests"
 
@@ -74,17 +79,17 @@ elif [ "$1" = "linux" ]; then
       dd-trace --crank-import="trace_stats_linux.json"
     fi
 
-    echo "Running manual instrumentation throughput tests"
-
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_and_automatic_linux.json"
-
 elif [ "$1" = "linux_arm64" ]; then
     echo "Cleaning previous results"
     rm -f baseline_linux_arm64.json
     rm -f calltarget_ngen_linux_arm64.json
     rm -f trace_stats_linux_arm64.json
     rm -f manual_and_automatic_linux_arm64.json
+
+    echo "Running manual instrumentation throughput tests"
+    
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_linux_arm64.json"
 
     echo "Running Linux arm64 throughput tests"
 
@@ -99,11 +104,6 @@ elif [ "$1" = "linux_arm64" ]; then
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux_arm64 --json trace_stats_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_linux_arm64.json"
     fi
-
-    echo "Running manual instrumentation throughput tests"
-    
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_and_automatic_linux_arm64.json"
 
 else
     echo "Unknown argument $1"

--- a/tracer/build/crank/run.sh
+++ b/tracer/build/crank/run.sh
@@ -33,11 +33,6 @@ if [ "$1" = "windows" ]; then
     rm -f calltarget_ngen_windows.json
     rm -f trace_stats_windows.json
     rm -f manual_and_automatic_windows.json
-
-    echo "Running manual instrumentation throughput tests"
-
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_and_automatic_windows.json"
     
     echo "Running windows throughput tests"
 
@@ -53,17 +48,17 @@ if [ "$1" = "windows" ]; then
       dd-trace --crank-import="trace_stats_windows.json"
     fi
 
+    echo "Running manual instrumentation throughput tests"
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile windows --json manual_and_automatic_windows.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=windows --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_windows.json"
+
 elif [ "$1" = "linux" ]; then
     echo "Cleaning previous results"
     rm -f baseline_linux.json
     rm -f calltarget_ngen_linux.json
     rm -f trace_stats_linux.json
     rm -f manual_and_automatic_linux.json
-
-    echo "Running manual instrumentation throughput tests"
-
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_and_automatic_linux.json"
 
     echo "Running Linux x64 throughput tests"
 
@@ -79,17 +74,17 @@ elif [ "$1" = "linux" ]; then
       dd-trace --crank-import="trace_stats_linux.json"
     fi
 
+    echo "Running manual instrumentation throughput tests"
+
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux --json manual_and_automatic_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_linux.json"
+
 elif [ "$1" = "linux_arm64" ]; then
     echo "Cleaning previous results"
     rm -f baseline_linux_arm64.json
     rm -f calltarget_ngen_linux_arm64.json
     rm -f trace_stats_linux_arm64.json
     rm -f manual_and_automatic_linux_arm64.json
-
-    echo "Running manual instrumentation throughput tests"
-    
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="manual_and_automatic_linux_arm64.json"
 
     echo "Running Linux arm64 throughput tests"
 
@@ -104,6 +99,11 @@ elif [ "$1" = "linux_arm64" ]; then
       crank --config Samples.AspNetCoreSimpleController.yml --scenario trace_stats --profile linux_arm64 --json trace_stats_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=trace_stats --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
       dd-trace --crank-import="trace_stats_linux_arm64.json"
     fi
+
+    echo "Running manual instrumentation throughput tests"
+    
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario manual_and_automatic --profile linux_arm64 --json manual_and_automatic_linux_arm64.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=manual_and_automatic --property profile=linux_arm64 --property arch=arm64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="manual_and_automatic_linux_arm64.json"
 
 else
     echo "Unknown argument $1"

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -50,7 +50,7 @@ namespace Samples.AspNetCoreSimpleController
                 Console.WriteLine(" * Running without profiler.");
             }
 
-#if MANUAL_INSTRUMENTATION
+#if MANUAL_INSTRUMENTATION && !MANUAL_ONLY_INSTRUMENTATION
             managedTracerVersion = SampleHelpers.GetManagedTracerVersion();
             if(managedTracerVersion == "None")
             {

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net5.0</TargetFramework>
     <Platforms>x64;x86;AnyCPU</Platforms>
     <DefineConstants Condition="'$(MANUAL_INSTRUMENTATION)' == 'true'">$(DefineConstants);MANUAL_INSTRUMENTATION</DefineConstants>
-    <DefineConstants Condition="'$(VERSION_MISMATCH)' == 'true'">$(DefineConstants);VERSION_MISMATCH</DefineConstants>
+    <DefineConstants Condition="'$(MANUAL_ONLY_INSTRUMENTATION)' == 'true'">$(DefineConstants);MANUAL_ONLY_INSTRUMENTATION</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MANUAL_INSTRUMENTATION)' == 'true'">

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
@@ -7,18 +7,16 @@
     <DefineConstants Condition="'$(VERSION_MISMATCH)' == 'true'">$(DefineConstants);VERSION_MISMATCH</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(MANUAL_INSTRUMENTATION)' == 'true' AND '$(VERSION_MISMATCH)' != 'true'">
+  <ItemGroup Condition="'$(MANUAL_INSTRUMENTATION)' == 'true'">
+    <!-- TODO: We can't throughput test version mismatch with Datadog.Trace.Manual until we have published a version -->
+    <!-- but there's probably no point anyway, as it has no expected impact -->
     <!--    If you want to run the app locally, switch the reference out for this-->
-    <!--    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />-->
-    <Reference Include="Datadog.Trace">
-      <HintPath>Datadog.Trace.dll</HintPath>
+    <!--    <ProjectReference Include="..\..\..\..\src\Datadog.Trace.Manual\Datadog.Trace.Manual.csproj" />-->
+    <Reference Include="Datadog.Trace.Manual">
+      <HintPath>Datadog.Trace.Manual.dll</HintPath>
     </Reference>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(MANUAL_INSTRUMENTATION)' == 'true' AND '$(VERSION_MISMATCH)' == 'true'">
-    <PackageReference Include="Datadog.Trace" Version="2.22.0" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of changes

- Remove the manual-only throughput tests (manual-only isn't a thing in v3)
- Remove the version-conflict scenario (not something we support in v3)
- Use the Datadog.Trace.Manual dll for manual+automatic tests
- Update the throughput comparison

## Reason for change

Manual-only isn't a thing in v3 and the manual instrumentation no longer uses the Datadog.Trace.dll _directly_, but instead uses Datadog.Trace.Manual.

## Implementation details

- Update the throughput test sample app to reference Datadog.Trace.Manual.dll instead of Datadog.Trace.dll
- Remove non-applicable tests

## Test coverage

Essentially the same

## Other details
Stacked on

- https://github.com/DataDog/dd-trace-dotnet/pull/5065
- https://github.com/DataDog/dd-trace-dotnet/pull/5071
- https://github.com/DataDog/dd-trace-dotnet/pull/5072
- https://github.com/DataDog/dd-trace-dotnet/pull/5073
- https://github.com/DataDog/dd-trace-dotnet/pull/5214

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
