### PR TITLE
Running All Datadog.Trace.ClrProfiler.IntegrationTests Tests Serially 

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs
@@ -192,10 +192,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion(ServiceVersion);
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
 
-            // After updating the regex implementation multiple runtimes started hitting the timeout.
-            // Increasing timeout here to prevent flaky tests.
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.ObfuscationQueryStringRegexTimeout, "5000");
-
             _testName = testName;
             _metadataSchemaVersion = metadataSchemaVersion;
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs
@@ -72,10 +72,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetServiceVersion(ServiceVersion);
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);
 
-            // After updating the regex implementation multiple runtimes started hitting the timeout.
-            // Increasing timeout here to prevent flaky tests.
-            SetEnvironmentVariable(Configuration.ConfigurationKeys.ObfuscationQueryStringRegexTimeout, "5000");
-
             _testName = testName;
             _metadataSchemaVersion = metadataSchemaVersion;
         }

--- a/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/CustomTestFramework.cs
@@ -152,6 +152,13 @@ namespace Datadog.Trace.TestHelpers
             private static bool IsParallelizationDisabled(ITestCollection collection)
             {
                 var attr = collection.CollectionDefinition?.GetCustomAttributes(typeof(CollectionDefinitionAttribute)).SingleOrDefault();
+                var isIntegrationTest = collection.DisplayName.Contains("Datadog.Trace.ClrProfiler.IntegrationTests");
+
+                if (isIntegrationTest)
+                {
+                    return true;
+                }
+
                 return attr?.GetNamedArgument<bool>(nameof(CollectionDefinitionAttribute.DisableParallelization)) is true;
             }
         }


### PR DESCRIPTION
## Summary of changes
Added an `if` statement to disable running tests in parallel if they live within the `Datadog.Trace.ClrProfiler.IntegrationTests` assembly.

## Reason for change
To test and monitor the error rate of tests within this assembly in `master`(if any 😼).