### PR TITLE
[ASM] Dont deserialize rcm payloads until they are needed for memory optimization

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rcm/AsmFeaturesProduct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/AsmFeaturesProduct.cs
@@ -6,9 +6,7 @@
 #nullable enable
 
 using System.Collections.Generic;
-using System.Linq;
 using Datadog.Trace.AppSec.Rcm.Models.AsmFeatures;
-using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.RemoteConfigurationManagement;
 
 namespace Datadog.Trace.AppSec.Rcm;

--- a/tracer/src/Datadog.Trace/AppSec/Rcm/ConfigurationStatus.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/ConfigurationStatus.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.AppSec.Rcm.Models.AsmData;
 using Datadog.Trace.AppSec.Rcm.Models.AsmDd;
 using Datadog.Trace.AppSec.Rcm.Models.AsmFeatures;
 using Datadog.Trace.AppSec.Waf.Initialization;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
@@ -217,6 +218,7 @@ internal record ConfigurationStatus
                 // only treat asm_features as it will decide if asm gets toggled on and if we deserialize all the others
                 _asmFeatureProduct.ProcessUpdates(this, asmFeaturesToUpdate);
                 _asmFeatureProduct.ProcessRemovals(this, asmFeaturesToRemove);
+                EnableAsm = !AsmFeaturesByFile.IsEmpty() && AsmFeaturesByFile.All(a => a.Value.Enabled == true);
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Rcm/Models/AsmFeatures/AsmFeature.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/Models/AsmFeatures/AsmFeature.cs
@@ -5,7 +5,7 @@
 
 #nullable enable
 
-namespace Datadog.Trace.AppSec;
+namespace Datadog.Trace.AppSec.Rcm.Models.AsmFeatures;
 
 internal class AsmFeature
 {

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -171,7 +171,8 @@ namespace Datadog.Trace.AppSec
 
             try
             {
-                var anyChange = _configurationStatus.StoreConfigs(configsByProduct, removedConfigs);
+                // store the last config state, clearing any previous state, without deserializing any payloads yet.
+                var anyChange = _configurationStatus.StoreLastConfigState(configsByProduct, removedConfigs);
                 var securityStateChange = Enabled != _configurationStatus.EnableAsm;
 
                 // normally CanBeToggled should not need a check as asm_features capacity is only sent if AppSec env var is null, but still guards it in case

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -187,6 +187,11 @@ namespace Datadog.Trace.AppSec
                         _configurationStatus.ApplyStoredFiles();
                         InitWafAndInstrumentations(true);
                         rcmUpdateError = _wafInitResult?.ErrorMessage;
+                        if (_wafInitResult?.RuleFileVersion is not null)
+                        {
+                            WafRuleFileVersion = _wafInitResult.RuleFileVersion;
+                        }
+
                         _configurationStatus.IncomingUpdateState.SecurityStateChange = false;
                     }
                 }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -69,10 +69,18 @@ namespace Datadog.Trace.AppSec.Waf
 
             // set the log level and setup the logger
             wafLibraryInvoker.SetupLogging(wafDebugEnabled);
-            object? configurationToEncode = configurationStatus is not null
-                                                ? configurationStatus.BuildDictionaryForWafAccordingToIncomingUpdate()
-                                                : WafConfigurator.DeserializeEmbeddedOrStaticRules(
-                                                    embeddedRulesetPath)!;
+
+            object? configurationToEncode = null;
+            if (configurationStatus is not null)
+            {
+                var configFromRcm = configurationStatus.BuildDictionaryForWafAccordingToIncomingUpdate();
+                if (configFromRcm.Count > 0)
+                {
+                    configurationToEncode = configFromRcm;
+                }
+            }
+
+            configurationToEncode ??= WafConfigurator.DeserializeEmbeddedOrStaticRules(embeddedRulesetPath)!;
 
             if (configurationToEncode is null)
             {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
@@ -38,7 +38,7 @@ public class ContextTests : WafLibraryRequiredTest
             AppSec.WafEncoding.Encoder.SetPoolSize(0);
         }
 
-        var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty, setupWafSchemaExtraction: true, useUnsafeEncoder: useUnsafeEncoder);
+        var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty, useUnsafeEncoder: useUnsafeEncoder);
         using var waf = initResult.Waf;
         waf.Should().NotBeNull();
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Security.Unit.Tests
 
         private void ExecuteInternal(string address, object[] values, bool[] matches, string flow, string rule, bool newEncoder)
         {
-            var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty, setupWafSchemaExtraction: false, useUnsafeEncoder: newEncoder);
+            var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty, useUnsafeEncoder: newEncoder);
             using var waf = initResult.Waf;
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -147,7 +147,7 @@ namespace Datadog.Trace.Security.Unit.Tests
                 args.Add(AddressesConstants.RequestMethod, "GET");
             }
 
-            var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty, setupWafSchemaExtraction: extractSchema, useUnsafeEncoder: newEncoder);
+            var initResult = Waf.Create(WafLibraryInvoker, string.Empty, string.Empty, useUnsafeEncoder: newEncoder);
             using var waf = initResult.Waf;
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();


### PR DESCRIPTION
## Summary of changes

Make ConfigurationStatus class smaller in memory by not deserializing payloads if ASM is disabled
Only deserialize payloads if necessary. Store payloads for when activation happens.

## Reason for change

Configuration status too big in memory when appsec disabled

## Implementation details
before 
![config status master](https://github.com/DataDog/dd-trace-dotnet/assets/8353486/29a0288e-b69c-4d5e-aabb-a79464c47e34)

after
![config status branch](https://github.com/DataDog/dd-trace-dotnet/assets/8353486/516a9795-c992-4281-a2ea-988c75c6571f)



## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
