### PR TITLE
[Profiler] Cleanup compilation warnings

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -29,9 +29,9 @@ LinuxStackFramesCollector::LinuxStackFramesCollector(ProfilerSignalManager* sign
     StackFramesCollectorBase(configuration),
     _lastStackWalkErrorCode{0},
     _stackWalkFinished{false},
-    _errorStatistics{},
     _processId{OpSysTools::GetProcId()},
     _signalManager{signalManager},
+    _errorStatistics{},
     _useBacktrace2{configuration->UseBacktrace2()}
 {
     _signalManager->RegisterHandler(LinuxStackFramesCollector::CollectStackSampleSignalHandler);
@@ -184,7 +184,7 @@ std::int32_t LinuxStackFramesCollector::CollectCallStackCurrentThread(void* ctx)
     try
     {
         // Collect data for TraceContext tracking:
-        bool traceContextDataCollected = TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot();
+        TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot();
 
         return _useBacktrace2 ? CollectStackWithBacktrace2(ctx) : CollectStackManually(ctx);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -11,8 +11,8 @@
 
 ProfilerSignalManager::ProfilerSignalManager() noexcept :
     _canReplaceSignalHandler{true},
-    _handler{nullptr},
     _signalToSend{SIGUSR1},
+    _handler{nullptr},
     _processId{OpSysTools::GetProcId()},
     _isHandlerInPlace{false},
     _previousAction{},

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/SystemCallsShield.h
@@ -10,7 +10,7 @@
 #include <memory>
 
 class IConfiguration;
-class ManagedThreadInfo;
+struct ManagedThreadInfo;
 
 class SystemCallsShield : public IService
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -62,9 +62,9 @@ AllocationsProvider::AllocationsProvider(
     _pCorProfilerInfo(pCorProfilerInfo),
     _pManagedThreadList(pManagedThreadList),
     _pFrameStore(pFrameStore),
-    _sampleLimit(pConfiguration->AllocationSampleLimit()),
-    _sampler(pConfiguration->AllocationSampleLimit(), pConfiguration->GetUploadInterval()),
     _pListener(pListener),
+    _sampler(pConfiguration->AllocationSampleLimit(), pConfiguration->GetUploadInterval()),
+    _sampleLimit(pConfiguration->AllocationSampleLimit()),
     _pConfiguration(pConfiguration)
 {
     _allocationsCountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_allocations");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -24,8 +24,8 @@ PCCOR_SIGNATURE ParseByte(PCCOR_SIGNATURE pbSig, BYTE* pByte);
 
 FrameStore::FrameStore(ICorProfilerInfo4* pCorProfilerInfo, IConfiguration* pConfiguration, IDebugInfoStore* debugInfoStore) :
     _pCorProfilerInfo{pCorProfilerInfo},
-    _resolveNativeFrames{pConfiguration->IsNativeFramesEnabled()},
-    _pDebugInfoStore{debugInfoStore}
+    _pDebugInfoStore{debugInfoStore},
+    _resolveNativeFrames{pConfiguration->IsNativeFramesEnabled()}
 {
 }
 
@@ -181,7 +181,7 @@ FrameInfoView FrameStore::GetManagedFrame(FunctionID functionId)
     // look into the cache first
     TypeDesc* pTypeDesc = nullptr;  // if already in the cache
     TypeDesc typeDesc;              // if needed to be built from a given classId
-    bool isEncoded = true;
+
     bool typeInCache = GetCachedTypeDesc(classId, pTypeDesc);
     // TODO: would it be interesting to have a (moduleId + mdTokenDef) -> TypeDesc cache for the non cached generic types?
 
@@ -896,7 +896,7 @@ std::tuple<std::string, std::string, std::string> FrameStore::GetManagedTypeName
 
     if (isArray)
     {
-        return std::make_tuple(std::move(ns), std::move(typeName), std::move(genericParameters + arraySuffix));
+        return std::make_tuple(std::move(ns), std::move(typeName), genericParameters + arraySuffix);
     }
     else
     {
@@ -935,7 +935,6 @@ std::string FrameStore::GetMethodSignature(ICorProfilerInfo4* pInfo, IMetaDataIm
     ULONG codeRva;
 
     // get the coded signature from metadata
-    ULONG nameCharCount = 0;
     HRESULT hr = pMetaData->GetMethodProps(mdTokenFunc, nullptr, nullptr, 0, nullptr, &attributes, &pSigBlob, &blobSize, &codeRva, &flags);
     if (FAILED(hr))
     {
@@ -956,8 +955,8 @@ std::string FrameStore::GetMethodSignature(ICorProfilerInfo4* pInfo, IMetaDataIm
     std::unique_ptr<ClassID[]> methodTypeArgs = nullptr;
     ULONG genericArgCount = 0;
     UINT32 methodTypeArgCount = 0;
-    ULONG32 classTypeArgCount = 0;
     std::vector<std::string> classTypeArgs;
+
     if ((callConv & IMAGE_CEE_CS_CALLCONV_GENERIC) != 0)
     {
         ModuleID moduleId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
@@ -10,7 +10,6 @@ LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address
     :
     _address(address),
     _weakHandle(nullptr),
-    _timestamp(timestamp),
     _gcCount(0)
 {
     auto id = s_nextObjectId++;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.cpp
@@ -10,6 +10,7 @@ LiveObjectInfo::LiveObjectInfo(std::shared_ptr<Sample> sample, uintptr_t address
     :
     _address(address),
     _weakHandle(nullptr),
+    _timestamp(timestamp),
     _gcCount(0)
 {
     auto id = s_nextObjectId++;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
@@ -28,6 +28,9 @@ private:
     std::shared_ptr<Sample> _sample;
     uintptr_t _address;
     ObjectHandleID _weakHandle;
+    // TODO This field is not yet used because the current implementation is incomple.
+    // Just keep to remind us to finish the implementation.
+    int64_t _timestamp;
     uint64_t _gcCount;
 
     static std::atomic<uint64_t> s_nextObjectId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectInfo.h
@@ -28,7 +28,6 @@ private:
     std::shared_ptr<Sample> _sample;
     uintptr_t _address;
     ObjectHandleID _weakHandle;
-    int64_t _timestamp;
     uint64_t _gcCount;
 
     static std::atomic<uint64_t> s_nextObjectId;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -35,9 +35,6 @@ LiveObjectsProvider::LiveObjectsProvider(
     MetricsRegistry& metricsRegistry)
     :
     _pCorProfilerInfo(pCorProfilerInfo),
-    _pFrameStore(pFrameStore),
-    _pAppDomainStore(pAppDomainStore),
-    _pRuntimeIdStore(pRuntimeIdStore),
     _isTimestampsAsLabelEnabled(pConfiguration->IsTimestampsAsLabelEnabled())
 {
     _pAllocationsProvider = std::make_unique<AllocationsProvider>(
@@ -162,11 +159,13 @@ bool LiveObjectsProvider::IsAlive(ObjectHandleID handle) const
         return false;
     }
 
-    ObjectID object = NULL;
+    static ObjectID NullObjectID = static_cast<ObjectID>(NULL);
+
+    auto object = NullObjectID;
     auto hr = _pCorProfilerInfo->GetObjectIDFromHandle(handle, &object);
     if (SUCCEEDED(hr))
     {
-        return object != NULL;
+        return object != NullObjectID;
     }
 
     return false;
@@ -174,7 +173,7 @@ bool LiveObjectsProvider::IsAlive(ObjectHandleID handle) const
 
 ObjectHandleID LiveObjectsProvider::CreateWeakHandle(uintptr_t address) const
 {
-    if (address == NULL)
+    if (reinterpret_cast<void*>(address) == nullptr)
     {
         return nullptr;
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -80,10 +80,6 @@ private:
     static std::vector<SampleValueType> SampleTypeDefinitions;
 
     ICorProfilerInfo13* _pCorProfilerInfo = nullptr;
-    IFrameStore* _pFrameStore = nullptr;
-    IAppDomainStore* _pAppDomainStore = nullptr;
-    IRuntimeIdStore* _pRuntimeIdStore = nullptr;
-    IThreadsCpuManager* _pThreadsCpuManager = nullptr;
     std::unique_ptr<AllocationsProvider> _pAllocationsProvider;
 
     bool _isTimestampsAsLabelEnabled = false;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
@@ -31,6 +31,8 @@ ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, DWORD osThreadId, HAN
     _osThreadHandle(osThreadHandle),
     _pThreadName(std::move(pThreadName)),
     _lastSampleHighPrecisionTimestampNanoseconds{0},
+    _cpuConsumptionMilliseconds{0},
+    _timestamp{0},
     _lastKnownSampleUnixTimeUtc{0},
     _highPrecisionNanosecsAtLastUnixTimeUpdate{0},
     _snapshotsPerformedSuccessCount{0},
@@ -41,8 +43,6 @@ ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, DWORD osThreadId, HAN
     _stackWalkLock(1),
     _isThreadDestroyed{false},
     _traceContextTrackingInfo{},
-    _cpuConsumptionMilliseconds{0},
-    _timestamp{0},
     _sharedMemoryArea{nullptr}
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -159,7 +159,7 @@ inline void ManagedThreadInfo::BuildProfileThreadId()
 {
     std::stringstream builder;
     builder << "<" << std::dec << _profilerThreadInfoId << "> [#" << _osThreadId << "]";
-    _profileThreadId = std::move(builder.str());
+    _profileThreadId = builder.str();
 }
 
 inline void ManagedThreadInfo::BuildProfileThreadName()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ProfileExporter.cpp
@@ -79,8 +79,8 @@ ProfileExporter::ProfileExporter(
     _sampleTypeDefinitions{std::move(sampleTypeDefinitions)},
     _applicationStore{applicationStore},
     _metricsRegistry{metricsRegistry},
-    _metadataProvider{metadataProvider},
     _allocationsRecorder{allocationsRecorder},
+    _metadataProvider{metadataProvider},
     _configuration{configuration}
 {
     _exporter = CreateExporter(_configuration, CreateTags(_configuration, runtimeInfo, enabledProfilers));

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
@@ -102,17 +102,17 @@ void SamplesCollector::Export()
         // batched samples are collected once just before export
         CollectSamples(_batchedSamplesProviders);
 
-        Log::Debug("Collected samples per provider:");
+        Log::Info("Collected samples per provider:");
         for (auto& samplesProvider : _samplesProviders)
         {
             auto name = samplesProvider.first->GetName();
-            Log::Debug(name, " : ", samplesProvider.second);
+            Log::Info(name, " : ", samplesProvider.second);
             samplesProvider.second = 0;
         }
         for (auto& batchedSamplesProvider : _batchedSamplesProviders)
         {
             auto name = batchedSamplesProvider.first->GetName();
-            Log::Debug(name, " : ", batchedSamplesProvider.second);
+            Log::Info(name, " : ", batchedSamplesProvider.second);
             batchedSamplesProvider.second = 0;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
@@ -102,17 +102,17 @@ void SamplesCollector::Export()
         // batched samples are collected once just before export
         CollectSamples(_batchedSamplesProviders);
 
-        Log::Info("Collected samples per provider:");
+        Log::Debug("Collected samples per provider:");
         for (auto& samplesProvider : _samplesProviders)
         {
             auto name = samplesProvider.first->GetName();
-            Log::Info(name, " : ", samplesProvider.second);
+            Log::Debug(name, " : ", samplesProvider.second);
             samplesProvider.second = 0;
         }
         for (auto& batchedSamplesProvider : _batchedSamplesProviders)
         {
             auto name = batchedSamplesProvider.first->GetName();
-            Log::Info(name, " : ", batchedSamplesProvider.second);
+            Log::Debug(name, " : ", batchedSamplesProvider.second);
             batchedSamplesProvider.second = 0;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ScopeFinalizer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ScopeFinalizer.h
@@ -70,4 +70,4 @@ FinalizerInvocationWrapper<F> operator*(DeferDummy, F&& f)
 #define DEFER_(LINE) zz_defer##LINE
 #define DEFER(LINE) DEFER_(LINE)
 #define on_leave \
-    const auto& DEFER(__COUNTER__) = DeferDummy{}* [&]()
+    [[maybe_unused]] const auto& DEFER(__COUNTER__) = DeferDummy{}* [&]()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -33,14 +33,6 @@
 using namespace std::chrono_literals;
 constexpr const WCHAR* ThreadName = WStr("DD.Profiler.StackSamplerLoop.Thread");
 
-#ifdef NDEBUG
-// Release build logs collection stats every 30 mins:
-constexpr uint64_t StackSamplerLoop_StackSnapshotResultsStats_LogPeriodNS = (30 * 60 * 1000000000ull);
-#else
-// Debug build build logs collection stats every 1 mins:
-constexpr uint64_t StackSamplerLoop_StackSnapshotResultsStats_LogPeriodNS = (1 * 60 * 1000000000ull);
-#endif
-
 StackSamplerLoop::StackSamplerLoop(
     ICorProfilerInfo4* pCorProfilerInfo,
     IConfiguration* pConfiguration,
@@ -54,9 +46,9 @@ StackSamplerLoop::StackSamplerLoop(
     MetricsRegistry& metricsRegistry)
     :
     _pCorProfilerInfo{pCorProfilerInfo},
-    _pConfiguration{pConfiguration},
     _pStackFramesCollector{pStackFramesCollector},
     _pManager{pManager},
+    _pConfiguration{pConfiguration},
     _pThreadsCpuManager{pThreadsCpuManager},
     _pManagedThreadList{pManagedThreadList},
     _pCodeHotspotsThreadList{pCodeHotspotThreadList},
@@ -67,6 +59,7 @@ StackSamplerLoop::StackSamplerLoop(
     _targetThread(nullptr),
     _iteratorWallTime{0},
     _iteratorCpuTime{0},
+    _iteratorCodeHotspot{0},
     _walltimeThreadsThreshold{pConfiguration->WalltimeThreadsThreshold()},
     _cpuThreadsThreshold{pConfiguration->CpuThreadsThreshold()},
     _codeHotspotsThreadsThreshold{pConfiguration->CodeHotspotsThreadsThreshold()},
@@ -327,8 +320,8 @@ void StackSamplerLoop::CpuProfilingIteration()
                     // detect overlapping CPU usage
                     if ((int64_t)(lastCpuTimestamp + cpuForSample * 1000000) > thisSampleTimestampNanosecs)
                     {
-                        int64_t cpuOverlap = (lastCpuTimestamp + cpuForSample * 1000000 - thisSampleTimestampNanosecs) / 1000000;
 #ifndef NDEBUG
+                        int64_t cpuOverlap = (lastCpuTimestamp + cpuForSample * 1000000 - thisSampleTimestampNanosecs) / 1000000;
                         // TODO: uncomment when debugging this issue
                         // Log::Warn("Overlapping CPU samples off ", cpuOverlap, " ms (", currentConsumption, " - ", lastConsumption, ")");
 #endif

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -38,8 +38,14 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     ) :
     _pCorProfilerInfo{pCorProfilerInfo},
     _pConfiguration{pConfiguration},
+    _pThreadsCpuManager{pThreadsCpuManager},
+    _pManagedThreadList{pManagedThreadList},
+    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
+    _pWallTimeCollector{pWallTimeCollector},
+    _pCpuTimeCollector{pCpuTimeCollector},
     _pStackFramesCollector{nullptr},
     _pStackSamplerLoop{nullptr},
+    _deadlockInterventionInProgress{0},
     _pWatcherThread{nullptr},
     _isWatcherShutdownRequested{false},
     _pTargetThread{nullptr},
@@ -52,13 +58,6 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     _totalDeadlockDetectionsCount{0},
     _metricsSender{metricsSender},
     _statisticsReadyToSend{nullptr},
-    _pClrLifetime{clrLifetime},
-    _pThreadsCpuManager{pThreadsCpuManager},
-    _pManagedThreadList{pManagedThreadList},
-    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
-    _pWallTimeCollector{pWallTimeCollector},
-    _pCpuTimeCollector{pCpuTimeCollector},
-    _deadlockInterventionInProgress{0},
     _metricsRegistry{metricsRegistry}
 {
     _pCorProfilerInfo->AddRef();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -236,6 +236,5 @@ private:
     MetricsRegistry& _metricsRegistry;
     std::shared_ptr<CounterMetric> _deadlockCountMetric;
 
-    IClrLifetime const* _pClrLifetime;
     bool _isStopped = false;
 };

--- a/shared/src/native-lib/PPDB/Reader/Streams.cpp
+++ b/shared/src/native-lib/PPDB/Reader/Streams.cpp
@@ -266,7 +266,7 @@ SequencePoints BlobHeapReader::GetAsSequencePoints(size_t initalDocumentIndex, s
 
     auto seqBlob = Get(offset);
     if (seqBlob.empty())
-        return std::move(result);
+        return result;
 
     auto curr = std::begin(seqBlob);
     result.LocalSignature = DecompressU32(&curr, std::end(seqBlob) - curr);
@@ -369,7 +369,7 @@ SequencePoints BlobHeapReader::GetAsSequencePoints(size_t initalDocumentIndex, s
         prevNonHiddenIdx = static_cast<int>(result.Points.size() - 1);
     }
 
-    return std::move(result);
+    return result;
 }
 
 std::vector<Import> BlobHeapReader::GetAsImports(size_t offset) const
@@ -394,14 +394,14 @@ std::vector<Import> BlobHeapReader::GetAsImports(size_t offset) const
         case ImportKind::ImportFromNamespace:
         {
             uint32_t nsIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.TargetNamespace = std::move(GetAsStringUtf8(nsIdx));
+            imp.TargetNamespace = GetAsStringUtf8(nsIdx);
             break;
         }
         case ImportKind::ImportFromNamespaceInAssembly:
         {
             imp.TargetAssembly = DecompressU32(&curr, std::end(importBlob) - curr);
             uint32_t nsIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.TargetNamespace = std::move(GetAsStringUtf8(nsIdx));
+            imp.TargetNamespace = GetAsStringUtf8(nsIdx);
             break;
         }
         case ImportKind::ImportFromTargetType:
@@ -412,44 +412,44 @@ std::vector<Import> BlobHeapReader::GetAsImports(size_t offset) const
         case ImportKind::ImportFromNamespaceWithAlias:
         {
             uint32_t aliasIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.Alias = std::move(GetAsStringUtf8(aliasIdx));
+            imp.Alias = GetAsStringUtf8(aliasIdx);
             uint32_t nsIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.TargetNamespace = std::move(GetAsStringUtf8(nsIdx));
+            imp.TargetNamespace = GetAsStringUtf8(nsIdx);
             break;
         }
         case ImportKind::ImportAssemblyAlias:
         {
             uint32_t aliasIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.Alias = std::move(GetAsStringUtf8(aliasIdx));
+            imp.Alias = GetAsStringUtf8(aliasIdx);
             break;
         }
         case ImportKind::DefineAssemblyAlias:
         {
             uint32_t aliasIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.Alias = std::move(GetAsStringUtf8(aliasIdx));
+            imp.Alias = GetAsStringUtf8(aliasIdx);
             imp.TargetAssembly = DecompressU32(&curr, std::end(importBlob) - curr);
             break;
         }
         case ImportKind::DefineNamespaceAlias:
         {
             uint32_t aliasIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.Alias = std::move(GetAsStringUtf8(aliasIdx));
+            imp.Alias = GetAsStringUtf8(aliasIdx);
             uint32_t nsIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.TargetNamespace = std::move(GetAsStringUtf8(nsIdx));
+            imp.TargetNamespace = GetAsStringUtf8(nsIdx);
             break;
         }
         case ImportKind::DefineNamespaceAliasFromAssembly:
         {
             uint32_t aliasIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.Alias = std::move(GetAsStringUtf8(aliasIdx));
+            imp.Alias = GetAsStringUtf8(aliasIdx);
             imp.TargetAssembly = DecompressU32(&curr, std::end(importBlob) - curr);
             uint32_t nsIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.TargetNamespace = std::move(GetAsStringUtf8(nsIdx));
+            imp.TargetNamespace = GetAsStringUtf8(nsIdx);
             break;
         }
         case ImportKind::DefineTargetTypeAlias:
             uint32_t aliasIdx = DecompressU32(&curr, std::end(importBlob) - curr);
-            imp.Alias = std::move(GetAsStringUtf8(aliasIdx));
+            imp.Alias = GetAsStringUtf8(aliasIdx);
             imp.TargetType = DecompressTypeDefOrRefOrSpecEncoded(&curr, std::end(importBlob) - curr);
             break;
         }
@@ -457,7 +457,7 @@ std::vector<Import> BlobHeapReader::GetAsImports(size_t offset) const
         imports.push_back(std::move(imp));
     }
 
-    return std::move(imports);
+    return imports;
 }
 
 LocalConstantSig BlobHeapReader::GetAsLocalConstantSig(size_t offset) const
@@ -568,7 +568,7 @@ LocalConstantSig BlobHeapReader::GetAsLocalConstantSig(size_t offset) const
     if (curr != std::end(sigBlob))
         throw Exception{ ErrorCode::CorruptFormat, MetadataTable::LocalConstant };
 
-    return std::move(sig);
+    return sig;
 }
 
 namespace
@@ -676,8 +676,8 @@ const std::string MetadataStreamReader::Name = "#~";
 
 MetadataStreamReader::MetadataStreamReader(std::shared_ptr<PortablePdbReader> reader, plat::data_view<uint8_t> view)
     : _view{ view }
-    , _tableReaders{}
     , _reader{ std::move(reader) }
+    , _tableReaders{}
 {
     if (_view.size() < sizeof(MetadataStreamMin))
         throw Exception{ ErrorCode::CorruptFormat, Name };
@@ -777,5 +777,5 @@ std::shared_ptr<TableReader> MetadataStreamReader::GetTableReader(MetadataTable 
     auto reader = _tableReaders[static_cast<size_t>(table)];
 
     assert(reader == nullptr || reader->GetTableId() == table);
-    return std::move(reader);
+    return reader;
 }


### PR DESCRIPTION
## Summary of changes

Fix complation warnings.

## Reason for change

It bothers me :) and some of them can kill the compiler optimizer.

## Implementation details
- Adjust order in initialization list
- remove `std::move(...)` when is not needed
- Mark variable as `[[maybe_unused`]] (mainly for syntactic sugar
- 
## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
