### PR TITLE
Fix crank by pinning bombardier.yml

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -291,6 +291,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "crank", "crank", "{E3FB283A
 		tracer\build\crank\run.sh = tracer\build\crank\run.sh
 		tracer\build\crank\Samples.AspNetCoreSimpleController.yml = tracer\build\crank\Samples.AspNetCoreSimpleController.yml
 		tracer\build\crank\Security.Samples.AspNetCoreSimpleController.yml = tracer\build\crank\Security.Samples.AspNetCoreSimpleController.yml
+		tracer\build\crank\bombardier.yml = tracer\build\crank\bombardier.yml
+		tracer\build\crank\loader.conf = tracer\build\crank\loader.conf
+		tracer\build\crank\README.md = tracer\build\crank\README.md
+		tracer\build\crank\run-adhoc.sh = tracer\build\crank\run-adhoc.sh
+		tracer\build\crank\run-appsec.sh = tracer\build\crank\run-appsec.sh
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DuplicateTypeProxy", "tracer\test\test-applications\regression\DuplicateTypeProxy\DuplicateTypeProxy.csproj", "{34B67004-7249-4EF1-8E12-6E6DA37EA6BE}"

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -1,5 +1,5 @@
 imports:
-  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+  - ./bombardier.yml
   - ./os.profiles.yml
 
 variables:

--- a/tracer/build/crank/Security.Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Security.Samples.AspNetCoreSimpleController.yml
@@ -1,5 +1,5 @@
 ﻿imports:
-  - https://raw.githubusercontent.com/dotnet/crank/main/src/Microsoft.Crank.Jobs.Bombardier/bombardier.yml
+  - ./bombardier.yml
   - ./os.profiles.yml
 
 variables:

--- a/tracer/build/crank/bombardier.yml
+++ b/tracer/build/crank/bombardier.yml
@@ -11,7 +11,7 @@ jobs:
   bombardier:
     source:
       repository: https://github.com/dotnet/crank.git
-      branchOrCommit: "#3e4b3cae6ae1a649f06502eb75f333b41deac9a3"
+      branchOrCommit: "main#3e4b3cae6ae1a649f06502eb75f333b41deac9a3"
       project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
       sourceKey: bombardier
       noBuild: true

--- a/tracer/build/crank/bombardier.yml
+++ b/tracer/build/crank/bombardier.yml
@@ -11,7 +11,7 @@ jobs:
   bombardier:
     source:
       repository: https://github.com/dotnet/crank.git
-      branchOrCommit: 3e4b3cae6ae1a649f06502eb75f333b41deac9a3
+      branchOrCommit: "#3e4b3cae6ae1a649f06502eb75f333b41deac9a3"
       project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
       sourceKey: bombardier
       noBuild: true

--- a/tracer/build/crank/bombardier.yml
+++ b/tracer/build/crank/bombardier.yml
@@ -1,0 +1,41 @@
+variables:
+  headers:
+    none: ''
+    plaintext: '--header "Accept: text/plain,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7" --header "Connection: keep-alive"'
+    html: '--header "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8" --header "Connection: keep-alive"'
+    json: '--header "Accept: application/json,text/html;q=0.9,application/xhtml+xml;q=0.9,application/xml;q=0.8,*/*;q=0.7" --header "Connection: keep-alive"'
+    connectionclose: '--header "Connection: close"'
+  presetHeaders: none
+
+jobs:
+  bombardier:
+    source:
+      repository: https://github.com/dotnet/crank.git
+      branchOrCommit: 3e4b3cae6ae1a649f06502eb75f333b41deac9a3
+      project: src/Microsoft.Crank.Jobs.Bombardier/Microsoft.Crank.Jobs.Bombardier.csproj
+      sourceKey: bombardier
+      noBuild: true
+    readyStateText: Bombardier Client
+    waitForExit: true
+    variables:
+      connections: 256
+      warmup: 15
+      duration: 15
+      requests: 0
+      timeout: 2
+      rate: 0
+      transport: fasthttp # | http1 | http2
+      serverScheme: http
+      serverAddress: localhost
+      serverPort: 5000
+      path:
+      body: # request body
+      bodyFile: # path or url for a file to use as the body content
+      certFile: # path or url for a file to use as the cert content
+      keyFile: # path or url for a file to use as the key content
+      stream: # specify whether to stream body
+      verb: # GET when nothing is specified
+      customHeaders: [ ] # list of headers with the format: '<name1>: <value1>', e.g. [ 'content-type: application/json' ]
+    arguments: "-c {{connections}} -w {{warmup}} -d {{duration}} -n {{requests}} -t {{timeout}}s --insecure -l {% if rate != 0 %} --rate {{ rate }} {% endif %} {% if transport %} --{{ transport}} {% endif %} {{headers[presetHeaders]}} {% for h in customHeaders %}{% assign s = h | split : ':' %}--header \"{{ s[0] }}: {{ s[1] | strip }}\" {% endfor %} {% if serverUri == blank or serverUri == empty %} {{serverScheme}}://{{serverAddress}}:{{serverPort}}{{path}} {% else %} {{serverUri}}:{{serverPort}}{{path}} {% endif %} {% if bodyFile != blank and bodyFile != empty %} -f {{bodyFile}} {% endif %} {% if certFile != blank and certFile != empty %} --cert {{certFile}} {% endif %} {% if keyFile != blank and keyFile != empty %} --key {{keyFile}} {% endif %} {% if stream != blank and stream != empty %} -s {% endif %} {% if body != blank and body != empty %} -b {{body}} {% endif %}  {% if verb != blank and verb != empty %} -m {{verb}} {% endif %}"
+    onConfigure:
+    # - job.timeout = Number(job.variables.duration) + Number(job.variables.warmup) + 10;


### PR DESCRIPTION
## Summary of changes

This PR tries to fix the throughput tests by pinning the bombardier.yml to a commit sha.

## Reason for change

We were using the `bombardier.yml` from the main branch in the crank repository and it was modified recently breaking or configuration.
