### PR TITLE
[Documentation] Add a sample that configures an ASP.NET Core app with OpenTelemetry

### DIFF
--- a/tracer/samples/OpenTelemetry/Debian.dockerfile
+++ b/tracer/samples/OpenTelemetry/Debian.dockerfile
@@ -1,0 +1,37 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /app
+
+# Copy csproj and restore as distinct layers
+COPY *.csproj ./
+RUN dotnet restore
+
+# Copy everything else and build
+COPY . ./
+RUN dotnet publish -c Release -f net8.0 -o out
+
+# Build runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+RUN apt-get update && apt-get install -y curl
+WORKDIR /app
+COPY --from=build /app/out .
+
+# Download the Datadog .NET Tracer
+ARG TRACER_VERSION=2.47.0
+RUN mkdir -p /var/log/datadog
+RUN mkdir -p /opt/datadog
+RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb
+RUN dpkg -i ./datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb
+
+# Set up the Datadog .NET Tracer automatic instrumentation
+ENV CORECLR_ENABLE_PROFILING=1
+ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+ENV DD_DOTNET_TRACER_HOME=/opt/datadog
+
+# Set up additional capabilities of the Datadog .NET Tracer
+ENV DD_APPSEC_ENABLED=true
+
+# Enable the OTEL tracing feature flag to receive OTEL spans
+ENV DD_TRACE_OTEL_ENABLED=true
+
+CMD ["dotnet", "OpenTelemetry.AspNetCoreApplication.dll"]

--- a/tracer/samples/OpenTelemetry/OpenTelemetry.AspNetCoreApplication.csproj
+++ b/tracer/samples/OpenTelemetry/OpenTelemetry.AspNetCoreApplication.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
+  </ItemGroup>
+
+</Project>

--- a/tracer/samples/OpenTelemetry/Program.cs
+++ b/tracer/samples/OpenTelemetry/Program.cs
@@ -1,0 +1,57 @@
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+using System.Diagnostics;
+
+namespace OpenTelemetry.AspNetCoreApplication;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        var builder = WebApplication.CreateBuilder(args);
+
+        // Configure important OpenTelemetry settings
+        builder.Services.AddOpenTelemetry()
+            .WithTracing(tracing =>
+            {
+                tracing.ConfigureResource(resource =>
+                        resource.AddService(
+                            serviceName: Telemetry.ServiceName,
+                            serviceVersion: Telemetry.ServiceVersion))
+                    .AddSource(Telemetry.ServiceName)
+                    //
+                    // Instrumentation Libraries
+                    // Note: Datadog automatic instrumentation has integrations for several supported libraries,
+                    //       so instrumentation libraries with a corresponding integration MAY be disabled.
+                    //
+                    .AddAspNetCoreInstrumentation() // Datadog Integration Name: AspNetCore
+                    .AddHttpClientInstrumentation() // Datadog Integration Name: HttpMessageHandler
+                    //
+                    // Exporters
+                    // Note: Datadog automatic instrumentation will generate and export Datadog spans,
+                    //       so OTEL exporters may not have accurate information and SHOULD be disabled.
+                    //       If any exporter is sending traces that get forwarded to the Datadog backend,
+                    //       they MUST be disabled to prevent the backend from receiving duplicate traces.
+                    //
+                    // .AddOtlpExporter()
+                    ;
+            });
+
+        var app = builder.Build();
+
+        app.MapGet("/", () =>
+        {
+            using (Activity? activity = Telemetry.ActivitySource.StartActivity("SayHello"))
+            {
+                // Do work and then return a result
+                activity?.SetTag("operation.value", 1);
+                activity?.SetTag("operation.name", "Saying hello!");
+                activity?.SetTag("operation.other-stuff", new int[] { 1, 2, 3 });
+
+                return "Hello World!";
+            }
+        });
+
+        app.Run();
+    }
+}

--- a/tracer/samples/OpenTelemetry/Properties/launchSettings.json
+++ b/tracer/samples/OpenTelemetry/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:5281",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+
+        "DD_TRACE_OTEL_ENABLED": "true"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:7236;http://localhost:5281",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+
+        "DD_TRACE_OTEL_ENABLED": "true"
+      }
+    }
+  }
+}

