### PR TITLE
[CI Visibility] - Fix DiscoveryService Agent configuration callback

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/NullDiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/NullDiscoveryService.cs
@@ -13,6 +13,10 @@ internal class NullDiscoveryService : IDiscoveryService
 {
     public static readonly NullDiscoveryService Instance = new();
 
+    private NullDiscoveryService()
+    {
+    }
+
     public void SubscribeToChanges(Action<AgentConfiguration> callback)
     {
     }

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -705,6 +705,7 @@ namespace Datadog.Trace.Ci
             public DiscoveryAgentConfigurationCallback(IDiscoveryService discoveryService)
             {
                 _manualResetEventSlim = new ManualResetEventSlim();
+                LifetimeManager.Instance.AddShutdownTask(() => _manualResetEventSlim.Set());
                 _discoveryService = discoveryService;
                 _callback = CallBack;
                 _agentConfiguration = null;

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -657,7 +657,7 @@ namespace Datadog.Trace.Ci
 
         private static EventPlatformProxySupport IsEventPlatformProxySupportedByAgent(IDiscoveryService discoveryService)
         {
-            if (discoveryService == NullDiscoveryService.Instance)
+            if (discoveryService is NullDiscoveryService)
             {
                 return EventPlatformProxySupport.None;
             }

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -663,7 +663,7 @@ namespace Datadog.Trace.Ci
             }
 
             Log.Debug("Waiting for agent configuration...");
-            var agentConfiguration = new DiscoveryAgentConfigurationCallback(discoveryService).WaitAndGet();
+            var agentConfiguration = new DiscoveryAgentConfigurationCallback(discoveryService).WaitAndGet(5_000);
             if (agentConfiguration is null)
             {
                 Log.Warning("Discovery service could not retrieve the agent configuration after 5 seconds.");

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -657,21 +657,13 @@ namespace Datadog.Trace.Ci
 
         private static EventPlatformProxySupport IsEventPlatformProxySupportedByAgent(IDiscoveryService discoveryService)
         {
-            var manualResetEventSlim = new ManualResetEventSlim();
-            AgentConfiguration? agentConfiguration = null;
-            LifetimeManager.Instance.AddShutdownTask(() => manualResetEventSlim.Set());
-
-            Log.Debug("Waiting for agent configuration...");
-            discoveryService.SubscribeToChanges(CallBack);
-            void CallBack(AgentConfiguration aConfiguration)
+            if (discoveryService == NullDiscoveryService.Instance)
             {
-                agentConfiguration = aConfiguration;
-                manualResetEventSlim.Set();
-                discoveryService.RemoveSubscription(CallBack);
-                Log.Debug("Agent configuration received.");
+                return EventPlatformProxySupport.None;
             }
 
-            manualResetEventSlim.Wait(5_000);
+            Log.Debug("Waiting for agent configuration...");
+            var agentConfiguration = new DiscoveryAgentConfigurationCallback(discoveryService).WaitAndGet();
             if (agentConfiguration is null)
             {
                 Log.Warning("Discovery service could not retrieve the agent configuration after 5 seconds.");
@@ -701,6 +693,37 @@ namespace Datadog.Trace.Ci
             }
 
             return EventPlatformProxySupport.None;
+        }
+
+        private class DiscoveryAgentConfigurationCallback
+        {
+            private readonly ManualResetEventSlim _manualResetEventSlim;
+            private readonly Action<AgentConfiguration> _callback;
+            private readonly IDiscoveryService _discoveryService;
+            private AgentConfiguration? _agentConfiguration;
+
+            public DiscoveryAgentConfigurationCallback(IDiscoveryService discoveryService)
+            {
+                _manualResetEventSlim = new ManualResetEventSlim();
+                _discoveryService = discoveryService;
+                _callback = CallBack;
+                _agentConfiguration = null;
+                _discoveryService.SubscribeToChanges(_callback);
+            }
+
+            public AgentConfiguration? WaitAndGet(int timeoutInMs = 5_000)
+            {
+                _manualResetEventSlim.Wait(timeoutInMs);
+                return _agentConfiguration;
+            }
+
+            private void CallBack(AgentConfiguration agentConfiguration)
+            {
+                _agentConfiguration = agentConfiguration;
+                _manualResetEventSlim.Set();
+                _discoveryService.RemoveSubscription(_callback);
+                Log.Debug("Agent configuration received.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR fixes the agentless case where we were setting the callbacks for the `NullDiscoveryService` instance and waiting for 5 seconds.

This PR also refactors the `IsEventPlatformProxySupportedByAgent` fixing the previous calls to `SubscribeToChanges` and `RemoveSubscription` where we were passing different `Action<AgentConfiguration>` instances.
