### PR TITLE
[IAST] Vulnerability and Evidence truncation

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Iast.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Iast.cs
@@ -84,7 +84,13 @@ namespace Datadog.Trace.Configuration
             /// Configuration key for IAST verbosity.
             /// Default value is INFORMATION
             /// </summary>
-            public const string IastTelemetryVerbosity = "DD_IAST_TELEMETRY_VERBOSITY";
+            public const string TelemetryVerbosity = "DD_IAST_TELEMETRY_VERBOSITY";
+
+            /// <summary>
+            /// Configuration key for IAST evidence max lenght in chars.
+            /// Default value is 250
+            /// </summary>
+            public const string TruncationMaxValueLength = "IAST_TRUNCATION_MAX_VALUE_LENGTH";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Iast.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Iast.cs
@@ -90,7 +90,7 @@ namespace Datadog.Trace.Configuration
             /// Configuration key for IAST evidence max lenght in chars.
             /// Default value is 250
             /// </summary>
-            public const string TruncationMaxValueLength = "IAST_TRUNCATION_MAX_VALUE_LENGTH";
+            public const string TruncationMaxValueLength = "DD_IAST_TRUNCATION_MAX_VALUE_LENGTH";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/EvidenceConverter.cs
+++ b/tracer/src/Datadog.Trace/Iast/EvidenceConverter.cs
@@ -78,7 +78,7 @@ internal class EvidenceConverter : JsonConverter<Evidence?>
         if (evidenceValue.Ranges == null || evidenceValue.Ranges.Length == 0)
         {
             writer.WritePropertyName("value");
-            writer.WriteTruncableValue(evidenceValue.Value);
+            writer.WriteTruncatableValue(evidenceValue.Value);
         }
         else
         {
@@ -125,7 +125,7 @@ internal class EvidenceConverter : JsonConverter<Evidence?>
         if (value == null) { return; }
         writer.WriteStartObject();
         writer.WritePropertyName("value");
-        writer.WriteTruncableValue(value);
+        writer.WriteTruncatableValue(value);
         if (source != null)
         {
             writer.WritePropertyName("source");
@@ -143,7 +143,7 @@ internal class EvidenceConverter : JsonConverter<Evidence?>
         if (value != null)
         {
             writer.WritePropertyName("pattern");
-            writer.WriteTruncableValue(value);
+            writer.WriteTruncatableValue(value);
         }
 
         if (source != null)

--- a/tracer/src/Datadog.Trace/Iast/EvidenceConverter.cs
+++ b/tracer/src/Datadog.Trace/Iast/EvidenceConverter.cs
@@ -78,7 +78,7 @@ internal class EvidenceConverter : JsonConverter<Evidence?>
         if (evidenceValue.Ranges == null || evidenceValue.Ranges.Length == 0)
         {
             writer.WritePropertyName("value");
-            writer.WriteValue(evidenceValue.Value);
+            writer.WriteTruncableValue(evidenceValue.Value);
         }
         else
         {
@@ -125,7 +125,7 @@ internal class EvidenceConverter : JsonConverter<Evidence?>
         if (value == null) { return; }
         writer.WriteStartObject();
         writer.WritePropertyName("value");
-        writer.WriteValue(value);
+        writer.WriteTruncableValue(value);
         if (source != null)
         {
             writer.WritePropertyName("source");
@@ -143,7 +143,7 @@ internal class EvidenceConverter : JsonConverter<Evidence?>
         if (value != null)
         {
             writer.WritePropertyName("pattern");
-            writer.WriteValue(value);
+            writer.WriteTruncableValue(value);
         }
 
         if (source != null)

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -299,7 +299,7 @@ internal static partial class IastModule
             timeout = Regex.InfiniteMatchTimeout;
         }
 
-        return settings.RedactionEnabled ? new EvidenceRedactor(settings.RedactionKeysRegex, settings.RedactionValuesRegex, timeout, settings.TruncationMaxValueLength) : null;
+        return settings.RedactionEnabled ? new EvidenceRedactor(settings.RedactionKeysRegex, settings.RedactionValuesRegex, timeout) : null;
     }
 
     private static string BuildCommandInjectionEvidence(string file, string argumentLine, Collection<string>? argumentList)
@@ -496,7 +496,7 @@ internal static partial class IastModule
 
     internal static VulnerabilityBatch GetVulnerabilityBatch()
     {
-        return new VulnerabilityBatch(EvidenceRedactorLazy.Value);
+        return new VulnerabilityBatch(iastSettings.TruncationMaxValueLength, EvidenceRedactorLazy.Value);
     }
 
     // This method adds web vulnerabilities, with no location, only on web environments

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -299,7 +299,7 @@ internal static partial class IastModule
             timeout = Regex.InfiniteMatchTimeout;
         }
 
-        return settings.RedactionEnabled ? new EvidenceRedactor(settings.RedactionKeysRegex, settings.RedactionValuesRegex, timeout) : null;
+        return settings.RedactionEnabled ? new EvidenceRedactor(settings.RedactionKeysRegex, settings.RedactionValuesRegex, timeout, settings.TruncationMaxValueLength) : null;
     }
 
     private static string BuildCommandInjectionEvidence(string file, string argumentLine, Collection<string>? argumentList)

