### PR TITLE
[Profiling] Reduce available symbols

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -129,6 +129,7 @@ add_dependencies(${PROFILER_STATIC_LIB_NAME} libdatadog-lib libunwind-lib corecl
 # ******************************************************
 # Define shared target
 # ******************************************************
+set(dd_profiling_linker_script "${CMAKE_SOURCE_DIR}/datadog_profiling.version")
 
 add_library(${PROFILER_SHARED_LIB_NAME} SHARED
     ../Datadog.Profiler.Native/DllMain.cpp

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -129,13 +129,16 @@ add_dependencies(${PROFILER_STATIC_LIB_NAME} libdatadog-lib libunwind-lib corecl
 # ******************************************************
 # Define shared target
 # ******************************************************
-set(dd_profiling_linker_script "${CMAKE_SOURCE_DIR}/datadog_profiling.version")
+set(dd_profiling_linker_script "${CMAKE_CURRENT_SOURCE_DIR}/datadog_profiling.version")
 
 add_library(${PROFILER_SHARED_LIB_NAME} SHARED
     ../Datadog.Profiler.Native/DllMain.cpp
 )
 
 set_target_properties(${PROFILER_SHARED_LIB_NAME} PROPERTIES PREFIX "")
+set_target_properties(${PROFILER_SHARED_LIB_NAME} PROPERTIES LINK_DEPENDS "${dd_profiling_linker_script}")
+target_link_options(${PROFILER_SHARED_LIB_NAME} PRIVATE
+                    "LINKER:--version-script=${dd_profiling_linker_script}")
 
 # Define linker libraries
 target_link_libraries(${PROFILER_SHARED_LIB_NAME}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/datadog_profiling.version
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/datadog_profiling.version
@@ -1,0 +1,4 @@
+{
+  global: GetNativeProfilerIsReadyPtr; GetPointerToNativeTraceContext; Profiler_Version; SetApplicationInfoForAppDomain; SetEndpointForTrace; SetGitMetadataForApplication; ThreadsCpuManager_Map;
+  local: *;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/datadog_profiling.version
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/datadog_profiling.version
@@ -1,4 +1,4 @@
 {
-  global: GetNativeProfilerIsReadyPtr; GetPointerToNativeTraceContext; Profiler_Version; SetApplicationInfoForAppDomain; SetEndpointForTrace; SetGitMetadataForApplication; ThreadsCpuManager_Map;
+  global: GetNativeProfilerIsReadyPtr; GetPointerToNativeTraceContext; Profiler_Version; SetApplicationInfoForAppDomain; SetEndpointForTrace; SetGitMetadataForApplication; ThreadsCpuManager_Map; DllGetClassObject; DllCanUnloadNow;
   local: *;
 };


### PR DESCRIPTION
## Summary of changes

Add a linker script to define what symbols should be published

## Reason for change

Avoid exposing rust internal symbols as it can cause issues, as mentioned here:
https://github.com/rust-lang/rust/issues/100774

## Implementation details

Adding a linker script 

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
