### PR TITLE
[Dynamic Instrumentation] Fix not equal (ne\!=) operator in EL

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.Binary.cs
@@ -14,7 +14,7 @@ internal partial class ProbeExpressionParser<T>
 {
     private Expression NotEqual(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
-        return BinaryOperation(reader, parameters, itParameter, "==");
+        return BinaryOperation(reader, parameters, itParameter, "!=");
     }
 
     private Expression Equal(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -159,7 +159,7 @@ internal partial class ProbeExpressionParser<T>
                                     }
 
                                 case "!=":
-                                case "neq":
+                                case "ne":
                                     {
                                         return NotEqual(reader, parameters, itParameter);
                                     }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
@@ -1,0 +1,61 @@
+﻿Condition:
+Json:
+{
+  "or": [
+    {
+      "eq": [
+        {
+          "getmember": [
+            {
+              "ref": "Nested"
+            },
+            "NestedString"
+          ]
+        },
+        "dd"
+      ]
+    },
+    {
+      "ne": [
+        {
+          "getmember": [
+            {
+              "ref": "Nested"
+            },
+            "NestedString"
+          ]
+        },
+        null
+      ]
+    }
+  ]
+}
+
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = (this.Nested.NestedString == "dd") || (this.Nested.NestedString != null);
+
+    return $dd_el_result;
+}
+Result: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/NotEqual.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/NotEqual.json
@@ -1,0 +1,31 @@
+{
+  "dsl": "Nested.NestedString == \"d\" or Nested.NestedString != null",
+  "or": [
+    {
+      "eq": [
+        {
+          "getmember": [
+            {
+              "ref": "Nested"
+            },
+            "NestedString"
+          ]
+        },
+        "dd"
+      ]
+    },
+    {
+      "ne": [
+        {
+          "getmember": [
+            {
+              "ref": "Nested"
+            },
+            "NestedString"
+          ]
+        },
+        null
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of changes
This PR fixes a bug in our expression language where != was handled incorrect.

## Test coverage
NotEqial.json
