### PR TITLE
[Tracer] Adding Optional Parameter for MockTraceAgent's WaitForSpans

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -302,7 +302,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     var spans = agent.WaitForSpans(totalExpectedSpans, 500);
 
                     using var scope = new AssertionScope();
-                    spans.Count.Should().Be(totalExpectedSpans);
 
                     if (!isGrpcSupported)
                     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -299,7 +299,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             {
                 using (processResult = await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
                 {
-                    var spans = agent.WaitForSpans(totalExpectedSpans, 500);
+                    var spans = agent.WaitForSpans(totalExpectedSpans, 500, assertExpectedCount: false);
 
                     using var scope = new AssertionScope();
 

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -124,13 +124,15 @@ namespace Datadog.Trace.TestHelpers
         /// <param name="operationName">The integration we're testing</param>
         /// <param name="minDateTime">Minimum time to check for spans from</param>
         /// <param name="returnAllOperations">When true, returns every span regardless of operation name</param>
+        /// <param name="assertExpectedCount">When true, asserts that the number of spans to return matches the count</param>
         /// <returns>The list of spans.</returns>
         public IImmutableList<MockSpan> WaitForSpans(
             int count,
             int timeoutInMilliseconds = 20000,
             string operationName = null,
             DateTimeOffset? minDateTime = null,
-            bool returnAllOperations = false)
+            bool returnAllOperations = false,
+            bool assertExpectedCount = true)
         {
             var deadline = DateTime.UtcNow.AddMilliseconds(timeoutInMilliseconds);
             var minimumOffset = (minDateTime ?? DateTimeOffset.MinValue).ToUnixTimeNanoseconds();
@@ -171,7 +173,10 @@ namespace Datadog.Trace.TestHelpers
                 Thread.Sleep(500);
             }
 
-            relevantSpans.Should().HaveCountGreaterThanOrEqualTo(count, "because we want to ensure that we don't timeout while waiting for spans from the mock tracer agent");
+            if (assertExpectedCount)
+            {
+                relevantSpans.Should().HaveCountGreaterThanOrEqualTo(count, "because we want to ensure that we don't timeout while waiting for spans from the mock tracer agent");
+            }
 
             foreach (var headers in TraceRequestHeaders)
             {


### PR DESCRIPTION
## Summary of changes
In [a previous PR](https://github.com/DataDog/dd-trace-dotnet/pull/5246) I removed the assertion where we confirm that the spans to return match the expected `count`, in this one added a condition when checking those within the WaitForSpans method where we are erroring out first which prevents Snapshots generation.

## Reason for change
To troubleshoot a flaky test with hopefully the resulting snapshots after a failed test.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
