### PR TITLE
Add some null protection for IReceiveMessageRequest

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SQS/AwsSqsHandlerCommon.cs
@@ -117,8 +117,8 @@ internal static class AwsSqsHandlerCommon
         }
 
         // request the message attributes that a datadog instrumentation might have set when sending
-        request.MessageAttributeNames.AddDistinct(ContextPropagation.SqsKey);
-        request.AttributeNames.AddDistinct("SentTimestamp");
+        request.MessageAttributeNames?.AddDistinct(ContextPropagation.SqsKey);
+        request.AttributeNames?.AddDistinct("SentTimestamp");
 
         return new CallTargetState(scope, queueName);
     }


### PR DESCRIPTION
## Summary of changes

Adds some `?` to `MessageAttributeNames` and `AttributeNames`

## Reason for change

Since `IReceiveMessageRequest` is a `IDuckType` I think these can be `null` we are also seeing errors where their `?.AddDistinct(....)` is throwing a NullReferenceException within `Newtonsoft.Json.Utilities.CollectionUtils.ContainsValue`.

## Implementation details

Added two `?`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
