### PR TITLE
[ASM] Rework encoder telemetry and logs

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -14,9 +14,12 @@ using System.Text;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
 using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.AppSec.WafEncoding
 {
@@ -103,13 +106,22 @@ namespace Datadog.Trace.AppSec.WafEncoding
                             return StringBuilderCache.GetStringAndRelease(sb);
                         }
 
-                        Log.Warning("EncodeDictionary: object graph too deep, truncating nesting {Items}", GetItemsAsString());
+                        TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ObjectTooDeep);
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            Log.Debug("EncodeDictionary: object graph too deep, truncating nesting {Items}", GetItemsAsString());
+                        }
+
                         return ddWafObjectMap;
                     }
 
                     if (count > WafConstants.MaxContainerSize)
                     {
-                        Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                        TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                        }
                     }
                 }
 
@@ -160,7 +172,11 @@ namespace Datadog.Trace.AppSec.WafEncoding
                             if (string.IsNullOrEmpty(key))
                             {
                                 childrenCount--;
-                                Log.Warning("EncodeDictionary: ignoring dictionary member with null name");
+                                if (Log.IsEnabled(LogEventLevel.Debug))
+                                {
+                                    Log.Debug("EncodeDictionary: ignoring dictionary member with null name");
+                                }
+
                                 continue;
                             }
 
@@ -181,7 +197,11 @@ namespace Datadog.Trace.AppSec.WafEncoding
                         if (string.IsNullOrEmpty(key))
                         {
                             childrenCount--;
-                            Log.Warning("EncodeDictionary: ignoring dictionary member with null name");
+                            if (Log.IsEnabled(LogEventLevel.Debug))
+                            {
+                                Log.Debug("EncodeDictionary: ignoring dictionary member with null name");
+                            }
+
                             continue;
                         }
 
@@ -368,7 +388,12 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
                     if (applySafetyLimits && remainingDepth-- <= 0)
                     {
-                        Log.Warning("EncodeList: object graph too deep, truncating nesting {Items}", string.Join(", ", enumerable));
+                        TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ObjectTooDeep);
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            Log.Debug("EncodeList: object graph too deep, truncating nesting {Items}", string.Join(", ", enumerable));
+                        }
+
                         break;
                     }
 
@@ -376,7 +401,11 @@ namespace Datadog.Trace.AppSec.WafEncoding
                     {
                         if (applySafetyLimits && count > WafConstants.MaxContainerSize)
                         {
-                            Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                            TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
+                            if (Log.IsEnabled(LogEventLevel.Debug))
+                            {
+                                Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                            }
                         }
 
                         var childrenCount = !applySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
@@ -450,7 +479,12 @@ namespace Datadog.Trace.AppSec.WafEncoding
                             childrenCount++;
                             if (applySafetyLimits && childrenCount == WafConstants.MaxContainerSize)
                             {
-                                Log.Warning<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                                TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
+                                if (Log.IsEnabled(LogEventLevel.Debug))
+                                {
+                                    Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                                }
+
                                 break;
                             }
                         }
@@ -483,11 +517,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 }
 
                 default:
-                    if (Log.IsEnabled(Vendors.Serilog.Events.LogEventLevel.Debug))
-                    {
-                        Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
-                    }
-
+                    Log.Warning("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
                     ddwafObjectStruct = GetStringObject(string.Empty);
                     break;
             }

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -517,7 +517,11 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 }
 
                 default:
-                    Log.Warning("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        Log.Warning("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+                    }
+
                     ddwafObjectStruct = GetStringObject(string.Empty);
                     break;
             }

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/EncoderLegacy.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/EncoderLegacy.cs
@@ -59,7 +59,10 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
         private static Obj EncodeUnknownType(object o, WafLibraryInvoker wafLibraryInvoker)
         {
-            Log.Warning("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                Log.Debug("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
+            }
 
             var s = o.ToString() ?? string.Empty;
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -52,6 +52,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -90,6 +91,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -69,6 +69,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1);
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 
     public void RecordCountIastExecutedPropagations(int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 342;
+    private const int CountLength = 345;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -355,7 +355,11 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // executed.source, index = 306
+            // waf.input_truncated, index = 306
+            new(new[] { "truncation_reason:string_too_long" }),
+            new(new[] { "truncation_reason:list_or_map_too_large" }),
+            new(new[] { "truncation_reason:object_too_deep" }),
+            // executed.source, index = 309
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -368,9 +372,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.cookie.value" }),
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
-            // executed.propagation, index = 318
+            // executed.propagation, index = 321
             new(null),
-            // executed.sink, index = 319
+            // executed.sink, index = 322
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -393,7 +397,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:nosql_mongodb_injection" }),
             new(new[] { "vulnerability_type:xpath_injection" }),
             new(new[] { "vulnerability_type:reflection_injection" }),
-            // request.tainted, index = 341
+            // request.tainted, index = 344
             new(null),
         };
 
