### PR TITLE
Clean dangling AgentWriter instances in unit tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Data;
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
@@ -57,10 +58,10 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetDbCommands))]
-        public void CreateDbCommandScope_ReturnsScopeForEnabledIntegration(Type commandType, string integrationName, string dbType)
+        public async Task CreateDbCommandScope_ReturnsScopeForEnabledIntegration(Type commandType, string integrationName, string dbType)
         {
             var command = (IDbCommand)Activator.CreateInstance(commandType);
-            using var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: true);
+            await using var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: true);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -70,13 +71,13 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetDbCommands))]
-        public void CreateDbCommandScope_ReturnNullForDisabledIntegration(Type commandType, string integrationName, string dbType)
+        public async Task CreateDbCommandScope_ReturnNullForDisabledIntegration(Type commandType, string integrationName, string dbType)
         {
             var command = (IDbCommand)Activator.CreateInstance(commandType);
             // HACK: avoid analyzer warning about not using arguments
             _ = dbType;
 
-            using var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: false);
+            await using var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: false);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -85,7 +86,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetDbCommands))]
-        public void CreateDbCommandScope_ReturnNullForAdoNetDisabledIntegration(Type commandType, string integrationName, string dbType)
+        public async Task CreateDbCommandScope_ReturnNullForAdoNetDisabledIntegration(Type commandType, string integrationName, string dbType)
         {
             var command = (IDbCommand)Activator.CreateInstance(commandType);
             // HACK: avoid analyzer warning about not using arguments
@@ -94,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var tracerSettings = new TracerSettings();
             tracerSettings.Integrations[integrationName].Enabled = true;
             tracerSettings.Integrations[nameof(IntegrationId.AdoNet)].Enabled = false;
-            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -103,7 +104,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetDbCommands))]
-        public void CreateDbCommandScope_UsesReplacementServiceNameWhenProvided(Type commandType, string integrationName, string dbType)
+        public async Task CreateDbCommandScope_UsesReplacementServiceNameWhenProvided(Type commandType, string integrationName, string dbType)
         {
             var command = (IDbCommand)Activator.CreateInstance(commandType);
             // HACK: avoid analyzer warning about not using arguments
@@ -113,7 +114,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var collection = new NameValueCollection { { ConfigurationKeys.ServiceNameMappings, $"{dbType}:my-custom-type" } };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source);
-            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -122,7 +123,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetDbCommands))]
-        public void CreateDbCommandScope_IgnoresReplacementServiceNameWhenNotProvided(Type commandType, string integrationName, string dbType)
+        public async Task CreateDbCommandScope_IgnoresReplacementServiceNameWhenNotProvided(Type commandType, string integrationName, string dbType)
         {
             var command = (IDbCommand)Activator.CreateInstance(commandType);
             // HACK: avoid analyzer warning about not using arguments
@@ -133,7 +134,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var collection = new NameValueCollection { { ConfigurationKeys.ServiceNameMappings, "something:my-custom-type" } };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source);
-            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -142,9 +143,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetEnabledDbmData))]
-        public void CreateDbCommandScope_InjectsDbmWhenEnabled(Type commandType, string dbmMode)
+        public async Task CreateDbCommandScope_InjectsDbmWhenEnabled(Type commandType, string dbmMode)
         {
-            var command = (IDbCommand)Activator.CreateInstance(commandType);
+            var command = (IDbCommand)Activator.CreateInstance(commandType)!;
             command.CommandText = DbmCommandText;
 
             var collection = new NameValueCollection
@@ -153,7 +154,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
             scope.Should().NotBeNull();
@@ -164,9 +165,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetEnabledDbmData))]
-        public void CreateDbCommandScope_OnlyInjectsDbmOnceWhenCommandIsReused(Type commandType, string dbmMode)
+        public async Task CreateDbCommandScope_OnlyInjectsDbmOnceWhenCommandIsReused(Type commandType, string dbmMode)
         {
-            var command = (IDbCommand)Activator.CreateInstance(commandType);
+            var command = (IDbCommand)Activator.CreateInstance(commandType)!;
             command.CommandText = DbmCommandText;
 
             var collection = new NameValueCollection
@@ -175,7 +176,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using (var scope = CreateDbCommandScope(tracer, command))
             {
@@ -199,9 +200,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetEnabledDbmData))]
-        public void CreateDbCommandScope_DoesNotInjectDbmIntoStoredProcedures(Type commandType, string dbmMode)
+        public async Task CreateDbCommandScope_DoesNotInjectDbmIntoStoredProcedures(Type commandType, string dbmMode)
         {
-            var command = (IDbCommand)Activator.CreateInstance(commandType);
+            var command = (IDbCommand)Activator.CreateInstance(commandType)!;
             command.CommandText = DbmCommandText;
             command.CommandType = CommandType.StoredProcedure;
 
@@ -211,7 +212,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
             scope.Should().NotBeNull();
@@ -222,9 +223,9 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
 
         [Theory]
         [MemberData(nameof(GetDbmCommands))]
-        public void CreateDbCommandScope_DoesNotInjectDbmWhenDisabled(Type commandType)
+        public async Task CreateDbCommandScope_DoesNotInjectDbmWhenDisabled(Type commandType)
         {
-            var command = (IDbCommand)Activator.CreateInstance(commandType);
+            var command = (IDbCommand)Activator.CreateInstance(commandType)!;
             command.CommandText = DbmCommandText;
 
             var collection = new NameValueCollection
@@ -233,7 +234,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
             scope.Should().NotBeNull();
@@ -246,7 +247,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [MemberData(nameof(GetDbCommands))]
         internal void TryGetIntegrationDetails_CorrectNameGenerated(Type commandType, string expectedIntegrationName, string expectedDbType)
         {
-            var command = (IDbCommand)Activator.CreateInstance(commandType);
+            var command = (IDbCommand)Activator.CreateInstance(commandType)!;
             command.CommandText = DbmCommandText;
 
             bool result = DbScopeFactory.TryGetIntegrationDetails(command.GetType().FullName, out var actualIntegrationId, out var actualDbType);

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         public void CreateDbCommandScope_ReturnsScopeForEnabledIntegration(Type commandType, string integrationName, string dbType)
         {
             var command = (IDbCommand)Activator.CreateInstance(commandType);
-            var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: true);
+            using var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: true);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -76,7 +76,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             // HACK: avoid analyzer warning about not using arguments
             _ = dbType;
 
-            var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: false);
+            using var tracer = CreateTracerWithIntegrationEnabled(integrationName, enabled: false);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -94,7 +94,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var tracerSettings = new TracerSettings();
             tracerSettings.Integrations[integrationName].Enabled = true;
             tracerSettings.Integrations[nameof(IntegrationId.AdoNet)].Enabled = false;
-            var tracer = TracerHelper.Create(tracerSettings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -113,7 +113,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var collection = new NameValueCollection { { ConfigurationKeys.ServiceNameMappings, $"{dbType}:my-custom-type" } };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source);
-            var tracer = TracerHelper.Create(tracerSettings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -133,7 +133,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var collection = new NameValueCollection { { ConfigurationKeys.ServiceNameMappings, "something:my-custom-type" } };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source);
-            var tracer = TracerHelper.Create(tracerSettings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             // Create scope
             using var scope = CreateDbCommandScope(tracer, command);
@@ -153,7 +153,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            var tracer = TracerHelper.Create(tracerSettings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
             scope.Should().NotBeNull();
@@ -175,7 +175,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            var tracer = TracerHelper.Create(tracerSettings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using (var scope = CreateDbCommandScope(tracer, command))
             {
@@ -211,7 +211,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            var tracer = TracerHelper.Create(tracerSettings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
             scope.Should().NotBeNull();
@@ -233,7 +233,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
             var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
-            var tracer = TracerHelper.Create(tracerSettings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
             scope.Should().NotBeNull();
@@ -285,7 +285,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.Equal(expectedDbType, actualDbType);
         }
 
-        private static Tracer CreateTracerWithIntegrationEnabled(string integrationName, bool enabled)
+        private static TracerHelper.ScopedTracer CreateTracerWithIntegrationEnabled(string integrationName, bool enabled)
         {
             // Set up tracer
             var tracerSettings = new TracerSettings();

--- a/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
+++ b/tracer/test/Datadog.Trace.TestHelpers/Datadog.Trace.TestHelpers.csproj
@@ -2,6 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="MessagePack" Version="1.9.11" />
     <PackageReference Include="HttpMultipartParser" Version="5.1.0" />

--- a/tracer/test/Datadog.Trace.TestHelpers/TracerHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TracerHelper.cs
@@ -1,12 +1,14 @@
-﻿// <copyright file="TracerHelper.cs" company="Datadog">
+// <copyright file="TracerHelper.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Vendors.StatsdClient;
+using Moq;
 
 namespace Datadog.Trace.TestHelpers
 {
@@ -15,14 +17,36 @@ namespace Datadog.Trace.TestHelpers
         /// <summary>
         /// Create a test instance of the Tracer, that doesn't used any shared instances
         /// </summary>
-        public static Tracer Create(
+        public static ScopedTracer Create(
             TracerSettings settings = null,
             IAgentWriter agentWriter = null,
             ITraceSampler sampler = null,
             IScopeManager scopeManager = null,
             IDogStatsd statsd = null)
         {
-            return new Tracer(settings, agentWriter, sampler, scopeManager, statsd);
+            return new ScopedTracer(settings, agentWriter, sampler, scopeManager, statsd);
+        }
+
+        /// <summary>
+        /// Create a test instance of the Tracer, that doesn't used any shared instances
+        /// </summary>
+        public static ScopedTracer CreateWithFakeAgent(
+            TracerSettings settings = null)
+        {
+            return new ScopedTracer(settings, Mock.Of<IAgentWriter>());
+        }
+
+        public class ScopedTracer : Tracer, IDisposable
+        {
+            public ScopedTracer(TracerSettings settings = null, IAgentWriter agentWriter = null, ITraceSampler sampler = null, IScopeManager scopeManager = null, IDogStatsd statsd = null)
+                : base(settings, agentWriter, sampler, scopeManager, statsd)
+            {
+            }
+
+            public void Dispose()
+            {
+                TracerManager.ShutdownAsync().GetAwaiter().GetResult();
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/TracerHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TracerHelper.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
@@ -36,16 +37,16 @@ namespace Datadog.Trace.TestHelpers
             return new ScopedTracer(settings, Mock.Of<IAgentWriter>());
         }
 
-        public class ScopedTracer : Tracer, IDisposable
+        public class ScopedTracer : Tracer, IAsyncDisposable
         {
             public ScopedTracer(TracerSettings settings = null, IAgentWriter agentWriter = null, ITraceSampler sampler = null, IScopeManager scopeManager = null, IDogStatsd statsd = null)
                 : base(settings, agentWriter, sampler, scopeManager, statsd)
             {
             }
 
-            public void Dispose()
+            public async ValueTask DisposeAsync()
             {
-                TracerManager.ShutdownAsync().GetAwaiter().GetResult();
+                await TracerManager.ShutdownAsync();
             }
         }
     }

--- a/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Tests
         public void SimpleActivitiesAndSpansTest()
         {
             var settings = new TracerSettings();
-            var tracer = TracerHelper.Create(settings);
+            var tracer = TracerHelper.CreateWithFakeAgent(settings);
             Tracer.UnsafeSetTracerInstance(tracer);
 
             Tracer.Instance.ActiveScope.Should().BeNull();
@@ -134,7 +134,7 @@ namespace Datadog.Trace.Tests
         public void SimpleSpansAndActivitiesTest()
         {
             var settings = new TracerSettings();
-            var tracer = TracerHelper.Create(settings);
+            var tracer = TracerHelper.CreateWithFakeAgent(settings);
             Tracer.UnsafeSetTracerInstance(tracer);
 
             Tracer.Instance.ActiveScope.Should().BeNull();

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
@@ -118,7 +118,7 @@ public class SpanMessagePackFormatterTests
     {
         var mockApi = new MockApi();
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled, generate128BitTraceId } });
-        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: null, automaticFlush: false);
         var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null, NullTelemetryController.Instance, NullDiscoveryService.Instance);
 
         using (_ = tracer.StartActive("root"))

--- a/tracer/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/CorrelationIdentifierTests.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Tests
                 ServiceVersion = version,
                 Environment = env
             };
-            var tracer = TracerHelper.Create(settings);
+            var tracer = TracerHelper.CreateWithFakeAgent(settings);
             Tracer.UnsafeSetTracerInstance(tracer);
 
             using (var parentScope = Tracer.Instance.StartActive("parent"))
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Tests
         public void VersionAndEnv_EmptyStringIfUnset()
         {
             var settings = new TracerSettings();
-            var tracer = TracerHelper.Create(settings);
+            var tracer = TracerHelper.CreateWithFakeAgent(settings);
             Tracer.UnsafeSetTracerInstance(tracer);
 
             using (var parentScope = Tracer.Instance.StartActive("parent"))
@@ -96,7 +96,7 @@ namespace Datadog.Trace.Tests
         public void Service_DefaultServiceNameIfUnset()
         {
             var settings = new TracerSettings();
-            var tracer = TracerHelper.Create(settings);
+            var tracer = TracerHelper.CreateWithFakeAgent(settings);
             Tracer.UnsafeSetTracerInstance(tracer);
 
             using (var parentScope = Tracer.Instance.StartActive("parent"))

--- a/tracer/test/Datadog.Trace.Tests/DistributedTraceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTraceTests.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void ManuallyDistributedTrace_CarriesExpectedValues()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
 
             ulong traceId;
             ulong parentSpanId;
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Tests
             }
 
             var distributedTraceContext = new SpanContext(traceId, parentSpanId);
-            var secondTracer = TracerHelper.Create();
+            using var secondTracer = TracerHelper.CreateWithFakeAgent();
             var spanCreationSettings = new SpanCreationSettings() { Parent = distributedTraceContext };
 
             using (var scope = secondTracer.StartActive("manual.trace", spanCreationSettings))

--- a/tracer/test/Datadog.Trace.Tests/DistributedTraceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTraceTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Threading.Tasks;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 
@@ -11,9 +12,9 @@ namespace Datadog.Trace.Tests
     public class DistributedTraceTests
     {
         [Fact]
-        public void ManuallyDistributedTrace_CarriesExpectedValues()
+        public async Task ManuallyDistributedTrace_CarriesExpectedValues()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
 
             ulong traceId;
             ulong parentSpanId;
@@ -33,7 +34,7 @@ namespace Datadog.Trace.Tests
             }
 
             var distributedTraceContext = new SpanContext(traceId, parentSpanId);
-            using var secondTracer = TracerHelper.CreateWithFakeAgent();
+            await using var secondTracer = TracerHelper.CreateWithFakeAgent();
             var spanCreationSettings = new SpanCreationSettings() { Parent = distributedTraceContext };
 
             using (var scope = secondTracer.StartActive("manual.trace", spanCreationSettings))

--- a/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -7,7 +7,7 @@ using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
-using System.Threading;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.TestHelpers;
@@ -40,10 +40,10 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void Do_not_send_metrics_when_disabled()
+        public async Task Do_not_send_metrics_when_disabled()
         {
             var statsd = new Mock<IDogStatsd>();
-            var spans = SendSpan(tracerMetricsEnabled: false, statsd.Object);
+            var spans = await SendSpan(tracerMetricsEnabled: false, statsd.Object);
 
             Assert.True(spans.Count == 1, AssertionFailureMessage(1, spans));
 
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void Send_metrics_when_enabled()
+        public async Task Send_metrics_when_enabled()
         {
             var statsd = new Mock<IDogStatsd>();
 
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Tests
             statsd.Setup(s => s.Counter(TracerMetricNames.Api.Responses, 1, 1, It.IsAny<string[]>())).Callback(() => requestSuccessful = true);
             statsd.Setup(s => s.Counter(TracerMetricNames.Api.Errors, 1, 1, It.IsAny<string[]>())).Callback(() => requestEncounteredErrors = true);
 
-            var spans = SendSpan(tracerMetricsEnabled: true, statsd.Object);
+            var spans = await SendSpan(tracerMetricsEnabled: true, statsd.Object);
 
             Assert.True(spans.Count == 1, AssertionFailureMessage(1, spans));
 
@@ -225,7 +225,7 @@ namespace Datadog.Trace.Tests
         }
 #endif
 
-        private static IImmutableList<MockSpan> SendSpan(bool tracerMetricsEnabled, IDogStatsd statsd)
+        private static async Task<IImmutableList<MockSpan>> SendSpan(bool tracerMetricsEnabled, IDogStatsd statsd)
         {
             IImmutableList<MockSpan> spans;
             var agentPort = TcpPortProvider.GetOpenPort();
@@ -242,12 +242,12 @@ namespace Datadog.Trace.Tests
                     StartupDiagnosticLogEnabled = false,
                 };
 
-                using var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd);
+                await using var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd);
 
                 using (var scope = tracer.StartActive("root"))
                 {
                     scope.Span.ResourceName = "resource";
-                    Thread.Sleep(5);
+                    await Task.Delay(5);
                 }
 
                 spans = agent.WaitForSpans(1);

--- a/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DogStatsDTests.cs
@@ -242,7 +242,7 @@ namespace Datadog.Trace.Tests
                     StartupDiagnosticLogEnabled = false,
                 };
 
-                var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd);
+                using var tracer = TracerHelper.Create(settings, agentWriter: null, sampler: null, scopeManager: null, statsd);
 
                 using (var scope = tracer.StartActive("root"))
                 {

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Lambda;
 using Datadog.Trace.TestHelpers;
 
@@ -21,9 +22,9 @@ namespace Datadog.Trace.Tests
         private readonly Mock<ILambdaExtensionRequest> _lambdaRequestMock = new();
 
         [Fact]
-        public void TestCreatePlaceholderScopeSuccessWithTraceIdOnly()
+        public async Task TestCreatePlaceholderScopeSuccessWithTraceIdOnly()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", null);
 
             scope.Should().NotBeNull();
@@ -33,9 +34,9 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void TestCreatePlaceholderScopeSuccessWithSamplingPriorityOnly()
+        public async Task TestCreatePlaceholderScopeSuccessWithSamplingPriorityOnly()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, "-1");
 
             scope.Should().NotBeNull();
@@ -46,9 +47,9 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void TestCreatePlaceholderScopeSuccessWithFullContext()
+        public async Task TestCreatePlaceholderScopeSuccessWithFullContext()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             scope.Should().NotBeNull();
@@ -60,9 +61,9 @@ namespace Datadog.Trace.Tests
 
         [Fact]
         [Trait("Category", "ArmUnsupported")]
-        public void TestCreatePlaceholderScopeSuccessWithoutContext()
+        public async Task TestCreatePlaceholderScopeSuccessWithoutContext()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
 
             scope.Should().NotBeNull();
@@ -72,16 +73,16 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void TestCreatePlaceholderScopeInvalidTraceId()
+        public async Task TestCreatePlaceholderScopeInvalidTraceId()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             Assert.Throws<FormatException>(() => LambdaCommon.CreatePlaceholderScope(tracer, "invalid-trace-id", "-1"));
         }
 
         [Fact]
-        public void TestCreatePlaceholderScopeInvalidSamplingPriority()
+        public async Task TestCreatePlaceholderScopeInvalidSamplingPriority()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             Assert.Throws<FormatException>(() => LambdaCommon.CreatePlaceholderScope(tracer, "1234", "invalid-sampling-priority"));
         }
 
@@ -142,9 +143,9 @@ namespace Datadog.Trace.Tests
 
         [Fact]
         [Trait("Category", "ArmUnsupported")]
-        public void TestSendEndInvocationFailure()
+        public async Task TestSendEndInvocationFailure()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
@@ -162,9 +163,9 @@ namespace Datadog.Trace.Tests
 
         [Fact]
         [Trait("Category", "ArmUnsupported")]
-        public void TestSendEndInvocationSuccess()
+        public async Task TestSendEndInvocationSuccess()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
@@ -185,9 +186,9 @@ namespace Datadog.Trace.Tests
 
         [Fact]
         [Trait("Category", "ArmUnsupported")]
-        public void TestSendEndInvocationFalse()
+        public async Task TestSendEndInvocationFalse()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);

--- a/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaCommonTests.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestCreatePlaceholderScopeSuccessWithTraceIdOnly()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", null);
 
             scope.Should().NotBeNull();
@@ -35,7 +35,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestCreatePlaceholderScopeSuccessWithSamplingPriorityOnly()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, "-1");
 
             scope.Should().NotBeNull();
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestCreatePlaceholderScopeSuccessWithFullContext()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             scope.Should().NotBeNull();
@@ -62,7 +62,7 @@ namespace Datadog.Trace.Tests
         [Trait("Category", "ArmUnsupported")]
         public void TestCreatePlaceholderScopeSuccessWithoutContext()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
 
             scope.Should().NotBeNull();
