### PR TITLE
Force update to latest Octokit version

### DIFF
--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -35,6 +35,9 @@
     <PackageReference Include="Nuke.Common" Version="6.3.0" ExcludeAssets="build" />
     <PackageReference Include="Colorful.Console" Version="1.2.15" />
     <PackageReference Include="Octokit.GraphQL" Version="0.1.8-beta" />
+
+    <!-- Explicitly overide the version of octokit used by Nuke -->
+    <PackageReference Include="Octokit" Version="10.0.0" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
     <PackageReference Include="Sep" Version="0.3.0" />
     <PackageReference Include="ByteSize" Version="2.1.0" />

--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Colorful.Console" Version="1.2.15" />
     <PackageReference Include="Octokit.GraphQL" Version="0.1.8-beta" />
 
-    <!-- Explicitly overide the version of octokit used by Nuke -->
+    <!-- Explicitly override the version of octokit used by Nuke -->
     <PackageReference Include="Octokit" Version="10.0.0" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
     <PackageReference Include="Sep" Version="0.3.0" />


### PR DESCRIPTION
## Summary of changes

Forces Nuke to use the latest version of Octokit which fixes a critical bug

## Reason for change

[There's a critical bug in Octokit](https://github.com/octokit/octokit.net/issues/2889) that prevents it working. [The bug is in Octokit.GraqhQL too](https://github.com/octokit/octokit.graphql.net/issues/311), but that actually doesn't appear to impact us.

## Implementation details

Manually reference the package with the fix

## Test coverage

Tested locally, it works :phew:

## Other details


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