@@ -403,7 +407,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 12, 1, 22, 1, };
+        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 3, 12, 1, 22, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -576,25 +580,31 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
         var index = 306 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    {
+        var index = 309 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[318], increment);
+        Interlocked.Add(ref _buffer.Count[321], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 319 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[341], increment);
+        Interlocked.Add(ref _buffer.Count[344], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -52,6 +52,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -90,6 +91,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -69,6 +69,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1);
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 
     public void RecordCountIastExecutedPropagations(int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 342;
+    private const int CountLength = 345;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -355,7 +355,11 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // executed.source, index = 306
+            // waf.input_truncated, index = 306
+            new(new[] { "truncation_reason:string_too_long" }),
+            new(new[] { "truncation_reason:list_or_map_too_large" }),
+            new(new[] { "truncation_reason:object_too_deep" }),
+            // executed.source, index = 309
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -368,9 +372,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.cookie.value" }),
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
-            // executed.propagation, index = 318
+            // executed.propagation, index = 321
             new(null),
-            // executed.sink, index = 319
+            // executed.sink, index = 322
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -393,7 +397,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:nosql_mongodb_injection" }),
             new(new[] { "vulnerability_type:xpath_injection" }),
             new(new[] { "vulnerability_type:reflection_injection" }),
-            // request.tainted, index = 341
+            // request.tainted, index = 344
             new(null),
         };
 
@@ -403,7 +407,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 12, 1, 22, 1, };
+        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 3, 12, 1, 22, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -576,25 +580,31 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
         var index = 306 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    {
+        var index = 309 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[318], increment);
+        Interlocked.Add(ref _buffer.Count[321], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 319 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[341], increment);
+        Interlocked.Add(ref _buffer.Count[344], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -52,6 +52,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -90,6 +91,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -69,6 +69,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1);
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 
     public void RecordCountIastExecutedPropagations(int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 342;
+    private const int CountLength = 345;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -355,7 +355,11 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // executed.source, index = 306
+            // waf.input_truncated, index = 306
+            new(new[] { "truncation_reason:string_too_long" }),
+            new(new[] { "truncation_reason:list_or_map_too_large" }),
+            new(new[] { "truncation_reason:object_too_deep" }),
+            // executed.source, index = 309
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -368,9 +372,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.cookie.value" }),
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
-            // executed.propagation, index = 318
+            // executed.propagation, index = 321
             new(null),
-            // executed.sink, index = 319
+            // executed.sink, index = 322
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -393,7 +397,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:nosql_mongodb_injection" }),
             new(new[] { "vulnerability_type:xpath_injection" }),
             new(new[] { "vulnerability_type:reflection_injection" }),
-            // request.tainted, index = 341
+            // request.tainted, index = 344
             new(null),
         };
 
@@ -403,7 +407,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 12, 1, 22, 1, };
+        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 3, 12, 1, 22, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -576,25 +580,31 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
         var index = 306 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    {
+        var index = 309 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[318], increment);
+        Interlocked.Add(ref _buffer.Count[321], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 319 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[341], increment);
+        Interlocked.Add(ref _buffer.Count[344], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 34;
+    public const int Length = 35;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -52,6 +52,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "waf.init",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "waf.updates",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "waf.requests",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "waf.input_truncated",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "executed.source",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "executed.propagation",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "executed.sink",
@@ -90,6 +91,7 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.WafInit => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafUpdates => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.WafRequests => "appsec",
+            Datadog.Trace.Telemetry.Metrics.Count.InputTruncated => "appsec",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSources => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedPropagations => "iast",
             Datadog.Trace.Telemetry.Metrics.Count.IastExecutedSinks => "iast",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -69,6 +69,8 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1);
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1);
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1);
 
     public void RecordCountIastExecutedPropagations(int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 342;
+    private const int CountLength = 345;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -355,7 +355,11 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // executed.source, index = 306
+            // waf.input_truncated, index = 306
+            new(new[] { "truncation_reason:string_too_long" }),
+            new(new[] { "truncation_reason:list_or_map_too_large" }),
+            new(new[] { "truncation_reason:object_too_deep" }),
+            // executed.source, index = 309
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -368,9 +372,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.cookie.value" }),
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
-            // executed.propagation, index = 318
+            // executed.propagation, index = 321
             new(null),
-            // executed.sink, index = 319
+            // executed.sink, index = 322
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -393,7 +397,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:nosql_mongodb_injection" }),
             new(new[] { "vulnerability_type:xpath_injection" }),
             new(new[] { "vulnerability_type:reflection_injection" }),
-            // request.tainted, index = 341
+            // request.tainted, index = 344
             new(null),
         };
 