@@ -74,14 +74,14 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestCreatePlaceholderScopeInvalidTraceId()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             Assert.Throws<FormatException>(() => LambdaCommon.CreatePlaceholderScope(tracer, "invalid-trace-id", "-1"));
         }
 
         [Fact]
         public void TestCreatePlaceholderScopeInvalidSamplingPriority()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             Assert.Throws<FormatException>(() => LambdaCommon.CreatePlaceholderScope(tracer, "1234", "invalid-sampling-priority"));
         }
 
@@ -144,7 +144,7 @@ namespace Datadog.Trace.Tests
         [Trait("Category", "ArmUnsupported")]
         public void TestSendEndInvocationFailure()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
@@ -164,7 +164,7 @@ namespace Datadog.Trace.Tests
         [Trait("Category", "ArmUnsupported")]
         public void TestSendEndInvocationSuccess()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);
@@ -187,7 +187,7 @@ namespace Datadog.Trace.Tests
         [Trait("Category", "ArmUnsupported")]
         public void TestSendEndInvocationFalse()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
 
             var response = new Mock<HttpWebResponse>(MockBehavior.Loose);

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -18,7 +18,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestGetEndInvocationRequestWithError()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);
@@ -32,7 +32,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestGetEndInvocationRequestWithoutError()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, false);
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestGetEndInvocationRequestWithScope()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, false);
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestGetEndInvocationRequestWithErrorTags()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             scope.Span.SetTag("error.msg", "Exception");
             scope.Span.SetTag("error.type", "Exception");
