### PR TITLE
[ASM] Try fix memory buildup in asm benchmarks removing destructor in Obj

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -38,6 +38,8 @@ partial class Build : NukeBuild
                     "tracer/src/Datadog.Trace/Iast",
                     "tracer/src/Datadog.Tracer.Native/iast",
                     "tracer/src/Datadog.Trace/AppSec",
+                    "tracer/test/benchmarks/Benchmarks.Trace/Asm",
+                    "tracer/test/benchmarks/Benchmarks.Trace/Iast",
                     "tracer/test/Datadog.Trace.Security.IntegrationTests",
                     "tracer/test/Datadog.Trace.Security.Unit.Tests",
                     "tracer/test/test-applications/security",

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Obj.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Obj.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
         private IntPtr ptr;
         private DdwafObjectStruct innerObj;
         private bool innerObjInitialized;
+        private bool _disposed;
 
         public Obj(IntPtr ptr) => this.ptr = ptr;
 
@@ -68,10 +69,14 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
         public void Dispose()
         {
-            if (ptr != IntPtr.Zero)
+            if (!_disposed)
             {
-                Marshal.FreeHGlobal(ptr);
-                ptr = IntPtr.Zero;
+                _disposed = true;
+                if (ptr != IntPtr.Zero)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                    ptr = IntPtr.Zero;
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Obj.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Obj.cs
@@ -16,14 +16,8 @@ namespace Datadog.Trace.AppSec.WafEncoding
         private IntPtr ptr;
         private DdwafObjectStruct innerObj;
         private bool innerObjInitialized;
-        private bool disposed;
 
         public Obj(IntPtr ptr) => this.ptr = ptr;
-
-        ~Obj()
-        {
-            Dispose(false);
-        }
 
         public ObjType ArgsType
         {
@@ -72,32 +66,8 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
         public IntPtr RawPtr => ptr;
 
-        public void Dispose(WafLibraryInvoker libraryInvoker)
-        {
-            if (libraryInvoker != null)
-            {
-                var rawPtr = ptr;
-                libraryInvoker.ObjectFreePtr(ref rawPtr);
-                Dispose();
-            }
-        }
-
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (disposed)
-            {
-                ptr = IntPtr.Zero;
-                return;
-            }
-
-            disposed = true;
-
             if (ptr != IntPtr.Zero)
             {
                 Marshal.FreeHGlobal(ptr);

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
@@ -96,8 +96,7 @@ public class AppSecEncoderBenchmark
         return new NestedMap(root, nestingDepth, withAttack);
     }
 
-    // deactivate for now as it's slowing CI down. Reactivate when run only when an appsecfile changed is setup in CI
-    // [Benchmark]
+    [Benchmark]
     public void EncodeArgs()
     {
         using var pwArgs = _encoder.Encode(_args.Map, applySafetyLimits: true);


### PR DESCRIPTION
## Summary of changes

Remove Obj destructor and suppress finalizer to allow gc do its job.
Fix/add little things in benchmark

## Reason for change

Benchmarks show a build up in memory 

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
