### PR TITLE
[Tracer] Updating GrpcLegacy Sample App and Tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs
@@ -248,7 +248,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                     + 1 // 1 server streaming
                                     + 1 // 1 client streaming
                                     + 1 // 1 both streaming
-                                    + 2 // Deadline exceeded (sync + async)
+                                    + 1 // Deadline exceeded (async)
                                     + (4 * 2); // 4 Error types (sync + async)
 
             // Get between 3 and 5 spans per request:

--- a/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV0.verified.txt
+++ b/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV0.verified.txt
@@ -1237,7 +1237,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
     TraceId: Id_53,
     SpanId: Id_54,
     Name: internal,
-    Resource: SendVerySlowRequest,
+    Resource: SendVerySlowRequestAsync,
     Service: Samples.GrpcLegacy,
     Type: custom,
     Tags: {
@@ -1300,99 +1300,6 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
     Service: Samples.GrpcLegacy,
     Type: grpc,
     ParentId: Id_55,
-    Error: 1,
-    Tags: {
-      clientmeta: other-client-value,
-      component: Grpc,
-      env: integration_tests,
-      error.msg: Deadline Exceeded,
-      grpc.method.kind: unary,
-      grpc.method.name: VerySlow,
-      grpc.method.package: greet.tester,
-      grpc.method.path: /greet.tester.Greeter/VerySlow,
-      grpc.method.service: Greeter,
-      grpc.request.metadata.client-value1: some-client-value,
-      grpc.response.metadata.server-value1: some-server-value,
-      grpc.status.code: 4,
-      language: dotnet,
-      runtime-id: Guid_2,
-      servermeta: other-server-value,
-      span.kind: server
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_57,
-    SpanId: Id_58,
-    Name: internal,
-    Resource: SendVerySlowRequestAsync,
-    Service: Samples.GrpcLegacy,
-    Type: custom,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.Grpc,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_16,
-      runtime-id: Guid_2,
-      span.kind: internal
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_57,
-    SpanId: Id_59,
-    Name: grpc.request,
-    Resource: /greet.tester.Greeter/VerySlow,
-    Service: Samples.GrpcLegacy-grpc-client,
-    Type: grpc,
-    ParentId: Id_58,
-    Error: 1,
-    Tags: {
-      clientmeta: other-client-value,
-      component: Grpc,
-      env: integration_tests,
-      error.msg: Deadline Exceeded,
-      error.type: Grpc.Core.Internal.CoreErrorDetailException,
-      grpc.method.kind: unary,
-      grpc.method.name: VerySlow,
-      grpc.method.package: greet.tester,
-      grpc.method.path: /greet.tester.Greeter/VerySlow,
-      grpc.method.service: Greeter,
-      grpc.request.metadata.client-value1: some-client-value,
-      grpc.status.code: 4,
-      out.host: 127.0.0.1,
-      peer.hostname: 127.0.0.1,
-      runtime-id: Guid_2,
-      span.kind: client
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_57,
-    SpanId: Id_60,
-    Name: grpc.request,
-    Resource: /greet.tester.Greeter/VerySlow,
-    Service: Samples.GrpcLegacy,
-    Type: grpc,
-    ParentId: Id_59,
     Error: 1,
     Tags: {
       clientmeta: other-client-value,

--- a/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV1.verified.txt
+++ b/tracer/test/snapshots/GrpcLegacy.SubmitTraces_httpclient=False.SchemaV1.verified.txt
@@ -1237,7 +1237,7 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
     TraceId: Id_53,
     SpanId: Id_54,
     Name: internal,
-    Resource: SendVerySlowRequest,
+    Resource: SendVerySlowRequestAsync,
     Service: Samples.GrpcLegacy,
     Type: custom,
     Tags: {
@@ -1300,99 +1300,6 @@ Grpc.Core.Internal.CoreErrorDetailException: {"created":"@00000000000.000000000"
     Service: Samples.GrpcLegacy,
     Type: grpc,
     ParentId: Id_55,
-    Error: 1,
-    Tags: {
-      clientmeta: other-client-value,
-      component: Grpc,
-      env: integration_tests,
-      error.msg: Deadline Exceeded,
-      grpc.method.kind: unary,
-      grpc.method.name: VerySlow,
-      grpc.method.package: greet.tester,
-      grpc.method.path: /greet.tester.Greeter/VerySlow,
-      grpc.method.service: Greeter,
-      grpc.request.metadata.client-value1: some-client-value,
-      grpc.response.metadata.server-value1: some-server-value,
-      grpc.status.code: 4,
-      language: dotnet,
-      runtime-id: Guid_2,
-      servermeta: other-server-value,
-      span.kind: server
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_57,
-    SpanId: Id_58,
-    Name: internal,
-    Resource: SendVerySlowRequestAsync,
-    Service: Samples.GrpcLegacy,
-    Type: custom,
-    Tags: {
-      env: integration_tests,
-      language: dotnet,
-      otel.library.name: Samples.Grpc,
-      otel.status_code: STATUS_CODE_UNSET,
-      otel.trace_id: Guid_16,
-      runtime-id: Guid_2,
-      span.kind: internal
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.top_level: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_57,
-    SpanId: Id_59,
-    Name: grpc.client.request,
-    Resource: /greet.tester.Greeter/VerySlow,
-    Service: Samples.GrpcLegacy,
-    Type: grpc,
-    ParentId: Id_58,
-    Error: 1,
-    Tags: {
-      clientmeta: other-client-value,
-      component: Grpc,
-      env: integration_tests,
-      error.msg: Deadline Exceeded,
-      error.type: Grpc.Core.Internal.CoreErrorDetailException,
-      grpc.method.kind: unary,
-      grpc.method.name: VerySlow,
-      grpc.method.package: greet.tester,
-      grpc.method.path: /greet.tester.Greeter/VerySlow,
-      grpc.method.service: Greeter,
-      grpc.request.metadata.client-value1: some-client-value,
-      grpc.status.code: 4,
-      out.host: 127.0.0.1,
-      peer.hostname: 127.0.0.1,
-      peer.service: Greeter,
-      span.kind: client,
-      _dd.peer.service.source: rpc.service
-    },
-    Metrics: {
-      process_id: 0,
-      _dd.agent_psr: 1.0,
-      _dd.tracer_kr: 1.0,
-      _sampling_priority_v1: 1.0
-    }
-  },
-  {
-    TraceId: Id_57,
-    SpanId: Id_60,
-    Name: grpc.server.request,
-    Resource: /greet.tester.Greeter/VerySlow,
-    Service: Samples.GrpcLegacy,
-    Type: grpc,
-    ParentId: Id_59,
     Error: 1,
     Tags: {
       clientmeta: other-client-value,

--- a/tracer/test/test-applications/integrations/Samples.GrpcLegacy/ClientWorker.cs
+++ b/tracer/test/test-applications/integrations/Samples.GrpcLegacy/ClientWorker.cs
@@ -62,7 +62,6 @@ public class ClientWorker
             _logger.LogInformation("Creating GRPC client");
             var client = new Greeter.GreeterClient(callInvoker);
 
-            SendVerySlowRequest(client);
             await SendVerySlowRequestAsync(client);
             delay = Task.Delay(6_000); // longer than the slow request duration
 


### PR DESCRIPTION
## Summary of changes
Removing the not Async `SendVerySlowRequest` which seems to be problematic when ran in `master`, updated the test and snapshots to account for such change.

## Reason for change
After taking a look at the failing tests in `master` we found that the errors we saw, either missing span or missing tags on that span which sometimes goes missing, where always as a result of the `SendVerySlowRequest(client)` run.

As opposed to trying updating the timeout or checking why the server could be hitting this error, since we already know is kinda overloaded, instead will remove the test case instead which should remove the daily flakes this test gets (can come back to it if other issues arise).

