### PR TITLE
[CI Visibility] Sanitize git get-objects output

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -312,6 +312,18 @@ internal class IntelligentTestRunnerClient
         var repository = await _getRepositoryUrlTask.ConfigureAwait(false);
         var branchName = await _getBranchNameTask.ConfigureAwait(false);
         var currentShaCommand = await _getShaTask.ConfigureAwait(false);
+        if (repository is null)
+        {
+            Log.Warning("ITR: 'git config --get remote.origin.url' command is null");
+            return default;
+        }
+
+        if (branchName is null)
+        {
+            Log.Warning("ITR: 'git branch --show-current' command is null");
+            return default;
+        }
+
         if (currentShaCommand is null)
         {
             Log.Warning("ITR: 'git rev-parse HEAD' command is null");
@@ -407,6 +419,12 @@ internal class IntelligentTestRunnerClient
         var framework = FrameworkDescription.Instance;
         var repository = await _getRepositoryUrlTask.ConfigureAwait(false);
         var currentShaCommand = await _getShaTask.ConfigureAwait(false);
+        if (repository is null)
+        {
+            Log.Warning("ITR: 'git config --get remote.origin.url' command is null");
+            return new SkippableTestsResponse();
+        }
+
         if (currentShaCommand is null)
         {
             Log.Warning("ITR: 'git rev-parse HEAD' command is null");


### PR DESCRIPTION
## Summary of changes

This PR sanitize the output of the `git get-objects` command and applies some checks before making the GetSettings and GetSkippableTests requests.

## Reason for change

In an Azure Pipelines demo project we were getting:
```2024-02-22 14:32:14.825 +00:00 [DBG] ITR: Repository is not in a shallow state, uploading changes...  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:14.825 +00:00 [DBG] ITR: Packing and sending delta of commits and tree objects...  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:14.825 +00:00 [DBG] ITR: Getting objects...  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:14.825 +00:00 [DBG] Running command: git rev-list --objects --no-object-names --filter=blob:none --since="1 month ago" HEAD  7026fc7335f7c2c4f80f7a92cd8a552c3a17eb97 672dfdb291fe38746f16e4b1739b332917880bd7 d6f8c39f2778d5faeeff5d4d6ab126c8eefecd98 2ecea6289f7adcb98de8bc68087d309999341601  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:14.934 +00:00 [DBG] Process finished with exit code: 0.  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:14.934 +00:00 [DBG] ITR: Packing objects...  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:14.934 +00:00 [DBG] Running command: git pack-objects --compression=9 --max-pack-size=3m "C:\Users\VssAdministrator\AppData\Local\Temp\tmpC2EA.tmp"  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:15.075 +00:00 [DBG] Process finished with exit code: 128.  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:15.075 +00:00 [WRN] ITR: 'git pack-objects...' command error: fatal: expected object ID, got garbage:
 ﻿7026fc7335f7c2c4f80f7a92cd8a552c3a17eb97

  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
2024-02-22 14:32:15.075 +00:00 [INF] ITR: Tests skipping is disabled.  { MachineName: ".", Process: "[1276 vstest.console]", AppDomain: "[1 vstest.console.exe]", TracerVersion: "2.47.0.0" }
```

Due to invalid chars in the get-objects output.

## Implementation details

Now we check the output and extract the objects using a regex instance.

## Test coverage

There's no way to create a repro case in the test, although we test the regex.
