### PR TITLE
Add analyzer to avoid implicitly capturing parameters with primary constructors

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Analyzers/PrimaryConstructorAnalyzer/DoNotCapturePrimaryConstructorParametersAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/PrimaryConstructorAnalyzer/DoNotCapturePrimaryConstructorParametersAnalyzer.cs
@@ -1,0 +1,75 @@
+﻿// <copyright file="DoNotCapturePrimaryConstructorParametersAnalyzer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// This code is based on the analyzer provided here: https://github.com/dotnet/roslyn-analyzers/blob/4af06010a6699f5ee8f8d5a6c6091ba23f8fceeb/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotCapturePrimaryContructorParameters.cs
+// Licensed as:
+// Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
+
+#nullable enable
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Datadog.Trace.Tools.Analyzers.PrimaryConstructorAnalyzer;
+
+/// <summary>
+/// Analyzer that prevents you using primary constructor parameters in a way that captures them into member state.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class DoNotCapturePrimaryConstructorParametersAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The diagnostic ID displayed in error messages
+    /// </summary>
+    public const string DiagnosticId = "DD0003";
+
+    private static readonly DiagnosticDescriptor Rule = new(
+        DiagnosticId,
+        "Do not capture primary constructor parameters",
+        "Primary constructor parameter '{0}' should not be implicitly captured",
+        "Maintainability",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Primary constructor parameters should not be implicitly captured. Manually assign them to fields at the start of the type.");
+
+    /// <inheritdoc/>
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+    /// <inheritdoc/>
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        context.RegisterOperationAction(AnalyzeOperation, OperationKind.ParameterReference);
+    }
+
+    private static void AnalyzeOperation(OperationAnalysisContext context)
+    {
+        var operation = (IParameterReferenceOperation)context.Operation;
+
+        if (SymbolEqualityComparer.Default.Equals(operation.Parameter.ContainingSymbol, context.ContainingSymbol) || operation.Parameter.ContainingSymbol is not IMethodSymbol { MethodKind: MethodKind.Constructor })
+        {
+            // We're in the primary constructor itself, so no capture.
+            // Or, this isn't a primary constructor parameter at all.
+            return;
+        }
+
+        IOperation rootOperation = operation;
+        for (; rootOperation.Parent != null; rootOperation = rootOperation.Parent)
+        {
+        }
+
+        if (rootOperation is IPropertyInitializerOperation or IFieldInitializerOperation)
+        {
+            // This is an explicit capture into member state. That's fine.
+            return;
+        }
+
+        // This must be a capture. Error
+        context.ReportDiagnostic(Diagnostic.Create(Rule, operation.Syntax.GetLocation(), operation.Parameter.Name));
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/DoNotCapturePrimaryConstructorParametersAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/DoNotCapturePrimaryConstructorParametersAnalyzerTests.cs
@@ -1,0 +1,168 @@
+﻿// <copyright file="DoNotCapturePrimaryConstructorParametersAnalyzerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.PrimaryConstructorAnalyzer;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.AnalyzerVerifier<
+    Datadog.Trace.Tools.Analyzers.PrimaryConstructorAnalyzer.DoNotCapturePrimaryConstructorParametersAnalyzer>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests;
+
+public class DoNotCapturePrimaryConstructorParametersAnalyzerTests
+{
+    private const string DiagnosticId = DoNotCapturePrimaryConstructorParametersAnalyzer.DiagnosticId;
+
+    [Fact]
+    public async Task ErrorOnCapture_InMethod()
+    {
+        var source = """
+                     class C(int i)
+                     {
+                         private int M() => [|i|];
+                     }
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ErrorOnCapture_InProperty()
+    {
+        var source = """
+                     class C(int i)
+                     {
+                         private int P
+                         {
+                             get => [|i|];
+                             set => [|i|] = value;
+                         }
+                     }
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ErrorOnCapture_InIndexer()
+    {
+        var source = """
+                     class C(int i)
+                     {
+                         private int this[int param]
+                         {
+                             get => [|i|];
+                             set => [|i|] = value;
+                         }
+                     }
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ErrorOnCapture_InEvent()
+    {
+        var source = """
+                     class C(int i)
+                     {
+                         public event System.Action E
+                         {
+                             add => _ = [|i|];
+                             remove => _ = [|i|];
+                         }
+                     }
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task ErrorOnCapture_UseInSubsequentConstructor()
+    {
+        var source = """
+                     class C(int i)
+                     {
+                         C(bool b) : this(1)
+                         {
+                             _ = i;
+                         }
+                     }
+                     """;
+        var primaryCtorDiagnostic = new DiagnosticResult(DiagnosticId, DiagnosticSeverity.Error)
+                                   .WithSpan(5, 13, 5, 14)
+                                   .WithArguments("i");
+        var compilerError = DiagnosticResult.CompilerError("CS9105")
+                                            .WithSpan(5, 13, 5, 14)
+                                            .WithArguments("int i");
+
+        await Verifier.VerifyAnalyzerAsync(source, primaryCtorDiagnostic, compilerError);
+    }
+
+    [Fact]
+    public async Task NoError_PassToBase()
+    {
+        var source = """
+                     class Base(int i);
+                     class Derived(int i) : Base(i);
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoError_FieldInitializer()
+    {
+        var source = """
+                     class C(int i)
+                     {
+                         public int I = i;
+                     }
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoError_PropertyInitializer()
+    {
+        var source = """
+                     class C(int i)
+                     {
+                         public int I { get; set; } = i;
+                     }
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoError_CapturedInLambda()
+    {
+        var source = """
+                     using System;
+                     public class Base(Action action);
+                     public class Derived(int i) : Base(() => Console.WriteLine(i));
+                     """;
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+
+    [Fact]
+    public async Task NoError_LocalFunctionParameterReference()
+    {
+        var source = """
+                     using System;
+                     class C
+                     {
+                        void M()
+                        {
+                            Nested1(1);
+                            void Nested1(int i)
+                            {
+                                Nested2();
+                                void Nested2() => Console.WriteLine(i);
+                            }
+                        }
+                     }
+                     """;
+
+        await Verifier.VerifyAnalyzerAsync(source);
+    }
+}


### PR DESCRIPTION
## Summary of changes

Adds an analyzer that ensures that if we use primary constructors, we don't implicitly capture the variable.

## Reason for change

Primary constructors are nice and all, but one of the concerns I (and @kevingosse) have had when discussing them is that they are hard to reason about. You can reference them _anywhere_ in your type, so they're not like _normal_ constructor parameters. And if you _do_ reference them in methods or some such, then the compiler implicitly creates a new field in the type, which increases the allocations and could change the layout of the type, which could be problematic. Additionally, you can't currently make the parameters readonly if you use them like this.

An alternative approach is to only use the parameters for initialization of fields. If you take this approach, there's no implicit capture, and so you don't have any of the above drawbacks, you just get a slightly nicer syntax for implementing "simple" constructors.

Rather than block primary constructors entirely (we've already snuck some usages in!) this analyzer just makes sure you don't use them in a "problematic" way

> I got the idea listening to Jared Parsons talking to Jeffrey Palermo [on a recent podcast](https://azuredevopspodcast.clear-measure.com/jared-parsons-designing-c-and-testing-a-compiler-episode-287) - this is the approach the Roslyn compiler team use too!

## Implementation details

This analyzer [is actually available in the dotnet/rosyln-analyzers repo](https://github.com/dotnet/roslyn-analyzers/blob/4af06010a6699f5ee8f8d5a6c6091ba23f8fceeb/src/Roslyn.Diagnostics.Analyzers/CSharp/CSharpDoNotCapturePrimaryContructorParameters.cs), but currently referencing that would [require adding new NuGet sources etc](https://github.com/dotnet/roslyn/pull/71905/files#r1473707798), and it seemed easier just to vendor it in as it's very simple 🤷‍♂️ 

## Test coverage

Added unit tests from [the roslyn-analyzer repo](https://github.com/dotnet/roslyn-analyzers/blob/4af06010a6699f5ee8f8d5a6c6091ba23f8fceeb/src/Roslyn.Diagnostics.Analyzers/UnitTests/CSharpDoNotCapturePrimaryConstructorParametersTests.cs#L7), plus, you can see it works!

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/984a23b6-2602-4ce0-8074-53d11c980820)


## Other details

These analyzers only apply to `src/` projects - if you want to use the implicit capture in tests you can. But you may be judged 😉 🧑‍⚖️  

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
