### PR TITLE
Don't require additional Windows SDK for Nuke desktop notification

### DIFF
--- a/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
+++ b/tracer/build/_build/BuildFinishedNotificationAttribute.Windows.cs
@@ -1,5 +1,5 @@
 ﻿
-#if IS_WINDOWS
+#if NUKE_NOTIFY
 #nullable enable
 
 using System;

--- a/tracer/build/_build/BuildFinishedNotificationAttribute.cs
+++ b/tracer/build/_build/BuildFinishedNotificationAttribute.cs
@@ -3,7 +3,7 @@ using Nuke.Common.Execution;
 
 public partial class BuildFinishedNotificationAttribute : BuildExtensionAttributeBase, IOnBuildFinished
 {
-#if !IS_WINDOWS
+#if !NUKE_NOTIFY
     public void OnBuildFinished(NukeBuild build)
     {}
 #endif

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <TargetFramework Condition="$(OS.StartsWith('Windows'))">$(TargetFramework)-windows10.0.17763</TargetFramework>
-    <DefineConstants Condition="$(OS.StartsWith('Windows'))">IS_WINDOWS</DefineConstants>
+    <TargetFramework Condition="$(OS.StartsWith('Windows')) AND '$(NUKE_NOTIFY)' != ''">$(TargetFramework)-windows10.0.17763</TargetFramework>
+    <DefineConstants Condition="$(OS.StartsWith('Windows')) AND '$(NUKE_NOTIFY)' != ''">$(DefineConstants);NUKE_NOTIFY</DefineConstants>
     <RollForward>LatestMajor</RollForward>
     <RootNamespace></RootNamespace>
     <!-- NU* are workaround for Rider bug: https://youtrack.jetbrains.com/issue/RIDER-103207/Cannot-suppress-vulnerable-package-errors -->
@@ -40,9 +40,9 @@
     <PackageReference Include="ByteSize" Version="2.1.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- on it's own, since windows only and just used for notifications -->
-    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" Condition="$(OS.StartsWith('Windows'))" />
+  <!-- On it's own, since windows only and just used for notifications -->
+  <ItemGroup Condition="$(OS.StartsWith('Windows')) AND '$(NUKE_NOTIFY)' != ''">
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
   </ItemGroup>
   
   <ItemGroup>

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-    <TargetFramework Condition="$(OS.StartsWith('Windows')) AND '$(NUKE_NOTIFY)' != ''">$(TargetFramework)-windows10.0.17763</TargetFramework>
+    <TargetFramework Condition="$(OS.StartsWith('Windows')) AND '$(NUKE_NOTIFY)' != ''">$(TargetFramework)-windows10.0.19041</TargetFramework>
     <DefineConstants Condition="$(OS.StartsWith('Windows')) AND '$(NUKE_NOTIFY)' != ''">$(DefineConstants);NUKE_NOTIFY</DefineConstants>
     <RollForward>LatestMajor</RollForward>
     <RootNamespace></RootNamespace>


### PR DESCRIPTION
## Summary of changes
- Change the targeted version of Windows
- Don't add the extra dependencies etc unless you're actually using the Windows notification

## Reason for change

Targeting a different version of Windows (10.0.17763 instead of 10.0.19041) and don't want to have the extra dependencies if you're not using the nuke notification.

## Implementation details

Changed some versions, check for the NUKE_NOTIFY env-var in the build

## Test coverage

Tested locally, it works

## Other details
We have space issues on the benchmark agents, and part of the issue is a tonne of Windows SDKs, so I'm trying to clear some out

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
