### PR TITLE
Update `DatadogHttpClient` to support `chunked` encoding

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -112,6 +112,9 @@
    <assembly fullname="StackExchange.Redis" />
    <assembly fullname="StackExchange.Redis.StrongName" />
    <assembly fullname="System" />
+   <assembly fullname="System.Buffers">
+      <type fullname="System.Buffers.ArrayPool`1" />
+   </assembly>
    <assembly fullname="System.Collections">
       <type fullname="System.Collections.BitArray" />
       <type fullname="System.Collections.Generic.Comparer`1" />

--- a/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/ChunkedEncodingReadStream.cs
@@ -12,7 +12,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Util.Streams;
+
+#if NETCOREAPP
+using ArrayPool = System.Buffers.ArrayPool<byte>;
+#else
 using ArrayPool = Datadog.Trace.VendoredMicrosoftCode.System.Buffers.ArrayPool<byte>;
+#endif
 
 namespace Datadog.Trace.HttpOverStreams;
 

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
@@ -6,6 +6,7 @@ Microsoft.AspNetCore.Routing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a
 Microsoft.AspNetCore.Routing.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 Microsoft.Net.Http.Headers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
+System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 System.Collections, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.Concurrent, Version=4.0.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.NonGeneric, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a


### PR DESCRIPTION
## Summary of changes

Update `DatadogHttpClient` and `HttpStreamRequest` to support chunked encoding

## Reason for change

When a lot of services are talking to the trace-agent, it sends a big response with the various service sample rates. The response is large enough that it can be `chunked`. We need to handle these responses in our custom `HttpClient` (we didn't support this previously).

## Implementation details

- Updated `DatadogHttpClient` to use `ChunkedEncodingReadStream` when it sees the `Transfer-Encoding: chunked` header
- When the content-length is not known, use a `MemoryStream` without a fixed buffer size to read the response
- Fixed a minor bug in `DatadogHttpClientTests.RegulatedStream` 

## Test coverage

Added unit tests that the `DatadogHttpClient` reads the chunked response ok. It's annoying difficult to test most of our other Http sending abstractions, so @kevingosse did a manual test and confirmed this solves the issues

## Other details

It's unrelated to this PR, but it feels like there's a _lot_ of scope for refactoring here. We currently always buffer the entire response in memory for example, wrap it with a `MemoryStream`, and then expose that. We could almost certainly improve memory usage and perf here by avoiding that initial copy, not to mention consider using the newly vendored arraypool implementations where appropriate.

Follows #5241.