### PR TITLE
Support DOTNET_EnableDiagnostics in dd-dotnet

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -526,6 +526,8 @@ namespace Datadog.Trace.Tools.Runner
                 // Preventively set EnableDiagnostics to override any ambient value
                 ["COMPlus_EnableDiagnostics"] = "1",
                 ["DOTNET_EnableDiagnostics"] = "1",
+                ["DOTNET_EnableDiagnostics_Profiler"] = "1",
+                ["COMPlus_EnableDiagnostics_Profiler"] = "1",
             };
 
             if (!string.IsNullOrEmpty(ldPreload))

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -523,6 +523,9 @@ namespace Datadog.Trace.Tools.Runner
                 ["COR_PROFILER"] = Profilerid,
                 ["COR_PROFILER_PATH_32"] = tracerProfiler32,
                 ["COR_PROFILER_PATH_64"] = tracerProfiler64,
+                // Preventively set EnableDiagnostics to override any ambient value
+                ["COMPlus_EnableDiagnostics"] = "1",
+                ["DOTNET_EnableDiagnostics"] = "1",
             };
 
             if (!string.IsNullOrEmpty(ldPreload))

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -696,19 +696,20 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
         private static bool CheckEnableDiagnostics(ProcessInfo process)
         {
-            if (process.EnvironmentVariables.TryGetValue("DOTNET_EnableDiagnostics", out var value) && value == "0")
+            var variablesToCheck = new[] { "DOTNET_EnableDiagnostics", "COMPlus_EnableDiagnostics", "DOTNET_EnableDiagnostics_Profiler", "COMPlus_EnableDiagnostics_Profiler" };
+
+            bool result = true;
+
+            foreach (var key in variablesToCheck)
             {
-                Utils.WriteError(EnableDiagnosticsSet("DOTNET_EnableDiagnostics"));
-                return false;
+                if (process.EnvironmentVariables.TryGetValue(key, out var value) && value == "0")
+                {
+                    Utils.WriteError(EnableDiagnosticsSet(key));
+                    result = false;
+                }
             }
 
-            if (process.EnvironmentVariables.TryGetValue("COMPlus_EnableDiagnostics", out value) && value == "0")
-            {
-                Utils.WriteError(EnableDiagnosticsSet("COMPlus_EnableDiagnostics"));
-                return false;
-            }
-
-            return true;
+            return result;
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -187,6 +187,8 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                 Utils.WriteSuccess(CorrectlySetupEnvironment(corEnableKey, "1"));
             }
 
+            ok &= CheckEnableDiagnostics(process);
+
             process.EnvironmentVariables.TryGetValue(corProfilerPathKey, out var corProfilerPathValue);
             process.EnvironmentVariables.TryGetValue(corProfilerPathKey32, out var corProfilerPathValue32);
             process.EnvironmentVariables.TryGetValue(corProfilerPathKey64, out var corProfilerPathValue64);
@@ -417,6 +419,55 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             return ok;
         }
 