@@ -92,7 +92,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void TestGetEndInvocationRequestWithoutErrorTags()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 #if NET6_0_OR_GREATER
+using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Lambda;
 using Datadog.Trace.TestHelpers;
 
@@ -16,9 +17,9 @@ namespace Datadog.Trace.Tests
     public class LambdaRequestBuilderTests
     {
         [Fact]
-        public void TestGetEndInvocationRequestWithError()
+        public async Task TestGetEndInvocationRequestWithError()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);
@@ -30,9 +31,9 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void TestGetEndInvocationRequestWithoutError()
+        public async Task TestGetEndInvocationRequestWithoutError()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, false);
@@ -44,9 +45,9 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void TestGetEndInvocationRequestWithScope()
+        public async Task TestGetEndInvocationRequestWithScope()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, false);
@@ -70,9 +71,9 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void TestGetEndInvocationRequestWithErrorTags()
+        public async Task TestGetEndInvocationRequestWithErrorTags()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             scope.Span.SetTag("error.msg", "Exception");
             scope.Span.SetTag("error.type", "Exception");
@@ -90,9 +91,9 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void TestGetEndInvocationRequestWithoutErrorTags()
+        public async Task TestGetEndInvocationRequestWithoutErrorTags()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
@@ -3,19 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Reflection;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
-using Xunit.Sdk;
 
 namespace Datadog.Trace.Tests.PlatformHelpers
 {
@@ -27,14 +22,6 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         private const string AppServiceType = "app";
         private const string FunctionKind = "functionapp";
         private const string FunctionType = "function";
-
-        private static readonly List<string> EnvVars = new List<string>()
-        {
-            ConfigurationKeys.AzureAppService.AzureAppServicesContextKey,
-            ConfigurationKeys.AzureAppService.WebsiteOwnerNameKey,
-            ConfigurationKeys.AzureAppService.ResourceGroupKey,
-            ConfigurationKeys.AzureAppService.SiteNameKey
-        };
 
         private static readonly string SubscriptionId = "8c500027-5f00-400e-8f00-60000000000f";
         private static readonly string PlanResourceGroup = "apm-dotnet";
@@ -200,12 +187,12 @@ namespace Datadog.Trace.Tests.PlatformHelpers
         }
 
         [Fact]
