### PR TITLE
[CI Visibility] Fix some test to avoid flakiness on retries.

### DIFF
--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ReferenceType/ReferenceTypeFieldTests.cs
@@ -105,6 +105,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckAbstract.PublicStaticReferenceTypeField);
             Assert.Equal("60", duckVirtual.PublicStaticReferenceTypeField);
 
+            duckInterface.PublicStaticReferenceTypeField = "20";
             // *
 
             Assert.Equal("21", duckInterface.InternalStaticReferenceTypeField);
@@ -126,6 +127,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckAbstract.InternalStaticReferenceTypeField);
             Assert.Equal("60", duckVirtual.InternalStaticReferenceTypeField);
 
+            duckInterface.InternalStaticReferenceTypeField = "21";
             // *
 
             Assert.Equal("22", duckInterface.ProtectedStaticReferenceTypeField);
@@ -147,6 +149,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckAbstract.ProtectedStaticReferenceTypeField);
             Assert.Equal("60", duckVirtual.ProtectedStaticReferenceTypeField);
 
+            duckInterface.ProtectedStaticReferenceTypeField = "22";
             // *
 
             Assert.Equal("23", duckInterface.PrivateStaticReferenceTypeField);
@@ -167,6 +170,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckInterface.PrivateStaticReferenceTypeField);
             Assert.Equal("60", duckAbstract.PrivateStaticReferenceTypeField);
             Assert.Equal("60", duckVirtual.PrivateStaticReferenceTypeField);
+
+            duckInterface.PrivateStaticReferenceTypeField = "23";
         }
 
         [Theory]
@@ -241,6 +246,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckAbstract.PublicReferenceTypeField);
             Assert.Equal("60", duckVirtual.PublicReferenceTypeField);
 
+            duckInterface.PublicReferenceTypeField = "40";
             // *
 
             Assert.Equal("41", duckInterface.InternalReferenceTypeField);
@@ -262,6 +268,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckAbstract.InternalReferenceTypeField);
             Assert.Equal("60", duckVirtual.InternalReferenceTypeField);
 
+            duckInterface.InternalReferenceTypeField = "41";
             // *
 
             Assert.Equal("42", duckInterface.ProtectedReferenceTypeField);
@@ -283,6 +290,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckAbstract.ProtectedReferenceTypeField);
             Assert.Equal("60", duckVirtual.ProtectedReferenceTypeField);
 
+            duckInterface.ProtectedReferenceTypeField = "42";
             // *
 
             Assert.Equal("43", duckInterface.PrivateReferenceTypeField);
@@ -303,6 +311,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ReferenceType
             Assert.Equal("60", duckInterface.PrivateReferenceTypeField);
             Assert.Equal("60", duckAbstract.PrivateReferenceTypeField);
             Assert.Equal("60", duckVirtual.PrivateReferenceTypeField);
+
+            duckInterface.PrivateReferenceTypeField = "43";
         }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Fields/ValueType/ValueTypeFieldTests.cs
@@ -105,6 +105,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckAbstract.PublicStaticValueTypeField);
             Assert.Equal(60, duckVirtual.PublicStaticValueTypeField);
 
+            duckInterface.PublicStaticValueTypeField = 20;
             // *
 
             Assert.Equal(21, duckInterface.InternalStaticValueTypeField);
@@ -126,6 +127,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckAbstract.InternalStaticValueTypeField);
             Assert.Equal(60, duckVirtual.InternalStaticValueTypeField);
 
+            duckInterface.InternalStaticValueTypeField = 21;
             // *
 
             Assert.Equal(22, duckInterface.ProtectedStaticValueTypeField);
@@ -147,6 +149,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckAbstract.ProtectedStaticValueTypeField);
             Assert.Equal(60, duckVirtual.ProtectedStaticValueTypeField);
 
+            duckInterface.ProtectedStaticValueTypeField = 22;
             // *
 
             Assert.Equal(23, duckInterface.PrivateStaticValueTypeField);
