### PR TITLE
Disable profiling in benchmarks

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3080,7 +3080,9 @@ stages:
       displayName: RunBenchmarks
       env:
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
-        DD_PROFILING_ENABLED: true
+        # Currently, enabling profiling enables the CI Visibility tracer to enable code hotspots.
+        # We may be able to mitigate that in the future, but disabling it for now.
+        DD_PROFILING_ENABLED: false
         DD_API_KEY: $(ddApiKey)
         DD_DOTNET_TRACER_HOME: $(monitoringHome)
 


### PR DESCRIPTION
## Summary of changes

Disables the profiler in benchmarks in CI

## Reason for change

Enabling the profiler enables Ci-visibility, which is triggering some extensive logging in some cases. For now, just disable profiling in ci.

## Implementation details

Flip the switch

## Test coverage

Will check that we're not hitting the same issues after merging

## Other details
Also mitigated in this PR:
- https://github.com/DataDog/dd-trace-dotnet/pull/5261

Tony doesn't think we _need_ to have ci-vis enabled in this case, and will dig in further later, but this should fix it for now

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