+        internal static void CheckLinuxInstallation(string installDirectory)
+        {
+            string archFolder;
+            var osArchitecture = RuntimeInformation.OSArchitecture;
+
+            if (osArchitecture == Architecture.X64)
+            {
+                archFolder = Utils.IsAlpine() ? "linux-musl-x64" : "linux-x64";
+            }
+            else if (osArchitecture == Architecture.Arm64)
+            {
+                archFolder = "linux-arm64";
+            }
+            else
+            {
+                Utils.WriteError(UnsupportedLinuxArchitecture(osArchitecture.ToString()));
+                return;
+            }
+
+            try
+            {
+                var joinedPath = Path.Join(installDirectory, archFolder);
+
+                if (Directory.Exists(joinedPath))
+                {
+                    Utils.WriteSuccess(CorrectLinuxDirectoryFound(joinedPath));
+                }
+                else
+                {
+                    string[] directories = Directory.GetDirectories(installDirectory);
+
+                    // Iterate through directories and filter based on the starting string
+                    foreach (string directory in directories)
+                    {
+                        DirectoryInfo dirInfo = new DirectoryInfo(directory);
+                        if (dirInfo.Name.StartsWith("linux-", StringComparison.OrdinalIgnoreCase))
+                        {
+                            Utils.WriteError(WrongLinuxFolder(archFolder, dirInfo.Name));
+                            return;
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Utils.WriteError(ErrorCheckingLinuxDirectory(ex.Message));
+            }
+        }
+
         private static bool CheckClsid(IRegistryService registry, string registryKey)
         {
             var profilerPath = registry.GetLocalMachineValue(registryKey);
@@ -643,53 +694,21 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             return versionFound;
         }
 
-        internal static void CheckLinuxInstallation(string installDirectory)
+        private static bool CheckEnableDiagnostics(ProcessInfo process)
         {
-            string archFolder;
-            var osArchitecture = RuntimeInformation.OSArchitecture;
-
-            if (osArchitecture == Architecture.X64)
+            if (process.EnvironmentVariables.TryGetValue("DOTNET_EnableDiagnostics", out var value) && value == "0")
             {
-                archFolder = Utils.IsAlpine() ? "linux-musl-x64" : "linux-x64";
-            }
-            else if (osArchitecture == Architecture.Arm64)
-            {
-                archFolder = "linux-arm64";
-            }
-            else
-            {
-                Utils.WriteError(UnsupportedLinuxArchitecture(osArchitecture.ToString()));
-                return;
+                Utils.WriteError(EnableDiagnosticsSet("DOTNET_EnableDiagnostics"));
+                return false;
             }
 
-            try
+            if (process.EnvironmentVariables.TryGetValue("COMPlus_EnableDiagnostics", out value) && value == "0")
             {
-                var joinedPath = Path.Join(installDirectory, archFolder);
-
-                if (Directory.Exists(joinedPath))
-                {
-                    Utils.WriteSuccess(CorrectLinuxDirectoryFound(joinedPath));
-                }
-                else
-                {
-                    string[] directories = Directory.GetDirectories(installDirectory);
-
-                    // Iterate through directories and filter based on the starting string
-                    foreach (string directory in directories)
-                    {
-                        DirectoryInfo dirInfo = new DirectoryInfo(directory);
-                        if (dirInfo.Name.StartsWith("linux-", StringComparison.OrdinalIgnoreCase))
-                        {
-                            Utils.WriteError(WrongLinuxFolder(archFolder, dirInfo.Name));
-                            return;
-                        }
-                    }
-                }
+                Utils.WriteError(EnableDiagnosticsSet("COMPlus_EnableDiagnostics"));
+                return false;
             }
-            catch (Exception ex)
-            {
-                Utils.WriteError(ErrorCheckingLinuxDirectory(ex.Message));
-            }
+
+            return true;
         }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Resources.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/Resources.cs
@@ -57,6 +57,8 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
 
         public static void ResetChecks() => _checkNumber = 1;
 
+        public static string EnableDiagnosticsSet(string key) => $"The environment variable {key} is set to 0, which disables profiling.";
+
         public static string GetProcessError(string error) => $"Could not fetch information about target process: {error}. Make sure to run the command from an elevated prompt, and check that the pid is correct.";
 
         public static string TracerNotEnabled(string value) => $"Tracing is explicitly disabled through DD_TRACE_ENABLED with a value of {value}, to enable automatic tracing set it to true.";

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
@@ -130,6 +130,9 @@ internal class Utils
             ["COR_PROFILER"] = Profilerid,
             ["COR_PROFILER_PATH_32"] = tracerProfiler32,
             ["COR_PROFILER_PATH_64"] = tracerProfiler64,
+            // Preventively set EnableDiagnostics to override any ambient value
+            ["COMPlus_EnableDiagnostics"] = "1",
+            ["DOTNET_EnableDiagnostics"] = "1",
         };
 
         if (!string.IsNullOrEmpty(ldPreload))

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
@@ -133,6 +133,8 @@ internal class Utils
             // Preventively set EnableDiagnostics to override any ambient value
             ["COMPlus_EnableDiagnostics"] = "1",
             ["DOTNET_EnableDiagnostics"] = "1",
+            ["DOTNET_EnableDiagnostics_Profiler"] = "1",
+            ["COMPlus_EnableDiagnostics_Profiler"] = "1",
         };
 
         if (!string.IsNullOrEmpty(ldPreload))

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -501,6 +501,10 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     [InlineData("DOTNET_EnableDiagnostics", "0")]
     [InlineData("COMPlus_EnableDiagnostics", "1")]
     [InlineData("COMPlus_EnableDiagnostics", "0")]
+    [InlineData("DOTNET_EnableDiagnostics_Profiler", "0")]
+    [InlineData("DOTNET_EnableDiagnostics_Profiler", "1")]
+    [InlineData("COMPlus_EnableDiagnostics_Profiler", "0")]
+    [InlineData("COMPlus_EnableDiagnostics_Profiler", "1")]
     public async Task EnableDiagnostics(string key, string value)
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);


### PR DESCRIPTION
## Summary of changes

The behavior of `DOTNET_EnableDiagnostics` has changed in .NET 8, it can now disable profiling: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_enablediagnostics
`DOTNET_EnableDiagnostics_Profiler` will have a similar effect: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_enablediagnostics_profiler

This PR makes two changes:
 - `dd-dotnet check` checks that those environment variable aren't set to 0
 - `dd-dotnet run` and `dd-trace run` explicitly sets them to 1 to override preventively override the ambient value
 
## Test coverage

Added an integration test to verify that `dd-dotnet check` detects those environment variables.