### PR TITLE
[ASM] Add processors and scanners to ruleset 

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rcm/Models/AsmDd/RuleSet.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/Models/AsmDd/RuleSet.cs
@@ -19,11 +19,25 @@ internal class RuleSet
     [JsonProperty("rules")]
     internal JToken? Rules { get; set; }
 
+    [JsonProperty("processors")]
+    internal JToken? Processors { get; set; }
+
+    [JsonProperty("scanners")]
+    internal JToken? Scanners { get; set; }
+
     public JToken? All { get; set; }
 
     public static RuleSet From(JToken result)
     {
-        var ruleset = new RuleSet { Version = result["version"]?.ToString(), Metadata = result["metadata"], Rules = result["rules"], All = result };
+        var ruleset = new RuleSet
+        {
+            Version = result["version"]?.ToString(),
+            Metadata = result["metadata"],
+            Rules = result["rules"],
+            Processors = result["processors"],
+            Scanners = result["scanners"],
+            All = result
+        };
         return ruleset;
     }
 
@@ -46,6 +60,16 @@ internal class RuleSet
         if (Version != null)
         {
             dictionary.Add("version", Version);
+        }
+
+        if (Processors != null)
+        {
+            dictionary.Add("processors", Processors);
+        }
+
+        if (Scanners != null)
+        {
+            dictionary.Add("scanners", Scanners);
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Add processors and scanners to asm_dd payload.

## Reason for change

We don't have them, they're necessary to api security when we deserialize from rmote config.

## Implementation details


## Test coverage
There's already tests for api security and tests for rcm and ruleset taken into account. I dont think another test for rcm and api security is necessary.
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