--- a/tracer/src/Datadog.Trace/Iast/SensitiveData/EvidenceRedactor.cs
+++ b/tracer/src/Datadog.Trace/Iast/SensitiveData/EvidenceRedactor.cs
@@ -21,10 +21,12 @@ internal class EvidenceRedactor
     private TimeSpan _timeout;
     private Dictionary<string, ITokenizer> _tokenizers;
 
-    public EvidenceRedactor(string keysPattern, string valuesPattern, TimeSpan timeout, IDatadogLogger? logger = null)
+    public EvidenceRedactor(string keysPattern, string valuesPattern, TimeSpan timeout, int truncationMaxValueLength, IDatadogLogger? logger = null)
     {
         _timeout = timeout;
         _logger = logger;
+
+        TruncationUtils.Init(truncationMaxValueLength);
 
         var options = RegexOptions.IgnoreCase | RegexOptions.Compiled;
 

--- a/tracer/src/Datadog.Trace/Iast/SensitiveData/EvidenceRedactor.cs
+++ b/tracer/src/Datadog.Trace/Iast/SensitiveData/EvidenceRedactor.cs
@@ -21,12 +21,10 @@ internal class EvidenceRedactor
     private TimeSpan _timeout;
     private Dictionary<string, ITokenizer> _tokenizers;
 
-    public EvidenceRedactor(string keysPattern, string valuesPattern, TimeSpan timeout, int truncationMaxValueLength, IDatadogLogger? logger = null)
+    public EvidenceRedactor(string keysPattern, string valuesPattern, TimeSpan timeout, IDatadogLogger? logger = null)
     {
         _timeout = timeout;
         _logger = logger;
-
-        TruncationUtils.Init(truncationMaxValueLength);
 
         var options = RegexOptions.IgnoreCase | RegexOptions.Compiled;
 

--- a/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
@@ -20,6 +20,7 @@ internal class IastSettings
     public const int VulnerabilitiesPerRequestDefault = 2;
     public const int MaxConcurrentRequestDefault = 2;
     public const int RequestSamplingDefault = 30;
+    public const int TruncationMaxValueLengthDefault = 250;
 
     /// <summary>
     /// Default keys readaction regex if none specified via env DD_IAST_REDACTION_KEYS_REGEXP
@@ -65,8 +66,8 @@ internal class IastSettings
                                 .WithKeys(ConfigurationKeys.Iast.RegexTimeout)
                                 .AsDouble(200, val1 => val1 is >= 0).Value;
 
-        IastTelemetryVerbosity = config
-            .WithKeys(ConfigurationKeys.Iast.IastTelemetryVerbosity)
+        TelemetryVerbosity = config
+            .WithKeys(ConfigurationKeys.Iast.TelemetryVerbosity)
             .GetAs(
                 getDefaultValue: () => IastMetricsVerbosityLevel.Information,
                 converter: value => value.ToLowerInvariant() switch
@@ -78,6 +79,10 @@ internal class IastSettings
                     _ => ParsingResult<IastMetricsVerbosityLevel>.Failure()
                 },
                 validator: null);
+
+        TruncationMaxValueLength = config
+            .WithKeys(ConfigurationKeys.Iast.TruncationMaxValueLength)
+            .AsInt32(TruncationMaxValueLengthDefault, x => x > 0);
     }
 
     public bool Enabled { get; set; }
@@ -106,7 +111,9 @@ internal class IastSettings
 
     public double RegexTimeout { get; }
 
-    public IastMetricsVerbosityLevel IastTelemetryVerbosity { get; }
+    public IastMetricsVerbosityLevel TelemetryVerbosity { get; }
+
+    public int TruncationMaxValueLength { get; }
 
     public static IastSettings FromDefaultSources()
     {

--- a/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
@@ -82,7 +82,8 @@ internal class IastSettings
 
         TruncationMaxValueLength = config
             .WithKeys(ConfigurationKeys.Iast.TruncationMaxValueLength)
-            .AsInt32(TruncationMaxValueLengthDefault, x => x > 0);
+            .AsInt32(TruncationMaxValueLengthDefault, x => x > 0)
+            .Value;
     }
 
     public bool Enabled { get; set; }

--- a/tracer/src/Datadog.Trace/Iast/SourceConverter.cs
+++ b/tracer/src/Datadog.Trace/Iast/SourceConverter.cs
@@ -63,13 +63,13 @@ internal class SourceConverter : JsonConverter<Source>
                 if (source.RedactedValue != null)
                 {
                     writer.WritePropertyName("pattern");
-                    writer.WriteTruncableValue(source.RedactedValue);
+                    writer.WriteTruncatableValue(source.RedactedValue);
                 }
             }
             else if (source.Value != null)
             {
                 writer.WritePropertyName("value");
-                writer.WriteTruncableValue(source.Value);
+                writer.WriteTruncatableValue(source.Value);
             }
 
             writer.WriteEndObject();

--- a/tracer/src/Datadog.Trace/Iast/SourceConverter.cs
+++ b/tracer/src/Datadog.Trace/Iast/SourceConverter.cs
@@ -63,13 +63,13 @@ internal class SourceConverter : JsonConverter<Source>
                 if (source.RedactedValue != null)
                 {
                     writer.WritePropertyName("pattern");
-                    writer.WriteValue(source.RedactedValue);
+                    writer.WriteTruncableValue(source.RedactedValue);
                 }
             }
             else if (source.Value != null)
             {
                 writer.WritePropertyName("value");
-                writer.WriteValue(source.Value);
+                writer.WriteTruncableValue(source.Value);
             }
 
             writer.WriteEndObject();

--- a/tracer/src/Datadog.Trace/Iast/SourceConverter.cs
+++ b/tracer/src/Datadog.Trace/Iast/SourceConverter.cs
@@ -26,8 +26,11 @@ internal class SourceConverter : JsonConverter<Source>
     // When redacted output is:
     // { "origin": "http.request.parameter.name", "name": "name", "redacted": true }
 
-    public SourceConverter()
+    private int _maxValueLength;
+
+    public SourceConverter(int maxValueLength)
     {
+        _maxValueLength = maxValueLength;
     }
 
     public override bool CanRead => true;
@@ -63,13 +66,13 @@ internal class SourceConverter : JsonConverter<Source>
                 if (source.RedactedValue != null)
                 {
                     writer.WritePropertyName("pattern");
-                    writer.WriteTruncatableValue(source.RedactedValue);
+                    writer.WriteTruncatableValue(source.RedactedValue, _maxValueLength);
                 }
             }
             else if (source.Value != null)
             {
                 writer.WritePropertyName("value");
-                writer.WriteTruncatableValue(source.Value);
+                writer.WriteTruncatableValue(source.Value, _maxValueLength);
             }
 
             writer.WriteEndObject();

--- a/tracer/src/Datadog.Trace/Iast/Telemetry/ExecutedTelemetryHelper.cs
+++ b/tracer/src/Datadog.Trace/Iast/Telemetry/ExecutedTelemetryHelper.cs
@@ -19,7 +19,7 @@ internal class ExecutedTelemetryHelper
     private const string SinkExecutedTag = "executed.sink.";
     private const string PropagationExecutedTag = BasicExecutedTag + "executed.propagation";
     private const string RequestTaintedTag = BasicExecutedTag + "request.tainted";
-    private static IastMetricsVerbosityLevel _verbosityLevel = Iast.Instance.Settings.IastTelemetryVerbosity;
+    private static IastMetricsVerbosityLevel _verbosityLevel = Iast.Instance.Settings.TelemetryVerbosity;
     private int[] _executedSinks = new int[Trace.Telemetry.Metrics.IastInstrumentedSinksExtensions.Length];
     private int[] _executedSources = new int[Trace.Telemetry.Metrics.IastInstrumentedSourcesExtensions.Length];
     private int _executedPropagations = 0;

--- a/tracer/src/Datadog.Trace/Iast/TruncatedVulnerabilities.cs
+++ b/tracer/src/Datadog.Trace/Iast/TruncatedVulnerabilities.cs
@@ -53,12 +53,10 @@ internal struct TruncatedVulnerabilities
                 writer.WriteValue(value.Value.Type);
                 writer.WritePropertyName("evidence");
                 serializer.Serialize(writer, value.Value.Evidence);
-                // writer.WriteValue(value.Value.Evidence);
                 writer.WritePropertyName("hash");
                 writer.WriteValue(value.Value.Hash);
                 writer.WritePropertyName("location");
                 serializer.Serialize(writer, value.Value.Location);
-                // writer.WriteValue(value.Value.Location);
 
                 writer.WriteEndObject();
             }

