### PR TITLE
[Tracer] Fixing Missing Query String for CleanUri_HttpUrlTag Tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Util;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -119,6 +120,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         {
             // Set up Tracer
             var dictionary = new Dictionary<string, object> { { ConfigurationKeys.QueryStringReportingEnabled, includeQuerystring } };
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                dictionary.Add(ConfigurationKeys.ObfuscationQueryStringRegexTimeout, "5000");
+            }
+
 #if NETCOREAPP2_1
             // Add old one otherwise NullReferenceException on arm64/netcoreapp2.1
             if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
@@ -135,8 +142,8 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
             using (var automaticScope = ScopeFactory.CreateOutboundHttpScope(tracer, method, new Uri(uri), IntegrationId.HttpMessageHandler, out var tags))
             {
-                Assert.Equal(expected, automaticScope.Span.GetTag(Tags.HttpUrl));
-                Assert.Equal(expected, tags.HttpUrl);
+                expected.Should().Be(automaticScope.Span.GetTag(Tags.HttpUrl));
+                expected.Should().Be(tags.HttpUrl);
             }
         }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/ScopeFactoryTests.cs
@@ -119,12 +119,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         public void CleanUri_HttpUrlTag(string uri, string expected, bool includeQuerystring)
         {
             // Set up Tracer
-            var dictionary = new Dictionary<string, object> { { ConfigurationKeys.QueryStringReportingEnabled, includeQuerystring } };
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            var dictionary = new Dictionary<string, object>
             {
-                dictionary.Add(ConfigurationKeys.ObfuscationQueryStringRegexTimeout, "5000");
-            }
+                { ConfigurationKeys.QueryStringReportingEnabled, includeQuerystring },
+                { ConfigurationKeys.ObfuscationQueryStringRegexTimeout, "5000" }
+            };
 
 #if NETCOREAPP2_1
             // Add old one otherwise NullReferenceException on arm64/netcoreapp2.1


### PR DESCRIPTION
## Summary of changes
As in the previous PR increasing the timeout here since I was able to replicate the issue locally when lowering the timeout and updating the query to a more complex one.

## Reason for change
There are a couple of integrations test that started flaking because of missing expected HTTP query(https://github.com/DataDog/dd-trace-dotnet/pull/5255), this test started doing the same around the same time in MacOs for .NET 8 at the same time.

## Implementation details
Update the `CleanUri_HttpUrlTag` with a higher obfuscation timeout and added fluent assertions for the method in question when running on Mac to prevent flakes(if the issue happens outside of MacOs then will come back to this).