### PR TITLE
Check to ignore Activity when creating TraceID

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlersRegister.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlersRegister.cs
@@ -9,11 +9,13 @@ namespace Datadog.Trace.Activity.Handlers
 {
     internal static class ActivityHandlersRegister
     {
+        // Ignore Activity Handler catches existing integrations that also emits activities.
+        internal static readonly IgnoreActivityHandler IgnoreHandler = new();
+
         // Activity handlers in order, the first handler where ShouldListenTo returns true will always handle that source.
         internal static readonly IActivityHandler[] Handlers =
         {
-            // Ignore Activity Handler catches existing integrations that also emits activities.
-            new IgnoreActivityHandler(),
+            IgnoreHandler,
 
             // Azure Service Bus handlers
             new AzureServiceBusActivityHandler(),

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -448,8 +448,8 @@ namespace Datadog.Trace
                 {
                     bool useActivityTraceId = true;
 
-                    // Handlers[0] is the IgnoreActivityHandler - if it _should_ listen to an activity, that activity _should_ be ignored
-                    if (activity is Activity.DuckTypes.IActivity5 activity5 && ActivityHandlersRegister.Handlers[0].ShouldListenTo(activity5.Source.Name, activity5.Source.Version))
+                    // if the ignore handler _should_ listen to an activity, that activity _should_ be ignored
+                    if (activity is Activity.DuckTypes.IActivity5 activity5 && ActivityHandlersRegister.IgnoreHandler.ShouldListenTo(activity5.Source.Name, activity5.Source.Version))
                     {
                         // if the activity was ignored, we don't want to use its traceID as it'd create orphaned spans in the traces
                         useActivityTraceId = false;


### PR DESCRIPTION
## Summary of changes

Fixes an issue when OpenTelemetry is enabled that the tracer checks for the current `Activity` and will use that Trace ID, but wasn't checking whether we've ignored the `Activity`.

_Note that this doesn't fix all instances of this happening, just most. It also doesn't check for `Activity` objects being ignored based on OperationName nor any `Activity` objects that don't have the `Source` property._

## Reason for change

Creates a mis-parented spans for integrations that emit `Activity` and Datadog Auto Instrumentation, while the integration itself is ignored. For example, the `Couchbase` integration.

## Implementation details

Checking the `IActivity5` as it is the first version guaranteed to have the `Source` property on it, and then we use the `[0]` ActivityHandler which should be the `IgnoreActivityHandler` to check for it being ignored. This doesn't cover: `Activity` ignored by operation name nor `Activity` prior to addition of `Source` property.

An alternative approach (if feasible) could be to add some extra `bool` property onto our duck-typed `Activity` (ex `IActivity.Ignored`) and set that property to `true` whenever we don't want to create a Datadog span for that `Activity`.

## Test coverage

- I manually enabled OpenTelemetry for the Couchbase sample, saw the issue, applied this fix, and the issue went away.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
