### PR TITLE
[ASM] Add dummy agent writer for benchmarks

### DIFF
--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBenchmarkUtils.cs
@@ -7,11 +7,18 @@ using System;
 using System.IO;
 using Datadog.Trace;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
+using Datadog.Trace.Configuration;
 
 namespace Benchmarks.Trace.Asm;
 
 internal class AppSecBenchmarkUtils
 {
+    internal static void SetupDummyAgent()
+    {
+        var settings = new TracerSettings { StartupDiagnosticLogEnabled = false, MaxTracesSubmittedPerSecond = 0 };
+        Tracer.UnsafeSetTracerInstance(new Tracer(settings, new DummyAgentWriter(), null, null, null));
+    }
+
     internal static WafLibraryInvoker CreateWafLibraryInvoker()
     {
         var fDesc = FrameworkDescription.Instance;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -52,6 +52,7 @@ namespace Benchmarks.Trace.Asm
 
         static AppSecBodyBenchmark()
         {
+            AppSecBenchmarkUtils.SetupDummyAgent();
             var dir = Directory.GetCurrentDirectory();
             Environment.SetEnvironmentVariable("DD_APPSEC_ENABLED", "true");
             _security = Security.Instance;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecEncodeBenchmark.cs
@@ -26,8 +26,8 @@ public class AppSecEncoderBenchmark
 
     static AppSecEncoderBenchmark()
     {
+        AppSecBenchmarkUtils.SetupDummyAgent();
         _encoder = new Encoder();
-
         var wafLibraryInvoker = AppSecBenchmarkUtils.CreateWafLibraryInvoker();
         _encoderLegacy = new EncoderLegacy(wafLibraryInvoker);
 
@@ -96,7 +96,7 @@ public class AppSecEncoderBenchmark
         return new NestedMap(root, nestingDepth, withAttack);
     }
 
-    [Benchmark]
+    // [Benchmark]
     public void EncodeArgs()
     {
         using var pwArgs = _encoder.Encode(_args.Map, applySafetyLimits: true);

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -31,6 +31,7 @@ public class AppSecWafBenchmark
 
     static AppSecWafBenchmark()
     {
+        AppSecBenchmarkUtils.SetupDummyAgent();
         var wafLibraryInvoker = AppSecBenchmarkUtils.CreateWafLibraryInvoker();
 
         var rulesPath = Path.Combine(Directory.GetCurrentDirectory(), "Asm", "rule-set.1.10.0.json");


### PR DESCRIPTION
## Summary of changes

Fix logs `Error discovering available agent services System.Net.Http.HttpRequestException`
Add a dummy agent writer like for the other tracer benchmarks

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
