### PR TITLE
[v3] Add unit tests for the `[Instrumented]` attribute

### DIFF
--- a/tracer/src/Datadog.Trace.Manual/Configuration/IntegrationSettingsCollection.cs
+++ b/tracer/src/Datadog.Trace.Manual/Configuration/IntegrationSettingsCollection.cs
@@ -26,6 +26,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="integrationName">The name of the integration.</param>
         /// <returns>The integration-specific settings for the specified integration.</returns>
+        [Instrumented]
         public IntegrationSettings this[string integrationName]
         {
             get

--- a/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
+++ b/tracer/src/Datadog.Trace.OpenTracing/OpenTracingTracerFactory.cs
@@ -24,6 +24,7 @@ namespace Datadog.Trace.OpenTracing
         /// <returns>A Datadog compatible ITracer implementation</returns>
         [PublicApi]
         [Obsolete(DeprecationMessage)]
+        [Instrumented]
         public static global::OpenTracing.ITracer CreateTracer(Uri agentEndpoint = null, string defaultServiceName = null, bool isDebugEnabled = false)
         {
             // Keep supporting this older public method by creating a TracerConfiguration
@@ -53,6 +54,7 @@ namespace Datadog.Trace.OpenTracing
         /// <returns>A Datadog compatible ITracer implementation</returns>
         [PublicApi]
         [Obsolete(DeprecationMessage)]
+        [Instrumented]
         public static global::OpenTracing.ITracer WrapTracer(Tracer tracer)
         {
             return new OpenTracingTracer(tracer, OpenTracingTracer.CreateDefaultScopeManager(), tracer.DefaultServiceName);

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
@@ -13,9 +13,18 @@
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+
+    <!-- These are only required because we load Datadog.Trace using reflection  -->
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Abstractions" Version="2.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Datadog.Trace.Tests\ManualInstrumentation\InstrumentationTests.cs" Link="InstrumentationTests.cs"  />
   </ItemGroup>
 </Project>

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/OpenTracingInstrumentationTests.cs
@@ -1,0 +1,12 @@
+﻿// <copyright file="OpenTracingInstrumentationTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Tests.ManualInstrumentation;
+
+namespace Datadog.Trace.OpenTracing.Tests;
+
+public class OpenTracingInstrumentationTests : InstrumentationTests<OpenTracingHttpHeadersCarrier>
+{
+}

--- a/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/DatadogTraceManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/DatadogTraceManualInstrumentationTests.cs
@@ -1,0 +1,14 @@
+﻿// <copyright file="DatadogTraceManualInstrumentationTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+extern alias DatadogTraceManual;
+
+using ManualTracer = DatadogTraceManual::Datadog.Trace.Tracer;
+
+namespace Datadog.Trace.Tests.ManualInstrumentation;
+
+public class DatadogTraceManualInstrumentationTests : InstrumentationTests<ManualTracer>
+{
+}

--- a/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ManualInstrumentation/InstrumentationTests.cs
@@ -1,0 +1,143 @@
+﻿// <copyright file="InstrumentationTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+extern alias DatadogTraceManual;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Datadog.Trace.ClrProfiler;
+using FluentAssertions;
+using Xunit;
+using ManualInstrumented = DatadogTraceManual::Datadog.Trace.SourceGenerators.InstrumentedAttribute;
+using ManualTracer = DatadogTraceManual::Datadog.Trace.Tracer;
+
+namespace Datadog.Trace.Tests.ManualInstrumentation;
+
+public abstract class InstrumentationTests<T>
+{
+    [Fact]
+    public void DatadogTraceManual_AllInstrumentedMethodsAreDecoratedWithInstrumentedAttribute()
+    {
+        var manualAssembly = typeof(T).Assembly;
+        var assemblyName = manualAssembly.GetName().Name;
+
+        // find all types in Datadog.Trace that instrument methods in the target assembly
+        var instrumentations = GetAllInstrumentations(assemblyName).GroupBy(x => x.Attribute.TypeName);
+
+        var attributedMembers = manualAssembly
+                               .GetTypes()
+                               .SelectMany(
+                                    x => x.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                                          .Where(y => y.GetCustomAttribute<ManualInstrumented>() != null))
+                               .ToList();
+
+        foreach (var @group in instrumentations)
+        {
+            var targetType = manualAssembly.GetType(@group.Key, throwOnError: false);
+            targetType.Should().NotBeNull($"target {targetType} required for instrumentation");
+            var allMembers = targetType.GetMembers(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static);
+            foreach (var (instrumentationType, attribute) in @group)
+            {
+                var methodName = attribute.MethodName;
+                var parameters = attribute.ParameterTypeNames?.Select(x => GetType(x, manualAssembly)).ToList();
+
+                var member = allMembers
+                            .Should()
+                            .ContainSingle(
+                                 x => IsTarget(x, methodName, parameters),
+                                 $"type '{targetType.Name}' should have member '{methodName}'")
+                            .Subject;
+
+                // allow for decorating the property
+                var instrumentedAttribute = member.GetCustomAttribute<ManualInstrumented>();
+                if (instrumentedAttribute is null && (methodName.StartsWith("get_") || methodName.StartsWith("set_")))
+                {
+                    var snippedName = methodName.Substring(4);
+                    (var property, instrumentedAttribute) = allMembers
+                                           .Where(x => x is PropertyInfo && x.Name == snippedName)
+                                           .Select(x => (x, x.GetCustomAttribute<ManualInstrumented>()))
+                                           .SingleOrDefault();
+                    attributedMembers.Remove(property);
+                }
+
+                instrumentedAttribute.Should().NotBeNull($"'{targetType.Name}.{methodName}' should have [Instrumented] attribute");
+                attributedMembers.Remove(member);
+            }
+        }
+
+        attributedMembers.Should().BeEmpty("Every member instrumented with [Instrumented] should be instrumented");
+    }
+
+    private static Type GetType(string type, Assembly targetAssembly)
+    {
+        // this is a royal pain, because we don't know _where_ to load the type from
+        // so just try a bunch of stuff
+        return Type.GetType(type) // currently executing or mscorlib.dll/System.Private.CoreLib.dll
+            ?? targetAssembly.GetType(type) // the target assembly
+            ?? typeof(ManualTracer).Assembly.GetType(type) // the manual assembly
+            ?? (type.StartsWith("System.") ? Type.GetType($"{type}, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089") : null); // maybe in System?
+    }
+
+    private static IEnumerable<(Type Type, InstrumentMethodAttribute Attribute)> GetAllInstrumentations(string assemblyName)
+    {
+        return typeof(Datadog.Trace.Tracer)
+              .Assembly
+              .GetTypes()
+              .SelectMany(t => t.GetCustomAttributes(typeof(InstrumentMethodAttribute), false)
+                                .Select(a => (Type: t, Attribute: (InstrumentMethodAttribute)a)))
+              .Where(x => x.Attribute.AssemblyNames is { } names
+                              ? names.Contains(assemblyName)
+                              : x.Attribute.AssemblyName == assemblyName);
+    }
+
+    private static bool IsTarget(MemberInfo memberInfo, string methodName, List<Type> expectedParams)
+    {
+        if (memberInfo.Name != methodName)
+        {
+            return false;
+        }
+
+        if (memberInfo is MethodInfo method && expectedParams is not null)
+        {
+            var parameters = method.GetParameters();
+            return CompareParameters(expectedParams, parameters);
+        }
+
+        if (memberInfo is ConstructorInfo ctor && expectedParams is not null)
+        {
+            var parameters = ctor.GetParameters();
+            return CompareParameters(expectedParams, parameters);
+        }
+
+        return true;
+
+        static bool CompareParameters(List<Type> types, ParameterInfo[] parameters)
+        {
+            if (parameters.Length == types.Count)
+            {
+                for (int i = 0; i < parameters.Length; i++)
+                {
+                    var expected = types[i];
+                    var actual = parameters[i].ParameterType;
+                    if (expected is null && (actual.IsGenericParameter || actual.GenericTypeArguments.Any(x => x.IsGenericParameter)))
+                    {
+                        // generic parameters, a bit of a pain to do properly, so this will do
+                        continue;
+                    }
+
+                    if (actual != expected)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

- Adds unit tests for the usages of `[Instrumented]` in Datadog.Trace.Manual and Datadog.Trace.OpenTracing
- Fix some usages

## Reason for change

In #5072 we added an `[Instrumented]` attribute in _Datadog.Trace.Manual_. The attribute itself doesn't drive any behaviour, it just helps to make clear what we rely on for our v3 instrumentation, i.e. what we shouldn't change (which could be non-public APIs too)

## Implementation details

Use reflection to load the defined instrumentations in Datadog.Trace and the members decorated with 
`[Instrumented]` in Datadog.Trace.Manual and Datadog.Trace.OpenTracing. Make sure they all match. Yeah it's pretty hacky, but meh.

## Test coverage

This adds some

## Other details

Fixed a couple of cases that weren't correctly marked

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
