### PR TITLE
Don't allow adding `null` to the GRPC headers

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
@@ -181,8 +181,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
         private static void AddTemporaryHeaders(IMetadata metadata, int grpcType, string? methodName, string? serviceName, DateTimeOffset startTime, ISpanContext? parentContext)
         {
             metadata.Add(TemporaryHeaders.MethodKind, GrpcCommon.GetGrpcMethodKind(grpcType));
-            metadata.Add(TemporaryHeaders.MethodName, methodName);
-            metadata.Add(TemporaryHeaders.Service, serviceName);
+            if (methodName is not null)
+            {
+                metadata.Add(TemporaryHeaders.MethodName, methodName);
+            }
+
+            if (serviceName is not null)
+            {
+                metadata.Add(TemporaryHeaders.Service, serviceName);
+            }
+
             metadata.Add(TemporaryHeaders.StartTime, startTime.ToUnixTimeMilliseconds().ToString());
             if (parentContext is not null)
             {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/MetadataArraySafeHandleCreateInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/MetadataArraySafeHandleCreateInstrumentation.cs
@@ -46,19 +46,17 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
             // But we only add the extra headers for the client side code, so do a short-circuit check
             // for one of the temporary headers that should always be there in client side code
             var metadata = metadataInstance.DuckCast<IMetadata>();
-            if (GetAndRemove(metadata, TemporaryHeaders.Service) is { } service)
+            if (GetAndRemove(metadata, TemporaryHeaders.MethodKind) is { } methodKind)
             {
                 // Remove our temporary headers so they don't get sent over the wire
-                var methodKind = GetAndRemove(metadata, TemporaryHeaders.MethodKind);
+                var service = GetAndRemove(metadata, TemporaryHeaders.Service);
                 var methodName = GetAndRemove(metadata, TemporaryHeaders.MethodName);
                 var startTime = GetAndRemove(metadata, TemporaryHeaders.StartTime);
 
                 var parentId = GetAndRemove(metadata, TemporaryHeaders.ParentId);
                 var parentService = GetAndRemove(metadata, TemporaryHeaders.ParentService);
 
-                if (methodKind is not null
-                 && methodName is not null
-                 && startTime is not null)
+                if (startTime is not null)
                 {
                     var temporaryHeaders = new TemporaryGrpcHeaders(
                         metadata,
@@ -98,8 +96,16 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
                 // Add our temporary headers back in, so we can access them later
                 var metadata = headers.Metadata;
                 metadata.Add(headers.MethodKind);
-                metadata.Add(headers.MethodName);
-                metadata.Add(headers.Service);
+                if (headers.MethodName is not null)
+                {
+                    metadata.Add(headers.MethodName);
+                }
+
+                if (headers.Service is not null)
+                {
+                    metadata.Add(headers.Service);
+                }
+
                 metadata.Add(headers.StartTime);
 
                 if (headers.ParentId is not null)
@@ -120,8 +126,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
         {
             public TemporaryGrpcHeaders(
                 IMetadata metadata,
-                object service,
-                object methodName,
+                object? service,
+                object? methodName,
                 object startTime,
                 object methodKind,
                 object? parentId,
@@ -138,9 +144,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
 
             public IMetadata Metadata { get; }
 
-            public object Service { get; }
+            public object? Service { get; }
 
-            public object MethodName { get; }
+            public object? MethodName { get; }
 
             public object StartTime { get; }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/IMetadata.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/IMetadata.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc
 
         public IEnumerable GetAll(string key);
 
-        public void Add(string key, string? value);
+        public void Add(string key, string value);
 
         public void Add(object entry);
 


### PR DESCRIPTION
## Summary of changes

Check values for null before trying to add them to `IMetadata`.

## Reason for change

Grpc.Core checks the value for null, and throws a `NullReferenceException` if it is. 

## Implementation details

Update annotations to make it clear that `Add()` must not be called with a `null` value. Update the usages to account for that.

## Test coverage

Covered by existing tests for the most part, but I'm not sure _how_ these can ever be null, so somewhat of a speculative fix.

## Other details
Spotted in telemetry logs.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