--- a/tracer/src/Datadog.Trace/Iast/TruncatedVulnerabilities.cs
+++ b/tracer/src/Datadog.Trace/Iast/TruncatedVulnerabilities.cs
@@ -1,0 +1,92 @@
+// <copyright file="TruncatedVulnerabilities.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Iast.SensitiveData;
+using Datadog.Trace.Iast.Settings;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
+using Datadog.Trace.Vendors.Newtonsoft.Json.Utilities;
+
+namespace Datadog.Trace.Iast;
+
+/// <summary>
+/// Custom JSON serializer for <see cref="Datadog.Trace.Iast.Source"/> struct
+/// </summary>
+internal struct TruncatedVulnerabilities
+{
+    private const string MaxSizeExceeded = "MAX SIZE EXCEEDED";
+
+    private List<Vulnerability> vulnerabilities;
+
+    public TruncatedVulnerabilities(List<Vulnerability> vulnerabilities)
+    {
+        this.vulnerabilities = vulnerabilities;
+    }
+
+    public List<Vulnerability> Vulnerabilities => vulnerabilities;
+
+    public class VulnerabilityConverter : JsonConverter<Vulnerability?>
+    {
+        public VulnerabilityConverter()
+        {
+        }
+
+        public override bool CanRead => true;
+
+        public override Vulnerability? ReadJson(JsonReader reader, Type objectType, Vulnerability? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, Vulnerability? value, JsonSerializer serializer)
+        {
+            if (value != null)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("type");
+                writer.WriteValue(value.Value.Type);
+                writer.WritePropertyName("evidence");
+                serializer.Serialize(writer, value.Value.Evidence);
+                // writer.WriteValue(value.Value.Evidence);
+                writer.WritePropertyName("hash");
+                writer.WriteValue(value.Value.Hash);
+                writer.WritePropertyName("location");
+                serializer.Serialize(writer, value.Value.Location);
+                // writer.WriteValue(value.Value.Location);
+
+                writer.WriteEndObject();
+            }
+        }
+    }
+
+    public class EvidenceConverter : JsonConverter<Evidence?>
+    {
+        public EvidenceConverter()
+        {
+        }
+
+        public override bool CanRead => true;
+
+        public override Evidence? ReadJson(JsonReader reader, Type objectType, Evidence? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void WriteJson(JsonWriter writer, Evidence? value, JsonSerializer serializer)
+        {
+            if (value != null)
+            {
+                writer.WriteStartObject();
+                writer.WritePropertyName("value");
+                writer.WriteValue(MaxSizeExceeded);
+                writer.WriteEndObject();
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Iast/TruncationUtils.cs
+++ b/tracer/src/Datadog.Trace/Iast/TruncationUtils.cs
@@ -29,7 +29,7 @@ internal static class TruncationUtils
         }
     }
 
-    public static void WriteTruncableValue(this JsonWriter writer, string? value)
+    public static void WriteTruncatableValue(this JsonWriter writer, string? value)
     {
         if (value != null && value.Length > maxValueLength)
         {

--- a/tracer/src/Datadog.Trace/Iast/TruncationUtils.cs
+++ b/tracer/src/Datadog.Trace/Iast/TruncationUtils.cs
@@ -1,0 +1,45 @@
+// <copyright file="TruncationUtils.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Iast.Settings;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Iast;
+
+internal static class TruncationUtils
+{
+    private const string TRUNCATED = "truncated";
+    private const string RIGHT = "right";
+    private static int maxValueLength = 250;
+
+    public static void Init(int truncationMaxValueLength)
+    {
+        if (truncationMaxValueLength > 0)
+        {
+            maxValueLength = truncationMaxValueLength;
+        }
+    }
+
+    public static void WriteTruncableValue(this JsonWriter writer, string? value)
+    {
+        if (value != null && value.Length > maxValueLength)
+        {
+            writer.WriteValue(value.Substring(0, maxValueLength));
+            writer.WritePropertyName(TRUNCATED);
+            writer.WriteValue(RIGHT);
+        }
+        else
+        {
+            writer.WriteValue(value);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Iast/TruncationUtils.cs
+++ b/tracer/src/Datadog.Trace/Iast/TruncationUtils.cs
@@ -19,19 +19,10 @@ internal static class TruncationUtils
 {
     private const string TRUNCATED = "truncated";
     private const string RIGHT = "right";
-    private static int maxValueLength = 250;
 
-    public static void Init(int truncationMaxValueLength)
+    public static void WriteTruncatableValue(this JsonWriter writer, string? value, int maxValueLength)
     {
-        if (truncationMaxValueLength > 0)
-        {
-            maxValueLength = truncationMaxValueLength;
-        }
-    }
-
-    public static void WriteTruncatableValue(this JsonWriter writer, string? value)
-    {
-        if (value != null && value.Length > maxValueLength)
+        if (value != null && value.Length > maxValueLength && maxValueLength > 0)
         {
             writer.WriteValue(value.Substring(0, maxValueLength));
             writer.WritePropertyName(TRUNCATED);

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
@@ -8,10 +8,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Datadog.Trace.Iast.SensitiveData;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util.Http;
+using Datadog.Trace.Vendors.dnlib;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
 
@@ -19,21 +21,12 @@ namespace Datadog.Trace.Iast;
 
 internal class VulnerabilityBatch
 {
+    private const int MaxSpanTagSize = 25000; // In bytes
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(VulnerabilityBatch));
 
-    private static JsonSerializerSettings _defaultSettings = new JsonSerializerSettings()
-    {
-        NullValueHandling = NullValueHandling.Ignore,
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
-        Converters = new List<JsonConverter> { new SourceConverter(), new EvidenceConverter(false) }
-    };
-
-    private static JsonSerializerSettings _redactionSettings = new JsonSerializerSettings()
-    {
-        NullValueHandling = NullValueHandling.Ignore,
-        ContractResolver = new CamelCasePropertyNamesContractResolver(),
-        Converters = new List<JsonConverter> { new SourceConverter(), new EvidenceConverter(true) }
-    };
+    private static Lazy<JsonSerializerSettings> _defaultSettings = new(() => CreateSerializerSettings(false, false));
+    private static Lazy<JsonSerializerSettings> _redactionSettings = new(() => CreateSerializerSettings(true, false));
+    private static Lazy<JsonSerializerSettings> _truncatedSettings = new(() => CreateSerializerSettings(false, true));
 
     private EvidenceRedactor? _evidenceRedactor;
     private JsonSerializerSettings _serializerSettings;
@@ -42,14 +35,37 @@ internal class VulnerabilityBatch
     public VulnerabilityBatch(EvidenceRedactor? evidenceRedactor = null)
     {
         _evidenceRedactor = evidenceRedactor;
-        _serializerSettings = _evidenceRedactor != null ? _redactionSettings : _defaultSettings;
+        _serializerSettings = _evidenceRedactor != null ? _redactionSettings.Value : _defaultSettings.Value;
     }
 
-    internal static JsonSerializerSettings JsonRedactionSettings => _redactionSettings;
+    internal static JsonSerializerSettings JsonRedactionSettings => _redactionSettings.Value;
+
+    internal static JsonSerializerSettings JsonTruncatedSettings => _truncatedSettings.Value;
 
     public List<Vulnerability> Vulnerabilities { get; } = new List<Vulnerability>();
 
     public List<Source>? Sources { get; private set; } = null;
+
+    private static JsonSerializerSettings CreateSerializerSettings(bool redacted, bool truncated)
+    {
+        List<JsonConverter> converters = [new SourceConverter()];
+        if (truncated)
+        {
+            converters.Add(new TruncatedVulnerabilities.VulnerabilityConverter());
+            converters.Add(new TruncatedVulnerabilities.EvidenceConverter());
+        }
+        else
+        {
+            converters.Add(new EvidenceConverter(redacted));
+        }
+
+        return new JsonSerializerSettings()
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = converters
+        };
+    }
 
     public void Add(Vulnerability vulnerability)
     {
@@ -103,6 +119,11 @@ internal class VulnerabilityBatch
 
                     _vulnerabilitiesJson = JsonConvert.SerializeObject(this, Formatting.Indented, _serializerSettings);
                 }
+
+                if (System.Text.ASCIIEncoding.Unicode.GetByteCount(_vulnerabilitiesJson) > MaxSpanTagSize)
+                {
+                    _vulnerabilitiesJson = ToTruncatedJson();
+                }
             }
 
             return _vulnerabilitiesJson;
@@ -112,6 +133,11 @@ internal class VulnerabilityBatch
             Log.Error(ex, $"Error in {nameof(VulnerabilityBatch)}.{nameof(ToJson)}");
             return string.Empty;
         }
+    }
+
+    internal string ToTruncatedJson()
+    {
+        return JsonConvert.SerializeObject(new TruncatedVulnerabilities(Vulnerabilities), Formatting.Indented, _truncatedSettings.Value);
     }
 
     public override string ToString()

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
@@ -11,6 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Datadog.Trace.Iast.SensitiveData;
+using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util.Http;
 using Datadog.Trace.Vendors.dnlib;
@@ -24,40 +25,47 @@ internal class VulnerabilityBatch
     private const int MaxSpanTagSize = 25000; // In bytes
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(VulnerabilityBatch));
 
-    private static Lazy<JsonSerializerSettings> _defaultSettings = new(() => CreateSerializerSettings(false, false));
-    private static Lazy<JsonSerializerSettings> _redactionSettings = new(() => CreateSerializerSettings(true, false));
-    private static Lazy<JsonSerializerSettings> _truncatedSettings = new(() => CreateSerializerSettings(false, true));
+    private static JsonSerializerSettings? _defaultSettings = null;
+    private static JsonSerializerSettings? _redactionSettings = null;
+    private static Lazy<JsonSerializerSettings> _truncatedSettings = new(() => CreateTruncatedSettings());
 
     private EvidenceRedactor? _evidenceRedactor;
     private JsonSerializerSettings _serializerSettings;
     private string? _vulnerabilitiesJson;
 
-    public VulnerabilityBatch(EvidenceRedactor? evidenceRedactor = null)
+    public VulnerabilityBatch(int truncationMaxValueLength = IastSettings.TruncationMaxValueLengthDefault, EvidenceRedactor? evidenceRedactor = null)
     {
         _evidenceRedactor = evidenceRedactor;
-        _serializerSettings = _evidenceRedactor != null ? _redactionSettings.Value : _defaultSettings.Value;
+        if (_evidenceRedactor is null)
+        {
+            _defaultSettings ??= CreateSerializerSettings(truncationMaxValueLength, false);
+            _serializerSettings = _defaultSettings;
+        }
+        else
+        {
+            _redactionSettings ??= CreateSerializerSettings(truncationMaxValueLength, true);
+            _serializerSettings = _redactionSettings;
+        }
     }
-
-    internal static JsonSerializerSettings JsonRedactionSettings => _redactionSettings.Value;
-
-    internal static JsonSerializerSettings JsonTruncatedSettings => _truncatedSettings.Value;
 
     public List<Vulnerability> Vulnerabilities { get; } = new List<Vulnerability>();
 
     public List<Source>? Sources { get; private set; } = null;
 
-    private static JsonSerializerSettings CreateSerializerSettings(bool redacted, bool truncated)
+    internal static JsonSerializerSettings CreateSerializerSettings(int truncationMaxValueLength, bool redacted)
     {
-        List<JsonConverter> converters = [new SourceConverter()];
-        if (truncated)
+        List<JsonConverter> converters = [new SourceConverter(truncationMaxValueLength), new EvidenceConverter(truncationMaxValueLength, redacted)];
+        return new JsonSerializerSettings()
         {
-            converters.Add(new TruncatedVulnerabilities.VulnerabilityConverter());
-            converters.Add(new TruncatedVulnerabilities.EvidenceConverter());
-        }
-        else
-        {
-            converters.Add(new EvidenceConverter(redacted));
-        }
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            Converters = converters
+        };
+    }
+
+    private static JsonSerializerSettings CreateTruncatedSettings()
+    {
+        List<JsonConverter> converters = [new TruncatedVulnerabilities.VulnerabilityConverter(), new TruncatedVulnerabilities.EvidenceConverter()];
 
         return new JsonSerializerSettings()
         {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/Utils.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/Utils.cs
@@ -40,7 +40,7 @@ internal static class Utils
 
     public static VulnerabilityBatch GetRedactedBatch(double? timeoutMs = null)
     {
-        return new VulnerabilityBatch(GetDefaultRedactor(timeoutMs));
+        return new VulnerabilityBatch(IastSettings.TruncationMaxValueLengthDefault, GetDefaultRedactor(timeoutMs));
     }
 
     public static System.Func<string, string, bool> GetRegexScrubber(params string[] rules)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.Bundle.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.Bundle.cs
@@ -32,7 +32,7 @@ public partial class VulnerabilityBatchTests
 #pragma warning restore SA1401 // Fields should be private
 
     private const double _regexTimeout = 0;
-    private static JsonSerializerSettings _serializerSettings = VulnerabilityBatch.JsonRedactionSettings;
+    private static JsonSerializerSettings _serializerSettings = VulnerabilityBatch.CreateSerializerSettings(Trace.Iast.Settings.IastSettings.TruncationMaxValueLengthDefault, true);
     private static EvidenceRedactor _redactor = Utils.GetDefaultRedactor(_regexTimeout);
 
     [Theory]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityBatchTests.cs
@@ -3,12 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using Datadog.Trace.Configuration;
+using System.Text;
 using Datadog.Trace.Iast;
 using Datadog.Trace.TestHelpers.FluentAssertionsExtensions.Json;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
+using YamlDotNet.Core.Tokens;
 
 namespace Datadog.Trace.Security.Unit.Tests.IAST.Tainted;
 
@@ -17,7 +18,7 @@ namespace Datadog.Trace.Security.Unit.Tests.IAST.Tainted;
 /// </summary>
 public partial class VulnerabilityBatchTests
 {
-    private static System.Func<string, string, bool> _sourcesScrubber = Utils.GetRegexScrubber("$[*].pattern");
+    private static System.Func<string, string, bool> _sourcesScrubber = Utils.GetRegexScrubber("$[*].pattern", "$[*].truncated");
     private static System.Func<string, string, bool> _vulnerabilitiesScrubber = Utils.GetRegexScrubber("$.vulnerabilities[*].hash", "$.vulnerabilities[*].location");
     private readonly ITestOutputHelper _output = null;
 
@@ -438,5 +439,124 @@ public partial class VulnerabilityBatchTests
             }
             """,
             _vulnerabilitiesScrubber);
+    }
+
+    [Fact]
+    public void GivenOneLongEvidenceValueVuln_WhenSerializing_JsonIsTruncated()
+    {
+        var batch = new VulnerabilityBatch();
+        var evidence = new Evidence(GenerateLargeString());
+        batch.Add(new Vulnerability("WEAK_HASH", 1042880134, new Location("foo", "fooMethod", 1, 123456), evidence));
+
+        var json = batch.ToTruncatedJson();
+        json.Should().BeJsonEquivalentTo(
+            """
+            {
+              "vulnerabilities": [
+                {
+                  "type": "WEAK_HASH",
+                  "evidence": {
+                    "value": "MAX SIZE EXCEEDED"
+                  },
+                  "hash":1042880134,
+                  "location": {
+                    "spanId": 123456,
+                    "line": 1,
+                    "method": "fooMethod",
+                    "path": "foo"
+                  }
+                }
+              ]
+            }
+            """,
+            _vulnerabilitiesScrubber);
+    }
+
+    [Fact]
+    public void GivenTwoLongEvidenceValueVulns_WhenSerializing_JsonIsTruncated()
+    {
+        var batch = new VulnerabilityBatch();
+        var evidence = new Evidence(GenerateLargeString());
+        batch.Add(new Vulnerability("WEAK_HASH", 1042880134, new Location("foo", "fooMethod", 1, 123456), evidence));
+        batch.Add(new Vulnerability("WEAK_HASH", 1042880134, new Location("foo", "fooMethod", 1, 123456), evidence));
+
+        var json = batch.ToTruncatedJson();
+        json.Should().BeJsonEquivalentTo(
+            """
+            {
+              "vulnerabilities": [
+                {
+                  "evidence": {
+                    "value": "MAX SIZE EXCEEDED"
+                  },
+                  "hash": 1042880134,
+                  "location": {
+                    "spanId": 123456,
+                    "line": 1,
+                    "method": "fooMethod",
+                    "path": "foo"
+                  },
+                  "type": "WEAK_HASH"
+                },
+                {
+                  "evidence": {
+                    "value": "MAX SIZE EXCEEDED"
+                  },
+                  "hash": 1042880134,
+                  "location": {
+                    "spanId": 123456,
+                    "line": 1,
+                    "method": "fooMethod",
+                    "path": "foo"
+                  },
+                  "type": "WEAK_HASH"
+                }
+              ]
+            }
+            """,
+            _vulnerabilitiesScrubber);
+    }
+
+    [Fact]
+    public void GivenLotsOfVulns_WhenSerializing_JsonIsTruncated()
+    {
+        var batch = new VulnerabilityBatch();
+        for (int i = 0; i < 40; i++)
+        {
+            batch.Add(GenerateBigVulnerability());
+        }
+
+        var json = batch.ToJson();
+        json.Should().NotContain("source");
+        CountGenericEvidenceOccurrences(json).Should().Be(batch.Vulnerabilities.Count);
+    }
+
+    private static string GenerateLargeString()
+    {
+        int targetSize = 26 * 1024;
+        StringBuilder sb = new StringBuilder();
+        System.Random random = new System.Random();
+        while (sb.Length < targetSize)
+        {
+            sb.Append(random.Next());
+        }
+
+        return sb.ToString();
+    }
+
+    private static Vulnerability GenerateBigVulnerability()
+    {
+        var largeString = GenerateLargeString();
+        return new Vulnerability(
+            "WEAK_HASH",
+            new Location("foo", "fooMethod", 1, 1042880134),
+            new Evidence(largeString, [new Range(0, largeString.Length, new Source(SourceType.RequestParameterValue, "key2", largeString))]));
+    }
+
+    private static int CountGenericEvidenceOccurrences(string input)
+    {
+        var pattern = new System.Text.RegularExpressions.Regex(@"""evidence""\:\s+\{\s+""value"":\s+""MAX SIZE EXCEEDED""\s+\}", System.Text.RegularExpressions.RegexOptions.Compiled);
+        var matches = pattern.Matches(input);
+        return matches.Count;
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/evidence-redaction-suite.yml
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/evidence-redaction-suite.yml
@@ -1636,7 +1636,7 @@ suite:
             }
           }
         ]
-      }
+      }   
 
   - type: 'VULNERABILITIES'
     description: 'SQLi exploited'
@@ -1671,7 +1671,6 @@ suite:
           }
         ]
       }
