### PR TITLE
IntegrationMapper.ConvertType simplification and Ducktype optimization

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -803,13 +803,13 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         private static TTo UnwrapReturnValue<TFrom, TTo>(TFrom returnValue)
             where TFrom : IDuckType
         {
-            return returnValue.GetInternalDuckTypeInstance<TTo>();
+            return returnValue.GetInternalDuckTypedInstance<TTo>();
         }
 
         private static async Task<TTo> UnwrapTaskReturnValue<TFrom, TTo>(Task<TFrom> returnValue, bool preserveContext)
             where TFrom : IDuckType
         {
-            return (await returnValue.ConfigureAwait(preserveContext)).GetInternalDuckTypeInstance<TTo>();
+            return (await returnValue.ConfigureAwait(preserveContext)).GetInternalDuckTypedInstance<TTo>();
         }
 
         private static void WriteIntValue(ILGenerator il, int value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -803,13 +803,13 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
         private static TTo UnwrapReturnValue<TFrom, TTo>(TFrom returnValue)
             where TFrom : IDuckType
         {
-            return (TTo)returnValue.Instance;
+            return returnValue.GetInternalDuckTypeInstance<TTo>();
         }
 
         private static async Task<TTo> UnwrapTaskReturnValue<TFrom, TTo>(Task<TFrom> returnValue, bool preserveContext)
             where TFrom : IDuckType
         {
-            return (TTo)(await returnValue.ConfigureAwait(preserveContext)).Instance;
+            return (await returnValue.ConfigureAwait(preserveContext)).GetInternalDuckTypeInstance<TTo>();
         }
 
         private static void WriteIntValue(ILGenerator il, int value)

--- a/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CallTarget/Handlers/IntegrationMapper.cs
@@ -888,14 +888,7 @@ namespace Datadog.Trace.ClrProfiler.CallTarget.Handlers
 
         private static T ConvertType<T>(object value)
         {
-            var conversionType = typeof(T);
-            if (value is null || conversionType == typeof(object))
-            {
-                return (T)value;
-            }
-
-            Type valueType = value.GetType();
-            if (valueType == conversionType || conversionType.IsAssignableFrom(valueType))
+            if (value is null or T)
             {
                 return (T)value;
             }

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -466,7 +466,7 @@ namespace Datadog.Trace.DuckTyping
             getInstanceMethod.SetReturnType(getInstanceGenericTypeParameters[0].MakeByRefType());
             il = getInstanceMethod.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
-            il.Emit(OpCodes.Ldfld, instanceField);
+            il.Emit(OpCodes.Ldflda, instanceField);
             il.Emit(OpCodes.Ret);
 
             var toStringTargetType = targetType.GetMethod("ToString", Type.EmptyTypes);

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -466,6 +466,7 @@ namespace Datadog.Trace.DuckTyping
             getInstanceMethod.SetReturnType(getInstanceGenericTypeParameters[0].MakeByRefType());
             il = getInstanceMethod.GetILGenerator();
             il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ldfld, instanceField);
             il.Emit(OpCodes.Ret);
 
             var toStringTargetType = targetType.GetMethod("ToString", Type.EmptyTypes);

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -459,6 +459,15 @@ namespace Datadog.Trace.DuckTyping
             il.Emit(OpCodes.Ret);
             propType.SetGetMethod(getPropType);
 
+            MethodBuilder getInstanceMethod = proxyTypeBuilder.DefineMethod(
+                "GetInternalDuckTypeInstance",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot);
+            var getInstanceGenericTypeParameters = getInstanceMethod.DefineGenericParameters("TReturn");
+            getInstanceMethod.SetReturnType(getInstanceGenericTypeParameters[0].MakeByRefType());
+            il = getInstanceMethod.GetILGenerator();
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Ret);
+
             var toStringTargetType = targetType.GetMethod("ToString", Type.EmptyTypes);
             if (toStringTargetType is not null)
             {

--- a/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/DuckType.cs
@@ -430,7 +430,7 @@ namespace Datadog.Trace.DuckTyping
 
             FieldBuilder instanceField = proxyTypeBuilder.DefineField("_currentInstance", instanceType, FieldAttributes.Private | FieldAttributes.InitOnly);
 
-            PropertyBuilder propInstance = proxyTypeBuilder.DefineProperty("Instance", PropertyAttributes.None, typeof(object), null);
+            PropertyBuilder propInstance = proxyTypeBuilder.DefineProperty(nameof(IDuckType.Instance), PropertyAttributes.None, typeof(object), null);
             MethodBuilder getPropInstance = proxyTypeBuilder.DefineMethod(
                 "get_Instance",
                 MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
@@ -447,7 +447,7 @@ namespace Datadog.Trace.DuckTyping
             il.Emit(OpCodes.Ret);
             propInstance.SetGetMethod(getPropInstance);
 
-            PropertyBuilder propType = proxyTypeBuilder.DefineProperty("Type", PropertyAttributes.None, typeof(Type), null);
+            PropertyBuilder propType = proxyTypeBuilder.DefineProperty(nameof(IDuckType.Type), PropertyAttributes.None, typeof(Type), null);
             MethodBuilder getPropType = proxyTypeBuilder.DefineMethod(
                 "get_Type",
                 MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot,
@@ -460,7 +460,7 @@ namespace Datadog.Trace.DuckTyping
             propType.SetGetMethod(getPropType);
 
             MethodBuilder getInstanceMethod = proxyTypeBuilder.DefineMethod(
-                "GetInternalDuckTypeInstance",
+                nameof(IDuckType.GetInternalDuckTypedInstance),
                 MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.Final | MethodAttributes.HideBySig | MethodAttributes.NewSlot);
             var getInstanceGenericTypeParameters = getInstanceMethod.DefineGenericParameters("TReturn");
             getInstanceMethod.SetReturnType(getInstanceGenericTypeParameters[0].MakeByRefType());
@@ -469,10 +469,10 @@ namespace Datadog.Trace.DuckTyping
             il.Emit(OpCodes.Ldflda, instanceField);
             il.Emit(OpCodes.Ret);
 
-            var toStringTargetType = targetType.GetMethod("ToString", Type.EmptyTypes);
+            var toStringTargetType = targetType.GetMethod(nameof(IDuckType.ToString), Type.EmptyTypes);
             if (toStringTargetType is not null)
             {
-                MethodBuilder toStringMethod = proxyTypeBuilder.DefineMethod("ToString", toStringTargetType.Attributes, typeof(string), Type.EmptyTypes);
+                MethodBuilder toStringMethod = proxyTypeBuilder.DefineMethod(nameof(IDuckType.ToString), toStringTargetType.Attributes, typeof(string), Type.EmptyTypes);
                 il = toStringMethod.GetILGenerator();
                 il.Emit(OpCodes.Ldarg_0);
                 if (instanceType.IsValueType)

--- a/tracer/src/Datadog.Trace/DuckTyping/IDuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/IDuckType.cs
@@ -28,6 +28,13 @@ namespace Datadog.Trace.DuckTyping
         Type Type { get; }
 
         /// <summary>
+        /// Gets the instance without boxing to an object
+        /// </summary>
+        /// <typeparam name="TReturn">Return type (should be compatible with Type)</typeparam>
+        /// <returns>Returns the instance</returns>
+        ref TReturn GetInternalDuckTypeInstance<TReturn>();
+
+        /// <summary>
         /// Calls ToString() on the instance
         /// </summary>
         /// <returns>ToString result</returns>

--- a/tracer/src/Datadog.Trace/DuckTyping/IDuckType.cs
+++ b/tracer/src/Datadog.Trace/DuckTyping/IDuckType.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.DuckTyping
         /// </summary>
         /// <typeparam name="TReturn">Return type (should be compatible with Type)</typeparam>
         /// <returns>Returns the instance</returns>
-        ref TReturn GetInternalDuckTypeInstance<TReturn>();
+        ref TReturn GetInternalDuckTypedInstance<TReturn>();
 
         /// <summary>
         /// Calls ToString() on the instance

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
@@ -50,6 +50,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal("10", duckInterface.PublicStaticReadonlyReferenceTypeField);
             Assert.Equal("10", duckAbstract.PublicStaticReadonlyReferenceTypeField);
@@ -79,6 +82,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal("20", duckInterface.PublicStaticReferenceTypeField);
             Assert.Equal("20", duckAbstract.PublicStaticReferenceTypeField);
@@ -172,6 +178,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal("30", duckInterface.PublicReadonlyReferenceTypeField);
             Assert.Equal("30", duckAbstract.PublicReadonlyReferenceTypeField);
@@ -201,6 +210,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal("40", duckInterface.PublicReferenceTypeField);
             Assert.Equal("40", duckAbstract.PublicReferenceTypeField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal("10", duckInterface.PublicStaticReadonlyReferenceTypeField);
@@ -84,7 +84,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal("20", duckInterface.PublicStaticReferenceTypeField);
             Assert.Equal("20", duckAbstract.PublicStaticReferenceTypeField);
@@ -179,7 +179,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal("30", duckInterface.PublicReadonlyReferenceTypeField);
@@ -212,7 +212,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal("40", duckInterface.PublicReferenceTypeField);
             Assert.Equal("40", duckAbstract.PublicReferenceTypeField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -83,7 +83,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal("20", duckInterface.PublicStaticReferenceTypeField);
@@ -178,7 +178,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -211,7 +211,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal("40", duckInterface.PublicReferenceTypeField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal(10, duckInterface.PublicStaticReadonlyValueTypeField);
@@ -84,7 +84,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal(20, duckInterface.PublicStaticValueTypeField);
             Assert.Equal(20, duckAbstract.PublicStaticValueTypeField);
@@ -179,7 +179,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal(30, duckInterface.PublicReadonlyValueTypeField);
@@ -212,7 +212,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal(40, duckInterface.PublicValueTypeField);
             Assert.Equal(40, duckAbstract.PublicValueTypeField);
@@ -307,7 +307,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Null(duckInterface.PublicStaticNullableIntField);
             Assert.Null(duckAbstract.PublicStaticNullableIntField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -83,7 +83,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal(20, duckInterface.PublicStaticValueTypeField);
@@ -178,7 +178,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -211,7 +211,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal(40, duckInterface.PublicValueTypeField);
@@ -306,7 +306,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Null(duckInterface.PublicStaticNullableIntField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
@@ -50,6 +50,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal(10, duckInterface.PublicStaticReadonlyValueTypeField);
             Assert.Equal(10, duckAbstract.PublicStaticReadonlyValueTypeField);
@@ -79,6 +82,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal(20, duckInterface.PublicStaticValueTypeField);
             Assert.Equal(20, duckAbstract.PublicStaticValueTypeField);
@@ -172,6 +178,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal(30, duckInterface.PublicReadonlyValueTypeField);
             Assert.Equal(30, duckAbstract.PublicReadonlyValueTypeField);
@@ -201,6 +210,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal(40, duckInterface.PublicValueTypeField);
             Assert.Equal(40, duckAbstract.PublicValueTypeField);
@@ -293,6 +305,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Null(duckInterface.PublicStaticNullableIntField);
             Assert.Null(duckAbstract.PublicStaticNullableIntField);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
@@ -49,6 +49,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal("10", duckInterface.PublicStaticGetReferenceType);
             Assert.Equal("10", duckAbstract.PublicStaticGetReferenceType);
@@ -78,6 +81,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal("20", duckInterface.PublicStaticGetSetReferenceType);
             Assert.Equal("20", duckAbstract.PublicStaticGetSetReferenceType);
@@ -199,6 +205,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal("30", duckInterface.PublicGetReferenceType);
             Assert.Equal("30", duckAbstract.PublicGetReferenceType);
@@ -228,6 +237,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal("40", duckInterface.PublicGetSetReferenceType);
             Assert.Equal("40", duckAbstract.PublicGetSetReferenceType);
@@ -328,6 +340,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             duckInterface["1"] = "100";
             Assert.Equal("100", duckInterface["1"]);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal("10", duckInterface.PublicStaticGetReferenceType);
@@ -83,7 +83,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal("20", duckInterface.PublicStaticGetSetReferenceType);
             Assert.Equal("20", duckAbstract.PublicStaticGetSetReferenceType);
@@ -206,7 +206,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal("30", duckInterface.PublicGetReferenceType);
@@ -239,7 +239,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal("40", duckInterface.PublicGetSetReferenceType);
             Assert.Equal("40", duckAbstract.PublicGetSetReferenceType);
@@ -342,7 +342,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             duckInterface["1"] = "100";
             Assert.Equal("100", duckInterface["1"]);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ReferenceType/ReferenceTypePropertyTests.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -82,7 +82,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal("20", duckInterface.PublicStaticGetSetReferenceType);
@@ -205,7 +205,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -238,7 +238,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal("40", duckInterface.PublicGetSetReferenceType);
@@ -341,7 +341,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ReferenceType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             duckInterface["1"] = "100";

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal(10, duckInterface.PublicStaticGetValueType);
@@ -85,7 +85,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal(20, duckInterface.PublicStaticGetSetValueType);
             Assert.Equal(20, duckAbstract.PublicStaticGetSetValueType);
@@ -188,7 +188,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             // *
             Assert.Equal(30, duckInterface.PublicGetValueType);
@@ -221,7 +221,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal(40, duckInterface.PublicGetSetValueType);
             Assert.Equal(40, duckAbstract.PublicGetSetValueType);
@@ -332,7 +332,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             duckInterface[1] = 100;
             Assert.Equal(100, duckInterface[1]);
@@ -360,7 +360,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Null(duckInterface.PublicStaticNullableInt);
             Assert.Null(duckAbstract.PublicStaticNullableInt);
@@ -455,7 +455,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
             ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
-            Assert.NotNull(originalObject);
+            Assert.Same(obscureObject, originalObject);
 
             Assert.Equal(TaskStatus.RanToCompletion, duckInterface.Status);
             Assert.Equal(TaskStatus.RanToCompletion, duckAbstract.Status);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
@@ -51,7 +51,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -84,7 +84,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal(20, duckInterface.PublicStaticGetSetValueType);
@@ -187,7 +187,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             // *
@@ -220,7 +220,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal(40, duckInterface.PublicGetSetValueType);
@@ -331,7 +331,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             duckInterface[1] = 100;
@@ -359,7 +359,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Null(duckInterface.PublicStaticNullableInt);
@@ -454,7 +454,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
-            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypedInstance<object>();
             Assert.NotNull(originalObject);
 
             Assert.Equal(TaskStatus.RanToCompletion, duckInterface.Status);

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
@@ -51,6 +51,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal(10, duckInterface.PublicStaticGetValueType);
             Assert.Equal(10, duckAbstract.PublicStaticGetValueType);
@@ -80,6 +83,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal(20, duckInterface.PublicStaticGetSetValueType);
             Assert.Equal(20, duckAbstract.PublicStaticGetSetValueType);
@@ -181,6 +187,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             // *
             Assert.Equal(30, duckInterface.PublicGetValueType);
             Assert.Equal(30, duckAbstract.PublicGetValueType);
@@ -210,6 +219,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal(40, duckInterface.PublicGetSetValueType);
             Assert.Equal(40, duckAbstract.PublicGetSetValueType);
@@ -319,6 +331,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
 
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
+
             duckInterface[1] = 100;
             Assert.Equal(100, duckInterface[1]);
             Assert.Equal(100, duckAbstract[1]);
@@ -343,6 +358,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Null(duckInterface.PublicStaticNullableInt);
             Assert.Null(duckAbstract.PublicStaticNullableInt);
@@ -435,6 +453,9 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             var duckInterface = obscureObject.DuckCast<IObscureDuckType>();
             var duckAbstract = obscureObject.DuckCast<ObscureDuckTypeAbstractClass>();
             var duckVirtual = obscureObject.DuckCast<ObscureDuckTypeVirtualClass>();
+
+            ref var originalObject = ref ((IDuckType)duckInterface).GetInternalDuckTypeInstance<object>();
+            Assert.NotNull(originalObject);
 
             Assert.Equal(TaskStatus.RanToCompletion, duckInterface.Status);
             Assert.Equal(TaskStatus.RanToCompletion, duckAbstract.Status);

--- a/tracer/test/benchmarks/Benchmarks.Trace/ActivityBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/ActivityBenchmark.cs
@@ -9,6 +9,7 @@ using Datadog.Trace.Activity.DuckTypes;
 using Datadog.Trace.Activity.Handlers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DuckTyping;
+using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
 using ActivityIdFormat = System.Diagnostics.ActivityIdFormat;
 using ActivityKind = Datadog.Trace.Activity.DuckTypes.ActivityKind;
 using ActivityListener = System.Diagnostics.ActivityListener;
@@ -251,6 +252,11 @@ internal class MockActivity : IActivity
     public object SetStartTime(DateTime startTimeUtc)
     {
         return _activity.SetStartTime(startTimeUtc);
+    }
+
+    public ref TReturn GetInternalDuckTypedInstance<TReturn>()
+    {
+        return ref Unsafe.As<Activity, TReturn>(ref Unsafe.AsRef(in _activity));
     }
 
     string IDuckType.ToString()


### PR DESCRIPTION
## Summary of changes

This PR:

- Simplifies the `IntegrationMapper.ConvertType()` method.
- Adds `ref TReturn GetInternalDuckTypedInstance<TReturn>()` in `IDuckType` interface allowing to extract the internal instance from the proxy without boxing or casting as the `Instance` property.