@@ -403,7 +407,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 12, 1, 22, 1, };
+        = new int[]{ 4, 68, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 68, 1, 22, 3, 1, 1, 5, 3, 12, 1, 22, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -576,25 +580,31 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
-    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
         var index = 306 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
+    {
+        var index = 309 + (int)tag;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[318], increment);
+        Interlocked.Add(ref _buffer.Count[321], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 319 + (int)tag;
+        var index = 322 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[341], increment);
+        Interlocked.Add(ref _buffer.Count[344], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -132,6 +132,10 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
+    {
+    }
+
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -177,6 +177,11 @@ internal enum Count
     /// </summary>
     [TelemetryMetric<MetricTags.WafAnalysis>("waf.requests", isCommon: true, NS.ASM)] WafRequests,
 
+    /// <summary>
+    /// Waf inputs that have been truncated
+    /// </summary>
+    [TelemetryMetric<MetricTags.TruncationReason>("waf.input_truncated", isCommon: true, NS.ASM)] InputTruncated,
+
 #endregion
 #region Iast Namespace
 

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -243,6 +243,13 @@ internal static class MetricTags
         [Description("waf_version;rule_triggered:false;request_blocked:false;waf_timeout:false;request_excluded:true")]RequestExcludedViaFilter,
     }
 
+    public enum TruncationReason
+    {
+        [Description("truncation_reason:string_too_long")]StringTooLong = 1,
+        [Description("truncation_reason:list_or_map_too_large")]ListOrMapTooLarge = 2,
+        [Description("truncation_reason:object_too_deep")]ObjectTooDeep = 4,
+    }
+
     [EnumExtensions]
     public enum IastInstrumentedSources
     {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -451,6 +451,39 @@
       "description": "Requests analyzed by ddwaf",
       "send_to_user": false,
       "user_tags":[]
+    },
+    "waf.input_truncated": {
+      "tags": [
+        "truncation_reason"
+      ],
+      "metric_type": "count",
+      "data_type": "truncations",
+      "description": "Count of times a WAF input was truncated",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "waf.truncated_value_size": {
+      "tags": [
+        "truncation_reason"
+      ],
+      "metric_type": "distribution",
+      "data_type": "bytes",
+      "description": "Un-truncated size of truncated WAF inputs",
+      "send_to_user": false,
+      "user_tags":[]
+    },
+    "waf.config_errors": {
+      "tags": [
+        "waf_version",
+        "event_rules_version",
+        "config_key",
+        "scope"
+      ],
+      "metric_type": "count",
+      "data_type": "errors",
+      "description": "Count of errors reported by the WAF on about particular config item",
+      "send_to_user": false,
+      "user_tags":[]
     }
   },
   "iast": {
@@ -925,5 +958,6 @@
       "send_to_user": false,
       "user_tags":[]
     }
-  }
+  },
+  "profiler": {}
 }


### PR DESCRIPTION
## Summary of changes

Two related changes to the WAF encoders:
- Add a telemetry count to track the number of truncations made on WAF inputs.
- Down grade the logs from warning to debug

## Reason for change

The telemetry will be a more effective way of letting us understand how often truncation of WAF input occurs in client apps.

The logs have been downgrade to debug, as although they record undesirable situations, they are all things that can occur as part of normal operation of the app. As these logs can occur as part of normal app, they could occur frequently creating log bloat, it's therefore better that they are only logged in debug mode.