### PR TITLE
[ASM] increase waf timeout on flaky unit tests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
@@ -25,7 +25,8 @@ namespace Datadog.Trace.Security.Unit.Tests;
 
 public class ContextTests : WafLibraryRequiredTest
 {
-    public const int TimeoutMicroSeconds = 1_000_000;
+    // here we use just 1 sec instead of the 20sec common one as we dont really care about the result, just that it runs
+    public const int WafRunTimeoutMicroSeconds = 1_000_000;
 
     [Theory]
     [InlineData(true)]
@@ -100,12 +101,12 @@ public class ContextTests : WafLibraryRequiredTest
                             continue;
                         }
 
-                        var result = context.Run(args, TimeoutMicroSeconds);
+                        var result = context.Run(args, WafRunTimeoutMicroSeconds);
                         result.ReturnCode.Should().Be(WafReturnCode.Ok);
                         args.Clear();
 
                         args.Add(AddressesConstants.RequestBody, new List<string> { "dog1", "dog2", "dog3", "dog4" });
-                        result = context.Run(args, TimeoutMicroSeconds);
+                        result = context.Run(args, WafRunTimeoutMicroSeconds);
                         result.ReturnCode.Should().Be(WafReturnCode.Ok);
                         args.Clear();
 
@@ -116,7 +117,7 @@ public class ContextTests : WafLibraryRequiredTest
 #else
                         args.Add(AddressesConstants.RequestPathParams, new Dictionary<string, object> { { "controller", "Home" }, { "action", "Index" }, { "id", "appscan_fingerprint" } });
 #endif
-                        result = context.Run(args, TimeoutMicroSeconds);
+                        result = context.Run(args, WafRunTimeoutMicroSeconds);
                         args.Clear();
 
 #if NETFRAMEWORK
@@ -124,13 +125,13 @@ public class ContextTests : WafLibraryRequiredTest
 #else
                         args.Add(AddressesConstants.RequestPathParams, new Dictionary<string, object> { { "id", "appscan_fingerprint" } });
 #endif
-                        result = context.Run(args, TimeoutMicroSeconds);
+                        result = context.Run(args, WafRunTimeoutMicroSeconds);
                         args.Clear();
 
                         args.Add(AddressesConstants.ResponseBody, new List<object> { "dog1", true, 1.5, 1.40d, "dummy_rule", longArraylist, longArraylist });
                         args.Add(AddressesConstants.ResponseHeaderNoCookies, new Dictionary<string, ArrayList> { { "content-type", longArraylist } });
                         args.Add(AddressesConstants.ResponseStatus, "200");
-                        result = context.Run(args, TimeoutMicroSeconds);
+                        result = context.Run(args, WafRunTimeoutMicroSeconds);
                         result.ReturnCode.Should().Be(WafReturnCode.Ok);
                         args.Clear();
                     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -4,14 +4,17 @@
 // </copyright>
 
 #nullable enable
-using System;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
-using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests.Utils;
 
 public class WafLibraryRequiredTest
 {
+    /// <summary>
+    /// 15 seconds timeout for the waf. It shouldn't happen, but with a 1sec timeout, the tests are flaky.
+    /// </summary>
+    public const int TimeoutMicroSeconds = 15_000_000;
+
     static WafLibraryRequiredTest()
     {
         var result = WafLibraryInvoker.Initialize();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
@@ -22,8 +22,6 @@ namespace Datadog.Trace.Security.Unit.Tests
 {
     public class WafEphemeralDataTests : WafLibraryRequiredTest
     {
-        public const int TimeoutMicroSeconds = 1_000_000;
-
         [Theory]
         [InlineData("appscan_fingerprint", "security_scanner", "crs-913-120")]
         [InlineData("<script>", "xss", "crs-941-110")]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
@@ -24,8 +24,6 @@ namespace Datadog.Trace.Security.Unit.Tests
     [Collection(nameof(SecuritySequentialTests))]
     public class WafMemoryTests : WafLibraryRequiredTest
     {
-        public const int TimeoutMicroSeconds = 1_000_000;
-
         public const int OverheadMargin = 40_000_000; // 40Mb margin
 
         public void InitMemoryLeakCheck()

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Security.Unit.Tests
 
                 waf.Should().NotBeNull();
                 using var context = waf.CreateContext();
-                var result = context.Run(args, 1_000_000);
+                var result = context.Run(args, TimeoutMicroSeconds);
                 result.ReturnCode.Should().Be(WafReturnCode.Match);
                 result.Data.Should().NotBeNull();
                 var jsonString = JsonConvert.SerializeObject(result.Data);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -22,8 +22,6 @@ namespace Datadog.Trace.Security.Unit.Tests
 {
     public class WafTests : WafLibraryRequiredTest
     {
-        public const int TimeoutMicroSeconds = 1_000_000;
-
         [Theory]
         [InlineData("[$ne]", "arg", "nosql_injection", "crs-942-290")]
         [InlineData("attack", "appscan_fingerprint", "security_scanner", "crs-913-120")]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
@@ -25,8 +25,6 @@ namespace Datadog.Trace.Security.Unit.Tests
 {
     public class WafUpdateTests : WafLibraryRequiredTest
     {
-        public const int TimeoutMicroSeconds = 1_000_000;
-
         [Fact]
         public void RulesUpdate()
         {


### PR DESCRIPTION
## Summary of changes

Increase timeout for waf based unit tests

## Reason for change

When waf times out, the result is OK and no security result is found, which leads to assert failures.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
