### PR TITLE
Fix scenario where dogstatsd tries to send to the wrong hostname

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -827,6 +827,7 @@
       <type fullname="System.UriComponents" />
       <type fullname="System.UriCreationOptions" />
       <type fullname="System.UriFormat" />
+      <type fullname="System.UriHostNameType" />
       <type fullname="System.UriKind" />
       <type fullname="System.ValueTuple`1" />
       <type fullname="System.ValueTuple`2" />

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableExporterSettings.cs
@@ -54,6 +54,7 @@ namespace Datadog.Trace.Configuration
             TracesPipeTimeoutMsInternal = settings.TracesPipeTimeoutMsInternal;
 
             MetricsTransport = settings.MetricsTransport;
+            MetricsHostname = settings.MetricsHostname;
             MetricsPipeNameInternal = settings.MetricsPipeNameInternal;
             DogStatsdPortInternal = settings.DogStatsdPortInternal;
 
@@ -142,6 +143,11 @@ namespace Datadog.Trace.Configuration
         /// Gets the transport used to connect to the DogStatsD.
         /// </summary>
         internal Vendors.StatsdClient.Transport.TransportType MetricsTransport { get; }
+
+        /// <summary>
+        /// Gets the agent host to use when <see cref="MetricsTransport"/> is <see cref="Vendors.StatsdClient.Transport.TransportType.UDP"/>
+        /// </summary>
+        internal string MetricsHostname { get; }
 
         internal List<string> ValidationWarnings { get; }
     }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -323,25 +323,20 @@ namespace Datadog.Trace
                 switch (settings.ExporterInternal.MetricsTransport)
                 {
                     case MetricsTransportType.NamedPipe:
-                        Log.Information("Using windows named pipes for metrics transport.");
                         config.PipeName = settings.ExporterInternal.MetricsPipeNameInternal;
+                        Log.Information("Using windows named pipes for metrics transport: {PipeName}.", config.PipeName);
                         break;
 #if NETCOREAPP3_1_OR_GREATER
                     case MetricsTransportType.UDS:
-                        Log.Information("Using unix domain sockets for metrics transport.");
                         config.StatsdServerName = $"{ExporterSettings.UnixDomainSocketPrefix}{settings.ExporterInternal.MetricsUnixDomainSocketPathInternal}";
+                        Log.Information("Using unix domain sockets for metrics transport: {Socket}.", config.StatsdServerName);
                         break;
 #endif
                     case MetricsTransportType.UDP:
                     default:
-                        // If the customer has enabled UDS traces but _not_ UDS metrics, then the AgentUri will have
-                        // the UDS path set for it, and the DnsSafeHost returns "". Ideally, we would expose
-                        // a TracesAgentUri and MetricsAgentUri or something like that instead. This workaround
-                        // is a horrible hack, but I can't bear to touch ExporterSettings until it's had an
-                        // extensive tidy up, so this should do for now
-                        var traceHostname = settings.ExporterInternal.AgentUriInternal.DnsSafeHost;
-                        config.StatsdServerName = string.IsNullOrEmpty(traceHostname) ? "127.0.0.1" : traceHostname;
+                        config.StatsdServerName = settings.ExporterInternal.MetricsHostname;
                         config.StatsdPort = settings.ExporterInternal.DogStatsdPortInternal;
+                        Log.Information<string, int>("Using UDP for metrics transport: {Hostname}:{Port}.", config.StatsdServerName, config.StatsdPort);
                         break;
                 }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ImmutableExporterSettingsTests.cs
@@ -75,6 +75,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (e, i) => e.TracesPipeName == i.TracesPipeName,
                 (e, i) => e.DogStatsdPort == i.DogStatsdPort,
                 (e, i) => e.MetricsTransport == i.MetricsTransport,
+                (e, i) => e.MetricsHostname == i.MetricsHostname,
                 (e, i) => e.TracesTransport == i.TracesTransport,
                 (e, i) => e.TracesPipeTimeoutMs == i.TracesPipeTimeoutMs,
                 (e, i) => e.AgentUri == i.AgentUri,


### PR DESCRIPTION
## Summary of changes

- Fixes a scenario where we try to send runtime metrics to the wrong host
- nit: switch to fluent assertions in `ExporterSettingsTests`

## Reason for change

We recently had an escalation where the customer had set three properties (via single-step instrumentation)

- `DD_TRACE_AGENT_URL=unix:///var/run/datadog/apm.socket`
- `DD_AGENT_HOST=1.2.3.4`
- `DD_DOGSTATSD_URL=unix:///var/run/datadog/dsd.socket` (not currently supported)

The resulting configuration was:
- Traces: UDS: `/var/run/datadog/apm.socket` ✔️ 
- Metrics: UDP: `127.0.01:8125` ❌ Should be UDP: `1.2.3.4:8125`

The big problem in the the above is that the metrics is sending to localhost, which is incorrect.

> Ideally we would send to the UDS socket actually, but we'll add support for `DD_DOGSTATSD_URL` in a subsequent PR


## Implementation details

The problem was that we had this code to determine the host to use for metrics:

```csharp
var traceHostname = settings.ExporterInternal.AgentUriInternal.DnsSafeHost;
config.StatsdServerName = string.IsNullOrEmpty(traceHostname) ? "127.0.0.1" : traceHostname;
```

However, when we're using UDS traces, `AgentUriInternal` is `unix:///var/run/datadog/apm.socket` and `AgentUriInternal.DnsSafeHost` returns `""` so we fallback to `"127.0.0.1"`. In the current scenario, we don't actually store `DD_AGENT_HOST` anywhere. 

The implementation changes that to explicitly record the metrics host in `ExporterSettings` when it's being configured. That means we can use the value of `DD_AGENT_HOST` if it's set and fixes the bug.

## Test coverage

Updated `ExporterSettingsTests` to assert that we are setting the hostname correctly in `ExporterSettings` I _haven't_ tested that `TracerManagerFactory` uses it correctly when creating the dogstatsd client, as that's a bit of a PITA and I think the change is simple enough to not worry about (famous last words?)

## Other details
I'll do a PR to add support for `DD_DOGSTATSD_URL` stacked on this