### PR TITLE
Tweak OpenTelemetry sample

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -442,6 +442,7 @@ partial class Build
                 "tracer/samples/ConsoleApp/Alpine3.10.dockerfile",
                 "tracer/samples/ConsoleApp/Alpine3.9.dockerfile",
                 "tracer/samples/ConsoleApp/Debian.dockerfile",
+                "tracer/samples/OpenTelemetry/Debian.dockerfile",
                 "tracer/samples/WindowsContainer/Dockerfile",
                 "tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj",
                 "tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj",

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -215,6 +215,10 @@ namespace PrepareRelease
                     text => Regex.Replace(text, $"ARG TRACER_VERSION={VersionPattern()}", $"ARG TRACER_VERSION={VersionString()}"));
 
                 SynchronizeVersion(
+                    "samples/OpenTelemetry/Debian.dockerfile",
+                    text => Regex.Replace(text, $"ARG TRACER_VERSION={VersionPattern()}", $"ARG TRACER_VERSION={VersionString()}"));
+
+                SynchronizeVersion(
                     "samples/WindowsContainer/Dockerfile",
                     text => Regex.Replace(text, $"ARG TRACER_VERSION={VersionPattern()}", $"ARG TRACER_VERSION={VersionString()}"));
 

--- a/tracer/samples/OpenTelemetry/OpenTelemetry.AspNetCoreApplication.csproj
+++ b/tracer/samples/OpenTelemetry/OpenTelemetry.AspNetCoreApplication.csproj
@@ -8,7 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="OpenTelemetry" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <!-- // Note: Datadog automatic instrumentation will generate and export Datadog spans,
+         //       so OTEL exporters may not have accurate information and SHOULD be disabled.
+         //       If any exporter is sending traces that get forwarded to the Datadog backend,
+         //       they MUST be disabled to prevent the backend from receiving duplicate traces. -->
+    <!-- <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" /> -->
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />

--- a/tracer/samples/OpenTelemetry/appsettings.Development.json
+++ b/tracer/samples/OpenTelemetry/appsettings.Development.json
@@ -1,8 +1,0 @@
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}

--- a/tracer/samples/OpenTelemetry/docker-compose.yml
+++ b/tracer/samples/OpenTelemetry/docker-compose.yml
@@ -31,5 +31,7 @@ services:
       DD_AGENT_HOST: "datadog-agent"
       DD_ENV: "apm-docker-samples"
       ASPNETCORE_ENVIRONMENT: Production
-      # If the OTLP Exporter is enabled in the .NET application, use the GRPC endpoint
+      # If the OTLP Exporter is enabled in the .NET application, use the GRPC endpoint.
+      # This is only required if you're using OpenTelemetry ONLY (no Datadog autoinstrumentation)
+      # It is not required for this sample
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://datadog-agent:4317"

--- a/tracer/samples/OpenTelemetry/docker-compose.yml
+++ b/tracer/samples/OpenTelemetry/docker-compose.yml
@@ -13,9 +13,6 @@ services:
       DD_API_KEY: "${DD_API_KEY:?Set DD_API_KEY in your shell to send traces to Datadog}"
       DD_APM_ENABLED: "true"
       DD_APM_NON_LOCAL_TRAFFIC: "true"
-      # Configure the Datadog agent for OTLP Ingest
-      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
-      DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_HTTP_ENDPOINT: "0.0.0.0:4318"
 
   #
   # Application containers
@@ -31,7 +28,3 @@ services:
       DD_AGENT_HOST: "datadog-agent"
       DD_ENV: "apm-docker-samples"
       ASPNETCORE_ENVIRONMENT: Production
-      # If the OTLP Exporter is enabled in the .NET application, use the GRPC endpoint.
-      # This is only required if you're using OpenTelemetry ONLY (no Datadog autoinstrumentation)
-      # It is not required for this sample
-      OTEL_EXPORTER_OTLP_ENDPOINT: "http://datadog-agent:4317"


### PR DESCRIPTION
## Summary of changes

- Make sure we keep the Otel sample up to date
- Make it clear the exporter isn't required
- Copy some comments around

## Reason for change

- We want to keep the samples pointing to the latest version.
- The requirement for the exporter was the biggest question I had, so I think we should make it completely clear it's not necessary by not adding it.

## Implementation details

- Added the sample to the list of auto-bumped files
- Comments + comment out the exporter package

## Test coverage

Tested it, it works

## Other details
I wonder if we should remove the OTEL exporter settings defined in the docker-compose.yml entirely? IMO they just add confusion (as they're not actually used, and _shouldn't_ be used). I feel like a "Chekhov's gun" approach to the sample would be best, given that this can be a confusing setup?

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
