### PR TITLE
Add db name & host to sql injected tags

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -124,7 +124,6 @@ src/Datadog.Trace/ContinuousProfiler/IProfilerStatus.cs
 src/Datadog.Trace/ContinuousProfiler/NativeInterop.cs
 src/Datadog.Trace/ContinuousProfiler/Profiler.cs
 src/Datadog.Trace/ContinuousProfiler/ProfilerStatus.cs
-src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
 src/Datadog.Trace/DataStreamsMonitoring/CheckpointKind.cs
 src/Datadog.Trace/Debugger/ILineProbeResolver.cs
 src/Datadog.Trace/Debugger/LiveDebugger.cs

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     }
                     else
                     {
-                        var propagatedCommand = DatabaseMonitoringPropagator.PropagateSpanData(tracer.Settings.DbmPropagationMode, tracer.DefaultServiceName, scope.Span, integrationId, out var traceParentInjected);
+                        var propagatedCommand = DatabaseMonitoringPropagator.PropagateSpanData(tracer.Settings.DbmPropagationMode, tracer.DefaultServiceName, command.Connection?.Database, scope.Span, integrationId, out var traceParentInjected);
                         if (!string.IsNullOrEmpty(propagatedCommand))
                         {
                             command.CommandText = $"{propagatedCommand} {commandText}";

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     }
                     else
                     {
-                        var propagatedCommand = DatabaseMonitoringPropagator.PropagateSpanData(tracer.Settings.DbmPropagationMode, tracer.DefaultServiceName, command.Connection?.Database, scope.Span, integrationId, out var traceParentInjected);
+                        var propagatedCommand = DatabaseMonitoringPropagator.PropagateSpanData(tracer.Settings.DbmPropagationMode, tracer.DefaultServiceName, tagsFromConnectionString.DbName, tagsFromConnectionString.OutHost, scope.Span, integrationId, out var traceParentInjected);
                         if (!string.IsNullOrEmpty(propagatedCommand))
                         {
                             command.CommandText = $"{propagatedCommand} {commandText}";

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -18,11 +18,12 @@ namespace Datadog.Trace.DatabaseMonitoring
         private const string SqlCommentSpanService = "dddbs";
         private const string SqlCommentRootService = "ddps";
         private const string SqlCommentDbName = "dddb";
+        private const string SqlCommentOuthost = "ddh";
         private const string SqlCommentVersion = "ddpv";
         private const string SqlCommentEnv = "dde";
         internal const string DbmPrefix = $"/*{SqlCommentSpanService}='";
 
-        internal static string PropagateSpanData(DbmPropagationLevel propagationStyle, string configuredServiceName, string? dbName, Span span, IntegrationId integrationId, out bool traceParentInjected)
+        internal static string PropagateSpanData(DbmPropagationLevel propagationStyle, string configuredServiceName, string? dbName, string? outhost, Span span, IntegrationId integrationId, out bool traceParentInjected)
         {
             traceParentInjected = false;
 
@@ -43,6 +44,11 @@ namespace Datadog.Trace.DatabaseMonitoring
                 if (!string.IsNullOrEmpty(dbName))
                 {
                     propagatorStringBuilder.Append(value: ',').Append(SqlCommentDbName).Append("='").Append(Uri.EscapeDataString(dbName)).Append(value: '\'');
+                }
+
+                if (!string.IsNullOrEmpty(outhost))
+                {
+                    propagatorStringBuilder.Append(value: ',').Append(SqlCommentOuthost).Append("='").Append(Uri.EscapeDataString(outhost)).Append(value: '\'');
                 }
 
                 if (span.Context.TraceContext?.ServiceVersion is { } versionTag)

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -9,17 +9,20 @@ using Datadog.Trace.Propagators;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Util;
 
+#nullable enable
+
 namespace Datadog.Trace.DatabaseMonitoring
 {
     internal static class DatabaseMonitoringPropagator
     {
         private const string SqlCommentSpanService = "dddbs";
         private const string SqlCommentRootService = "ddps";
+        private const string SqlCommentDbName = "dddb";
         private const string SqlCommentVersion = "ddpv";
         private const string SqlCommentEnv = "dde";
         internal const string DbmPrefix = $"/*{SqlCommentSpanService}='";
 
-        internal static string PropagateSpanData(DbmPropagationLevel propagationStyle, string configuredServiceName, Span span, IntegrationId integrationId, out bool traceParentInjected)
+        internal static string PropagateSpanData(DbmPropagationLevel propagationStyle, string configuredServiceName, string? dbName, Span span, IntegrationId integrationId, out bool traceParentInjected)
         {
             traceParentInjected = false;
 
@@ -36,6 +39,11 @@ namespace Datadog.Trace.DatabaseMonitoring
                 }
 
                 propagatorStringBuilder.Append(',').Append(SqlCommentRootService).Append("='").Append(Uri.EscapeDataString(configuredServiceName)).Append('\'');
+
+                if (!string.IsNullOrEmpty(dbName))
+                {
+                    propagatorStringBuilder.Append(value: ',').Append(SqlCommentDbName).Append("='").Append(Uri.EscapeDataString(dbName)).Append(value: '\'');
+                }
 
                 if (span.Context.TraceContext?.ServiceVersion is { } versionTag)
                 {

--- a/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
@@ -42,9 +42,9 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
         [InlineData("string100", SamplingPriorityValues.UserKeep, "npgsql", "", "", false)]
         [InlineData("full", SamplingPriorityValues.UserKeep, "sqlite", "", "", false)]
         [InlineData("disabled", SamplingPriorityValues.UserKeep, "sqlclient", "", "", false)]
-        [InlineData("Service", SamplingPriorityValues.AutoReject, "npgsql", "Test.Service-postgres", "/*dddbs='Test.Service-postgres',ddps='Test.Service'*/", false)]
-        [InlineData("full", SamplingPriorityValues.UserReject, "sqlclient", "Test.Service-sql-server", "/*dddbs='Test.Service-sql-server',ddps='Test.Service'*/", false)]
-        [InlineData("fUlL", SamplingPriorityValues.AutoKeep, "mysql", "Test.Service-mysql", "/*dddbs='Test.Service-mysql',ddps='Test.Service',traceparent='00-00000000000000006172c1c9a829c71c-05a5f7b5320d6e4d-01'*/", true)]
+        [InlineData("Service", SamplingPriorityValues.AutoReject, "npgsql", "Test.Service-postgres", "/*dddbs='Test.Service-postgres',ddps='Test.Service',dddb='MyDatabase'*/", false)]
+        [InlineData("full", SamplingPriorityValues.UserReject, "sqlclient", "Test.Service-sql-server", "/*dddbs='Test.Service-sql-server',ddps='Test.Service',dddb='MyDatabase'*/", false)]
+        [InlineData("fUlL", SamplingPriorityValues.AutoKeep, "mysql", "Test.Service-mysql", "/*dddbs='Test.Service-mysql',ddps='Test.Service',dddb='MyDatabase',traceparent='00-00000000000000006172c1c9a829c71c-05a5f7b5320d6e4d-01'*/", true)]
         public void ExpectedCommentInjected(string propagationMode, int? samplingPriority, string integration, string dbServiceName, string expectedComment, bool traceParentInjected)
         {
             DbmPropagationLevel dbmPropagationLevel;
@@ -56,18 +56,17 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             var span = _v0Tracer.StartSpan(operationName: "mysql.query", parent: SpanContext.None, serviceName: dbServiceName, traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
             span.SetTraceSamplingPriority((SamplingPriority)samplingPriority.Value);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(dbmPropagationLevel, "Test.Service", span, integrationId, out var traceParentInjectedValue);
+            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(dbmPropagationLevel, "Test.Service", "MyDatabase", span, integrationId, out var traceParentInjectedValue);
 
             traceParentInjectedValue.Should().Be(traceParentInjected);
             returnedComment.Should().Be(expectedComment);
         }
 
         [Theory]
-
-        [InlineData("/*dddbs='Test.Service-mysql',dde='testing',ddps='Test.Service',ddpv='1.0.0'*/", "testing", "1.0.0")]
-        [InlineData("/*dddbs='Test.Service-mysql',ddps='Test.Service',ddpv='1.0.0'*/", null, "1.0.0")]
-        [InlineData("/*dddbs='Test.Service-mysql',dde='testing',ddps='Test.Service'*/", "testing", null)]
-        [InlineData("/*dddbs='Test.Service-mysql',ddps='Test.Service'*/", null, null)]
+        [InlineData("/*dddbs='Test.Service-mysql',dde='testing',ddps='Test.Service',dddb='MyDatabase',ddpv='1.0.0'*/", "testing", "1.0.0")]
+        [InlineData("/*dddbs='Test.Service-mysql',ddps='Test.Service',dddb='MyDatabase',ddpv='1.0.0'*/", null, "1.0.0")]
+        [InlineData("/*dddbs='Test.Service-mysql',dde='testing',ddps='Test.Service',dddb='MyDatabase'*/", "testing", null)]
+        [InlineData("/*dddbs='Test.Service-mysql',ddps='Test.Service',dddb='MyDatabase'*/", null, null)]
         public void ExpectedTagsInjected(string expectedComment, string env = null, string version = null)
         {
             var span = _v0Tracer.StartSpan(operationName: "mysql.query", parent: SpanContext.None, serviceName: "Test.Service-mysql", traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
@@ -75,7 +74,7 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             span.Context.TraceContext.ServiceVersion = version;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(DbmPropagationLevel.Service, "Test.Service", span, IntegrationId.MySql, out bool traceParentInjected);
+            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(DbmPropagationLevel.Service, "Test.Service", "MyDatabase", span, IntegrationId.MySql, out var traceParentInjected);
 
             // Always false since this test never runs for full mode
             traceParentInjected.Should().Be(false);
@@ -83,18 +82,18 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
         }
 
         [Theory]
-        [InlineData("/*dddbs='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D-mysql',dde='testing',ddps='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0'*/", "Test.Service !#$%&'()*+,/:;=?@[]", "testing", "1.0.0")]
-        [InlineData("/*dddbs='Test.Service-mysql',dde='te%23%27sti%2F%2Ang',ddps='Test.Service',ddpv='1.0.0'*/", "Test.Service", "te#'sti/*ng", "1.0.0")]
-        [InlineData("/*dddbs='Test.Service-mysql',dde='testing',ddps='Test.Service',ddpv='1.%2A0.0'*/", "Test.Service", "testing", "1.*0.0")]
-        [InlineData("/*dddbs='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D-mysql',dde='te%23%27sti%2F%2Ang',ddps='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.%2A0.0'*/", "Test.Service !#$%&'()*+,/:;=?@[]", "te#'sti/*ng", "1.*0.0")]
-        public void ExpectedTagsEncoded(string expectedComment, string service, string env, string version)
+        [InlineData("/*dddbs='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D-mysql',dde='testing',ddps='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',dddb='My.Database%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',ddpv='1.0.0'*/", "Test.Service !#$%&'()*+,/:;=?@[]", "My.Database !#$%&'()*+,/:;=?@[]", "testing", "1.0.0")]
+        [InlineData("/*dddbs='Test.Service-mysql',dde='te%23%27sti%2F%2Ang',ddps='Test.Service',ddpv='1.0.0'*/", "Test.Service", null, "te#'sti/*ng", "1.0.0")]
+        [InlineData("/*dddbs='Test.Service-mysql',dde='testing',ddps='Test.Service',ddpv='1.%2A0.0'*/", "Test.Service", "", "testing", "1.*0.0")]
+        [InlineData("/*dddbs='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D-mysql',dde='te%23%27sti%2F%2Ang',ddps='Test.Service%20%21%23%24%25%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D',dddb='My_Database',ddpv='1.%2A0.0'*/", "Test.Service !#$%&'()*+,/:;=?@[]", "My_Database", "te#'sti/*ng", "1.*0.0")]
+        public void ExpectedTagsEncoded(string expectedComment, string service, string dbName, string env, string version)
         {
             var span = _v0Tracer.StartSpan(operationName: "mysql.query", parent: SpanContext.None, serviceName: $"{service}-mysql", traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
             span.Context.TraceContext.Environment = env;
             span.Context.TraceContext.ServiceVersion = version;
             span.SetTraceSamplingPriority(SamplingPriority.AutoKeep);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(DbmPropagationLevel.Service, service, span, IntegrationId.MySql, out bool traceParentInjected);
+            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(DbmPropagationLevel.Service, service, dbName, span, IntegrationId.MySql, out var traceParentInjected);
 
             // Always false since this test never runs for full mode
             traceParentInjected.Should().Be(false);
@@ -108,14 +107,14 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             var integrationId = IntegrationId.Npgsql;
             var samplingPriority = SamplingPriority.AutoReject;
             var dbServiceName = "Test.Service-postgres";
-            var expectedComment = "/*dddbs='dbname',ddps='Test.Service'*/";
+            var expectedComment = "/*dddbs='dbname',ddps='Test.Service',dddb='MyDatabase'*/";
             var traceParentInjected = false;
             var dbName = "dbname";
 
             var span = _v1Tracer.StartSpan(tags: new SqlV1Tags() { DbName = dbName }, operationName: "mysql.query", parent: SpanContext.None, serviceName: dbServiceName, traceId: (TraceId)7021887840877922076, spanId: 407003698947780173);
             span.SetTraceSamplingPriority(samplingPriority);
 
-            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(dbmPropagationLevel, "Test.Service", span, integrationId, out var traceParentInjectedValue);
+            var returnedComment = DatabaseMonitoringPropagator.PropagateSpanData(dbmPropagationLevel, "Test.Service", "MyDatabase", span, integrationId, out var traceParentInjectedValue);
 
             traceParentInjectedValue.Should().Be(traceParentInjected);
             returnedComment.Should().Be(expectedComment);


### PR DESCRIPTION
## Summary of changes

Adding some tag values that were already present on the span as sql comments

## Reason for change

https://datadoghq.atlassian.net/browse/AIT-9565

## Implementation details

## Test coverage

✅

## Other details

same feature in other tracers:
https://github.com/DataDog/dd-trace-go/pull/2550
https://github.com/DataDog/dd-trace-py/pull/8286
https://github.com/DataDog/dd-trace-java/pull/6778
