### PR TITLE
Skip .NET Core 2.1 tests on ARM64

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1008,6 +1008,12 @@ partial class Build
             {
                 foreach (var targetFramework in TestingFrameworks.Where(x => x == Framework || Framework is null))
                 {
+                    if (IsArm64 && Framework is null && targetFramework == TargetFramework.NETCOREAPP2_1)
+                    {
+                        // Skip .NET Core 2.1 on ARM64 unless enabled explicitly - Some unit tests crash and it's not supported anyway
+                        continue;
+                    }
+
                     try
                     {
                         DotNetTest(x => x


### PR DESCRIPTION
## Summary of changes

Skip .NET Core 2.1 tests on ARM64

## Reason for change

The obfuscator regex crashes with .NET Core 2.1 on ARM64, and we don't support this runtime on that platform anyway.

## Implementation details

Filtering the runtime/platform in Nuke.

## Other details

Required to unblock https://github.com/DataDog/dd-trace-dotnet/pull/5266.