### PR TITLE
Include propagation style in the configuration log

### DIFF
--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -546,6 +546,29 @@ namespace Datadog.Trace
                     writer.WritePropertyName("service_mapping");
                     WriteDictionary(instanceSettings.ServiceNameMappings);
 
+                    writer.WritePropertyName("trace_propagation_style_extract_first_only");
+                    writer.WriteValue(instanceSettings.PropagationExtractFirstOnly);
+
+                    writer.WritePropertyName("trace_propagation_style_inject");
+                    writer.WriteStartArray();
+
+                    foreach (var warning in instanceSettings.PropagationStyleInject)
+                    {
+                        writer.WriteValue(warning);
+                    }
+
+                    writer.WriteEndArray();
+
+                    writer.WritePropertyName("trace_propagation_style_extract");
+                    writer.WriteStartArray();
+
+                    foreach (var warning in instanceSettings.PropagationStyleExtract)
+                    {
+                        writer.WriteValue(warning);
+                    }
+
+                    writer.WriteEndArray();
+
                     writer.WriteEndObject();
                     // ReSharper restore MethodHasAsyncOverload
                 }


### PR DESCRIPTION
## Summary of changes

Adds the propagation inject/extract styles used to the startup log

## Reason for change

This is useful information for support

## Implementation details

Write the values to the log on startup

## Test coverage

Meh

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
