### PR TITLE
Fix: Skip System.Text.Json tainting tests on netcore3.0

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Json/JsonDocumentTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Json/JsonDocumentTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Samples.InstrumentedTests.Iast.Vulnerabilities.Json;
 
-#if NETCOREAPP3_0_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
 
 public class JsonDocumentTests : InstrumentationTestsBase
 {


### PR DESCRIPTION
## Summary of changes

Skip the System.Text.Json tainting tests on netcore3.0.

## Reason for change

There was issues when running them on master and we do not support that runtime.
