### PR TITLE
Fix product data collected for tracer flare

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ErrorData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ErrorData.cs
@@ -7,7 +7,7 @@
 
 namespace Datadog.Trace.Telemetry;
 
-internal readonly struct ErrorData
+internal readonly record struct ErrorData
 {
     public ErrorData(TelemetryErrorCode error)
         : this(error, error.ToStringFast())


### PR DESCRIPTION
## Summary of changes

- Fixes the collection of product telemetry for the tracer flare
- Hopefully fixes a flaky test

## Reason for change

`TelemetryControllerTests.TelemetryControllerDumpsAllTelemetryToFile` was flaky, always failing because `ProductData` was unexpectedly null. This led me to a fairly obvious race condition in the `ProductsTelemetryCollector`.

## Implementation details

Previously we were only tracking the changes to Product data since the last telemetry flush. For the flare, we need the "latest" data. So made a couple of changes:

- Added an extra array for "previous" values of the products data, which is used when we're doing the tracer flare
- Added a lock to `GetData()` and `GetFullData()` for simplicity. Contention will be very rare here, only when a tracer flare is being requested at the same time as a tracer flush is happening

## Test coverage

Added unit tests for the behaviour. Failed prior to this change, passes after.

## Other details
Hopefully this will fix the flake, it makes sense for it to.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
