### PR TITLE
Remove usage of `ArrayPool<T>` from `ChunkedEncodingReadStream`

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -112,9 +112,6 @@
    <assembly fullname="StackExchange.Redis" />
    <assembly fullname="StackExchange.Redis.StrongName" />
    <assembly fullname="System" />
-   <assembly fullname="System.Buffers">
-      <type fullname="System.Buffers.ArrayPool`1" />
-   </assembly>
    <assembly fullname="System.Collections">
       <type fullname="System.Collections.BitArray" />
       <type fullname="System.Collections.Generic.Comparer`1" />

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.AssemblyReferencesHaveNotChanged.netcoreapp3.1.verified.txt
@@ -6,7 +6,6 @@ Microsoft.AspNetCore.Routing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a
 Microsoft.AspNetCore.Routing.Abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 Microsoft.Extensions.Primitives, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
 Microsoft.Net.Http.Headers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60
-System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51
 System.Collections, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.Concurrent, Version=4.0.15.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 System.Collections.NonGeneric, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a


### PR DESCRIPTION
## Summary of changes

Removes the `ArrayPool<>` usage from `ChunkedEncodingReadStream`

## Reason for change

The existing code (`DatadogHttpClient` _et al_.) does not dispose the `StreamContent`, which means we would be leaking a large `ArrayPool<byte>` array with every request 😱 

## Implementation details

Just new-up a new array. This is annoying from a perf PoV, but it's _safe_.

This code-path is only hit when the agent sends chunked-responses, and that's only when there's a lot of data to return, so it's not like we'll _always_ be making these allocations.

## Test coverage

Functionally unchanged, so covered by existing tests

## Other details

Obviously the alternative would be to dispose of the `Stream` properly, but that would require wider refactoring changes to all our abstractions which is more risk than I want to take on.

Also, our HTTP APIs here are _already_ pretty un-performant (we're always buffering responses in memory and wrapping a `MemoryStream` around them for example), so it doesn't seem worth the risk to optimize this one small part. There are lots of other places that would benefit from `ArrayPool<T>` usages if we want to take that approach, and in other paths we will have more visibility if we introduce memory leaks due to not returning to the pool correctly.


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
