### PR TITLE
Include the trace sampling priority in the span debug log

### DIFF
--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -174,7 +174,7 @@ namespace Datadog.Trace
             sb.AppendLine($"Duration: {Duration}");
             sb.AppendLine($"End: {StartTime.Add(Duration).ToString("O")}");
             sb.AppendLine($"Error: {Error}");
-            sb.AppendLine($"TraceSamplingPriority: {Context.TraceContext.SamplingPriority}");
+            sb.AppendLine($"TraceSamplingPriority: {(Context.TraceContext.SamplingPriority ?? "not set")}");
             sb.AppendLine($"Meta: {Tags}");
 
             return StringBuilderCache.GetStringAndRelease(sb);

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -174,6 +174,7 @@ namespace Datadog.Trace
             sb.AppendLine($"Duration: {Duration}");
             sb.AppendLine($"End: {StartTime.Add(Duration).ToString("O")}");
             sb.AppendLine($"Error: {Error}");
+            sb.AppendLine($"TraceSamplingPriority: {Context.TraceContext.SamplingPriority}");
             sb.AppendLine($"Meta: {Tags}");
 
             return StringBuilderCache.GetStringAndRelease(sb);

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -174,7 +174,7 @@ namespace Datadog.Trace
             sb.AppendLine($"Duration: {Duration}");
             sb.AppendLine($"End: {StartTime.Add(Duration).ToString("O")}");
             sb.AppendLine($"Error: {Error}");
-            sb.AppendLine($"TraceSamplingPriority: {(Context.TraceContext.SamplingPriority ?? "not set")}");
+            sb.AppendLine($"TraceSamplingPriority: {(Context.TraceContext.SamplingPriority?.ToString(CultureInfo.InvariantCulture) ?? "not set")}");
             sb.AppendLine($"Meta: {Tags}");
 
             return StringBuilderCache.GetStringAndRelease(sb);


### PR DESCRIPTION
## Summary of changes

Adds `Context.TraceContext.SamplingPriority` to the `Span.ToString()` which is written when Debug logs are enabled

## Reason for change

This is important information that we're currently missing. Even though it's _trace_ level information (rather than span-level) this is a quick, safe, easy change so makes sense to just put it there for now IMO.

## Implementation details

Added an extra line to `Span.ToString()`

## Test coverage

Meh

## Other details

We've wanted this several times in escalations

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
