### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -26,9 +26,9 @@ jobs:
         id: select_branch
         run: |
           if( "${{ github.event.release.tag_name}}".StartsWith("v1.")) {
-            echo "::set-output name=ref::release/1.x"
+            echo "ref=release/1.x" >> "$GITHUB_OUTPUT"
           } else {
-            echo "::set-output name=ref::master"
+            echo "ref=master" >> "$GITHUB_OUTPUT"
           }
 
       - name: Checkout


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter