### PR TITLE
Fix lib-injection container images

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -8,7 +8,28 @@ on:
         required: false
 
 jobs:
+  lib-injection-image-test:
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        lib-injection-connection: ['network','uds']
+        lib-injection-use-admission-controller: [false, true]
+        runtime: ['bullseye-slim','alpine']
+      fail-fast: false
+    uses: ./.github/workflows/lib-injection-test.yml
+    with:
+      commit_id: ${{ github.event.inputs.forced_commit_id || github.sha }}
+      lib_injection_connection: ${{ matrix.lib-injection-connection }}
+      lib_injection_use_admission_controller: ${{ matrix.lib-injection-use-admission-controller }}
+      runtime: ${{ matrix.runtime }}
+    secrets:
+      DOCKER_REGISTRY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   create_draft_release:
+    needs:
+      - lib-injection-image-test
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/lib-injection-test.yml
+++ b/.github/workflows/lib-injection-test.yml
@@ -1,0 +1,50 @@
+name: "Lib Injection Test"
+on:
+  workflow_call:
+    secrets:
+      DOCKER_REGISTRY_GITHUB_TOKEN:
+        required: true
+    inputs:
+      commit_id:
+        description: 'The commit ID to run the test against'
+        required: true
+        type: string
+      lib_injection_connection:
+        description: 'The connection type to use for the lib-injection test (e.g. network, uds)'
+        required: true
+        type: string
+      lib_injection_use_admission_controller:
+        description: 'Whether to use the admission controller'
+        type: boolean
+        required: true
+      runtime:
+        description: 'The runtime to use to run the tests (e.g. bullseye-slim, alpine)'
+        required: true
+        type: string
+
+jobs:
+  test-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      TEST_LIBRARY: dotnet
+      WEBLOG_VARIANT: 'dd-lib-dotnet-init-test-app'
+      LIBRARY_INJECTION_CONNECTION: ${{ inputs.lib_injection_connection }}
+      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ inputs.lib_injection_use_admission_controller == true && 'use-admission-controller' || '' }}
+      DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
+      DOCKER_IMAGE_TAG: ${{ inputs.commit_id }}${{ inputs.runtime == 'alpine' && '-musl' || '' }}
+      DOCKER_IMAGE_WEBLOG_TAG: ${{ inputs.commit_id }}-${{ inputs.runtime }}
+      RUNTIME: ${{ inputs.runtime }}
+      BUILDX_PLATFORMS: linux/amd64
+      MODE: manual
+    steps:
+      - name: lib-injection test runner
+        id: lib-injection-test-runner
+        uses: DataDog/system-tests/lib-injection/runner@main
+        with:
+          docker-registry: ghcr.io
+          docker-registry-username: ${{ github.repository_owner }}
+          docker-registry-password: ${{ secrets.DOCKER_REGISTRY_GITHUB_TOKEN }}
+          test-script: ./lib-injection/run-manual-lib-injection.sh

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -6,6 +6,10 @@ on:
       azdo_build_id:
         description: 'The specific AzDo build from which the release artifacts will be downloaded.'
         required: true
+      checkout_commit_id:
+        description: 'Force checking out a specific commit? If provided, this will use the Nuke build from this commit'
+        required: false
+        default: ''
 
 jobs:
   build-and-publish-init-image:
@@ -17,6 +21,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+        ref: '${{ github.event.inputs.checkout_commit_id }}'
 
     - uses: actions/setup-dotnet@v1
       with:
@@ -47,6 +52,8 @@ jobs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v2
+      with:
+        version: v0.12.1 # 0.13.0 is causing the builds to fail
 
     - name: Login to Docker
       run: docker login -u publisher -p ${{ secrets.GITHUB_TOKEN }} ghcr.io

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -1,4 +1,4 @@
-name: "Lib Injection Test"
+name: "Lib Injection Images"
 on:
   # This GitHub Action will be invoked automatically from the main Azure DevOps build
   workflow_dispatch:
@@ -125,42 +125,23 @@ jobs:
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-arm64v8.outputs.digest}}"
         docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}-musl
 
-  test:
+  lib-injection-image-test:
     needs:
       - build-and-publish-init-image
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
         lib-injection-connection: ['network','uds']
-        lib-injection-use-admission-controller: ['', 'use-admission-controller']
-        weblog-variant: ['dd-lib-dotnet-init-test-app']
+        lib-injection-use-admission-controller: [false, true]
         runtime: ['bullseye-slim','alpine']
-        include:
-          - runtime: 'bullseye-slim'
-            init-tag-suffix: ''
-          - runtime: 'alpine'
-            init-tag-suffix: '-musl'
       fail-fast: false
-    env:
-      TEST_LIBRARY: dotnet
-      WEBLOG_VARIANT: ${{ matrix.weblog-variant }}
-      LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
-      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
-      DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
-      DOCKER_IMAGE_TAG: ${{ github.event.inputs.commit_id || github.sha }}${{ matrix.init-tag-suffix }}
-      DOCKER_IMAGE_WEBLOG_TAG: ${{ github.event.inputs.commit_id || github.sha }}-${{ matrix.runtime }}
-      RUNTIME: ${{ matrix.runtime }}
-      BUILDX_PLATFORMS: linux/amd64
-      MODE: manual
-    steps:
-      - name: lib-injection test runner
-        id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@main
-        with:
-          docker-registry: ghcr.io
-          docker-registry-username: ${{ github.repository_owner }}
-          docker-registry-password: ${{ secrets.GITHUB_TOKEN }}
-          test-script: ./lib-injection/run-manual-lib-injection.sh
+    uses: ./.github/workflows/lib-injection-test.yml
+    with:
+      commit_id: ${{ github.event.inputs.commit_id || github.sha }}
+      lib_injection_connection: ${{ matrix.lib-injection-connection }}
+      lib_injection_use_admission_controller: ${{ matrix.lib-injection-use-admission-controller }}
+      runtime: ${{ matrix.runtime }}
+    secrets:
+      DOCKER_REGISTRY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -6,8 +6,8 @@ on:
       azdo_build_id:
         description: 'The specific AzDo build from which the release artifacts will be downloaded.'
         required: true
-      checkout_commit_id:
-        description: 'Force checking out a specific commit? If provided, this will use the Nuke build from this commit'
+      commit_id:
+        description: 'Use a specific commit? If provided, this commit will be checked out, and the github images will be tagged with this commit'
         required: false
         default: ''
 
@@ -16,12 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
+      COMMIT_SHA: "${{ github.event.inputs.commit_id || github.sha }}" 
     steps:
     - name: Checkout
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-        ref: '${{ github.event.inputs.checkout_commit_id }}'
+        ref: '${{ env.COMMIT_SHA }}'
 
     - uses: actions/setup-dotnet@v1
       with:
@@ -63,7 +64,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}'
         platforms: 'linux/amd64' # for windows, we can run windows/amd64,windows/386,windows/arm64
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
@@ -74,7 +75,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}'
         platforms: 'linux/arm64/v8'
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
@@ -85,7 +86,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}-musl'
         platforms: 'linux/amd64'
         context: ${{steps.assets.outputs.artifacts_path}}
         build-args: |
@@ -96,7 +97,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         push: true
-        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl'
+        tags: 'ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}-musl'
         platforms: 'linux/arm64/v8'
         context: ${{steps.assets.outputs.artifacts_path}}
         # When we actually produce linux-musl-arm64 binaries, use that instead of the placeholder 'linux-musl-arm' directory
@@ -113,16 +114,16 @@ jobs:
         # In the new manifest we directly reference each platform-specific image, so the tag becomes a multiarch image.
         
         docker manifest create \
-          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }} \
+          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }} \
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-amd64.outputs.digest}}" \
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-arm64v8.outputs.digest}}"
-        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}
+        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}
 
         docker manifest create \
-          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl \
+          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}-musl \
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-amd64.outputs.digest}}" \
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-arm64v8.outputs.digest}}"
-        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ github.sha }}-musl
+        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}-musl
 
   test:
     needs:
@@ -149,8 +150,8 @@ jobs:
       LIBRARY_INJECTION_CONNECTION: ${{ matrix.lib-injection-connection }}
       LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ matrix.lib-injection-use-admission-controller }}
       DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
-      DOCKER_IMAGE_TAG: ${{ github.sha }}${{ matrix.init-tag-suffix }}
-      DOCKER_IMAGE_WEBLOG_TAG: ${{ github.sha }}-${{ matrix.runtime }}
+      DOCKER_IMAGE_TAG: ${{ github.event.inputs.commit_id || github.sha }}${{ matrix.init-tag-suffix }}
+      DOCKER_IMAGE_WEBLOG_TAG: ${{ github.event.inputs.commit_id || github.sha }}-${{ matrix.runtime }}
       RUNTIME: ${{ matrix.runtime }}
       BUILDX_PLATFORMS: linux/amd64
       MODE: manual


### PR DESCRIPTION
## Summary of changes

- Fixes the lib-injection image building by pinning buildx
- Allow specifying the commit to use when manually re-building the images
- Extract lib-injection image testing to reusable workflow
- Call the reusable workflow in the create_draft_release workflow, to prevent releasing faulty packages

## Reason for change

We had an issue in the latest release where the lib-injection images pushed did not include the `linux/amd64` arch in the manifest. This wasn't caught, because we only run the lib-injection build/test on master, and there's no explicit quality gate that checks that it succeeded. 

> This isn't strictly true - we have a step in the release process that checks the image was _pushed_, but not that it's _correct_.

This PR fixes the image publish issue, adds the ability to "rebuild" the images for a specific commit (required to give a seemless fix for the pushed images), and ensures we explicitly test the images as the first step in the release.

## Implementation details

The fundamental cause was that `buildx` (which we use for building the multi-platform images) automatically updated to `v0.13.0`, and subsequently broke the images. I don't know _why_ yet, just that it did. Pinning to the previous version `0.12.1` has solved the build issue.

In order to prevent this happening again, also extracted the test stage as [a reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows), so it can be called from multiple stages, and added an explicit call to it to the release-process workflow

## Test coverage

- I have tested several times with the updated workflow, including [publishing updated images for the broken release images](https://github.com/DataDog/dd-trace-dotnet/actions/runs/8341630103)
- There's currently no way to test the draft release creation without first uploading to nuget, so can't test that part. The _good_ part is that if it is broken, we can ultimately iterate on it, but there's not much to go wrong there I hope

## Other details

I have already re-run the GitLab action that should fix the docker images in prod