### PR TITLE
Fix

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
@@ -42,6 +42,11 @@ namespace Datadog.Trace.AppSec
 
         internal static object Extract(object body)
         {
+            if (body == null)
+            {
+                return null;
+            }
+
             var visited = new HashSet<object>();
             var item = ExtractType(body.GetType(), body, 0, visited);
             return item;


### PR DESCRIPTION
## Summary of changes

Fix for [this ](https://app.datadoghq.com/logs/error-tracking/issue/4960f374-ccdb-11ee-8c71-da7ad0900002?query=source%3Adotnet security&index=instrumentation-telemetry-data&refresh_mode=sliding&view=spans&from_ts=1708420299300&to_ts=1708506699300&live=true)null reference exception

Since ObjectExtractor lacks #nullable enable and this directive would have pointed this issue, the directive has been added and the code, updated.

## Reason for change

Fix an unwanted exception

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
