### PR TITLE
[Tracing][ASM] http query string obfuscation should be case-insensitive

### DIFF
--- a/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
+++ b/tracer/src/Datadog.Trace/Util/Http/QueryStringObfuscation/Obfuscator.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Util.Http.QueryStringObfuscation
             _timeout = timeout;
             _logger = logger;
 
-            var options = RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace | RegexOptions.IgnorePatternWhitespace;
+            var options = RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace;
 
 #if NETCOREAPP3_1_OR_GREATER
             options |= RegexOptions.NonBacktracking;

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
@@ -32,7 +32,7 @@ public class QueryStringObfuscatorTests
             new(
                 "http://google.fr/waf?pass=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3",
                 "http://google.fr/waf?<redacted>&key2=val2&key3=val3"),
-            // test case-sensitiveness
+            // same as above, but with different case to test case-insensitivity
             new(
                 "http://google.fr/waf?PASS=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3",
                 "http://google.fr/waf?<redacted>&key2=val2&key3=val3"),
@@ -51,7 +51,7 @@ public class QueryStringObfuscatorTests
             new(
                 "http://google.fr/waf?password=12345&token=token:1234&bearer 1234&ecdsa-1-1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&old-pwd2=test&ssh-dss aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&application_key=test&app-key=test2",
                 "http://google.fr/waf?<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>"),
-            // test case-sensitiveness
+            // same as above, but with different case to test case-insensitivity
             new(
                 "http://google.fr/waf?PassWord=12345&Token=token:1234&Bearer 1234&ecdsa-1-1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&old-pwd2=test&ssh-dss aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&application_key=test&app-key=test2",
                 "http://google.fr/waf?<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>"),

--- a/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Http/QueryStringObfuscatorTests.cs
@@ -32,6 +32,10 @@ public class QueryStringObfuscatorTests
             new(
                 "http://google.fr/waf?pass=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3",
                 "http://google.fr/waf?<redacted>&key2=val2&key3=val3"),
+            // test case-sensitiveness
+            new(
+                "http://google.fr/waf?PASS=03cb9f67-dbbc-4cb8-b966-329951e10934&key2=val2&key3=val3",
+                "http://google.fr/waf?<redacted>&key2=val2&key3=val3"),
             new(
                 "http://google.fr/waf?key1=val1&public_key=MDNjYjlmNjctZGJiYy00Y2I4LWI5NjYtMzI5OTUxZTEwOTM0&key3=val3",
                 "http://google.fr/waf?key1=val1&<redacted>&key3=val3"),
@@ -46,6 +50,10 @@ public class QueryStringObfuscatorTests
                 "https://google.fr/waf?<redacted>&key1=val1&key2=val2&<redacted>&<redacted>&key3=val3&json=%7B%20<redacted>%7D"),
             new(
                 "http://google.fr/waf?password=12345&token=token:1234&bearer 1234&ecdsa-1-1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&old-pwd2=test&ssh-dss aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&application_key=test&app-key=test2",
+                "http://google.fr/waf?<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>"),
+            // test case-sensitiveness
+            new(
+                "http://google.fr/waf?PassWord=12345&Token=token:1234&Bearer 1234&ecdsa-1-1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&old-pwd2=test&ssh-dss aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa= test&application_key=test&app-key=test2",
                 "http://google.fr/waf?<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>&<redacted>"),
         };
         return allData.Select(e => new[] { e.Data, e.Expected });


### PR DESCRIPTION
## Summary of changes

Fix `RegexOptions` used in the obfuscator for http query string to be case-insensitive as intended.

## Reason for change

I found a bug.

## Implementation details

I fixed the bug.

## Test coverage

Added test cases with Capital Letters.

## Other details
n/a
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
