### PR TITLE
Add rate limit for the log written by `TraceRateLimiter`

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/RateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RateLimiter.cs
@@ -80,6 +80,10 @@ namespace Datadog.Trace.Sampling
 
         public abstract void OnDisallowed(Span span, int count, int intervalMs, int maxTracesPerInterval);
 
+        public virtual void OnRefresh(int intervalMs, int checksInLastInterval, int allowedInLastInterval)
+        {
+        }
+
         public abstract void OnFinally(Span span);
 
         public float GetEffectiveRate()
@@ -134,6 +138,7 @@ namespace Datadog.Trace.Sampling
                     _windowAllowed = 0;
                     _windowChecks = 0;
                     _windowBegin = now;
+                    OnRefresh(_intervalMilliseconds, _previousWindowChecks, _previousWindowAllowed);
                 }
 
                 while (_intervalQueue.TryPeek(out var time) && now.Subtract(time) > _interval)

--- a/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading;
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Sampling
@@ -10,6 +11,7 @@ namespace Datadog.Trace.Sampling
     internal class TracerRateLimiter : RateLimiter
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TracerRateLimiter>();
+        private bool _warningWritten;
 
         public TracerRateLimiter(int? maxTracesPerInterval)
             : base(maxTracesPerInterval)
@@ -18,7 +20,21 @@ namespace Datadog.Trace.Sampling
 
         public override void OnDisallowed(Span span, int count, int intervalMs, int maxTracesPerInterval)
         {
-            Log.Warning<string, int, int>("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.Context.RawTraceId, count, intervalMs);
+            if (!Volatile.Read(ref _warningWritten))
+            {
+                Log.Warning<string, int, int>("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.Context.RawTraceId, count, intervalMs);
+                _warningWritten = true;
+            }
+        }
+
+        public override void OnRefresh(int intervalMs, int checksInLastInterval, int allowedInLastInterval)
+        {
+            if (Volatile.Read(ref _warningWritten))
+            {
+                Log.Warning<int, int, int>("Trace rate limit interval reset: Allowed {Allowed} traces out of {Checked} in last {Interval}ms.", allowedInLastInterval, checksInLastInterval, intervalMs);
+            }
+
+            _warningWritten = false;
         }
 
         public override void OnFinally(Span span)

--- a/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TracerRateLimiter.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Sampling
         {
             if (!Volatile.Read(ref _warningWritten))
             {
-                Log.Warning<string, int, int>("Dropping trace id {TraceId} with count of {Count} for last {Interval}ms.", span.Context.RawTraceId, count, intervalMs);
+                Log.Warning<string, int, int>("Rate limiter dropped a trace ({TraceId}) after reaching {Count} traces in the last {Interval}ms.", span.Context.RawTraceId, count, intervalMs);
                 _warningWritten = true;
             }
         }


### PR DESCRIPTION
## Summary of changes

Add a rate limit for the `TraceRateLimiter` log file written when a trace is dropped

## Reason for change

We potentially spam customers logs with the warning. The log is expected to be written precisely when the service is under load, so we _expect_ to see it a lot if it's triggered. This could cause customer log files to rapidly fill up.

## Implementation details

- Add a boolean that is set when we write the log
- Add a method that is called when the interval is reset
- Add an extra log to describe how many traces were filtered

At worst, this means we write two logs per interval, instead of an unbounded number. 

## Test coverage

I'll check in the unit test logs to make sure they're not there any more, I think this is good enough



<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
