### PR TITLE
[CI Visibility] Fix MakeRelativePathFromSourceRoot method when the path is invalid

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIEnvironmentValues.cs
@@ -288,22 +288,31 @@ namespace Datadog.Trace.Ci
                 return pivotFolder;
             }
 
-            var folderSeparator = Path.DirectorySeparatorChar;
-            if (pivotFolder[pivotFolder.Length - 1] != folderSeparator)
+            try
             {
-                pivotFolder += folderSeparator;
+                var folderSeparator = Path.DirectorySeparatorChar;
+                if (pivotFolder[pivotFolder.Length - 1] != folderSeparator)
+                {
+                    pivotFolder += folderSeparator;
+                }
+
+                var pivotFolderUri = new Uri(pivotFolder);
+                var absolutePathUri = new Uri(absolutePath);
+                var relativeUri = pivotFolderUri.MakeRelativeUri(absolutePathUri);
+                if (useOSSeparator)
+                {
+                    return Uri.UnescapeDataString(
+                        relativeUri.ToString().Replace('/', folderSeparator));
+                }
+
+                return Uri.UnescapeDataString(relativeUri.ToString());
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Error creating a relative path for '{AbsolutePath}' from '{BasePath}'", absolutePath, pivotFolder);
             }
 
-            var pivotFolderUri = new Uri(pivotFolder);
-            var absolutePathUri = new Uri(absolutePath);
-            var relativeUri = pivotFolderUri.MakeRelativeUri(absolutePathUri);
-            if (useOSSeparator)
-            {
-                return Uri.UnescapeDataString(
-                    relativeUri.ToString().Replace('/', folderSeparator));
-            }
-
-            return Uri.UnescapeDataString(relativeUri.ToString());
+            return absolutePath;
         }
 
         internal void ReloadEnvironmentData()


### PR DESCRIPTION
## Summary of changes

This PR fixes the `MakeRelativePathFromSourceRoot` method when a path is invalid to avoid throwing an exception.

## Reason for change

This has been found in the datadogtestlogger logs:

```
Creating test module: Datadog.Trace.Security.Unit.Tests
  Creating test suite: Datadog.Trace.Security.Unit.Tests.IAST.Tainted.VulnerabilitiesEnumTests
    Creating test: AllVulnerabilitiesCreatedExistsInTheSchema(vulnerability: WeakRandomness, vulnerabilitiesNames: ["COMMAND_INJECTION", "HARDCODED_SECRET", "HEADER_INJECTION", "HSTS_HEADER_MISSING", "INSECURE_COOKIE", ...])
      Test name has been modified (parameters): AllVulnerabilitiesCreatedExistsInTheSchema
      Parameters: (vulnerability: WeakRandomness, vulnerabilitiesNames: ["COMMAND_INJECTION", "HARDCODED_SECRET", "HEADER_INJECTION", "HSTS_HEADER_MISSING", "INSECURE_COOKIE", ...])
          Param: vulnerability = WeakRandomness
          Param: vulnerabilitiesNames = ["COMMAND_INJECTION"
      Setting Test Method Info: Void AllVulnerabilitiesCreatedExistsInTheSchema(System.Object, System.String[])
System.UriFormatException: Invalid URI: The format of the URI could not be determined.
   at System.Uri.CreateThis(String uri, Boolean dontEscape, UriKind uriKind, UriCreationOptions& creationOptions)
   at System.Uri..ctor(String uriString)
   at DatadogTestLogger.Vendors.Datadog.Trace.Ci.CIEnvironmentValues.MakeRelativePathFromSourceRoot(String absolutePath, Boolean useOSSeparator) in /Users/tony.redondo/repos/github/tonyredondo/datadog-test-logger/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/CIEnvironmentValues.cs:line 261
   at DatadogTestLogger.Vendors.Datadog.Trace.Ci.Test.SetTestMethodInfo(MethodInfo methodInfo) in /Users/tony.redondo/repos/github/tonyredondo/datadog-test-logger/src/DatadogTestLogger/Vendors/Datadog.Trace/Ci/Test.cs:line 177
   at DatadogTestLogger.TestSuiteSerializer.Serialize(List`1 results, List`1 messages) in /Users/tony.redondo/repos/github/tonyredondo/datadog-test-logger/src/DatadogTestLogger/TestSuiteSerializer.cs:line 419
```
