### PR TITLE
[IAST] Enabled hash in integration tests

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastUtils.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastUtils.cs
@@ -86,23 +86,26 @@ internal static class IastUtils
             return -1;
         }
 
-        fixed (char* charPtr = target)
+        unchecked
         {
-            var int32Length = target.Length / 2;
-            var intPtr = (int*)charPtr;
-
-            var hash = StartHash;
-            for (var i = 0; i < int32Length; i++)
+            fixed (char* charPtr = target)
             {
-                hash += intPtr[i] * GoldenRatio;
-            }
+                var int32Length = target.Length / 2;
+                var intPtr = (int*)charPtr;
 
-            if (target.Length % 2 != 0)
-            {
-                hash += ((int)charPtr[target.Length - 1]) * GoldenRatio;
-            }
+                var hash = StartHash;
+                for (var i = 0; i < int32Length; i++)
+                {
+                    hash += intPtr[i] * GoldenRatio;
+                }
 
-            return hash;
+                if (target.Length % 2 != 0)
+                {
+                    hash += ((int)charPtr[target.Length - 1]) * GoldenRatio;
+                }
+
+                return hash;
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore2IastTests.cs
@@ -151,7 +151,7 @@ public class AspNetCore2IastTestsFullSamplingEnabled : AspNetCore2IastTestsFullS
         var spans = await SendRequestsAsync(agent, new string[] { url });
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
-        settings.AddIastScrubbing(scrubHash: false);
+        settings.AddIastScrubbing();
         await VerifyHelper.VerifySpans(spans, settings)
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();
@@ -414,7 +414,7 @@ public abstract class AspNetCore2IastTestsFullSampling : AspNetCore2IastTests
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
-        settings.AddIastScrubbing(scrubHash: false);
+        settings.AddIastScrubbing();
         await VerifyHelper.VerifySpans(spansFiltered, settings)
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -210,7 +210,7 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
         var spans = await SendRequestsAsync(agent, new string[] { url });
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
-        settings.AddIastScrubbing(scrubHash: false);
+        settings.AddIastScrubbing();
         await VerifyHelper.VerifySpans(spans, settings)
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();
@@ -248,7 +248,7 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
         var spans = await SendRequestsAsync(agent, new string[] { url });
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
-        settings.AddIastScrubbing(scrubHash: false);
+        settings.AddIastScrubbing();
         await VerifyHelper.VerifySpans(spans, settings)
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();
@@ -561,7 +561,7 @@ public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
 
         var settings = VerifyHelper.GetSpanVerifierSettings();
-        settings.AddIastScrubbing(scrubHash: false);
+        settings.AddIastScrubbing();
         await VerifyHelper.VerifySpans(spansFiltered, settings)
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetMvc5IastTests.cs
@@ -163,7 +163,7 @@ public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixtu
         var settings = VerifyHelper.GetSpanVerifierSettings(test, sanitisedUrl);
         var spans = await SendRequestsAsync(_iisFixture.Agent, new string[] { url });
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
-        settings.AddIastScrubbing(true);
+        settings.AddIastScrubbing();
         var sanitisedPath = VerifyHelper.SanitisePathsForVerify(url);
         await VerifyHelper.VerifySpans(spansFiltered, settings)
                           .UseFileName($"{_testName}.path={sanitisedPath}")
@@ -181,7 +181,7 @@ public class AspNetMvc5ClassicWithIastTelemetryEnabled : AspNetBase, IClassFixtu
         var settings = VerifyHelper.GetSpanVerifierSettings(test, sanitisedUrl);
         var spans = await SendRequestsAsync(_iisFixture.Agent, new string[] { url });
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
-        settings.AddIastScrubbing(true);
+        settings.AddIastScrubbing();
         var sanitisedPath = VerifyHelper.SanitisePathsForVerify(url);
         await VerifyHelper.VerifySpans(spansFiltered, settings)
                           .UseFileName($"{_testName}.path={sanitisedPath}")
@@ -254,7 +254,7 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         var settings = VerifyHelper.GetSpanVerifierSettings(test, sanitisedUrl);
         var spans = await SendRequestsAsync(_iisFixture.Agent, new string[] { url });
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
-        settings.AddIastScrubbing(false);
+        settings.AddIastScrubbing();
         var sanitisedPath = VerifyHelper.SanitisePathsForVerify(url);
         await VerifyHelper.VerifySpans(spansFiltered, settings)
                           .UseFileName($"{_testName}.path={sanitisedPath}")
@@ -504,7 +504,7 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         var settings = VerifyHelper.GetSpanVerifierSettings(AddressesConstants.RequestQuery, sanitisedUrl);
         var spans = await SendRequestsAsync(_iisFixture.Agent, new string[] { url });
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
-        settings.AddIastScrubbing(scrubHash: false);
+        settings.AddIastScrubbing();
         var filename = testName + "." + contentType.Replace("/", string.Empty) +
             "." + returnCode.ToString() + "." + (string.IsNullOrEmpty(hstsHeaderValue) ? "empty" : hstsHeaderValue)
             + "." + (string.IsNullOrEmpty(xForwardedProto) ? "empty" : xForwardedProto);
@@ -563,7 +563,7 @@ public abstract class AspNetMvc5IastTests : AspNetBase, IClassFixture<IisFixture
         var settings = VerifyHelper.GetSpanVerifierSettings(AddressesConstants.RequestQuery, sanitisedUrl);
         var spans = await SendRequestsAsync(_iisFixture.Agent, new string[] { url });
         var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
-        settings.AddIastScrubbing(scrubHash: false);
+        settings.AddIastScrubbing();
         await VerifyHelper.VerifySpans(spansFiltered, settings)
                           .UseFileName($"{testName}.path={sanitisedUrl}")
                           .DisableRequireUniquePrefix();

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastVerifyScrubberExtensions.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastVerifyScrubberExtensions.cs
@@ -14,17 +14,15 @@ namespace Datadog.Trace.Security.IntegrationTests.IAST
     {
         private static readonly (Regex RegexPattern, string Replacement) ClientIp = (new Regex(@"["" ""]*http.client_ip: .*,(\r|\n){1,2}"), string.Empty);
         private static readonly (Regex RegexPattern, string Replacement) NetworkClientIp = (new Regex(@"["" ""]*network.client.ip: .*,(\r|\n){1,2}"), string.Empty);
-        private static readonly (Regex RegexPattern, string Replacement) HashRegex = (new Regex(@"(\S)*""hash"": (-){0,1}([0-9]){1,12},(\r|\n){1,2}      "), string.Empty);
         private static readonly (Regex RegexPattern, string Replacement) RequestTaintedRegex = (new Regex(@"_dd.iast.telemetry.request.tainted:(\s)*([1-9])(\d*).?(\d*),"), "_dd.iast.telemetry.request.tainted:,");
         private static readonly (Regex RegexPattern, string Replacement) TelemetryExecutedSinks = (new Regex(@"_dd\.iast\.telemetry\.executed\.sink\.weak_.+: .{3},"), string.Empty);
 
         private static readonly (Regex RegexPattern, string Replacement) SpanIdRegex = (new Regex("\"spanId\": \\d+"), "\"spanId\": XXX");
         private static readonly (Regex RegexPattern, string Replacement) LineRegex = (new Regex("\"line\": \\d+"), "\"line\": XXX");
 
-        public static VerifySettings AddIastScrubbing(this VerifySettings settings, bool scrubHash = true)
+        public static VerifySettings AddIastScrubbing(this VerifySettings settings)
         {
             var scrubbers = new List<(Regex RegexPattern, string Replacement)>();
-            if (scrubHash) { scrubbers.Add(HashRegex); }
             return AddIastScrubbing(settings, scrubbers);
         }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashBasedDeduplicationTests.cs
@@ -12,6 +12,14 @@ namespace Datadog.Trace.Security.Unit.Tests.Iast;
 public class HashBasedDeduplicationTests
 {
     [Fact]
+    public void GivenAKownVulnerability_WhenCalculatedHash_ValueIsEspected()
+    {
+        var vulnerability = new Vulnerability(VulnerabilityTypeName.WeakHash, new Location(null, "AspNetCoreRateLimit.RateLimitProcessor::BuildCounterKey", null, 849303611103961300, null), new Evidence("SHA1"));
+        var hashCode = vulnerability.GetHashCode();
+        Assert.Equal(-367182571, hashCode);
+    }
+
+    [Fact]
     public void GivenTheSameVulnerabilityInstance_WhenAddedToDeduplication_OnlyOneIsStored()
     {
         var instance = new HashBasedDeduplication();

--- a/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CommandInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "hash": -177455026,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.CookieTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "hash": -177455026,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HardcodedSecrets.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -65,6 +65,7 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "hash": -956844721,
       "location": {
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
@@ -101,6 +102,7 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "hash": 1765594085,
       "location": {
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
@@ -137,6 +139,7 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "hash": 1916343769,
       "location": {
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"
@@ -173,6 +176,7 @@
   "vulnerabilities": [
     {
       "type": "HARDCODED_SECRET",
+      "hash": 465913083,
       "location": {
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
         "method": "HardcodedSecrets"

--- a/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.Cookie.SensitiveValue.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.Cookie.SensitiveValue.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "HEADER_INJECTION",
+      "hash": 2074088343,
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.MultipleHeaderValues.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.MultipleHeaderValues.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "HEADER_INJECTION",
+      "hash": 2074088343,
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.NoSensitive.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.NoSensitive.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "HEADER_INJECTION",
+      "hash": 2074088343,
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.Origin.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.Origin.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "HEADER_INJECTION",
+      "hash": 2074088343,
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.SensitiveName.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.SensitiveName.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "HEADER_INJECTION",
+      "hash": 2074088343,
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.SensitiveValue.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.SensitiveValue.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "HEADER_INJECTION",
+      "hash": 2074088343,
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.SensitiveValueComplex.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderInjection.AspNetCore5.Vuln.SensitiveValueComplex.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "HEADER_INJECTION",
+      "hash": 2074088343,
       "evidence": {
         "valueParts": [
           {

--- a/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.HeaderTainting.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "hash": -177455026,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.Ldap.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "LDAP_INJECTION",
+      "hash": 1194048027,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.NoSqlMongoDbInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.NoSqlMongoDbInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "NOSQL_MONGODB_INJECTION",
+      "hash": 507455816,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.PathTraversal.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "PATH_TRAVERSAL",
+      "hash": -1927798418,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTest.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "hash": 43540071,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.RequestBodyTestRazor.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
+      "hash": 2000904247,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.DataRazorIastPageModel",

--- a/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SSRF.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "SSRF",
+      "hash": -791383054,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.SqlInjection.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "SQL_INJECTION",
+      "hash": -1420150312,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "hash": -1443319821,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
@@ -42,6 +43,7 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "hash": -1443319821,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
@@ -58,6 +60,7 @@
     },
     {
       "type": "TRUST_BOUNDARY_VIOLATION",
+      "hash": -1443319821,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
@@ -81,12 +84,14 @@
     },
     {
       "type": "NO_SAMESITE_COOKIE",
+      "hash": -1222453805,
       "evidence": {
         "value": ".AspNetCore.Session"
       }
     },
     {
       "type": "INSECURE_COOKIE",
+      "hash": 1343789722,
       "evidence": {
         "value": ".AspNetCore.Session"
       }

--- a/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.UnvalidatedRedirect.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -75,6 +75,7 @@
   "vulnerabilities": [
     {
       "type": "UNVALIDATED_REDIRECT",
+      "hash": 656898286,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakHashing.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "WEAK_HASH",
+      "hash": 667172147,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",
@@ -37,6 +38,7 @@
     },
     {
       "type": "WEAK_HASH",
+      "hash": 667172147,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",

--- a/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.WeakRandomness.AspNetCore5.IastEnabled.verified.txt
@@ -26,6 +26,7 @@
   "vulnerabilities": [
     {
       "type": "WEAK_RANDOMNESS",
+      "hash": -877103513,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",


### PR DESCRIPTION
## Summary of changes
Removed hash scrubbing from snapshots.
Added unchecked clause to string hash calculation

## Reason for change
Two clients have reported different hashes for weak_hash vulnerability in the same spot in NetCore 7

## Implementation details
Removed hash scrubbing from snapshots, ensuring the same hash is calculated always for the same vuln

## Test coverage
Added a hash test with the failing value in the client
