### PR TITLE
[Profiler] Exclude export error message from flaky test

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SmokeTests/SmokeTestRunner.cs
@@ -51,10 +51,10 @@ namespace Datadog.Profiler.SmokeTests
             get => _testApplicationRunner.Environment;
         }
 
-        public void RunAndCheck()
+        public void RunAndCheck(string[] errorExceptions = null)
         {
             using var agent = Run();
-            RunChecks(agent);
+            RunChecks(agent, errorExceptions);
         }
 
         public MockDatadogAgent Run()
@@ -80,16 +80,16 @@ namespace Datadog.Profiler.SmokeTests
             return agent;
         }
 
-        private void RunChecks(MockDatadogAgent agent)
+        private void RunChecks(MockDatadogAgent agent, string[] errorExceptions)
         {
-            CheckLogFiles();
+            CheckLogFiles(errorExceptions);
             CheckPprofFiles();
             CheckAgent(agent);
         }
 
-        private void CheckLogFiles()
+        private void CheckLogFiles(string[] errorExceptions)
         {
-            CheckLogFiles("DD-DotNet-Profiler-Native*.*");
+            CheckLogFiles("DD-DotNet-Profiler-Native*.*", errorExceptions);
             CheckNoLogFiles("DD-DotNet-Profiler-Managed*.*");
             CheckNoLogFiles("DD-DotNet-Common-ManagedLoader*.*");
         }
@@ -101,7 +101,7 @@ namespace Datadog.Profiler.SmokeTests
             Assert.Empty(files);
         }
 
-        private void CheckLogFiles(string filePattern)
+        private void CheckLogFiles(string filePattern, string[] errorExceptions)
         {
             var files = Directory.EnumerateFiles(EnvironmentHelper.LogDir, filePattern, SearchOption.AllDirectories).ToList();
 
@@ -109,7 +109,7 @@ namespace Datadog.Profiler.SmokeTests
 
             foreach (string logFile in files)
             {
-                Assert.False(LogFileContainsErrorMessage(logFile), $"Found error message in the log file {logFile}");
+                Assert.False(LogFileContainsErrorMessage(logFile, errorExceptions), $"Found error message in the log file {logFile}");
             }
         }
 
@@ -124,7 +124,21 @@ namespace Datadog.Profiler.SmokeTests
             Assert.True(agent.NbCallsOnProfilingEndpoint >= MinimumExpectedNbPprofFiles, $"The number of calls to the agent was not greater than or equal to {MinimumExpectedNbPprofFiles}. Actual value {agent.NbCallsOnProfilingEndpoint}");
         }
 
-        private bool LogFileContainsErrorMessage(string logFile)
+
+        private bool SkipError(string line, string[] errorExceptions)
+        {
+            foreach (var errorException in errorExceptions)
+            {
+                if (line.Contains(errorException))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool LogFileContainsErrorMessage(string logFile, string[] errorExceptions)
         {
             var errorLinePattern = new Regex(@"\| error \|", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
@@ -137,6 +151,11 @@ namespace Datadog.Profiler.SmokeTests
 
                     if (line != null && errorLinePattern.IsMatch(line))
                     {
+                        if ((errorExceptions != null) && SkipError(line, errorExceptions))
+                        {
+                            continue;
+                        }
+
                         _output.WriteLine(line);
                         return true;
                     }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/NamedPipeTestcs.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/NamedPipeTestcs.cs
@@ -26,7 +26,8 @@ namespace Datadog.Profiler.IntegrationTests.WindowsOnly
         [TestAppFact("Samples.Computer01")]
         public void CheckProfilesSentThroughNamedPipe(string appName, string framework, string appAssembly)
         {
-            new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output, transportType: TransportType.NamedPipe).RunAndCheck();
+            string[] errorExceptions = { "failed ddog_prof_Exporter_send: operation timed out" };
+            new SmokeTestRunner(appName, framework, appAssembly, commandLine: "--scenario 1", output: _output, transportType: TransportType.NamedPipe).RunAndCheck(errorExceptions);
         }
 
         [TestAppFact("Samples.Computer01")]


### PR DESCRIPTION
## Summary of changes
Exclude export messages from named pipe tests

## Reason for change
Flakiness

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
