### PR TITLE
Add support for `DD_DOGSTATSD_URL`

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -549,6 +549,7 @@
       <type fullname="System.Exception" />
       <type fullname="System.FlagsAttribute" />
       <type fullname="System.FormatException" />
+      <type fullname="System.FormattableString" />
       <type fullname="System.Func`1" />
       <type fullname="System.Func`2" />
       <type fullname="System.Func`3" />
@@ -710,6 +711,7 @@
       <type fullname="System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1/ConfiguredValueTaskAwaiter" />
       <type fullname="System.Runtime.CompilerServices.DefaultInterpolatedStringHandler" />
       <type fullname="System.Runtime.CompilerServices.ExtensionAttribute" />
+      <type fullname="System.Runtime.CompilerServices.FormattableStringFactory" />
       <type fullname="System.Runtime.CompilerServices.IAsyncStateMachine" />
       <type fullname="System.Runtime.CompilerServices.ICriticalNotifyCompletion" />
       <type fullname="System.Runtime.CompilerServices.INotifyCompletion" />

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -96,7 +96,7 @@ namespace Datadog.Trace.Configuration
         public const string MetricsUnixDomainSocketPath = "DD_DOGSTATSD_SOCKET";
 
         /// <summary>
-        /// Configuration key for the Metrics location where the Tracer can send traces.
+        /// Configuration key for the location where the Tracer can send DogStatsD metrics.
         /// Default value is "udp://127.0.0.1:8125".
         /// </summary>
         /// <seealso cref="ExporterSettings.AgentUri"/>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Exporter.cs
@@ -94,5 +94,12 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ExporterSettings.MetricsUnixDomainSocketPath"/>
         public const string MetricsUnixDomainSocketPath = "DD_DOGSTATSD_SOCKET";
+
+        /// <summary>
+        /// Configuration key for the Metrics location where the Tracer can send traces.
+        /// Default value is "udp://127.0.0.1:8125".
+        /// </summary>
+        /// <seealso cref="ExporterSettings.AgentUri"/>
+        public const string MetricsUri = "DD_DOGSTATSD_URL";
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -292,13 +292,13 @@ namespace Datadog.Trace.Configuration
         /// Gets or sets the transport used to connect to the DogStatsD.
         /// Default is <c>TransportStrategy.Tcp</c>.
         /// </summary>
-        [IgnoreForSnapshot] // We don't record this in telemetry currently, but if we do, we'll record it when we set its
+        [IgnoreForSnapshot] // We don't record this in telemetry currently, but if we do, we'll record it when we set it
         internal MetricsTransportType MetricsTransport { get; private set; }
 
         /// <summary>
         /// Gets or sets the agent host to use when <see cref="MetricsTransport"/> is <see cref="TransportType.UDP"/>
         /// </summary>
-        [IgnoreForSnapshot] // We don't record this in telemetry currently, but if we do, we'll record it when we set its
+        [IgnoreForSnapshot] // We don't record this in telemetry currently, but if we do, we'll record it when we set it
         internal string MetricsHostname { get; private set; }
 #pragma warning restore SA1624
 

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -48,6 +48,7 @@ namespace Datadog.Trace.Configuration
         /// Default metrics UDS path.
         /// </summary>
         internal const string DefaultMetricsUnixDomainSocket = "/var/run/datadog/dsd.socket";
+        internal const string UdpPrefix = "udp://";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExporterSettings"/> class with default values.
@@ -108,12 +109,13 @@ namespace Datadog.Trace.Configuration
                            .WithKeys(ConfigurationKeys.AgentPort, "DATADOG_TRACE_AGENT_PORT")
                            .AsInt32();
 
+            var metricsUrl = config.WithKeys(ConfigurationKeys.MetricsUri).AsString();
             var dogStatsdPort = config.WithKeys(ConfigurationKeys.DogStatsdPort).AsInt32(0);
             var metricsPipeName = config.WithKeys(ConfigurationKeys.MetricsPipeName).AsString();
             var metricsUnixDomainSocketPath = config.WithKeys(ConfigurationKeys.MetricsUnixDomainSocketPath).AsString();
 
             ConfigureTraceTransport(traceAgentUrl, tracesPipeName, agentHost, agentPort, tracesUnixDomainSocketPath);