--- a/tracer/samples/OpenTelemetry/README.md
+++ b/tracer/samples/OpenTelemetry/README.md
@@ -9,3 +9,6 @@ This sample contains an example ASP.NET Core application with the OpenTelemetry 
 - Clone/download this repository
 - Update the `docker-compose.yml` by replacing the value for `DD_API_KEY`
 - Run `docker-compose up` & navigate to `http://localhost:8080`
+
+### Resulting .NET APM traces within Datadog:
+![trace_view](https://github.com/DataDog/dd-trace-dotnet/assets/13769665/8387f313-c2bb-4e3f-b9b0-15ddb6cf962f)

--- a/tracer/samples/OpenTelemetry/README.md
+++ b/tracer/samples/OpenTelemetry/README.md
@@ -1,0 +1,11 @@
+# OpenTelemetry
+
+### About the sample:
+
+This sample contains an example ASP.NET Core application with the OpenTelemetry SDK configured. The dockerfile downloads the Datadog .NET Tracer and configures automatic instrumentation (along with the Application Security Monitoring).
+
+### How to use:
+
+- Clone/download this repository
+- Update the `docker-compose.yml` by replacing the value for `DD_API_KEY`
+- Run `docker-compose up` & navigate to `http://localhost:8080`

--- a/tracer/samples/OpenTelemetry/Telemetry.cs
+++ b/tracer/samples/OpenTelemetry/Telemetry.cs
@@ -1,0 +1,10 @@
+using System.Diagnostics;
+
+namespace OpenTelemetry.AspNetCoreApplication;
+
+public static class Telemetry
+{
+    public static readonly string ServiceName = "OpenTelemetry.AspNetCoreApplication";
+    public static readonly string ServiceVersion = "1.0.0";
+    public static readonly ActivitySource ActivitySource = new(ServiceName);
+}

--- a/tracer/samples/OpenTelemetry/appsettings.Development.json
+++ b/tracer/samples/OpenTelemetry/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tracer/samples/OpenTelemetry/appsettings.json
+++ b/tracer/samples/OpenTelemetry/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/tracer/samples/OpenTelemetry/docker-compose.yml
+++ b/tracer/samples/OpenTelemetry/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       DD_API_KEY: "${DD_API_KEY:?Set DD_API_KEY in your shell to send traces to Datadog}"
       DD_APM_ENABLED: "true"
       DD_APM_NON_LOCAL_TRAFFIC: "true"
-      DD_ENV: "${DD_ENV}"
       # Configure the Datadog agent for OTLP Ingest
       DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
       DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: "0.0.0.0:4318"
@@ -29,7 +28,8 @@ services:
     depends_on:
       - datadog-agent
     environment:
-      ASPNETCORE_ENVIRONMENT: Production
       DD_AGENT_HOST: "datadog-agent"
+      DD_ENV: "apm-docker-samples"
+      ASPNETCORE_ENVIRONMENT: Production
       # If the OTLP Exporter is enabled in the .NET application, use the GRPC endpoint
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://datadog-agent:4317"

--- a/tracer/samples/OpenTelemetry/docker-compose.yml
+++ b/tracer/samples/OpenTelemetry/docker-compose.yml
@@ -1,0 +1,35 @@
+version: "3.9"
+services:
+  #
+  # Shared agent
+  datadog-agent:
+    image: "gcr.io/datadoghq/agent:7"
+    ports:
+      - "8126"
+      - "4317"
+      - "4318"
+    environment:
+      DD_HOSTNAME: "dev-datadog-agent"
+      DD_API_KEY: "${DD_API_KEY:?Set DD_API_KEY in your shell to send traces to Datadog}"
+      DD_APM_ENABLED: "true"
+      DD_APM_NON_LOCAL_TRAFFIC: "true"
+      DD_ENV: "${DD_ENV}"
+      # Configure the Datadog agent for OTLP Ingest
+      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
+      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: "0.0.0.0:4318"
+
+  #
+  # Application containers
+  debian:
+    build:
+      context: ./
+      dockerfile: ./Debian.dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - datadog-agent
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      DD_AGENT_HOST: "datadog-agent"
+      # If the OTLP Exporter is enabled in the .NET application, use the GRPC endpoint
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://datadog-agent:4317"


### PR DESCRIPTION
## Summary of changes
Adds a sample that developers can reference for updating an OpenTelemetry SDK application to using Datadog automatic instrumentation.

## Reason for change
We were missing easy-to-find examples.

## Implementation details

## Test coverage
I was able to run this on my machine with Docker and Docker Compose and verified that the traces are received in the Datadog UI.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
