### PR TITLE
Minor (potential) fixes for `NullReferenceException`

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -528,8 +528,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/OwinContextStruct.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/OwinRequestStruct.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ReflectedHttpActionDescriptor_ExecuteAsync_Integration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/RequestContextStruct.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_DisassociateFromCurrentThread_Integration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ViewContextStruct.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/AspNetCoreBlockMiddlewareIntegrationEnd.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BindingSource.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_AssociateWithCurrentThread_Integration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 #if NETFRAMEWORK
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;
@@ -39,8 +41,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
         internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, bool setImpersonationContext)
             where TTarget : IThreadContext
         {
+            // AssociateWithCurrentThread can only be used when HttpContext is non-null
             var httpContext = instance.HttpContext;
-            if (httpContext.Items[HttpContextScopeKey] is Scope scope && Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
+            if (httpContext.Items is not null
+                && httpContext.Items[HttpContextScopeKey] is Scope scope
+                && Tracer.Instance.ScopeManager is IScopeRawAccess rawAccess)
             {
                 rawAccess.Active = scope;
             }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_DisassociateFromCurrentThread_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ThreadContext_DisassociateFromCurrentThread_Integration.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 #if NETFRAMEWORK
 using System.ComponentModel;
 using Datadog.Trace.ClrProfiler.CallTarget;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -112,7 +112,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
                 var functionName = instanceParam.FunctionDescriptor.ShortName;
 
                 // Ignoring null because guaranteed running in AAS
-                if (tracer.Settings.AzureAppServiceMetadata!.IsIsolatedFunctionsApp
+                if (tracer.Settings.AzureAppServiceMetadata is { IsIsolatedFunctionsApp: true }
                  && tracer.InternalActiveScope is { } activeScope)
                 {
                     // We don't want to create a new scope here when running isolated functions,

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/Functions/AzureFunctionsCommon.cs
@@ -34,9 +34,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Azure.Functions
 
             if (tracer.Settings.IsIntegrationEnabled(IntegrationId))
             {
-                // Ignoring null because guaranteed running in AAS
-                if (tracer.Settings.AzureAppServiceMetadata!.IsIsolatedFunctionsApp
-                    && tracer.InternalActiveScope is null)
+                if (tracer.Settings.AzureAppServiceMetadata is { IsIsolatedFunctionsApp: true }
+                 && tracer.InternalActiveScope is null)
                 {
                     // in a "timer" trigger, or similar. Context won't be propagated to child, so no
                     // need to create the scope etc.

--- a/tracer/test/Datadog.Trace.Tests/Util/Delegates/FuncInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Util/Delegates/FuncInstrumentationTests.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Util.Delegates;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Util.Delegates;
@@ -59,6 +60,7 @@ public class FuncInstrumentationTests
                                                      Interlocked.Increment(ref value).Should().Be(3);
                                                      return ((int)returnValue) + 1;
                                                  }));
+        using var scope = new AssertionScope();
         func2().Should().Be(43);
         value.Should().Be(3);
     }
@@ -135,6 +137,7 @@ public class FuncInstrumentationTests
                                                      Interlocked.Increment(ref value).Should().Be(3);
                                                      return ((int)returnValue) + 1;
                                                  }));
+        using var scope = new AssertionScope();
         func2("Arg01").Should().Be(43);
         value.Should().Be(3);
     }
@@ -198,6 +201,7 @@ public class FuncInstrumentationTests
                                                      Interlocked.Increment(ref value).Should().Be(3);
                                                      return ((int)returnValue) + 1;
                                                  }));
+        using var scope = new AssertionScope();
         func2("Arg01", "Arg02").Should().Be(43);
         value.Should().Be(3);
     }
@@ -263,6 +267,7 @@ public class FuncInstrumentationTests
                                                      Interlocked.Increment(ref value).Should().Be(3);
                                                      return ((int)returnValue) + 1;
                                                  }));
+        using var scope = new AssertionScope();
         func2("Arg01", "Arg02", "Arg03").Should().Be(43);
         value.Should().Be(3);
     }
@@ -330,6 +335,7 @@ public class FuncInstrumentationTests
                                                      Interlocked.Increment(ref value).Should().Be(3);
                                                      return ((int)returnValue) + 1;
                                                  }));
+        using var scope = new AssertionScope();
         func2("Arg01", "Arg02", "Arg03", "Arg04").Should().Be(43);
         value.Should().Be(3);
     }
@@ -399,6 +405,7 @@ public class FuncInstrumentationTests
                                                      Interlocked.Increment(ref value).Should().Be(3);
                                                      return ((int)returnValue) + 1;
                                                  }));
+        using var scope = new AssertionScope();
         func2("Arg01", "Arg02", "Arg03", "Arg04", "Arg05").Should().Be(43);
         value.Should().Be(3);
     }
@@ -414,6 +421,7 @@ public class FuncInstrumentationTests
 
         public object OnDelegateBegin<TArg1, TArg2, TArg3, TArg4, TArg5>(object sender, ref TArg1 arg1, ref TArg2 arg2, ref TArg3 arg3, ref TArg4 arg4, ref TArg5 arg5)
         {
+            using var scope = new AssertionScope();
             arg1.Should().Be("Arg01");
             arg2.Should().Be("Arg02");
             arg3.Should().Be("Arg03");
@@ -475,6 +483,7 @@ public class FuncInstrumentationTests
                                                      return ((int)returnValue) + 1;
                                                  }));
         result = await func2("Arg01").ConfigureAwait(false);
+        using var scope = new AssertionScope();
         result.Should().Be(43);
         value.Should().Be(4);
     }
@@ -530,7 +539,7 @@ public class FuncInstrumentationTests
                                                      await Task.Delay(100).ConfigureAwait(false);
                                                      return ((int)returnValue) + 1;
                                                  }));
-
+        using var scope = new AssertionScope();
         await Assert.ThrowsAsync<DivideByZeroException>(
             async () =>
             {
@@ -589,7 +598,7 @@ public class FuncInstrumentationTests
                                                      await Task.Delay(100).ConfigureAwait(false);
                                                      return ((int)returnValue) + 1;
                                                  }));
-
+        using var scope = new AssertionScope();
         await Assert.ThrowsAsync<DivideByZeroException>(
             async () =>
             {


### PR DESCRIPTION
## Summary of changes

- Try to fix a strange null ref in Azure Functions
- Fix null ref in `ThreadContext_AssociateWithCurrentThread_Integration`
- Add `AssertionScope` for debugging purposes

## Reason for change

Identified some null references from telemetry. Weird unit test failure in `FuncInstrumentationTests.Async1Test#478`.

## Implementation details

- Be extra safe about nulls
- Add an `AssertionScope` so we can see the full failure context next time flake happens

## Test coverage

Meh