-
   - type: 'VULNERABILITIES'
     description: 'Consecutive ranges - at the beginning'
     input: >
@@ -1751,7 +1750,8 @@ suite:
             }
           }
         ]
-      }
+      } 
+
   - type: 'VULNERABILITIES'
     description: 'Tainted range based redaction - with redactable source '
     input: >
@@ -1854,7 +1854,8 @@ suite:
             }
           }
         ]
-      }
+      } 
+
   - type: 'VULNERABILITIES'
     description: 'Tainted range based redaction - first range at the beginning '
     input: >
@@ -1889,7 +1890,8 @@ suite:
             }
           }
         ]
-      }
+      } 
+
   - type: 'VULNERABILITIES'
     description: 'Tainted range based redaction - last range at the end '
     input: >
@@ -1923,7 +1925,8 @@ suite:
             }
           }
         ]
-      }
+      } 
+
   - type: 'VULNERABILITIES'
     description: 'Tainted range based redaction - whole text '
     input: >
@@ -1953,7 +1956,7 @@ suite:
             }
           }
         ]
-      }
+      } 
 
   - type: 'VULNERABILITIES'
     description: 'Mongodb json query with sensitive source'
@@ -2120,6 +2123,291 @@ suite:
                 { "value": "\": " },
                 { "redacted": true },
                 { "value": "\n  }\n}" }
