### PR TITLE
Add a `ChunkedEncodingReadStream` to use when talking to the agent

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -325,6 +325,7 @@
       <type fullname="System.Buffers.Binary.BinaryPrimitives" />
       <type fullname="System.Buffers.StandardFormat" />
       <type fullname="System.Buffers.Text.Utf8Formatter" />
+      <type fullname="System.Buffers.Text.Utf8Parser" />
       <type fullname="System.MemoryExtensions" />
       <type fullname="System.Runtime.InteropServices.MemoryMarshal" />
    </assembly>

--- a/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.HexHelpers.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.HexHelpers.cs
@@ -1,0 +1,144 @@
+﻿// <copyright file="ChunkedEncodingReadStream.HexHelpers.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers.Text;
+
+namespace Datadog.Trace.HttpOverStreams;
+
+internal partial class ChunkedEncodingReadStream
+{
+    // internal for testing
+    internal static ulong ParseChunkHexString(byte[] buffer, int offset, int length)
+    {
+        // Try to format into our output buffer directly.
+        if (TryParseUInt64FromUtf8(buffer, offset, length, out var value, out var bytesConsumed))
+        {
+            if (bytesConsumed != length)
+            {
+                ValidateChunkExtension(buffer, offset + bytesConsumed, length - bytesConsumed);
+            }
+
+            return value;
+        }
+
+        throw new Exception($"Invalid response chunk header: {BitConverter.ToString(buffer, offset, length)}");
+
+        static void ValidateChunkExtension(byte[] buffer, int offset, int length)
+        {
+            // Until we see the ';' denoting the extension, the line after the chunk size
+            // must contain only tabs and spaces.  After the ';', anything goes.
+            for (var i = 0; i < length; i++)
+            {
+                var c = buffer[offset + i];
+                if (c == ';')
+                {
+                    break;
+                }
+
+                if (c != ' ' && c != '\t')
+                {
+                    // not called out in the RFC, but WinHTTP allows it
+
+                    throw new Exception($"Invalid response chunk, extension invalid: {BitConverter.ToString(buffer, offset, length)}");
+                }
+            }
+        }
+    }
+
+    private static bool TryParseUInt64FromUtf8(byte[] source, int sourceOffset, int sourceLength, out ulong value, out int bytesConsumed)
+#if NET6_0_OR_GREATER
+            => System.Buffers.Text.Utf8Parser.TryParse(source.AsSpan(sourceOffset, sourceLength), out value, out bytesConsumed, 'X');
+#else
+    {
+        // Essentially a clone of System.Buffers.Text.Utf8Parser.TryParse
+        if (sourceLength < 1)
+        {
+            bytesConsumed = 0;
+            value = default;
+            return false;
+        }
+
+        byte nextCharacter;
+        byte nextDigit;
+
+        // Parse the first digit separately. If invalid here, we need to return false.
+        nextCharacter = source[sourceOffset];
+        nextDigit = (byte)HexConverter.FromChar(nextCharacter);
+        if (nextDigit == 0xFF)
+        {
+            bytesConsumed = 0;
+            value = default;
+            return false;
+        }
+
+        ulong parsedValue = nextDigit;
+
+        if (sourceLength <= ParserHelpers.Int64OverflowLengthHex)
+        {
+            // Length is less than or equal to Parsers.Int64OverflowLengthHex; overflow is not possible
+            for (var index = 1; index < sourceLength; index++)
+            {
+                nextCharacter = source[sourceOffset + index];
+                nextDigit = (byte)HexConverter.FromChar(nextCharacter);
+                if (nextDigit == 0xFF)
+                {
+                    bytesConsumed = index;
+                    value = parsedValue;
+                    return true;
+                }
+
+                parsedValue = (parsedValue << 4) + nextDigit;
+            }
+        }
+        else
+        {
+            // Length is greater than Parsers.Int64OverflowLengthHex; overflow is only possible after Parsers.Int64OverflowLengthHex
+            // digits. There may be no overflow after Parsers.Int64OverflowLengthHex if there are leading zeroes.
+            for (var index = 1; index < ParserHelpers.Int64OverflowLengthHex; index++)
+            {
+                nextCharacter = source[sourceOffset + index];
+                nextDigit = (byte)HexConverter.FromChar(nextCharacter);
+                if (nextDigit == 0xFF)
+                {
+                    bytesConsumed = index;
+                    value = parsedValue;
+                    return true;
+                }
+
+                parsedValue = (parsedValue << 4) + nextDigit;
+            }
+
+            for (var index = ParserHelpers.Int64OverflowLengthHex; index < sourceLength; index++)
+            {
+                nextCharacter = source[sourceOffset + index];
+                nextDigit = (byte)HexConverter.FromChar(nextCharacter);
+                if (nextDigit == 0xFF)
+                {
+                    bytesConsumed = index;
+                    value = parsedValue;
+                    return true;
+                }
+
+                // If we try to append a digit to anything larger than ulong.MaxValue / 0x10, there will be overflow
+                if (parsedValue > ulong.MaxValue / 0x10)
+                {
+                    bytesConsumed = 0;
+                    value = default;
+                    return false;
+                }
+
+                parsedValue = (parsedValue << 4) + nextDigit;
+            }
+        }
+
+        bytesConsumed = sourceLength;
+        value = parsedValue;
+        return true;
+    }
+#endif
+}