-            ConfigureMetricsTransport(traceAgentUrl, agentHost, dogStatsdPort, metricsPipeName, metricsUnixDomainSocketPath);
+            ConfigureMetricsTransport(metricsUrl, traceAgentUrl, agentHost, dogStatsdPort, metricsPipeName, metricsUnixDomainSocketPath);
 
             TracesPipeTimeoutMsInternal = config
                                  .WithKeys(ConfigurationKeys.TracesPipeTimeoutMs)
@@ -315,8 +317,15 @@ namespace Datadog.Trace.Configuration
         }
 
         [MemberNotNull(nameof(MetricsHostname))]
-        private void ConfigureMetricsTransport(string? traceAgentUrl, string? agentHost, int dogStatsdPort, string? metricsPipeName, string? metricsUnixDomainSocketPath)
+        private void ConfigureMetricsTransport(string? metricsUrl, string? traceAgentUrl, string? agentHost, int dogStatsdPort, string? metricsPipeName, string? metricsUnixDomainSocketPath)
         {
+            if (!string.IsNullOrWhiteSpace(metricsUrl) && TrySetMetricsUriAndTransport(metricsUrl!))
+            {
+                // Keep the compiler happy when we're using UDS etc
+                MetricsHostname ??= DefaultDogstatsdHostname;
+                return;
+            }
+
             // Agent port is set to zero in places like AAS where it's needed to prevent port conflict
             // The agent will fail to start if it can not bind a port, so we need to override 8125 to prevent port conflict
             // Port 0 means it will pick some random available port
@@ -325,21 +334,27 @@ namespace Datadog.Trace.Configuration
                 ValidationWarnings.Add("The provided dogStatsD port isn't valid, it should be positive.");
             }
 
+            var dogStatsDPortSource = dogStatsdPort == 0 ? null : ConfigurationKeys.DogStatsdPort;
+            var dogStatsdPortToUse = dogStatsdPort > 0 ? dogStatsdPort : DefaultDogstatsdPort;
+
             if (!string.IsNullOrWhiteSpace(traceAgentUrl)
              && !traceAgentUrl!.StartsWith(UnixDomainSocketPrefix)
-             && Uri.TryCreate(traceAgentUrl, UriKind.Absolute, out var uri))
+             && Uri.TryCreate(traceAgentUrl, UriKind.Absolute, out var tcpUri))
             {
-                MetricsTransport = MetricsTransportType.UDP;
-                MetricsHostname = GetMetricsHostNameFromAgentUri(uri);
+                SetUdp(
+                    hostname: GetMetricsHostNameFromAgentUri(tcpUri),
+                    hostnameSource: ConfigurationKeys.AgentUri,
+                    port: dogStatsdPortToUse,
+                    portSource: dogStatsDPortSource);
             }
             else if (dogStatsdPort > 0 || agentHost != null)
             {
-                MetricsTransport = MetricsTransportType.UDP;
-                MetricsHostname = agentHost!; // assumes that agentHost is a valid hostname or IP address, just warn if it's not
-                if (Uri.CheckHostName(agentHost) is not (UriHostNameType.IPv4 or UriHostNameType.IPv6 or UriHostNameType.Dns))
-                {
-                    ValidationWarnings.Add($"The provided agent host '{agentHost}' is not a valid hostname or IP address.");
-                }
+                var hostSource = agentHost is null ? ConfigurationKeys.AgentHost : null;
+                SetUdp(
+                    hostname: agentHost ?? DefaultDogstatsdHostname,
+                    hostnameSource: hostSource,
+                    port: dogStatsdPortToUse,
+                    portSource: dogStatsDPortSource);
             }
             else if (!string.IsNullOrWhiteSpace(metricsPipeName))
             {
@@ -348,29 +363,129 @@ namespace Datadog.Trace.Configuration
             }
             else if (metricsUnixDomainSocketPath != null)
             {
-                MetricsTransport = MetricsTransportType.UDS;
-                MetricsUnixDomainSocketPathInternal = metricsUnixDomainSocketPath;
-
-                // check if the file exists to warn the user.
-                if (!_fileExists(metricsUnixDomainSocketPath))
-                {
-                    ValidationWarnings.Add($"The socket {metricsUnixDomainSocketPath} provided in '{ConfigurationKeys.MetricsUnixDomainSocketPath} cannot be found. The tracer will still rely on this socket to send metrics.");
-                }
+                SetUds(metricsUnixDomainSocketPath, metricsUnixDomainSocketPath, metricsUnixDomainSocketPath, ConfigurationKeys.MetricsUnixDomainSocketPath);
             }
             else if (_fileExists(DefaultMetricsUnixDomainSocket))
             {
-                MetricsTransport = MetricsTransportType.UDS;
-                MetricsUnixDomainSocketPathInternal = DefaultMetricsUnixDomainSocket;
+                SetUds(DefaultMetricsUnixDomainSocket, DefaultMetricsUnixDomainSocket, DefaultMetricsUnixDomainSocket, null);
             }
             else
             {
-                MetricsTransport = MetricsTransportType.UDP;
-                MetricsHostname = DefaultDogstatsdHostname;
-                DogStatsdPortInternal = DefaultDogstatsdPort;
+                SetUdp(
+                    hostname: DefaultDogstatsdHostname,
+                    hostnameSource: null,
+                    port: DefaultDogstatsdPort,
+                    portSource: null);
             }
 
