### PR TITLE
[Profiler] Remove flakiness for GC CPU comsumption

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -51,6 +51,7 @@ namespace Samples.Computer01
 #endif
         private Obfuscation _obfuscation;
         private ThreadSpikes _threadSpikes;
+        private StringConcat _stringConcat;
 
         public void StartService(Scenario scenario, int nbThreads, int parameter)
         {
@@ -174,6 +175,10 @@ namespace Samples.Computer01
 
                 case Scenario.ThreadSpikes:
                     StartThreadSpikes(nbThreads, parameter);
+                    break;
+
+                case Scenario.StringConcat:
+                    StartStringConcat(parameter);
                     break;
 
                 default:
@@ -301,6 +306,10 @@ namespace Samples.Computer01
 
                 case Scenario.ThreadSpikes:
                     StopThreadSpikes();
+                    break;
+
+                case Scenario.StringConcat:
+                    StopStringConcat();
                     break;
             }
         }
@@ -431,6 +440,10 @@ namespace Samples.Computer01
 
                     case Scenario.ThreadSpikes:
                         RunThreadSpikes(nbThreads, parameter);
+                        break;
+
+                    case Scenario.StringConcat:
+                        RunStringConcat(parameter);
                         break;
 
                     default:
@@ -629,6 +642,12 @@ namespace Samples.Computer01
             _threadSpikes.Start();
         }
 
+        private void StartStringConcat(int count)
+        {
+            _stringConcat = new StringConcat(count);
+            _stringConcat.Start();
+        }
+
         private void StopComputer()
         {
             using (_computer)
@@ -765,6 +784,11 @@ namespace Samples.Computer01
         private void StopThreadSpikes()
         {
             _threadSpikes.Stop();
+        }
+
+        private void StopStringConcat()
+        {
+            _stringConcat.Stop();
         }
 
         private void RunComputer()
@@ -938,6 +962,12 @@ namespace Samples.Computer01
         private void RunThreadSpikes(int threadCount, int duration)
         {
             var test = new ThreadSpikes(threadCount, duration);
+            test.Run();
+        }
+
+        private void RunStringConcat(int count)
+        {
+            var test = new StringConcat(count);
             test.Run();
         }
 

--- a/profiler/src/Demos/Samples.Computer01/Program.cs
+++ b/profiler/src/Demos/Samples.Computer01/Program.cs
@@ -39,6 +39,7 @@ namespace Samples.Computer01
         ForceSigSegvHandler,
         Obfuscation,
         ThreadSpikes,
+        StringConcat, // parameter = number of strings to concatenate
     }
 
     public class Program
@@ -74,6 +75,7 @@ namespace Samples.Computer01
             // 23: sigsegv handling validation
             // 24: use an obfuscated library
             // 25: create thread spikes
+            // 26: string concatenation
             //
             Console.WriteLine($"{Environment.NewLine}Usage:{Environment.NewLine} > {Process.GetCurrentProcess().ProcessName} " +
             $"[--service] [--iterations <number of iterations to execute>] " +

--- a/profiler/src/Demos/Samples.Computer01/StringConcat.cs
+++ b/profiler/src/Demos/Samples.Computer01/StringConcat.cs
@@ -1,0 +1,80 @@
+// <copyright file="StringConcat.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Samples.Computer01
+{
+    public class StringConcat : ScenarioBase
+    {
+        private int _count;
+
+        public StringConcat(int count = 10000)
+        {
+            _count = count;
+        }
+
+        public override void OnProcess()
+        {
+            AllocateStrings();
+        }
+
+        // from BuggyBits
+        public void AllocateStrings()
+        {
+            var sw = new Stopwatch();
+            sw.Start();
+
+            var products = GetAllProducts(_count);
+            var productsTable = "<table><tr><th>Product Name</th><th>Description</th><th>Price</th></tr>";
+            foreach (var product in products)
+            {
+                productsTable += $"<tr><td>{product.ProductName}</td><td>{product.Description}</td><td>${product.Price}</td></tr>";
+            }
+
+            productsTable += "</table>";
+            sw.Stop();
+            Console.WriteLine($"{products.Count} products for {productsTable.Length} characters in {sw.ElapsedMilliseconds} ms");
+        }
+
+        public List<Product> GetAllProducts(int count)
+        {
+            var allProducts = new List<Product>();
+            for (int i = 0; i < count; i++)
+            {
+                allProducts.Add(GetProduct(i));
+            }
+
+            return allProducts;
+        }
+
+        public Product GetProduct(int index)
+        {
+            if (index % 2 == 0)
+            {
+                return new Product { ProductName = "Product" + index, Description = "Description for product" + index, Price = "119,99" };
+            }
+            else
+            {
+                return new Product { ProductName = "Product" + index, Description = "Description for product" + index, Price = "99" };
+            }
+        }
+
+        public class Product
+        {
+            public string ProductName { get; set; }
+            public string Description { get; set; }
+            public string Price { get; set; }
+
+            // useful when debugging a List<Product>
+            public override string ToString()
+            {
+                return ProductName;
+            }
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/GarbageCollections/GarbageCollectorCpuTimeTest.cs
@@ -15,6 +15,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
     public class GarbageCollectorCpuTimeTest
     {
         private const string ScenarioGenerics = "--scenario 12 --param 2";
+        private const string ScenarioAllocations = "--scenario 26 --param 2500";
         private static readonly StackFrame GcFrame = new("|lm:[native] GC |ns: |ct: |cg: |fn:Garbage Collector |fg: |sg:");
         private static readonly StackFrame ClrFrame = new("|lm:[native] CLR |ns: |ct: |cg: |fn:.NET |fg: |sg:");
 
@@ -30,7 +31,7 @@ namespace Datadog.Profiler.IntegrationTests.GarbageCollections
         [TestAppFact("Samples.Computer01", new[] { "net6.0", "net7.0" })]
         public void CheckCpuTimeForGcThreadsIsReported(string appName, string framework, string appAssembly)
         {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioGenerics);
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: ScenarioAllocations);
             runner.Environment.SetVariable(EnvironmentVariables.GcThreadsCpuTimeEnabled, "1");
 
             // Enable walltime and check GC frame does not have a value for this column


### PR DESCRIPTION
## Summary of changes
Switch to an allocations scenario to measure triggered GCs CPU consumption

## Reason for change
Avoid flakiness

## Implementation details
Use an heavy allocations scenario to trigger GCs

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