--- a/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
@@ -1,0 +1,317 @@
+﻿// <copyright file="ChunkedEncodingReadStream.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Util.Streams;
+using ArrayPool = Datadog.Trace.VendoredMicrosoftCode.System.Buffers.ArrayPool<byte>;
+
+namespace Datadog.Trace.HttpOverStreams;
+
+internal sealed partial class ChunkedEncodingReadStream : DelegatingStream
+{
+    private const int ReadBufferSize =
+#if DEBUG
+        MaxChunkBytesAllowed * 2;
+#else
+        4096;
+#endif
+
+    /// <summary>How long a chunk indicator is allowed to be.</summary>
+    /// <remarks>
+    /// While most chunks indicators will contain no more than ulong.MaxValue.ToString("X").Length characters (i.e. 16),
+    /// "chunk extensions" are allowed. We place a limit on how long a line can be to avoid OOM issues if an
+    /// infinite chunk length is sent.  This value is arbitrary and can be changed as needed.
+    /// As we're not trying to handle extensions, we've set this to an arbitrary low limit
+    /// NOTE: this number needs to be &lt; ReadBufferSize * 2 to work with the current implementation
+    /// </remarks>
+    private const int MaxChunkBytesAllowed =
+#if DEBUG
+        32;
+#else
+        128;
+#endif
+
+    private static readonly ArrayPool Pool = ArrayPool.Shared;
+
+    private readonly Stream _innerStream;
+    private readonly byte[] _streamBuffer;
+    private ulong _bytesRemainingInChunk;
+
+    // The "unconsumed" data in _streamBuffer
+    private Segment _currentPosition;
+
+    /// <summary>The current state of the parsing state machine for the chunked response.</summary>
+    private ParsingState _state = ParsingState.ExpectChunkHeader;
+
+    public ChunkedEncodingReadStream(Stream innerStream)
+        : base(innerStream)
+    {
+        _innerStream = innerStream;
+        // We use a buffer that is double the size of the read buffer, so that we can move
+        // the bytes around if we end up hitting edge cases
+        _streamBuffer = Pool.Rent(ReadBufferSize * 2);
+        _currentPosition = new(offset: 0, count: 0);
+    }
+
+    private enum ParsingState : byte
+    {
+        ExpectChunkHeader,
+        ExpectChunkData,
+        ExpectChunkTerminator,
+        // For "simplicity" we don't support trailers currently
+        // ConsumeTrailers,
+        Done
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        Pool.Return(_streamBuffer);
+        base.Dispose(disposing);
+    }
+
+#if NETCOREAPP
+    public override ValueTask DisposeAsync()
+    {
+        Pool.Return(_streamBuffer);
+        return base.DisposeAsync();
+    }
+#endif
+
+    public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            // Cancellation requested.
+            await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
+            return 0;
+        }
+
+        while (true)
+        {
+            Segment currentLine;
+            switch (_state)
+            {
+                case ParsingState.ExpectChunkHeader:
+                    Debug.Assert(_bytesRemainingInChunk == 0, $"Expected {nameof(_bytesRemainingInChunk)} == 0, got {_bytesRemainingInChunk}");
+
+                    // Try to read the chunk header from the bytes we have available
+                    while (!TryReadNextChunkLine(out currentLine))
+                    {
+                        // We didn't have enough data to read the chunk header, so we need to refill the buffer
+                        // and try again
+                        await FillAsync().ConfigureAwait(false);
+                    }
+
+                    // We have a chunk header, so we can parse it
+                    _bytesRemainingInChunk = ParseChunkHexString(_streamBuffer, currentLine.Offset, currentLine.Length);
+
+                    // Proceed to handle the chunk.  If there's data in it, go read it.
+                    // Otherwise, finish handling the response.
+                    if (_bytesRemainingInChunk > 0)
+                    {
+                        _state = ParsingState.ExpectChunkData;
+                        break;
+                    }
+
+                    // We don't support trailers currently, so we expect another CRLF (chunk terminator)
+                    while (!TryReadNextChunkLine(out currentLine))
+                    {
+                        // We didn't have enough data to read the chunk terminator, so we need to refill the buffer
+                        // and try again
+                        await FillAsync().ConfigureAwait(false);
+                    }
+
+                    if (currentLine.Length != 0)
+                    {
+                        throw new Exception("Invalid response chunk terminator: expected 0 length terminator, received " + Encoding.ASCII.GetString(_streamBuffer, currentLine.Offset, currentLine.Length));
+                    }
+
+                    // all done!
+                    _state = ParsingState.Done;
+                    return 0;
+
+                case ParsingState.ExpectChunkData:
+                    // Read and return the chunk bytes
+                    // This reads the data from the stream directly into the provided buffer, instead
+                    // of into the _streamBuffer
+
+                    // As an optimization, we skip going through the connection's read buffer if both
+                    // the remaining chunk data and the buffer are both at least as large
+                    // as the connection buffer.  That avoids an unnecessary copy while still reading
+                    // the maximum amount we'd otherwise read at a time.
+                    if (_currentPosition.Length == 0
+                     && count >= ReadBufferSize
+                     && _bytesRemainingInChunk >= ReadBufferSize)
+                    {
+                        // We don't have enough for the whole chunk, so just read what we can, directly into the output buffer
+                        var bytesToRead = (int)Math.Min((ulong)count, _bytesRemainingInChunk);
+                        var bytesReadFromStream = await _innerStream.ReadAsync(buffer, offset, bytesToRead, cancellationToken).ConfigureAwait(false);
+
+                        // we might not have read the whole expected values, so just return what we have
+                        _bytesRemainingInChunk -= (ulong)bytesReadFromStream;
+                        if (_bytesRemainingInChunk <= 0)
+                        {
+                            _state = ParsingState.ExpectChunkTerminator;
+                        }
+
+                        return bytesReadFromStream;
+                    }
+
+                    if (_currentPosition.Length == 0)
+                    {
+                        // we have no data, so fill in some more
+                        await FillAsync().ConfigureAwait(false);
+                    }
+
+                    Debug.Assert(_currentPosition.Length > 0, "We should have some bytes now");
+
+                    // can't fill a full line with chunk data, so instead we need to consume from the existing _buffer
+                    var bytesToConsume = Math.Min(count, (int)Math.Min((ulong)_currentPosition.Length, _bytesRemainingInChunk));
+
+                    Debug.Assert(offset + bytesToConsume <= buffer.Length, "Should not try to consume more data than we have space to copy into");
+                    Debug.Assert(_currentPosition.Offset + bytesToConsume <= _streamBuffer.Length, "Should not try to consume more data than we have to read from");
+
+                    // Copy the data we have into the buffer
+                    Array.Copy(
+                        sourceArray: _streamBuffer,
+                        sourceIndex: _currentPosition.Offset,
+                        destinationArray: buffer,
+                        destinationIndex: offset,
+                        length: bytesToConsume);
+
+                    // update the currentPosition and expected bytes to reflect the consumed bytes
+                    _bytesRemainingInChunk -= (ulong)bytesToConsume;
+                    _currentPosition = new(_currentPosition.Offset + bytesToConsume, _currentPosition.Length - bytesToConsume);
+
+                    if (_bytesRemainingInChunk == 0)
+                    {
+                        _state = ParsingState.ExpectChunkTerminator;
+                    }
+
+                    return bytesToConsume;
+                case ParsingState.ExpectChunkTerminator:
+                    Debug.Assert(_bytesRemainingInChunk == 0, $"Expected {nameof(_bytesRemainingInChunk)} == 0, got {_bytesRemainingInChunk}");
+
+                    while (!TryReadNextChunkLine(out currentLine))
+                    {
+                        // We didn't have enough data to read the chunk terminator, so we need to refill the buffer
+                        // and try again
+                        await FillAsync().ConfigureAwait(false);
+                    }
+
+                    if (currentLine.Length != 0)
+                    {
+                        throw new Exception("Invalid response chunk terminator: expected 0 length terminator, received " + Encoding.ASCII.GetString(_streamBuffer, currentLine.Offset, currentLine.Length));
+                    }
+
+                    _state = ParsingState.ExpectChunkHeader;
+                    break;
+
+                case ParsingState.Done: // Shouldn't be called once we're done
+                    Debug.Fail($"Unexpected state: {_state}");
+
+                    return default;
+            }
+        }
+    }
+
+    private bool TryReadNextChunkLine(out Segment chunkHeader)
+    {
+        // try to read the data we have in _currentPosition for a `\n`
+        // if we don't have anything in the buffer, then we need to do a fetch
+
+        // This will actually potentially search _beyond_ the remaining values, but just handle it later
+        var lineFeedIndex = Array.IndexOf(_streamBuffer, (byte)'\n', _currentPosition.Offset);
+        if (lineFeedIndex < 0 || lineFeedIndex >= _currentPosition.Offset + _currentPosition.Length)
+        {
+            // didn't find a line feed in the available bytes
+            if (_currentPosition.Length < MaxChunkBytesAllowed)
+            {
+                // In this case, we only have a few bytes that we've looked through
+                // So we need to extend the buffer and try again
+                chunkHeader = default;
+                return false;
+            }
+
+            // Oops, we _should_ have found it, so something is wrong here, so throw chunk size too big
+        }
+        else
+        {
+            int bytesConsumedIndex = lineFeedIndex + 1;
+            if ((bytesConsumedIndex - _currentPosition.Offset) <= MaxChunkBytesAllowed)
+            {
+                int carriageReturnIndex = lineFeedIndex - 1;
+
+                int lengthFromStart = (uint)carriageReturnIndex < (uint)(_currentPosition.Offset + _currentPosition.Length) && _streamBuffer[carriageReturnIndex] == '\r'
+                                 ? carriageReturnIndex
+                                 : lineFeedIndex;
+
+                var lineLength = lengthFromStart - _currentPosition.Offset;
+                chunkHeader = new Segment(_currentPosition.Offset, lineLength);
+
+                // increment the current position to _after_ the chunk Header
+                var shiftBy = bytesConsumedIndex - _currentPosition.Offset;
+
+                _currentPosition = new(bytesConsumedIndex, _currentPosition.Length - shiftBy);
+                return true;
+            }
+        }
+
+        throw new Exception($"Chunk size header was too large: more than maximum of {MaxChunkBytesAllowed} bytes");
+    }
+
+    /// <summary>
+    /// Trys to fill up the associated buffer segment from the underlying stream
+    /// If we still have some existing bytes left over in <see cref="_currentPosition"/>,
+    /// these are moved to the start of the array, and preserved
+    /// </summary>
+    private async Task FillAsync()
+    {
+        var prependedBytes = 0;
+        if (_currentPosition.Length > 0)
+        {
+            // we still have some bytes remaining, move them to the start
+            Array.Copy(
+                sourceArray: _streamBuffer,
+                sourceIndex: _currentPosition.Offset,
+                destinationArray: _streamBuffer,
+                destinationIndex: 0,
+                length: _currentPosition.Length);
+
+            prependedBytes = _currentPosition.Length;
+        }
+
+        var bytesReadFromStream = await _innerStream.ReadAsync(_streamBuffer, offset: prependedBytes, ReadBufferSize).ConfigureAwait(false);
+
+        // this should always return some bytes because we're _expecting_ bytes to be read
+        if (bytesReadFromStream == 0)
+        {
+            throw new EndOfStreamException("Invalid HTTP response - unexpected end of stream");
+        }
+
+        // update _currentPosition to include both the prepended bytes and the new bytes
+        _currentPosition = new Segment(offset: 0, count: prependedBytes + bytesReadFromStream);
+    }
+
+    [DebuggerDisplay("Offset = {Offset}, Length = {Length}")]
+    private readonly struct Segment
+    {
+        public readonly int Offset;
+        public readonly int Length;
+
+        public Segment(int offset, int count)
+        {
+            Offset = offset;
+            Length = count;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
@@ -252,6 +252,9 @@ internal sealed partial class ChunkedEncodingReadStream : DelegatingStream
             {
                 int carriageReturnIndex = lineFeedIndex - 1;
 
+                // Note that this has a bounds check on both the high and lower end
+                // if lineFeedIndex == 0, and carriageReturnIndex == -1, then
+                // (uint)carriageReturnIndex == uint.MaxValue, and the check will be false
                 int lengthFromStart = (uint)carriageReturnIndex < (uint)(_currentPosition.Offset + _currentPosition.Length) && _streamBuffer[carriageReturnIndex] == '\r'
                                  ? carriageReturnIndex
                                  : lineFeedIndex;

--- a/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
@@ -93,12 +93,7 @@ internal sealed partial class ChunkedEncodingReadStream : DelegatingStream
 
     public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
-        if (cancellationToken.IsCancellationRequested)
-        {
-            // Cancellation requested.
-            await Task.FromCanceled(cancellationToken).ConfigureAwait(false);
-            return 0;
-        }
+        cancellationToken.ThrowIfCancellationRequested();
 
         while (true)
         {
@@ -163,7 +158,7 @@ internal sealed partial class ChunkedEncodingReadStream : DelegatingStream
 
                         // we might not have read the whole expected values, so just return what we have
                         _bytesRemainingInChunk -= (ulong)bytesReadFromStream;
-                        if (_bytesRemainingInChunk <= 0)
+                        if (_bytesRemainingInChunk == 0)
                         {
                             _state = ParsingState.ExpectChunkTerminator;
                         }

--- a/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatadogHttpClientTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -20,15 +19,6 @@ namespace Datadog.Trace.Tests
 {
     public class DatadogHttpClientTests
     {
-        private static readonly int[] Chunks = [1, 2, 5, 10, 15];
-        private static readonly int[] BufferSizes = [1, 2, 5, 10, 15];
-
-        public static IEnumerable<object[]> GetChunkSizes()
-            => from chunks in Chunks
-               from chunkSize in ChunkedEncodingReadStreamTests.ChunkSizes
-               from bufferSize in ChunkedEncodingReadStreamTests.ChunkSizes
-               select new object[] { chunks, chunkSize, bufferSize };
-
         [Fact]
         public async Task DatadogHttpClient_CanParseResponse()
         {

--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/ChunkedEncodingReadStreamTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/ChunkedEncodingReadStreamTests.cs
@@ -1,0 +1,156 @@
+﻿// <copyright file="ChunkedEncodingReadStreamTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.HttpOverStreams;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+using static Datadog.Trace.Util.EncodingHelpers;
+
+namespace Datadog.Trace.Tests.HttpOverStreams;
+
+public class ChunkedEncodingReadStreamTests
+{
+    public static readonly int[] ChunkSizes = [5, 9, 50, 127, 255, 256, 257, 1053, 4095, 4096, 4097, 8192,];
+    private static readonly int[] Offsets = [0, 1, 5, 15];
+    private static readonly int[] BufferSizesRelativeToChunk = [-100, -10, -1, 0, 1, 10, 100];
+
+    public static IEnumerable<object[]> GetChunkAndBufferSizes()
+        => from chunkSize in ChunkSizes
+           from offset in Offsets
+           from bufferRelativeSize in BufferSizesRelativeToChunk
+           let bufferSize = chunkSize + bufferRelativeSize
+           where bufferSize - offset > 0
+           select new object[] { bufferSize, chunkSize, offset };
+
+    [Theory]
+    [InlineData(0, "0")]
+    [InlineData(15, "F")]
+    [InlineData(12345, "3039")]
+    [InlineData(int.MaxValue, "7FFFFFFF")]
+    public void ParseChunkHexString_GivesCorrectOutput(int chunkSize, string headerBytes)
+    {
+        // doing a bigger buffer with a somewhat random offset
+        var offset = 3;
+        var buffer = new byte[20];
+        var bytesWritten = Utf8NoBom.GetBytes(headerBytes, 0, headerBytes.Length, buffer, offset);
+
+        var parsedValue = (int)ChunkedEncodingReadStream.ParseChunkHexString(buffer, offset, bytesWritten);
+        parsedValue.Should().Be(chunkSize);
+    }
+
+    [Theory]
+    [InlineData(12345, "3039;")]
+    [InlineData(12345, "3039;test")]
+    [InlineData(12345, "3039;test1;test2;")]
+    [InlineData(12345, "3039;test1 x=123;test2;")]
+    public void ParseChunkHexString_IgnoresExtensions_GivesCorrectOutput(int chunkSize, string headerBytes)
+    {
+        // doing a bigger buffer with a somewhat random offset
+        var offset = 3;
+        var buffer = new byte[128];
+        var bytesWritten = Utf8NoBom.GetBytes(headerBytes, 0, headerBytes.Length, buffer, offset);
+
+        var parsedValue = (int)ChunkedEncodingReadStream.ParseChunkHexString(buffer, offset, bytesWritten);
+        parsedValue.Should().Be(chunkSize);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetChunkAndBufferSizes))]
+    public async Task ChunkedEncodingReadStream_IsReadCorrectly(int bufferSize, int chunkSize, int offset)
+    {
+        const int chunkCount = 10;
+        var hexChunkSize = chunkSize.ToString("X");
+        var chars = GetChunk(chunkSize);
+        var expected = string.Join(string.Empty, Enumerable.Repeat(chars, chunkCount));
+
+        var chunk = hexChunkSize + "\r\n" + chars + "\r\n";
+
+        var sb = new StringBuilder();
+        for (var i = 0; i < chunkCount; i++)
+        {
+            sb.Append(chunk);
+        }
+
+        // final chunk
+        sb.Append("0\r\n\r\n");
+
+        var input = Utf8NoBom.GetBytes(sb.ToString());
+
+        using var ms = new MemoryStream(input);
+
+        var totalBytesRead = await ReadChunkedData(bufferSize, offset, ms, sb);
+
+        using var scope = new AssertionScope();
+        totalBytesRead.Should().Be(chunkSize * 10);
+        sb.ToString().Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(GetChunkAndBufferSizes))]
+    public async Task ChunkedEncodingReadStream_AndWriteStream_CanRoundTrip(int bufferSize, int chunkSize, int offset)
+    {
+        const int chunkCount = 10;
+
+        var chars = GetChunk(chunkSize);
+        var charsAsByteArray = Utf8NoBom.GetBytes(chars);
+        var expected = string.Join(string.Empty, Enumerable.Repeat(chars, chunkCount));
+
+        using var ms = new MemoryStream();
+        using var chunkWriter = new ChunkedEncodingWriteStream(ms);
+
+        for (var i = 0; i < chunkCount; i++)
+        {
+            await chunkWriter.WriteAsync(charsAsByteArray, 0, charsAsByteArray.Length);
+        }
+
+        await chunkWriter.FinishAsync();
+
+        // reset to start
+        ms.Position = 0;
+        var sb = new StringBuilder();
+
+        var totalBytesRead = await ReadChunkedData(bufferSize, offset, ms, sb);
+
+        using var scope = new AssertionScope();
+        totalBytesRead.Should().Be(charsAsByteArray.Length * 10);
+        sb.ToString().Should().Be(expected);
+    }
+
+    internal static string GetChunk(int chunkSize)
+        => string.Join(
+            string.Empty,
+            Enumerable.Range(0, chunkSize).Select(x => (x % 16).ToString("x")));
+
+    private static async Task<int> ReadChunkedData(int bufferSize, int offset, MemoryStream ms, StringBuilder sb)
+    {
+        var streamEncoding = new ChunkedEncodingReadStream(ms);
+
+        int totalBytesRead = 0;
+        int bytesRead = 0;
+
+        var destinationBuffer = new byte[bufferSize];
+        var length = bufferSize - offset;
+        sb.Clear();
+
+        do
+        {
+            bytesRead = await streamEncoding.ReadAsync(destinationBuffer, offset, length);
+            totalBytesRead += bytesRead;
+
+            // this is obviously inefficient, but don't care
+            sb.Append(Utf8NoBom.GetString(destinationBuffer, offset, bytesRead));
+        }
+        while (bytesRead > 0);
+
+        return totalBytesRead;
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Adds a `ChunkedEncodingReadStream` type
- Replace that janky one we used in our tests with the new one.

## Reason for change

We discovered that in some cases (typically high-load) the trace-agent returns chunked-encoded responses. Also, even if we send `HTTP/1.0`, the agent does _not_ add a `Content-Length`, so that's not a "quick" fix.

## Implementation details

This is part 1 of the fix. It adds support for a "wrapper" stream, `ChunkedEncodingReadStream`, which wraps the response stream and decodes it as the chunks are received.

The implementation is partially based on the existing test implementation (which is removed in this PR), but that didn't handle edge cases: specifically where the chunk size header falls at the end of a buffer block. The implementation is heavily based on the version [in the .NET runtime](https://github.com/dotnet/runtime/blob/8ccb71eadfc318017a78e1b7d356356dae5688a2/src/libraries/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/ChunkedEncodingReadStream.cs#L326) (for .NET 8).

Unfortunately, the version in the runtime relies heavily on spans to get "nice" semantics which just wasn't working out for me. I played with having a ring buffer, having a small auxilliary buffer, but they all ended up in a big mess. In the end, I settled for allocation a buffer that's 2x the max read size, and setting a small enough `MaxChunkBytesAllowed` so that we know we won't ever run into issues with needing bigger.

> This makes an assumption that the trace-header doesn't try to use chunk extensions. We don't support any, but I've added validation for them, but if they _do_ plan to send them, we'll likely need to increase `MaxChunkBytesAllowed`.

The core of the implementation is a state machine that alternates between 3 main states. We try to read in large-ish chunks (`ReadBufferSize`), and then process this data, looking for chunk boundaries. Note that we _don't_ currently support trailers (hopefully the trace-agent won't send any, as we don't opt-in with the request header).

In the next PR, we'll actually _use_ this stream if the response is chunked. 

## Test coverage

Added a bunch of unit tests with a range of buffer sizes and chunk sizes to try to make sure we hit the edge cases.

Also added tests to make sure we can round-trip with the `ChunkedEncodingWriteStream` we already had to add (for the tracer flare)

## Other details

Next PR will add changes to the `DatadogHttpClient` (update: #5244)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
