### PR TITLE
[ASM] Deactivate benchmark for legacy encoder to help CI

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
@@ -96,8 +96,8 @@ public class AppSecEncoderBenchmark
         return new NestedMap(root, nestingDepth, withAttack);
     }
 
-
-    [Benchmark]
+    // deactivate for now as it's slowing CI down. Reactivate when run only when an appsecfile changed is setup in CI
+    // [Benchmark]
     public void EncodeArgs()
     {
         using var pwArgs = _encoder.Encode(_args.Map, applySafetyLimits: true);


### PR DESCRIPTION
## Summary of changes

Deactivate benchmarks for legacy encoder for now, to relieve CI for now

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