-            DogStatsdPortInternal = dogStatsdPort > 0 ? dogStatsdPort : DefaultDogstatsdPort;
+            // set these values if they're not already set just to keep some things happy
+            DogStatsdPortInternal = DogStatsdPortInternal > 0 ? DogStatsdPortInternal : dogStatsdPortToUse;
             MetricsHostname ??= DefaultDogstatsdHostname;
+
+            return;
+
+            [MemberNotNull(nameof(MetricsHostname))]
+            bool TrySetMetricsUriAndTransport(string metricsUrl)
+            {
+                if (!Uri.TryCreate(metricsUrl, UriKind.Absolute, out var uri))
+                {
+                    ValidationWarnings.Add($"The Uri: '{metricsUrl}' in {ConfigurationKeys.MetricsUri} is not valid. It won't be taken into account to send metrics. Note that only absolute urls are accepted.");
+                    return false;
+                }
+
+                var origin = ConfigurationOrigins.Default; // only called from the constructor
+                if (uri.OriginalString.StartsWith(UnixDomainSocketPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    var absoluteUri = uri.AbsoluteUri.Replace(UnixDomainSocketPrefix, string.Empty);
+                    var probablyValid = SetUds(uri.PathAndQuery, uri.OriginalString, absoluteUri, ConfigurationKeys.AgentUri);
+                    _telemetry.Record(
+                        ConfigurationKeys.MetricsUnixDomainSocketPath,
+                        MetricsUnixDomainSocketPathInternal,
+                        recordValue: true,
+                        origin,
+                        probablyValid ? null : TelemetryErrorCode.PotentiallyInvalidUdsPath);
+                    return true;
+                }
+
+                if (uri.OriginalString.StartsWith(UdpPrefix, StringComparison.OrdinalIgnoreCase))
+                {
+                    // If you don't specify the port explicitly in the url, it uses -1
+                    var port = uri.Port > 0 ? uri.Port : DefaultDogstatsdPort;
+
+                    SetUdp(
+                        hostname: uri.Host,
+                        hostnameSource: ConfigurationKeys.AgentUri,
+                        port: port,
+                        portSource: ConfigurationKeys.AgentUri);
+                    return true;
+                }
+
+                ValidationWarnings.Add($"Unknown transport type in {ConfigurationKeys.MetricsUri}. Only {UdpPrefix} and {UnixDomainSocketPrefix} are supported. It won't be taken into account to send metrics.");
+                return false;
+            }
+
+            [MemberNotNull(nameof(MetricsHostname))]
+            bool SetUds(string unixSocket, string original, string absoluteUri, string? source)
+            {
+                // Only called in the constructor;
+                MetricsTransport = MetricsTransportType.UDS;
+                MetricsUnixDomainSocketPathInternal = unixSocket;
+
+                var probablyValid = true;
+                if (source is not null && !Path.IsPathRooted(absoluteUri))
+                {
+                    probablyValid = false;
+                    ValidationWarnings.Add($"The provided metrics Uri {original} contains a relative path which may not work. This is the path to the socket that will be used: {unixSocket}");
+                }
+
+                // check if the file exists to warn the user.
+                if (source is not null && !_fileExists(unixSocket))
+                {
+                    // We don't fallback in that case as the file could be mounted separately.
+                    probablyValid = false;
+                    ValidationWarnings.Add($"The socket {unixSocket} provided in '{source}' cannot be found. The tracer will still rely on this socket to send metrics.");
+                }
+
+                return probablyValid;
+            }
+
+            [MemberNotNull(nameof(MetricsHostname))]
+            bool SetUdp(string hostname, string? hostnameSource, int port, string? portSource)
+            {
+                MetricsTransport = MetricsTransportType.UDP;
+                var probablyValid = true;
+
+                if (string.Equals(hostname, "localhost", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Replace localhost with 127.0.0.1 to avoid DNS resolution.
+                    // When ipv6 is enabled, localhost is first resolved to ::1, which fails
+                    // because the trace agent is only bound to ipv4.
+                    // This causes delays when sending traces.
+                    MetricsHostname = "127.0.0.1";
+                }
+                else
+                {
+                    MetricsHostname = hostname; // assumes that agentHost is a valid hostname or IP address, just warn if it's not
+                    if (hostnameSource is not null && Uri.CheckHostName(hostname) is not (UriHostNameType.IPv4 or UriHostNameType.IPv6 or UriHostNameType.Dns))
+                    {
+                        probablyValid = false;
+                        ValidationWarnings.Add($"The provided agent host '{hostname}' in '{hostnameSource}' is not a valid hostname or IP address.");
+                    }
+                }
+
+                // Agent port is set to zero in places like AAS where it's needed to prevent port conflict
+                // The agent will fail to start if it can not bind a port, so we need to override 8125 to prevent port conflict
+                // Port 0 means it will pick some random available port
+                DogStatsdPortInternal = port;
+                if (portSource is not null && port < 0)
+                {
+                    probablyValid = false;
+                    ValidationWarnings.Add(FormattableString.Invariant($"The provided dogStatsD port '{port}' from {portSource} isn't valid, it should be positive."));
+                }
+
+                // TODO: use this to mark config as errors
+                return probablyValid;
+            }
         }
 
         private void RecordTraceTransport(string transport, ConfigurationOrigins origin = ConfigurationOrigins.Default)

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -463,6 +463,7 @@
   "DD_TRACE_PARTIAL_FLUSH_MIN_SPANS": "trace_partial_flush_min_spans",
   "DD_APM_RECEIVER_SOCKET": "trace_agent_socket",
   "DD_DOGSTATSD_SOCKET": "dogstatsd_socket",
+  "DD_DOGSTATSD_URL": "dogstatsd_url",
   "DD_IAST_ENABLED": "iast_enabled",
   "DD_IAST_WEAK_HASH_ALGORITHMS": "iast_weak_hash_algorithms",
   "DD_IAST_WEAK_CIPHER_ALGORITHMS": "iast_weak_cipher_algorithms",


### PR DESCRIPTION
## Summary of changes

- Adds support for `DD_DOGSTATSD_URL` for controlling where metrics are sent
- Some refactoring of ExporterSettings 🤮 

## Reason for change

Single step instrumentation currently sets `DD_TRACE_AGENT_URL` and `DD_DOGSTATSD_URL` to be a UDS path, but we don't check `DD_DOGSTATSD_URL` so we end up falling back to UDP (which has a bug fixed in #5222). Adding support for the setting fixes this scenario.

Other languages already all seem to support this setting, so we're just playing catchup

## Implementation details

_Mostly_ copied the style of implementation we use for setting `DD_TRACE_AGENT_URL`, to make sure we record the settings in telemetry (where we currently record in telemetry). Then refactored a bit to reduce the duplication. We prioritize this setting above all the others, so it has the _potential_ to be a breaking change if customers have set this to an "invalid" value, but I think that's probably OK

I'm hoping we'll be able to significantly simplify all this logic in v3 🤞 

## Test coverage

Added a bunch of unit tests to make sure our parsing makes sense, and that it mostly works the same as parsing the trace agent url (although with a `udp` scheme instead of `http`)

## Other details

Stacked on (for simplicity)
- https://github.com/DataDog/dd-trace-dotnet/pull/5222

We should probably also
- [ ] Update the parsing spec
- [ ] Add the setting to the feature parity dashboard
- [ ] Add a system test for it(?)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
