### PR TITLE
Add IntegrationIdExtensions.cs to codeowners common files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@ missing-nullability-files.csv             @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Generated/      @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Configuration/IntegrationId.cs @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace/Telemetry/Metrics/IntegrationIdExtensions.cs @DataDog/apm-dotnet
 
 # CI
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet


### PR DESCRIPTION
## Summary of changes

Add the IntegrationIdExtensions.cs to codeowners APM team, so anyone can modify them freely.

## Reason for change

Same as this PR [#5151](https://github.com/DataDog/dd-trace-dotnet/pull/5151)
> Most of the PRs end up needing the approval of a Tracing team member because these files (null file, trimming, datadog.tracer.csproj) are usually modified.