### PR TITLE
[IAST] Add support to AspectMethodReplace with struct arguments

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/Aspects/DebugAspects.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/DebugAspects.cs
@@ -6,6 +6,7 @@
 #if DEBUG
 
 using System;
+using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -13,6 +14,11 @@ namespace Datadog.Trace.Iast.Aspects;
 /// <summary> String class aspects </summary>
 internal class DebugAspects
 {
+    private interface ITestStruct
+    {
+        public string GetText();
+    }
+
     /// <summary>
     /// AspectMethodReplace test method
     /// </summary>
@@ -23,6 +29,18 @@ internal class DebugAspects
     {
         Console.WriteLine($"[AspectMethodReplace]DebugAspects.AspectMethodReplace(string {target}, string {param1})");
         return string.Concat(target, param1);
+    }
+
+    /// <summary>
+    /// AspectMethodReplace test method
+    /// </summary>
+    /// <param name="target">main object instance </param>
+    /// <returns>target concatenated to param1</returns>
+    public static string AspectMethodReplace(object target)
+    {
+        Console.WriteLine($"[AspectMethodReplace]DebugAspects.AspectMethodReplace(object {target})");
+        var tTarget = target.DuckCast<ITestStruct>();
+        return tTarget.GetText();
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
@@ -169,6 +169,31 @@ namespace iast
     bool InstructionInfo::IsSwitch() { return _instruction->m_opcode == CEE_SWITCH; }
     bool InstructionInfo::IsRet() { return _instruction->m_opcode == CEE_RET; }
     bool InstructionInfo::IsDup() { return _instruction->m_opcode == CEE_DUP; }
+    bool InstructionInfo::IsAddressLoad()
+    {
+        return _instruction->m_opcode == CEE_LDARGA || _instruction->m_opcode == CEE_LDARGA_S ||
+               _instruction->m_opcode == CEE_LDLOCA || _instruction->m_opcode == CEE_LDLOCA_S;
+    }
+
+    void InstructionInfo::ConvertToNonAddressLoad()
+    {
+        if (_instruction->m_opcode == CEE_LDARGA_S)
+        {
+            _instruction->m_opcode = CEE_LDARG_S;
+        }
+        else if (_instruction->m_opcode == CEE_LDLOCA_S)
+        {
+            _instruction->m_opcode = CEE_LDLOC_S;
+        }
+        else if (_instruction->m_opcode == CEE_LDARGA)
+        {
+            _instruction->m_opcode = CEE_LDARG;
+        }
+        else if (_instruction->m_opcode == CEE_LDLOCA)
+        {
+            _instruction->m_opcode = CEE_LDLOC;
+        }
+    }
 
     bool InstructionInfo::IsField() { return (_instructionFlags[_instruction->m_opcode] & OPCODEFLAGS_Field) == OPCODEFLAGS_Field; }
     bool InstructionInfo::IsLocal()

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.h
@@ -87,10 +87,13 @@ namespace iast
         bool IsThrow();
         bool IsRet();
         bool IsDup();
+        bool IsAddressLoad();
 
         bool IsField();
         bool IsLocal();
         bool IsArgument();
+
+        void ConvertToNonAddressLoad();
 
         mdToken InferTypeToken();
         SignatureInfo* GetArgumentSignature();

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.cpp
@@ -112,14 +112,19 @@ HRESULT ModuleInfo::GetTypeDef(const WSTRING& typeName, mdTypeDef* pTypeDef)
 {
     HRESULT hr = S_OK;
     auto parts = Split(typeName, WStr("+"));
-    if (parts.size() == 2)
+    if (parts.size() > 1)
     {
         mdTypeDef parentTypeDef;
-        hr = _metadataImport->FindTypeDefByName(parts[0].c_str(), 0, &parentTypeDef);
-        if (SUCCEEDED(hr))
+        mdTypeDef typeDef = 0;
+        for (int x = 0; x < parts.size(); x++)
         {
-            hr = _metadataImport->FindTypeDefByName(parts[1].c_str(), parentTypeDef, pTypeDef);
+            hr = _metadataImport->FindTypeDefByName(parts[x].c_str(), typeDef, &parentTypeDef);
+            if (SUCCEEDED(hr))
+            {
+                typeDef = parentTypeDef;
+            }
         }
+        *pTypeDef = typeDef;
     }
     else
     {

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallSite.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallSite.cs
@@ -16,6 +16,7 @@ partial class Program
                 @"  [AspectMethodInsertBefore(""CallTargetNativeTest.Program+CallSiteTargets::TargetMethodInsertBefore_0(System.String,System.String)"","""",[0],[False],[None],Propagation,[])] AspectMethodInsertBefore_0(System.String)",
                 @"  [AspectMethodInsertBefore(""CallTargetNativeTest.Program+CallSiteTargets::TargetMethodInsertBefore_1(System.String,System.String)"","""",[1],[False],[None],Propagation,[])] AspectMethodInsertBefore_1(System.String)",
                 @"  [AspectMethodInsertAfter(""CallTargetNativeTest.Program+CallSiteTargets::TargetMethodInsertAfter(System.String,System.String)"","""",[0],[False],[None],Propagation,[])] AspectMethodInsertAfter(System.String)",
+                @"  [AspectMethodReplace(""CallTargetNativeTest.Program+CallSiteTargets+TestStruct::GetText()"","""",[0],[True],[None],Propagation,[])] AspectMethodReplace(System.Object)",
         };
         NativeMethods.RegisterIastAspects(aspects);
     }
@@ -28,12 +29,13 @@ partial class Program
         Console.WriteLine($"CallSite Tests");
         string param1 = "concat1";
         string param2 = "CONCAT2";
-        string espected = param1 + param2;
-        CallSiteTests.RunMethod(() => tests.AspectCtorReplace(param1, param2, espected), $"[AspectCtorReplace]DebugAspects.AspectCtorReplace(string {param1}, string {param2})");
-        CallSiteTests.RunMethod(() => tests.AspectMethodReplace(param1, param2, espected), $"[AspectMethodReplace]DebugAspects.AspectMethodReplace(string {param1}, string {param2})");
-        CallSiteTests.RunMethod(() => tests.AspectMethodInsertBefore_0(param1, param2, espected), $"[AspectMethodInsertBefore]DebugAspects.AspectMethodInsertBefore_0(string {param2})");
-        CallSiteTests.RunMethod(() => tests.AspectMethodInsertBefore_1(param1, param2, espected), $"[AspectMethodInsertBefore]DebugAspects.AspectMethodInsertBefore_1(string {param1})");
-        CallSiteTests.RunMethod(() => tests.AspectMethodInsertAfter(param1, param2, espected), $"[AspectMethodInsertAfter]DebugAspects.AspectMethodInsertAfter(string {espected})");
+        string expected = param1 + param2;
+        CallSiteTests.RunMethod(() => tests.AspectCtorReplace(param1, param2, expected), $"[AspectCtorReplace]DebugAspects.AspectCtorReplace(string {param1}, string {param2})");
+        CallSiteTests.RunMethod(() => tests.AspectMethodReplace(param1, param2, expected), $"[AspectMethodReplace]DebugAspects.AspectMethodReplace(string {param1}, string {param2})");
+        CallSiteTests.RunMethod(() => tests.AspectMethodInsertBefore_0(param1, param2, expected), $"[AspectMethodInsertBefore]DebugAspects.AspectMethodInsertBefore_0(string {param2})");
+        CallSiteTests.RunMethod(() => tests.AspectMethodInsertBefore_1(param1, param2, expected), $"[AspectMethodInsertBefore]DebugAspects.AspectMethodInsertBefore_1(string {param1})");
+        CallSiteTests.RunMethod(() => tests.AspectMethodInsertAfter(param1, param2, expected), $"[AspectMethodInsertAfter]DebugAspects.AspectMethodInsertAfter(string {expected})");
+        CallSiteTests.RunMethod(() => tests.AspectMethodReplaceStruct(expected), $"[AspectMethodReplace]DebugAspects.AspectMethodReplace(object TestStruct {{{expected}}})");
     }
 
     public class CallSiteTests
@@ -61,55 +63,73 @@ partial class Program
             Console.WriteLine();
         }
 