+              ]
+            }
+          }
+        ]
+      }
+
+  - type: 'VULNERABILITIES'
+    description: 'Redacted source that needs to be truncated'
+    input: >
+      [
+        {
+          "type": "SQL_INJECTION",
+          "evidence": {
+            "value": "select * from users where username = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Sed ut perspiciatis unde omnis iste natus error sit voluptatem ac'",
+            "ranges": [
+              { "start" : 26, "length" : 523, "source": { "origin": "http.request.parameter", "name": "clause", "value": "username = 'Lorem%20ipsum%20dolor%20sit%20amet,%20consectetur%20adipiscing%20elit,%20sed%20do%20eiusmod%20tempor%20incididunt%20ut%20labore%20et%20dolore%20magna%20aliqua.%20Ut%20enim%20ad%20minim%20veniam,%20quis%20nostrud%20exercitation%20ullamco%20laboris%20nisi%20ut%20aliquip%20ex%20ea%20commodo%20consequat.%20Duis%20aute%20irure%20dolor%20in%20reprehenderit%20in%20voluptate%20velit%20esse%20cillum%20dolore%20eu%20fugiat%20nulla%20pariatur.%20Excepteur%20sint%20occaecat%20cupidatat%20non%20proident,%20sunt%20in%20culpa%20qui%20officia%20deserunt%20mollit%20anim%20id%20est%20laborum.Sed%20ut%20perspiciatis%20unde%20omnis%20iste%20natus%20error%20sit%20voluptatem%20ac'" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "clause", "redacted": true, "pattern": "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab", "truncated": "right"}
+        ],
+        "vulnerabilities": [
+          {
+            "type": "SQL_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "select * from users where " },
+                { "source": 0, "value": "username = '" },
+                { "source": 0, "redacted": true, "truncated": "right", "pattern": "**********************************************************************************************************************************************************************************************************************************************************" },
+                { "source": 0, "value": "'" }
+              ]
+            }
+          }
+        ]
+      } 
+
+  - type: 'VULNERABILITIES'
+    description: 'No redacted that needs to be truncated - whole text'
+    input: >
+      [
+        {
+          "type": "XSS",
+          "evidence": {
+            "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Sed ut perspiciatis unde omnis iste natus error sit voluptatem ac",
+            "ranges": [
+              { "start" : 0, "length" : 510, "source": { "origin": "http.request.parameter", "name": "text", "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.Sed ut perspiciatis unde omnis iste natus error sit voluptatem ac" }}
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "text", "truncated": "right", "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure do"}
+        ],
+        "vulnerabilities": [
+          {
+            "type": "XSS",
+            "evidence": {
+              "valueParts": [
+                { "source": 0, "truncated": "right", "value": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure do" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Header injection without sensitive data'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "custom: text",
+            "ranges": [
+              { "start" : 8, "length" : 4, "source": { "origin": "http.request.parameter", "name": "param", "value": "text" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "param", "value": "text" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "HEADER_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "custom: " },
+                { "source": 0, "value": "text" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Header injection with only sensitive data from tainted'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "custom: pass",
+            "ranges": [
+              { "start" : 8, "length" : 4, "source": { "origin": "http.request.parameter", "name": "password", "value": "pass" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "password", "redacted": true, "pattern": "abcd" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "HEADER_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "custom: " },
+                { "source": 0, "redacted": true, "pattern": "abcd" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Header injection with partial sensitive data from tainted'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "custom: this is pass",
+            "ranges": [
+              { "start" : 16, "length" : 4, "source": { "origin": "http.request.parameter", "name": "password", "value": "pass" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "password", "redacted": true, "pattern": "abcd" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "HEADER_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "custom: this is " },
+                { "source": 0, "redacted": true, "pattern": "abcd" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Header injection with sensitive data from header name'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "password: text",
+            "ranges": [
+              { "start" : 10, "length" : 4, "source": { "origin": "http.request.parameter", "name": "param", "value": "text" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "param", "redacted": true, "pattern": "abcd" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "HEADER_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "password: " },
+                { "source": 0, "redacted": true, "pattern": "abcd" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Header injection with sensitive data from header value'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "custom: bearer 1234123",
+            "ranges": [
+              { "start" : 15, "length" : 7, "source": { "origin": "http.request.parameter", "name": "param", "value": "1234123" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "param", "redacted": true, "pattern": "abcdefg" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "HEADER_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "custom: " },
+                { "redacted": true },
+                { "source": 0, "redacted": true, "pattern": "abcdefg" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Header injection with sensitive data from header and tainted'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "password: this is pass",
+            "ranges": [
+              { "start" : 18, "length" : 4, "source": { "origin": "http.request.parameter", "name": "password", "value": "pass" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "password", "redacted": true, "pattern": "abcd" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "HEADER_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "password: " },
+                { "redacted": true },
+                { "source": 0, "redacted": true, "pattern": "abcd" }
+              ]
+            }
+          }
+        ]
+      }
+  - type: 'VULNERABILITIES'
+    description: 'Header injection with sensitive data from header and tainted (source does not match)'
+    input: >
+      [
+        {
+          "type": "HEADER_INJECTION",
+          "evidence": {
+            "value": "password: this is key word",
+            "ranges": [
+              { "start" : 18, "length" : 8, "source": { "origin": "http.request.parameter", "name": "password", "value": "key%20word" } }
+            ]
+          }
+        }
+      ]
+    expected: >
+      {
+        "sources": [
+          { "origin": "http.request.parameter", "name": "password", "redacted": true, "pattern": "abcdefghij" }
+        ],
+        "vulnerabilities": [
+          {
+            "type": "HEADER_INJECTION",
+            "evidence": {
+              "valueParts": [
+                { "value": "password: " },
+                { "redacted": true },
+                { "source": 0, "redacted": true, "pattern": "********" }
               ]
             }
           }

--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/TestHelper.cs
@@ -394,7 +394,7 @@ namespace Datadog.Trace.TestHelpers
 
         public void EnableIastTelemetry(int level)
         {
-            SetEnvironmentVariable(ConfigurationKeys.Iast.IastTelemetryVerbosity, ((IastMetricsVerbosityLevel)level).ToString());
+            SetEnvironmentVariable(ConfigurationKeys.Iast.TelemetryVerbosity, ((IastMetricsVerbosityLevel)level).ToString());
         }
 
         public void DisableObfuscationQueryString()

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -479,6 +479,7 @@
   "DD_IAST_REDACTION_REGEXP_TIMEOUT": "iast_redaction_regexp_timeout",
   "DD_IAST_REGEXP_TIMEOUT": "iast_regexp_timeout",
   "DD_IAST_TELEMETRY_VERBOSITY": "iast_telemetry_verbosity",
+  "DD_IAST_TRUNCATION_MAX_VALUE_LENGTH": "iast_truncation_max_value_length",
   "DD_TRACE_STARTUP_LOGS": "trace_startup_logs_enabled",
   "DD_MAX_LOGFILE_SIZE": "trace_log_file_max_size",
   "DD_TRACE_LOGGING_RATE": "trace_log_rate",

--- a/tracer/test/snapshots/Iast.NewtonsoftJsonParseTainting.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.NewtonsoftJsonParseTainting.AspNetCore5.IastEnabled.verified.txt
@@ -26,7 +26,7 @@
   "vulnerabilities": [
     {
       "type": "COMMAND_INJECTION",
-      "hash": -177455026,
+      "hash": -430498668,
       "location": {
         "spanId": XXX,
         "path": "Samples.Security.AspNetCore5.Controllers.IastController",


### PR DESCRIPTION
## Summary of changes
Implementation of [this RFC](https://docs.google.com/document/d/1cAsBBOusoAvU6wRMez2M5JXqTwUwG6tddmX4LsxSAyI/edit#heading=h.yvvow75ahvw6)

## Reason for change
Under certain circumstances, evidences could be too long, incurring in an excessive resource consumption. Also, too big vulnerability batches (more than 25KB) could make the agent misbehave.

## Implementation details
Added controls to limit final vulnerability batch size and max evidence values length.

## Test coverage
Updated redaction test suite and implemented ad-hoc unit tests

