### PR TITLE
Use `TraceId128` in log instead of `TraceId`

### DIFF
--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -425,7 +425,7 @@ namespace Datadog.Trace
                 catch (Exception ex)
                 {
                     // We have found rare cases where exception.ToString() throws an exception, such as in a FileNotFoundException
-                    Log.Warning(ex, "Error setting exception tags on span {SpanId} in trace {TraceId}", SpanId, TraceId);
+                    Log.Warning(ex, "Error setting exception tags on span {SpanId} in trace {TraceId128}", SpanId, TraceId128);
                 }
             }
         }


### PR DESCRIPTION
## Summary of changes

Use `TraceId128` in log instead of `TraceId` when recording exception

## Reason for change

`TraceId` only gives the 64-bit TraceId, `TraceId128` gives the full thing

## Implementation details

`TraceId` -> `TraceId128`

## Test coverage

meh

## Other details

Originally done in 
- https://github.com/DataDog/dd-trace-dotnet/pull/5291

And flagged by @lucaspimentel [here](https://github.com/DataDog/dd-trace-dotnet/commit/7be52afa58adb6e7416ed0bd54dc71219c8463e4#r139744761)


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