-        public object AspectCtorReplace(string param1, string param2, string espected)
+        public object AspectCtorReplace(string param1, string param2, string expected)
         {
             var result = new CallSiteTargets(param1, param2); //This new call should be probed with the instance
-            System.Diagnostics.Debug.Assert(result.ToString() == espected);
+            System.Diagnostics.Debug.Assert(result.ToString() == expected);
 
             return result;
         }
-        public string AspectMethodReplace(string param1, string param2, string espected)
+        public string AspectMethodReplace(string param1, string param2, string expected)
         {
             var result = CallSiteTargets.TargetMethodReplace(param1, param2); // This call should be replaced by the Aspect
-            System.Diagnostics.Debug.Assert(result == espected);
+            System.Diagnostics.Debug.Assert(result == expected);
 
             return result;
         }
-        public string AspectMethodInsertBefore_0(string param1, string param2, string espected)
+        public string AspectMethodInsertBefore_0(string param1, string param2, string expected)
         {
             var result = CallSiteTargets.TargetMethodInsertBefore_0(param1, param2); //This call should be probed in param2
-            System.Diagnostics.Debug.Assert(result == espected);
+            System.Diagnostics.Debug.Assert(result == expected);
 
             return result;
         }
-        public string AspectMethodInsertBefore_1(string param1, string param2, string espected)
+        public string AspectMethodInsertBefore_1(string param1, string param2, string expected)
         {
             var result = CallSiteTargets.TargetMethodInsertBefore_1(param1, param2); //This call should be probed in param1
-            System.Diagnostics.Debug.Assert(result == espected);
+            System.Diagnostics.Debug.Assert(result == expected);
 
             return result;
         }
