### PR TITLE
Optimize HexString.TryParseByte

### DIFF
--- a/tracer/src/Datadog.Trace/Util/HexString.cs
+++ b/tracer/src/Datadog.Trace/Util/HexString.cs
@@ -16,6 +16,9 @@ using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
 using BitConverter = Datadog.Trace.Util.BitConverterShim;
 using MemoryMarshal = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices.MemoryMarshal;
 #endif
+#if NETFRAMEWORK
+using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
+#endif
 
 namespace Datadog.Trace.Util;
 
@@ -298,13 +301,12 @@ internal static class HexString
             return false;
         }
 
-        var bytesPtr = stackalloc byte[1];
+        var bytesPtr = Unsafe.AsPointer(ref value);
         var bytes = new Span<byte>(bytesPtr, 1);
 
         if (TryParseBytes(chars, bytes))
         {
             // no need to reverse endianness on a single byte
-            value = bytes[0];
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Util/HexString.cs
+++ b/tracer/src/Datadog.Trace/Util/HexString.cs
@@ -16,8 +16,8 @@ using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
 using BitConverter = Datadog.Trace.Util.BitConverterShim;
 using MemoryMarshal = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices.MemoryMarshal;
 #endif
-#if NETFRAMEWORK
-using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
+#if NETFRAMEWORK || NETSTANDARD2_0
+using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
 #endif
 
 namespace Datadog.Trace.Util;

--- a/tracer/src/Datadog.Trace/Util/HexString.cs
+++ b/tracer/src/Datadog.Trace/Util/HexString.cs
@@ -16,7 +16,7 @@ using MemoryMarshal = System.Runtime.InteropServices.MemoryMarshal;
 using BitConverter = Datadog.Trace.Util.BitConverterShim;
 using MemoryMarshal = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.InteropServices.MemoryMarshal;
 #endif
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NETCOREAPP3_0_OR_GREATER
 using Unsafe = Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe;
 #endif
 


### PR DESCRIPTION
## Summary of changes

In `TryParseByte`, we stackalloc a buffer for the result then write that result to the `out byte value` argument. But `out` arguments are already stackallocated, so we directly write to the stack space allocated by the caller.

The performance improvement on .NET Core 3.1 in the benchmarks is weird (and reproducible). I can't explain why it makes such a big difference, I guess the conditions are right to trigger some kind of JIT optimization.

| Method |            Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
|------- |------------------- |----------:|----------:|----------:|------:|--------:|----------:|------------:|
|    New |           .NET 6.0 |  3.904 ns | 0.1016 ns | 0.1321 ns |  1.01 |    0.04 |         - |          NA |
|    Old |           .NET 6.0 |  3.869 ns | 0.0643 ns | 0.0601 ns |  1.00 |    0.00 |         - |          NA |
|        |                    |           |           |           |       |         |           |             |
|    New |      .NET Core 3.1 | 12.047 ns | 0.1522 ns | 0.1424 ns |  0.62 |    0.01 |         - |          NA |
|    Old |      .NET Core 3.1 | 19.348 ns | 0.2232 ns | 0.2088 ns |  1.00 |    0.00 |         - |          NA |
|        |                    |           |           |           |       |         |           |             |
|    New | .NET Framework 4.8 | 19.340 ns | 0.1491 ns | 0.1395 ns |  0.97 |    0.01 |         - |          NA |
|    Old | .NET Framework 4.8 | 19.839 ns | 0.1763 ns | 0.1649 ns |  1.00 |    0.00 |         - |          NA |
