### PR TITLE
Fix version parsing in Dataflow

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -156,12 +156,14 @@ Dataflow::Dataflow(ICorProfilerInfo* profiler)
     HRESULT hr = profiler->QueryInterface(__uuidof(ICorProfilerInfo3), (void**) &_profiler);
     if (_profiler != nullptr)
     {
-        WCHAR version[1024];
-        ULONG versionLength;
-        if (SUCCEEDED(_profiler->GetRuntimeInformation(nullptr, &m_runtimeType, nullptr, nullptr, nullptr, nullptr, 1024,
-                                                    &versionLength, version)))
+        USHORT major;
+        USHORT minor;
+        USHORT build;
+
+        if (SUCCEEDED(_profiler->GetRuntimeInformation(nullptr, &m_runtimeType, &major, &minor, &build, nullptr, 0,
+                                                    nullptr, nullptr)))
         {
-            m_runtimeVersion = GetVersionInfo(version);
+            m_runtimeVersion = VersionInfo{major, minor, build, 0};
         }
     }
     trace::Logger::Info("Dataflow::Dataflow -> Detected runtime version : ", m_runtimeVersion.ToString());

--- a/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/iast_util.cpp
@@ -219,7 +219,7 @@ static thread_local std::unordered_map<void *, bool> locked;
     VersionInfo GetVersionInfo(const std::string& version)
     {
         auto v = version;
-        if (StartsWith(v, "V"))
+        if (StartsWith(v, "V") || StartsWith(v, "v"))
         {
             v = v.substr(1);
         }


### PR DESCRIPTION
## Summary of changes

The code to parse the version in Dataflow was looking for the "V" prefix, but not "v". Because of that, it always reported a major version of 0 on .NET Framework (`v4.0.30319`).

Also, since we're already getting the version as numerical values, I changed the code to directly create the VersionInfo without parsing the string.

## Reason for change

The logs weren't showing the right version:

```
Dataflow::Dataflow -> Detected runtime version : 0.0.30319.0
```