-        public void DoNotTagSpans()
+        public async Task DoNotTagSpans()
         {
             // AAS Tags are handled at serialization now. So no tags should be set on spans
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
             var settings = new TracerSettings(vars);
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             var spans = new List<ISpan>();
             var iterations = 5;
             var remaining = iterations;

--- a/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/PlatformHelpers/AzureAppServicesTests.cs
@@ -205,7 +205,7 @@ namespace Datadog.Trace.Tests.PlatformHelpers
             // AAS Tags are handled at serialization now. So no tags should be set on spans
             var vars = AzureAppServiceHelper.GetRequiredAasConfigurationValues(SubscriptionId, DeploymentId, PlanResourceGroup, SiteResourceGroup);
             var settings = new TracerSettings(vars);
-            var tracer = TracerHelper.Create(settings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             var spans = new List<ISpan>();
             var iterations = 5;
             var remaining = iterations;

--- a/tracer/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Moq;
 using Xunit;
@@ -33,7 +34,7 @@ namespace Datadog.Trace.Tests.Sampling
         {
             // create span, setting service and environment
             var settings = new TracerSettings { ServiceName = expectedService };
-            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             using var scope = (Scope)tracer.StartActive("root");
             scope.Span.Context.TraceContext.Environment = expectedEnv;
 
@@ -55,7 +56,7 @@ namespace Datadog.Trace.Tests.Sampling
             var rule = new DefaultSamplingRule();
 
             var settings = new TracerSettings();
-            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
 
             var firstScope = (Scope)tracer.StartActive("first");
             var firstSpan = firstScope.Span;

--- a/tracer/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/DefaultSamplingRuleTests.cs
@@ -3,14 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-using Datadog.Trace.Agent;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
-using Moq;
 using Xunit;
 
 namespace Datadog.Trace.Tests.Sampling
@@ -30,11 +28,11 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData("service:hello:1,env:world", "hello:1", "world", .5f)]
         // ':' in env name
         [InlineData("service:hello,env:world:1", "hello", "world:1", .5f)]
-        public void KeyParsing(string key, string expectedService, string expectedEnv, float expectedRate)
+        public async Task KeyParsing(string key, string expectedService, string expectedEnv, float expectedRate)
         {
             // create span, setting service and environment
             var settings = new TracerSettings { ServiceName = expectedService };
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             using var scope = (Scope)tracer.StartActive("root");
             scope.Span.Context.TraceContext.Environment = expectedEnv;
 
@@ -47,7 +45,7 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void DefaultSamplingRuleIsApplied()
+        public async Task DefaultSamplingRuleIsApplied()
         {
             const string configuredService = "NiceService";
             const string configuredEnv = "BeautifulEnv";
@@ -56,7 +54,7 @@ namespace Datadog.Trace.Tests.Sampling
             var rule = new DefaultSamplingRule();
 
             var settings = new TracerSettings();
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
 
             var firstScope = (Scope)tracer.StartActive("first");
             var firstSpan = firstScope.Span;

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Linq;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent.TraceSamplers;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
@@ -15,9 +16,9 @@ namespace Datadog.Trace.Tests.Sampling
     public class RareSamplerTests
     {
         [Fact]
-        public void SampleUniqueSpans()
+        public async Task SampleUniqueSpans()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
@@ -44,9 +45,9 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData(SamplingPriorityValues.AutoReject, true)]
         [InlineData(SamplingPriorityValues.UserKeep, false)]
         [InlineData(SamplingPriorityValues.AutoKeep, false)]
-        public void OnlySampleRejectPriorities(int priority, bool expected)
+        public async Task OnlySampleRejectPriorities(int priority, bool expected)
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
@@ -98,9 +99,9 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void OnlySampleTopLevelSpans()
+        public async Task OnlySampleTopLevelSpans()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
@@ -124,9 +125,9 @@ namespace Datadog.Trace.Tests.Sampling
         [Theory]
         [InlineData(Tags.Measured)]
         [InlineData(Tags.PartialSnapshot)]
-        public void SampleSpecialMetrics(string metricName)
+        public async Task SampleSpecialMetrics(string metricName)
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RareSamplerTests.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void SampleUniqueSpans()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData(SamplingPriorityValues.AutoKeep, false)]
         public void OnlySampleRejectPriorities(int priority, bool expected)
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void OnlySampleTopLevelSpans()
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 
@@ -126,7 +126,7 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData(Tags.PartialSnapshot)]
         public void SampleSpecialMetrics(string metricName)
         {
-            var tracer = TracerHelper.Create();
+            using var tracer = TracerHelper.CreateWithFakeAgent();
             var settings = TracerSettings.Create(new() { { ConfigurationKeys.RareSamplerEnabled, true } });
             var sampler = new RareSampler(new ImmutableTracerSettings(settings));
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -21,7 +21,8 @@ namespace Datadog.Trace.Tests.Sampling
         [Fact]
         public void One_Is_Allowed()
         {
-            var traceContext = new TraceContext(TracerHelper.Create());
+            using var tracer = TracerHelper.CreateWithFakeAgent();
+            var traceContext = new TraceContext(tracer);
             var spanContext = new SpanContext(null, traceContext, "Weeeee");
             var span = new Span(spanContext, null);
             var rateLimiter = new TracerRateLimiter(maxTracesPerInterval: null);
@@ -111,7 +112,8 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static int AskTheRateLimiterABunchOfTimes(RateLimiter rateLimiter, int howManyTimes)
         {
-            var traceContext = new TraceContext(TracerHelper.Create());
+            using var tracer = TracerHelper.CreateWithFakeAgent();
+            var traceContext = new TraceContext(tracer);
             var spanContext = new SpanContext(null, traceContext, "Weeeee");
             var span = new Span(spanContext, null);
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RateLimiterTests.cs
@@ -19,9 +19,9 @@ namespace Datadog.Trace.Tests.Sampling
         private const int DefaultLimitPerSecond = 100;
 
         [Fact]
-        public void One_Is_Allowed()
+        public async Task One_Is_Allowed()
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var traceContext = new TraceContext(tracer);
             var spanContext = new SpanContext(null, traceContext, "Weeeee");
             var span = new Span(spanContext, null);
@@ -31,26 +31,26 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void All_Traces_Disabled()
+        public async Task All_Traces_Disabled()
         {
             var rateLimiter = new TracerRateLimiter(maxTracesPerInterval: 0);
-            var allowedCount = AskTheRateLimiterABunchOfTimes(rateLimiter, 500);
+            var allowedCount = await AskTheRateLimiterABunchOfTimes(rateLimiter, 500);
             Assert.Equal(expected: 0, actual: allowedCount);
         }
 
         [Fact]
-        public void All_Traces_Allowed()
+        public async Task All_Traces_Allowed()
         {
             var rateLimiter = new TracerRateLimiter(maxTracesPerInterval: -1);
-            var allowedCount = AskTheRateLimiterABunchOfTimes(rateLimiter, 500);
+            var allowedCount = await AskTheRateLimiterABunchOfTimes(rateLimiter, 500);
             Assert.Equal(expected: 500, actual: allowedCount);
         }
 
         [Fact]
-        public void Only_100_Allowed_In_500_Burst_For_Default()
+        public async Task Only_100_Allowed_In_500_Burst_For_Default()
         {
             var rateLimiter = new TracerRateLimiter(maxTracesPerInterval: null);
-            var allowedCount = AskTheRateLimiterABunchOfTimes(rateLimiter, 500);
+            var allowedCount = await AskTheRateLimiterABunchOfTimes(rateLimiter, 500);
             Assert.Equal(expected: DefaultLimitPerSecond, actual: allowedCount);
         }
 
@@ -110,9 +110,9 @@ namespace Datadog.Trace.Tests.Sampling
                 $"Expected rate between {lowestRate} and {highestRate}, received {result.ReportedRate}.");
         }
 
-        private static int AskTheRateLimiterABunchOfTimes(RateLimiter rateLimiter, int howManyTimes)
+        private static async Task<int> AskTheRateLimiterABunchOfTimes(RateLimiter rateLimiter, int howManyTimes)
         {
-            using var tracer = TracerHelper.CreateWithFakeAgent();
+            await using var tracer = TracerHelper.CreateWithFakeAgent();
             var traceContext = new TraceContext(tracer);
             var spanContext = new SpanContext(null, traceContext, "Weeeee");
             var span = new Span(spanContext, null);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
+using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
 
@@ -145,7 +146,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Choose_Between_Sampling_Mechanisms()
         {
             var settings = new TracerSettings { ServiceName = ServiceName };
-            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
 
             using var scope = (Scope)tracer.StartActive(OperationName);
             scope.Span.Context.TraceContext.Environment = Env;
@@ -177,7 +178,7 @@ namespace Datadog.Trace.Tests.Sampling
             var userKeeps = 0;
 
             var settings = new TracerSettings { ServiceName = ServiceName };
-            var tracer = new Tracer(settings, agentWriter: null, sampler: null, scopeManager: null, statsd: null);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
 
             while (sampleSize-- > 0)
             {

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
@@ -25,10 +25,10 @@ namespace Datadog.Trace.Tests.Sampling
         private static readonly Dictionary<string, float> MockAgentRates = new() { { $"service:{ServiceName},env:{Env}", FallbackRate } };
 
         [Fact]
-        public void RateLimiter_Never_Applied_For_DefaultRule()
+        public async Task RateLimiter_Never_Applied_For_DefaultRule()
         {
             var sampler = new TraceSampler(new DenyAll());
-            RunSamplerTest(
+            await RunSamplerTest(
                 sampler,
                 iterations: 500,
                 expectedAutoKeepRate: 1,
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void RateLimiter_Denies_All_Traces()
+        public async Task RateLimiter_Denies_All_Traces()
         {
             var sampler = new TraceSampler(new DenyAll());
 
@@ -51,7 +51,7 @@ namespace Datadog.Trace.Tests.Sampling
                     resourceNamePattern: ".*",
                     tagPatterns: null));
 
-            RunSamplerTest(
+            await RunSamplerTest(
                 sampler,
                 iterations: 500,
                 expectedAutoKeepRate: 0,
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void Keep_Everything_Rule()
+        public async Task Keep_Everything_Rule()
         {
             var sampler = new TraceSampler(new NoLimits());
 
@@ -74,7 +74,7 @@ namespace Datadog.Trace.Tests.Sampling
                     resourceNamePattern: ".*",
                     tagPatterns: null));
 
-            RunSamplerTest(
+            await RunSamplerTest(
                 sampler,
                 iterations: 500,
                 expectedAutoKeepRate: 0,
@@ -83,7 +83,7 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void Keep_Nothing_Rule()
+        public async Task Keep_Nothing_Rule()
         {
             var sampler = new TraceSampler(new NoLimits());
 
@@ -97,7 +97,7 @@ namespace Datadog.Trace.Tests.Sampling
                     resourceNamePattern: ".*",
                     tagPatterns: null));
 
-            RunSamplerTest(
+            await RunSamplerTest(
                 sampler,
                 iterations: 500,
                 expectedAutoKeepRate: 0,
@@ -106,7 +106,7 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void Keep_Half_Rule()
+        public async Task Keep_Half_Rule()
         {
             var sampler = new TraceSampler(new NoLimits());
 
@@ -120,7 +120,7 @@ namespace Datadog.Trace.Tests.Sampling
                     resourceNamePattern: ".*",
                     tagPatterns: null));
 
-            RunSamplerTest(
+            await RunSamplerTest(
                 sampler,
                 iterations: 50_000, // Higher number for lower variance
                 expectedAutoKeepRate: 0,
@@ -129,12 +129,12 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void No_Registered_Rules_Uses_Legacy_Rates()
+        public async Task No_Registered_Rules_Uses_Legacy_Rates()
         {
             var sampler = new TraceSampler(new NoLimits());
             sampler.SetDefaultSampleRates(MockAgentRates);
 
-            RunSamplerTest(
+            await RunSamplerTest(
                 sampler,
                 iterations: 50_000, // Higher number for lower variance
                 expectedAutoKeepRate: FallbackRate,
@@ -143,10 +143,10 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void Choose_Between_Sampling_Mechanisms()
+        public async Task Choose_Between_Sampling_Mechanisms()
         {
             var settings = new TracerSettings { ServiceName = ServiceName };
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
 
             using var scope = (Scope)tracer.StartActive(OperationName);
             scope.Span.Context.TraceContext.Environment = Env;
@@ -166,7 +166,7 @@ namespace Datadog.Trace.Tests.Sampling
             mechanism2.Should().Be(SamplingMechanism.AgentRate);
         }
 
-        private void RunSamplerTest(
+        private async Task RunSamplerTest(
             ITraceSampler sampler,
             int iterations,
             float expectedAutoKeepRate,
@@ -178,7 +178,7 @@ namespace Datadog.Trace.Tests.Sampling
             var userKeeps = 0;
 
             var settings = new TracerSettings { ServiceName = ServiceName };
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
 
             while (sampleSize-- > 0)
             {

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -24,8 +24,8 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void NormalTracerInstanceSwap()
         {
-            var tracerOne = TracerHelper.Create();
-            var tracerTwo = TracerHelper.Create();
+            using var tracerOne = TracerHelper.CreateWithFakeAgent();
+            using var tracerTwo = TracerHelper.CreateWithFakeAgent();
 
             TracerRestorerAttribute.SetTracer(tracerOne);
             Tracer.Instance.Should().Be(tracerOne);
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Tests
         [Fact]
         public void LockedTracerInstanceSwap()
         {
-            var tracerOne = TracerHelper.Create();
+            using var tracerOne = TracerHelper.CreateWithFakeAgent();
             var tracerTwo = new LockedTracer();
 
             TracerRestorerAttribute.SetTracer(tracerOne);

--- a/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerInstanceTest.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Configuration;
@@ -22,10 +23,10 @@ namespace Datadog.Trace.Tests
     public class TracerInstanceTest
     {
         [Fact]
-        public void NormalTracerInstanceSwap()
+        public async Task NormalTracerInstanceSwap()
         {
-            using var tracerOne = TracerHelper.CreateWithFakeAgent();
-            using var tracerTwo = TracerHelper.CreateWithFakeAgent();
+            await using var tracerOne = TracerHelper.CreateWithFakeAgent();
+            await using var tracerTwo = TracerHelper.CreateWithFakeAgent();
 
             TracerRestorerAttribute.SetTracer(tracerOne);
             Tracer.Instance.Should().Be(tracerOne);
@@ -40,9 +41,9 @@ namespace Datadog.Trace.Tests
         }
 
         [Fact]
-        public void LockedTracerInstanceSwap()
+        public async Task LockedTracerInstanceSwap()
         {
-            using var tracerOne = TracerHelper.CreateWithFakeAgent();
+            await using var tracerOne = TracerHelper.CreateWithFakeAgent();
             var tracerTwo = new LockedTracer();
 
             TracerRestorerAttribute.SetTracer(tracerOne);

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -402,7 +402,7 @@ namespace Datadog.Trace.Tests
         public void SetEnv(string env)
         {
             var settings = new TracerSettings { Environment = env };
-            var tracer = TracerHelper.Create(settings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             var scope = (Scope)tracer.StartActive("operation");
 
             scope.Span.GetTag(Tags.Env).Should().Be(env);
@@ -415,7 +415,7 @@ namespace Datadog.Trace.Tests
         public void SetVersion(string version)
         {
             var settings = new TracerSettings { ServiceVersion = version };
-            var tracer = TracerHelper.Create(settings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             var scope = (Scope)tracer.StartActive("operation");
 
             scope.Span.GetTag(Tags.Version).Should().Be(version);
@@ -437,7 +437,7 @@ namespace Datadog.Trace.Tests
                 ServiceName = tracerServiceName,
             };
 
-            var tracer = TracerHelper.Create(settings);
+            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             ISpan span = tracer.StartSpan("operationName", serviceName: spanServiceName);
 
             if (expectedServiceName == null)

--- a/tracer/test/Datadog.Trace.Tests/TracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TracerTests.cs
@@ -399,10 +399,10 @@ namespace Datadog.Trace.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("test")]
-        public void SetEnv(string env)
+        public async Task SetEnv(string env)
         {
             var settings = new TracerSettings { Environment = env };
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             var scope = (Scope)tracer.StartActive("operation");
 
             scope.Span.GetTag(Tags.Env).Should().Be(env);
@@ -412,10 +412,10 @@ namespace Datadog.Trace.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("1.2.3")]
-        public void SetVersion(string version)
+        public async Task SetVersion(string version)
         {
             var settings = new TracerSettings { ServiceVersion = version };
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             var scope = (Scope)tracer.StartActive("operation");
 
             scope.Span.GetTag(Tags.Version).Should().Be(version);
@@ -430,14 +430,14 @@ namespace Datadog.Trace.Tests
         [InlineData(null, "spanService", "spanService")]
         // if more than one is set, follow precedence: span > tracer  > default
         [InlineData("tracerService", "spanService", "spanService")]
-        public void SetServiceName(string tracerServiceName, string spanServiceName, string expectedServiceName)
+        public async Task SetServiceName(string tracerServiceName, string spanServiceName, string expectedServiceName)
         {
             var settings = new TracerSettings()
             {
                 ServiceName = tracerServiceName,
             };
 
-            using var tracer = TracerHelper.CreateWithFakeAgent(settings);
+            await using var tracer = TracerHelper.CreateWithFakeAgent(settings);
             ISpan span = tracer.StartSpan("operationName", serviceName: spanServiceName);
 
             if (expectedServiceName == null)


### PR DESCRIPTION
## Summary of changes

Reduce the number of threads used in unit tests by avoiding the creation of AgentWriter when possible, and properly cleaning Tracer instances otherwise.

## Reason for change

Our unit tests create many instances of tracers, which in turn create agentWriters. AgentWriter uses a background thread for serialization, which stays alive unless the AgentWriter is properly cleaned up. Because of that, we were leaking many threads.

Before the changes, the unit tests used 120 threads on average with a peak at 160 (tested on my 20-cores machine).
After the changes, the unit tests use 60 threads on average with a peak at 120.

## Implementation details

 - Use TracerHelper whenever possible
 - Add a TracerHelper overload to use a mock AgentWriter
 - Return a disposable Tracer to easily clean the resources