-        public string AspectMethodInsertAfter(string param1, string param2, string espected)
+        public string AspectMethodInsertAfter(string param1, string param2, string expected)
         {
             var result = CallSiteTargets.TargetMethodInsertAfter(param1, param2); //This call should be probed in the result
-            System.Diagnostics.Debug.Assert(result == espected);
+            System.Diagnostics.Debug.Assert(result == expected);
 
             return result;
+        }
+
+        //---------------------------
+
+        public string AspectMethodReplaceStruct(string expected)
+        {
+            var testStruct = new CallSiteTargets.TestStruct { text = expected };
+            var txt = GetText(testStruct);
+
+            var result = testStruct.GetText(); //This call should be probed in the result
+            System.Diagnostics.Debug.Assert(result == expected);
+
+            return result;
+        }
+
+        private static string GetText(object obj)
+        {
+            return obj.ToString();
         }
     }
 
     public class CallSiteTargets
     {
-        private string espected;
+        private string expected;
 
         public CallSiteTargets(string param1, string param2)
         {
-            espected = param1 + param2;
+            expected = param1 + param2;
         }
 
         public override string ToString()
         {
-            return espected;
+            return expected;
         }
 
         public static string TargetMethodReplace(string param1, string param2)
@@ -129,5 +149,16 @@ partial class Program
             return string.Concat(param1, param2);
         }
 
+        public struct TestStruct
+        {
+            public string text;
+
+            public string GetText() => text;
+
+            public override string ToString()
+            {
+                return $"TestStruct {{{text}}}";
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes
Added support for struct parameters in `AspectMethodReplace `calls

## Reason for change
Until now, only `AspectMethodInserBefore `supported by val (struct) parameters

## Implementation details
Modified dataflow_aspect to insert a box instruction after the generation of the parameters being consumed by the aspect call

## Test coverage
Added test case to the `CallTargetNativeTest`