@@ -167,6 +170,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckInterface.PrivateStaticValueTypeField);
             Assert.Equal(60, duckAbstract.PrivateStaticValueTypeField);
             Assert.Equal(60, duckVirtual.PrivateStaticValueTypeField);
+
+            duckInterface.PrivateStaticValueTypeField = 23;
         }
 
         [Theory]
@@ -233,6 +238,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckAbstract.PublicValueTypeField);
             Assert.Equal(60, duckVirtual.PublicValueTypeField);
 
+            duckInterface.PublicValueTypeField = 40;
             // *
 
             Assert.Equal(41, duckInterface.InternalValueTypeField);
@@ -254,6 +260,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckAbstract.InternalValueTypeField);
             Assert.Equal(60, duckVirtual.InternalValueTypeField);
 
+            duckInterface.InternalValueTypeField = 41;
             // *
 
             Assert.Equal(42, duckInterface.ProtectedValueTypeField);
@@ -275,6 +282,7 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckAbstract.ProtectedValueTypeField);
             Assert.Equal(60, duckVirtual.ProtectedValueTypeField);
 
+            duckInterface.ProtectedValueTypeField = 42;
             // *
 
             Assert.Equal(43, duckInterface.PrivateValueTypeField);
@@ -295,6 +303,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Fields.ValueType
             Assert.Equal(60, duckInterface.PrivateValueTypeField);
             Assert.Equal(60, duckAbstract.PrivateValueTypeField);
             Assert.Equal(60, duckVirtual.PrivateValueTypeField);
+
+            duckInterface.PrivateValueTypeField = 43;
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -6,6 +6,8 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using Datadog.Trace.Ci;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.DuckTyping.Tests
@@ -47,13 +49,26 @@ namespace Datadog.Trace.DuckTyping.Tests
              * WARNING: This number is expected to change if you add
              * a another test to the ducktype assembly.
              */
+            if (!CIVisibility.IsRunning)
+            {
 #if NETFRAMEWORK
-            Assert.Equal(1131, asmDuckTypes);
+                asmDuckTypes.Should().Be(1131);
 #elif NETCOREAPP2_1
-            Assert.Equal(1134, asmDuckTypes);
+                asmDuckTypes.Should().Be(1134);
 #else
-            Assert.Equal(1135, asmDuckTypes);
+                asmDuckTypes.Should().Be(1135);
 #endif
+            }
+            else
+            {
+#if NETFRAMEWORK
+                asmDuckTypes.Should().BeGreaterThan(1131);
+#elif NETCOREAPP2_1
+                asmDuckTypes.Should().BeGreaterThan(1134);
+#else
+                asmDuckTypes.Should().BeGreaterThan(1135);
+#endif
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/GetAssemblyTests.cs
@@ -61,6 +61,7 @@ namespace Datadog.Trace.DuckTyping.Tests
             }
             else
             {
+                // When running inside CI Visibility, we will generate additional duck types
 #if NETFRAMEWORK
                 asmDuckTypes.Should().BeGreaterThan(1131);
 #elif NETCOREAPP2_1

--- a/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
+++ b/tracer/test/Datadog.Trace.DuckTyping.Tests/Properties/ValueType/ValueTypePropertyTests.cs
@@ -478,6 +478,8 @@ namespace Datadog.Trace.DuckTyping.Tests.Properties.ValueType
             Assert.Equal(TaskStatus.WaitingForActivation, duckInterface.Status);
             Assert.Equal(TaskStatus.WaitingForActivation, duckAbstract.Status);
             Assert.Equal(TaskStatus.WaitingForActivation, duckVirtual.Status);
+
+            duckInterface.Status = TaskStatus.RanToCompletion;
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes

This PR reset the ducktype tests to the initial value to avoid flakiness in case of retrying, also fixes the tests when CI Visibility is on.

## Reason for change

While working on the new early flake detection feature for CI Visibility these tests start to fail due to the static variable being modified and not being reset before the retry.