### PR TITLE
Add explicit "clean" step to clone repo

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -9,6 +9,11 @@ steps:
 - ${{ if endsWith(variables['build.sourceBranch'], '/merge') }}:
   - checkout: none
   - bash: |
+      # Azure devops _doesn't_ clean up the contents of the repo after the pipeline has finished
+      # So we do it manually
+      echo "Cleaning up source directories ..."
+      rm -rf $BUILD_REPOSITORY_LOCALPATH/*
+      
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
       prBranch=$SYSTEM_PULLREQUEST_SOURCEBRANCH
@@ -59,6 +64,10 @@ steps:
     condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
 
   - powershell: |
+      echo "Cleaning up source directories ..."
+      $localPath=$env:BUILD_REPOSITORY_LOCALPATH
+      rm $localPath/* -r -fo
+
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
       $prBranch=$env:SYSTEM_PULLREQUEST_SOURCEBRANCH
@@ -68,7 +77,6 @@ steps:
       # Disabled in the windows version
       # git lfs version 
 
-      $localPath=$env:BUILD_REPOSITORY_LOCALPATH
       echo "Initializing repository at $localPath ..."
       git init --initial-branch=${{ parameters.targetBranch }} "$localPath"
 


### PR DESCRIPTION
## Summary of changes

Clean the working directory before cloning into it

## Reason for change

Azure Devops explicitly _doesn't_ clean the directory after running a job. That's fine normally, but we're doing extra work (with a merge commit) to ensure we test the same code throughout the pipeline which currently assumes the checkout directory is empty. This has caused issues when we try to _disable_ provisioning of VMs (to increase throughput)

## Implementation details

Explicit `rm -rf` before we do anything else

## Test coverage

This is the test - if the PR builds, after merging to master I'll try disabling the de-provision steps, which will hopefully help throughput

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
