### PR TITLE
[Tracer] Delay sampling decisions

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/TraceChunkModel.cs
@@ -73,10 +73,12 @@ internal readonly struct TraceChunkModel
     private TraceChunkModel(in ArraySegment<Span> spans, TraceContext? traceContext, int? samplingPriority)
         : this(spans, traceContext?.RootSpan)
     {
+        // sampling decision override takes precedence over TraceContext.SamplingPriority
         SamplingPriority = samplingPriority;
 
         if (traceContext is not null)
         {
+            // only use TraceContext.SamplingPriority if there was  no override value
             SamplingPriority ??= traceContext.SamplingPriority;
 
             Environment = traceContext.Environment;

--- a/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
+++ b/tracer/src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Agent.TraceSamplers
         {
             for (int i = 0; i < trace.Count; i++)
             {
-                var span = trace.Array[i + trace.Offset];
+                var span = trace.Array![i + trace.Offset];
                 if (span.IsTopLevel || span.GetMetric(Tags.Measured) == 1.0 || span.GetMetric(Tags.PartialSnapshot) > 0)
                 {
                     UpdateSpan(span);
@@ -68,7 +68,7 @@ namespace Datadog.Trace.Agent.TraceSamplers
 
             for (int i = 0; i < trace.Count; i++)
             {
-                var span = trace.Array[i + trace.Offset];
+                var span = trace.Array![i + trace.Offset];
                 if (span.IsTopLevel || span.GetMetric(Tags.Measured) == 1.0 || span.GetMetric(Tags.PartialSnapshot) > 0)
                 {
                     // Follow agent implementation to mark and exit on first sampled span

--- a/tracer/src/Datadog.Trace/AppSec/ApiSecurity.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ApiSecurity.cs
@@ -10,6 +10,7 @@ using System.Collections.Specialized;
 using System.Runtime.CompilerServices;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Sampling;
 
 namespace Datadog.Trace.AppSec;
 
@@ -34,8 +35,9 @@ internal class ApiSecurity
     {
         try
         {
-            var samplingPriority = localRootSpan.Context.TraceContext.SamplingPriority;
-            if (_enabled && lastWafCall && samplingPriority is SamplingPriorityValues.AutoKeep or SamplingPriorityValues.UserKeep)
+            var samplingPriority = localRootSpan.Context.TraceContext.GetOrMakeSamplingDecision();
+
+            if (_enabled && lastWafCall && SamplingPriorityValues.IsKeep(samplingPriority))
             {
                 var httpRouteTag = localRootSpan.GetTag(Tags.AspNetCoreEndpoint) ?? localRootSpan.GetTag(Tags.HttpRoute);
                 var httpMethod = localRootSpan.GetTag(Tags.HttpMethod);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaCommon.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
-using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
@@ -40,9 +39,7 @@ internal abstract class LambdaCommon
         if (samplingPriority == null)
         {
             Log("samplingPriority not found");
-
-            var samplingDecision = tracer.CurrentTraceSettings.TraceSampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-            span.Context.TraceContext?.SetSamplingPriority(samplingDecision);
+            _ = span.Context.TraceContext?.GetOrMakeSamplingDecision();
         }
         else
         {

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaRequestBuilder.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/LambdaRequestBuilder.cs
@@ -47,10 +47,8 @@ internal class LambdaRequestBuilder : ILambdaExtensionRequest
             request.Headers.Set(HttpHeaderNames.TraceId, span.TraceId128.Lower.ToString(CultureInfo.InvariantCulture));
             request.Headers.Set(HttpHeaderNames.SpanId, span.SpanId.ToString(CultureInfo.InvariantCulture));
 
-            if (span.Context.TraceContext?.SamplingPriority is { } samplingPriority)
-            {
-                request.Headers.Set(HttpHeaderNames.SamplingPriority, samplingPriority.ToString());
-            }
+            var samplingPriority = span.Context.TraceContext?.GetOrMakeSamplingDecision();
+            request.Headers.Set(HttpHeaderNames.SamplingPriority, SamplingPriorityValues.ToString(samplingPriority));
 
             var errorMessage = span.GetTag("error.msg");
             if (errorMessage != null)
@@ -82,4 +80,3 @@ internal class LambdaRequestBuilder : ILambdaExtensionRequest
 }
 
 #endif
-

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
@@ -249,13 +249,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
             span.Type = SpanTypes.Grpc;
             span.ResourceName = methodFullName;
 
-            if (span.Context.TraceContext.SamplingPriority == null)
-            {
-                // If we don't add the span to the trace context, then we need to manually call the sampler
-                var samplingDecision = tracer.CurrentTraceSettings.TraceSampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-                span.Context.TraceContext.SetSamplingPriority(samplingDecision);
-            }
-
             return span;
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/ScopeFactory.cs
@@ -120,13 +120,6 @@ namespace Datadog.Trace.ClrProfiler
 
                 tags.SetAnalyticsSampleRate(integrationId, tracer.Settings, enabledWithGlobalSetting: false);
                 tracer.CurrentTraceSettings.Schema.RemapPeerService(tags);
-
-                if (!addToTraceContext && span.Context.TraceContext.SamplingPriority == null)
-                {
-                    // If we don't add the span to the trace context, then we need to manually call the sampler
-                    var samplingDecision = tracer.CurrentTraceSettings.TraceSampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default;
-                    span.Context.TraceContext.SetSamplingPriority(samplingDecision);
-                }
             }
             catch (Exception ex)
             {

--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -73,13 +73,11 @@ namespace Datadog.Trace.Propagators
 
         internal static void CreateHeaders(SpanContext context, out string traceId, out string spanId, out string sampled)
         {
-            // BUG: we should fall back to SamplingPriorityValues.AutoKeep
-            var samplingPriority = context.TraceContext?.SamplingPriority ??
-                                   context.SamplingPriority; // should never happen in production, but some tests rely on this
-
-            sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "1" : "0";
             traceId = context.RawTraceId;
             spanId = context.RawSpanId;
+
+            var samplingPriority = context.GetOrMakeSamplingDecision() ?? SamplingPriorityValues.Default;
+            sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "1" : "0";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -139,10 +139,7 @@ namespace Datadog.Trace.Propagators
 
         internal static string CreateHeader(SpanContext context)
         {
-            // BUG: we should fall back to SamplingPriorityValues.AutoKeep
-            var samplingPriority = context.TraceContext?.SamplingPriority ??
-                                   context.SamplingPriority; // should never happen in production, but some tests rely on this
-
+            var samplingPriority = context.GetOrMakeSamplingDecision() ?? SamplingPriorityValues.Default;
             var sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "1" : "0";
 
 #if NET6_0_OR_GREATER

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -36,10 +36,7 @@ namespace Datadog.Trace.Propagators
                 carrierSetter.Set(carrier, HttpHeaderNames.Origin, context.Origin);
             }
 
-            var samplingPriority = context.TraceContext?.SamplingPriority ??
-                                   context.SamplingPriority; // should never happen in production, but some tests rely on this
-
-            if (samplingPriority != null)
+            if (context.GetOrMakeSamplingDecision() is { } samplingPriority)
             {
                 var samplingPriorityString = SamplingPriorityValues.ToString(samplingPriority);
                 carrierSetter.Set(carrier, HttpHeaderNames.SamplingPriority, samplingPriorityString);

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -113,6 +113,9 @@ namespace Datadog.Trace.Propagators
             if (context == null!) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
 
+            // trigger a sampling decision if it hasn't happened yet
+            _ = context.GetOrMakeSamplingDecision();
+
             for (var i = 0; i < _injectors.Length; i++)
             {
                 _injectors[i].Inject(context, carrier, carrierSetter);

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -132,10 +132,7 @@ namespace Datadog.Trace.Propagators
 
         internal static string CreateTraceParentHeader(SpanContext context)
         {
-            var samplingPriority = context.TraceContext?.SamplingPriority ??
-                                   context.SamplingPriority ?? // should never happen in production, but some tests rely on this
-                                   SamplingPriorityValues.AutoKeep; // fallback
-
+            var samplingPriority = context.GetOrMakeSamplingDecision() ?? SamplingPriorityValues.Default;
             var sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "01" : "00";
 
 #if NET6_0_OR_GREATER
@@ -154,7 +151,7 @@ namespace Datadog.Trace.Propagators
                 sb.Append("dd=");
 
                 // sampling priority ("s:<value>")
-                if (context.TraceContext?.SamplingPriority is { } samplingPriority)
+                if (context.GetOrMakeSamplingDecision() is { } samplingPriority)
                 {
                     sb.Append("s:").Append(SamplingPriorityValues.ToString(samplingPriority)).Append(TraceStateDatadogPairsSeparator);
                 }

--- a/tracer/src/Datadog.Trace/SamplingPriorityValues.cs
+++ b/tracer/src/Datadog.Trace/SamplingPriorityValues.cs
@@ -59,8 +59,8 @@ namespace Datadog.Trace
             };
         }
 
-        internal static bool IsKeep(int? samplingPriority) => samplingPriority > 0;
+        internal static bool IsKeep(int samplingPriority) => samplingPriority > 0;
 
-        internal static bool IsDrop(int? samplingPriority) => samplingPriority <= 0;
+        internal static bool IsDrop(int samplingPriority) => samplingPriority <= 0;
     }
 }

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -360,8 +360,7 @@ namespace Datadog.Trace
 
                 case Keys.SamplingPriority:
                 case HttpHeaderNames.SamplingPriority:
-                    // return the value from TraceContext if available
-                    var samplingPriority = TraceContext?.SamplingPriority ?? SamplingPriority;
+                    var samplingPriority = GetOrMakeSamplingDecision();
                     value = samplingPriority?.ToString(invariant);
                     return true;
 
@@ -415,6 +414,14 @@ namespace Datadog.Trace
                        _ => (TraceId)context.TraceId
                    };
         }
+
+        /// <summary>
+        /// If <see cref="TraceContext"/> is not null, returns <see cref="Trace.TraceContext.GetOrMakeSamplingDecision"/>.
+        /// Otherwise, returns <see cref="SamplingPriority"/>.
+        /// </summary>
+        internal int? GetOrMakeSamplingDecision() =>
+            TraceContext?.GetOrMakeSamplingDecision() ?? // this SpanContext belongs to a local trace
+            SamplingPriority; // this a propagated context (also some tests rely on this)
 
         [return: MaybeNull]
         internal TraceTagCollection PrepareTagsForPropagation()

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -146,12 +146,6 @@ namespace Datadog.Trace
             if (Interlocked.CompareExchange(ref _rootSpan, span, null) == null)
             {
                 span.MarkSpanForExceptionDebugging();
-
-                // if we don't have a sampling priority yet, make a sampling decision now
-                if (_samplingPriority == null)
-                {
-                    SetSamplingPriority(CurrentTraceSettings?.TraceSampler?.MakeSamplingDecision(span) ?? SamplingDecision.Default);
-                }
             }
 
             lock (_rootSpan)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -32,7 +32,6 @@ namespace Datadog.Trace
 
         private ArrayBuilder<Span> _spans;
         private int _openSpans;
-        private int? _samplingPriority;
 
         // _rootSpan was chosen in #4125 to be the lock that protects
         // * _spans
@@ -82,10 +81,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the trace's sampling priority.
         /// </summary>
-        public int? SamplingPriority
-        {
-            get => _samplingPriority;
-        }
+        public int? SamplingPriority { get; private set; }
 
         public string? Environment { get; set; }
 
@@ -253,7 +249,7 @@ namespace Datadog.Trace
 
         public int GetOrMakeSamplingDecision()
         {
-            if (_samplingPriority is { } samplingPriority)
+            if (SamplingPriority is { } samplingPriority)
             {
                 // common case: we already have a sampling decision
                 return samplingPriority;
@@ -292,7 +288,7 @@ namespace Datadog.Trace
                 return;
             }
 
-            _samplingPriority = priority;
+            SamplingPriority = priority;
 
             const string tagName = Trace.Tags.Propagated.DecisionMaker;
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -282,6 +282,11 @@ namespace Datadog.Trace
             return samplingDecision.Priority;
         }
 
+        public void SetSamplingPriority(SamplingDecision decision, bool notifyDistributedTracer = true)
+        {
+            SetSamplingPriority(decision.Priority, decision.Mechanism, notifyDistributedTracer);
+        }
+
         public void SetSamplingPriority(int? priority, int? mechanism = null, bool notifyDistributedTracer = true)
         {
             if (priority == null)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -286,21 +286,21 @@ namespace Datadog.Trace
 
         public void SetSamplingPriority(int? priority, int? mechanism = null, bool notifyDistributedTracer = true)
         {
-            if (priority == null)
+            if (priority is not { } p)
             {
                 return;
             }
 
-            SamplingPriority = priority;
+            SamplingPriority = p;
 
-            if (priority > 0 && mechanism != null)
+            if (SamplingPriorityValues.IsKeep(p) && mechanism is { } m)
             {
-                // add the tag once, but never overwrite an existing tag
-                Tags.TryAddTag(Trace.Tags.Propagated.DecisionMaker, SamplingMechanism.GetTagValue(mechanism.Value));
+                // add the tag once if trace is sampled, but never overwrite an existing tag
+                Tags.TryAddTag(Trace.Tags.Propagated.DecisionMaker, SamplingMechanism.GetTagValue(m));
             }
-            else if (priority <= 0)
+            else if (SamplingPriorityValues.IsDrop(p))
             {
-                // remove tag if priority is AUTO_DROP (0) or USER_DROP (-1)
+                // remove tag if trace is not sampled
                 Tags.RemoveTag(Trace.Tags.Propagated.DecisionMaker);
             }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -228,6 +228,7 @@ namespace Datadog.Trace
 
             if (spansToWrite.Count > 0)
             {
+                GetOrMakeSamplingDecision();
                 RunSpanSampler(spansToWrite);
                 Tracer.Write(spansToWrite);
             }
@@ -246,6 +247,7 @@ namespace Datadog.Trace
 
             if (spansToWrite.Count > 0)
             {
+                GetOrMakeSamplingDecision();
                 RunSpanSampler(spansToWrite);
                 Tracer.Write(spansToWrite);
             }
@@ -315,11 +317,12 @@ namespace Datadog.Trace
                 return;
             }
 
-            if (SamplingPriorityValues.IsDrop(SamplingPriority))
+            if (SamplingPriority is { } samplingPriority && SamplingPriorityValues.IsDrop(samplingPriority))
             {
                 for (int i = 0; i < spans.Count; i++)
                 {
-                    CurrentTraceSettings.SpanSampler.MakeSamplingDecision(spans.Array![i + spans.Offset]);
+                    var span = spans.Array![i + spans.Offset];
+                    CurrentTraceSettings.SpanSampler.MakeSamplingDecision(span);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -27,8 +27,6 @@ namespace Datadog.Trace
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TraceContext>();
 
-        private readonly TraceClock _clock;
-
         private IastRequestContext? _iastRequestContext;
         private AppSecRequestContext? _appSecRequestContext;
 
@@ -62,7 +60,7 @@ namespace Datadog.Trace
 
             Tracer = tracer;
             Tags = tags ?? new TraceTagCollection();
-            _clock = TraceClock.Instance;
+            Clock = TraceClock.Instance;
         }
 
         public Span? RootSpan
@@ -70,7 +68,7 @@ namespace Datadog.Trace
             get => _rootSpan;
         }
 
-        public TraceClock Clock => _clock;
+        public TraceClock Clock { get; }
 
         public IDatadogTracer Tracer { get; }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -47,7 +47,7 @@ namespace Datadog.Trace
         {
             CurrentTraceSettings = tracer.PerTraceSettings;
 
-            // TODO: Environment, ServiceVersion, GitCommitSha, and GitRepositoryUrl are stored on the TraceContext
+            // TODO: Environment and ServiceVersion are stored on the TraceContext
             // even though they likely won't change for the lifetime of the process. We should consider moving them
             // elsewhere to reduce the memory usage.
             if (tracer.Settings is { } settings)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -265,6 +265,9 @@ namespace Datadog.Trace
                 // we can't make a sampling decision without a root span because:
                 // - we need a trace id, and for now trace id lives in SpanContext, not in TraceContext
                 // - we need to apply sampling rules to the root span
+
+                // note we do not set SamplingDecision
+                // so it remains null and we can try again later
                 return SamplingPriorityValues.Default;
             }
 

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -293,17 +293,15 @@ namespace Datadog.Trace
 
             SamplingPriority = priority;
 
-            const string tagName = Trace.Tags.Propagated.DecisionMaker;
-
             if (priority > 0 && mechanism != null)
             {
                 // add the tag once, but never overwrite an existing tag
-                Tags.TryAddTag(tagName, SamplingMechanism.GetTagValue(mechanism.Value));
+                Tags.TryAddTag(Trace.Tags.Propagated.DecisionMaker, SamplingMechanism.GetTagValue(mechanism.Value));
             }
             else if (priority <= 0)
             {
                 // remove tag if priority is AUTO_DROP (0) or USER_DROP (-1)
-                Tags.RemoveTag(tagName);
+                Tags.RemoveTag(Trace.Tags.Propagated.DecisionMaker);
             }
 
             if (notifyDistributedTracer)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -284,7 +284,7 @@ namespace Datadog.Trace
         {
             if (string.IsNullOrWhiteSpace(settings.SpanSamplingRules))
             {
-                return new SpanSampler(Enumerable.Empty<ISpanSamplingRule>());
+                return new SpanSampler([]);
             }
 
             return new SpanSampler(SpanSamplingRule.BuildFromConfigurationString(settings.SpanSamplingRules, RegexBuilder.DefaultTimeout));

--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -37,8 +37,12 @@ namespace Datadog.Trace.Util
 
         internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace)
         {
-            var traceContext = TraceContext.GetTraceContext(trace);
-            return SamplingPriorityValues.IsKeep(traceContext?.SamplingPriority);
+            if (TraceContext.GetTraceContext(trace)?.SamplingPriority is { } samplingPriority)
+            {
+                return SamplingPriorityValues.IsKeep(samplingPriority);
+            }
+
+            return false;
         }
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/Sampling/DelaySamplingDecisionTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Sampling/DelaySamplingDecisionTests.cs
@@ -66,6 +66,7 @@ public class DelaySamplingDecisionTests
 
         var tracer = new Tracer(settings, agentWriter.Object, sampler.Object, scopeManager, statsd);
         TraceContext traceContext;
+        int samplingPriority;
 
         using (var scope1 = (Scope)tracer.StartActive("operation"))
         {
@@ -81,11 +82,13 @@ public class DelaySamplingDecisionTests
             // sampling decision IS taken before propagating
             sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Once);
             traceContext.SamplingPriority.Should().NotBeNull();
-            headers["x-datadog-sampling-priority"].Should().Be(traceContext.SamplingPriority.ToString());
+            headers["x-datadog-sampling-priority"].Should().Be(SamplingPriorityValues.ToString(traceContext.SamplingPriority));
+
+            samplingPriority = traceContext.SamplingPriority!.Value;
         }
 
-        // sampling decision is still there and is NOT taken again when first span ends
+        // sampling decision hasn't changed and is NOT taken again when first span ends
         sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Once);
-        traceContext.SamplingPriority.Should().NotBeNull();
+        traceContext.SamplingPriority.Should().Be(samplingPriority);
     }
 }

--- a/tracer/test/Datadog.Trace.IntegrationTests/Sampling/DelaySamplingDecisionTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Sampling/DelaySamplingDecisionTests.cs
@@ -1,0 +1,91 @@
+﻿// <copyright file="DelaySamplingDecisionTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Specialized;
+using Datadog.Trace.Agent;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.DogStatsd;
+using Datadog.Trace.ExtensionMethods;
+using Datadog.Trace.Propagators;
+using Datadog.Trace.Sampling;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.IntegrationTests.Sampling;
+
+public class DelaySamplingDecisionTests
+{
+    [Fact]
+    public void SamplingDecisionIsNotMadeUntilLastSpanEnds()
+    {
+        var settings = new TracerSettings();
+        var agentWriter = new Mock<IAgentWriter>();
+        var sampler = new Mock<ITraceSampler>();
+        var scopeManager = new AsyncLocalScopeManager();
+        var statsd = new NoOpStatsd();
+
+        var tracer = new Tracer(settings, agentWriter.Object, sampler.Object, scopeManager, statsd);
+        TraceContext traceContext;
+
+        using (var scope1 = (Scope)tracer.StartActive("operation"))
+        {
+            traceContext = scope1.Span.Context.TraceContext;
+
+            // sampling decision not taken when first span starts
+            sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Never);
+            traceContext.SamplingPriority.Should().BeNull();
+
+            using ((Scope)tracer.StartActive("operation"))
+            {
+                // sampling decision still not taken when second span starts
+                sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Never);
+                traceContext.SamplingPriority.Should().BeNull();
+            }
+
+            // sampling decision still not taken when second span ends
+            sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Never);
+            traceContext.SamplingPriority.Should().BeNull();
+        }
+
+        // sampling decision IS taken after LAST span ends
+        sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Once);
+        traceContext.SamplingPriority.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void SamplingDecisionIsMadeWhenPropagating()
+    {
+        var settings = new TracerSettings();
+        var agentWriter = new Mock<IAgentWriter>();
+        var sampler = new Mock<ITraceSampler>();
+        var scopeManager = new AsyncLocalScopeManager();
+        var statsd = new NoOpStatsd();
+
+        var tracer = new Tracer(settings, agentWriter.Object, sampler.Object, scopeManager, statsd);
+        TraceContext traceContext;
+
+        using (var scope1 = (Scope)tracer.StartActive("operation"))
+        {
+            traceContext = scope1.Span.Context.TraceContext;
+
+            // sampling decision not taken when first span starts
+            sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Never);
+            traceContext.SamplingPriority.Should().BeNull();
+
+            var headers = new NameValueCollection();
+            SpanContextPropagator.Instance.Inject(scope1.Span.Context, headers.Wrap());
+
+            // sampling decision IS taken before propagating
+            sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Once);
+            traceContext.SamplingPriority.Should().NotBeNull();
+            headers["x-datadog-sampling-priority"].Should().Be(traceContext.SamplingPriority.ToString());
+        }
+
+        // sampling decision is still there and is NOT taken again when first span ends
+        sampler.Verify(s => s.MakeSamplingDecision(It.IsAny<Span>()), Times.Once);
+        traceContext.SamplingPriority.Should().NotBeNull();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -47,19 +47,18 @@ namespace Datadog.Trace.Tests.Propagators
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
-            // BUG: we should default to KEEP if there's no sampler, but this never happens in real life, will fix later
-            newHeaders.Verify(h => h.Set("x-b3-sampled", "0"), Times.Once());
+            newHeaders.Verify(h => h.Set("x-b3-sampled", "1"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
 
             B3Propagator.Inject(newContext, newHeaders.Object);
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
-            newHeaders.Verify(h => h.Set("x-b3-sampled", "1"), Times.Once());
+            newHeaders.Verify(h => h.Set("x-b3-sampled", "0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
         }
 
@@ -89,19 +88,18 @@ namespace Datadog.Trace.Tests.Propagators
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
-            // BUG: we should default to KEEP if there's no sampler, but this never happens in real life, will fix later
-            newHeaders.Verify(h => h.Set("x-b3-sampled", "0"), Times.Once());
+            newHeaders.Verify(h => h.Set("x-b3-sampled", "1"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
 
             B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
-            newHeaders.Verify(h => h.Set("x-b3-sampled", "1"), Times.Once());
+            newHeaders.Verify(h => h.Set("x-b3-sampled", "0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -40,15 +40,14 @@ namespace Datadog.Trace.Tests.Propagators
             var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object);
-            // BUG: we should default to KEEP if there's no sampler, but this never happens in real life, will fix later
-            newHeaders.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-0"), Times.Once());
+            newHeaders.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-1"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object);
-            newHeaders.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-1"), Times.Once());
+            newHeaders.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
         }
 
@@ -72,15 +71,14 @@ namespace Datadog.Trace.Tests.Propagators
             var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
-            // BUG: we should default to KEEP if there's no sampler, but this never happens in real life, will fix later
-            newHeaders.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-0"), Times.Once());
+            newHeaders.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-1"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
             // override sampling decision
-            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
+            newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserReject);
             newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
-            newHeaders.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-1"), Times.Once());
+            newHeaders.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -56,10 +56,10 @@ namespace Datadog.Trace.Tests.Propagators
         }
 
         [Theory]
-        // null/empty/whitespace
-        [InlineData(null, null, null, null, "dd=p:0000000000000002")]
-        [InlineData(null, "", "", "", "dd=p:0000000000000002")]
-        [InlineData(null, " ", " ", " ", "dd=p:0000000000000002")]
+        // null/empty/whitespace (sampling priority default is 1)
+        [InlineData(null, null, null, null, "dd=s:1;p:0000000000000002")]
+        [InlineData(null, "", "", "", "dd=s:1;p:0000000000000002")]
+        [InlineData(null, " ", " ", " ", "dd=s:1;p:0000000000000002")]
         // sampling priority only
         [InlineData(SamplingPriorityValues.UserReject, null, null, null, "dd=s:-1;p:0000000000000002")]
         [InlineData(SamplingPriorityValues.AutoReject, null, null, null, "dd=s:0;p:0000000000000002")]
@@ -68,19 +68,19 @@ namespace Datadog.Trace.Tests.Propagators
         [InlineData(3, null, null, null, "dd=s:3;p:0000000000000002")]
         [InlineData(-5, null, null, null, "dd=s:-5;p:0000000000000002")]
         // origin only
-        [InlineData(null, "abc", null, null, "dd=o:abc;p:0000000000000002")]
-        [InlineData(null, "synthetics~;,=web", null, null, "dd=o:synthetics___~web;p:0000000000000002")]
+        [InlineData(null, "abc", null, null, "dd=s:1;o:abc;p:0000000000000002")]
+        [InlineData(null, "synthetics~;,=web", null, null, "dd=s:1;o:synthetics___~web;p:0000000000000002")]
         // propagated tags only
-        [InlineData(null, null, "_dd.p.a=1", null, "dd=p:0000000000000002;t.a:1")]
-        [InlineData(null, null, "_dd.p.a=1,_dd.p.b=2", null, "dd=p:0000000000000002;t.a:1;t.b:2")]
-        [InlineData(null, null, "_dd.p.a=1,b=2", null, "dd=p:0000000000000002;t.a:1")]
-        [InlineData(null, null, "_dd.p.usr.id=MTIzNDU=", null, "dd=p:0000000000000002;t.usr.id:MTIzNDU~")] // convert '=' to '~'
+        [InlineData(null, null, "_dd.p.a=1", null, "dd=s:1;p:0000000000000002;t.a:1")]
+        [InlineData(null, null, "_dd.p.a=1,_dd.p.b=2", null, "dd=s:1;p:0000000000000002;t.a:1;t.b:2")]
+        [InlineData(null, null, "_dd.p.a=1,b=2", null, "dd=s:1;p:0000000000000002;t.a:1")]
+        [InlineData(null, null, "_dd.p.usr.id=MTIzNDU=", null, "dd=s:1;p:0000000000000002;t.usr.id:MTIzNDU~")] // convert '=' to '~'
         // additional state only
-        [InlineData(null, null, null, "key1=value1,key2=value2", "dd=p:0000000000000002,key1=value1,key2=value2")]
+        [InlineData(null, null, null, "key1=value1,key2=value2", "dd=s:1;p:0000000000000002,key1=value1,key2=value2")]
         // combined
         [InlineData(SamplingPriorityValues.UserKeep, "rum", null, "key1=value1", "dd=s:2;o:rum;p:0000000000000002,key1=value1")]
         [InlineData(SamplingPriorityValues.AutoReject, null, "_dd.p.a=b", "key1=value1", "dd=s:0;p:0000000000000002;t.a:b,key1=value1")]
-        [InlineData(null, "rum", "_dd.p.a=b", "key1=value1", "dd=o:rum;p:0000000000000002;t.a:b,key1=value1")]
+        [InlineData(null, "rum", "_dd.p.a=b", "key1=value1", "dd=s:1;o:rum;p:0000000000000002;t.a:b,key1=value1")]
         [InlineData(SamplingPriorityValues.AutoKeep, "rum", "_dd.p.dm=-4,_dd.p.usr.id=12345", "key1=value1", "dd=s:1;o:rum;p:0000000000000002;t.dm:-4;t.usr.id:12345,key1=value1")]
         public void CreateTraceStateHeader(int? samplingPriority, string origin, string tags, string additionalState, string expected)
         {


### PR DESCRIPTION
## Summary of changes

Instead of making a sampling decision as soon as we start a trace, delay the decision until it's needed. Actions that trigger a sampling decision include:
- serializing a trace chunk to send to the agent
- injecting trace context into propagation headers to send to a downstream service

Before this PR, we were making a sampling decision when the first span (local root) was added to a trace (and in a few other places where we created a span but didn't add it to a trace, so we triggered the sampling decision manually).

## Reason for change

Sampling rules require we wait as long as possible before we make a sampling decision because the data we need may not be available yet at the beginning of the first span. For example, an http route may not be determined yet at the time the first span is started. Similarly, matching by span tag may depend on tags that are not added yet when the first span is started.

[See also: RFC](https://docs.google.com/document/d/1xtKkHSMmzgz7X6ZAozltOU53qO6oI0D_jhWnbvN_k8s/edit?usp=sharing)

## Implementation details

- remove the code in `TraceContext.AddSpan()` that triggered a sampling decision when the first span (local root) is added to the trace
- remove code in some integrations which also triggered a sampling decision manually because they created a span without adding it to the trace context, so `TraceContext.AddSpan()` wasn't called yet
- add `int TraceContext.GetOrMakeSamplingDecision()` to trigger a sampling decision when required
- add helper `int? SpanContext.GetOrMakeSamplingDecision()` which defers to the `TraceContext` if available (unfortunately, `SpanContext` is overloaded and contexts are local while others are propagated, and we need to support both for now)
- call one of the `GetOrMakeSamplingDecision()` methods above before serializing a trace chunk or injecting propagation headers

Bonus:
- B3 headers: fix default sampling decision to `"1"` (keep)

## Test coverage

Add tests to assert:
- [ ] Sampling decision is _not_ triggered anymore when first span opens.
- [ ] Sampling decision is triggered when last span is closed.
- [ ] Sampling decision is triggered when we propagate context downstream.

## Other details
<!-- Fixes #{issue} -->
PRs:
1. #5477
2. #5545
3. (this one) #5306
4. #5453
