### PR TITLE
[Exception Debugging] Minor post-merge fix to Exception Debugging unwinding logic

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebuggingProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebuggingProcessor.cs
@@ -112,6 +112,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                         }
 
                         var exception = info.Value as Exception;
+                        snapshotCreator.TrackedStackFrameNode.LeavingException = exception;
                         snapshotCreator.LeaveHash = shadowStack.CurrentStackFrameNode?.LeaveSequenceHash ?? Fnv1aHash.FnvOffsetBias;
 
                         var leavingExceptionType = info.Value.GetType();

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -196,7 +196,8 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                     // Attach tags to the root span
                     var debugErrorPrefix = "_dd.debug.error";
                     rootSpan.Tags.SetTag("error.debug_info_captured", "true");
-                    rootSpan.Tags.SetTag($"{debugErrorPrefix}.exception_id", trackedExceptionCase.ErrorHash);
+                    rootSpan.Tags.SetTag($"{debugErrorPrefix}.exception_hash", trackedExceptionCase.ErrorHash);
+                    rootSpan.Tags.SetTag($"{debugErrorPrefix}.exception_id", Guid.NewGuid().ToString());
 
                     var @case = trackedExceptionCase.ExceptionCase;
                     var capturedFrames = resultCallStackTree.Frames;

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -336,11 +336,14 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             span.Tags.SetTag(tagPrefix + "frame_data.class_name", method.DeclaringType?.Name);
             span.Tags.SetTag(tagPrefix + "snapshot_id", snapshotId);
 
-            tagPrefix = tagPrefix.Replace("_", string.Empty);
+            if (Log.IsEnabled(LogEventLevel.Debug))
+            {
+                tagPrefix = tagPrefix.Replace("_", string.Empty);
 
-            span.Tags.SetTag(tagPrefix + "frame_data.function", method.Name);
-            span.Tags.SetTag(tagPrefix + "frame_data.class_name", method.DeclaringType?.Name);
-            span.Tags.SetTag(tagPrefix + "snapshot_id", snapshotId);
+                span.Tags.SetTag(tagPrefix + "frame_data.function", method.Name);
+                span.Tags.SetTag(tagPrefix + "frame_data.class_name", method.DeclaringType?.Name);
+                span.Tags.SetTag(tagPrefix + "snapshot_id", snapshotId);
+            }
 
             ExceptionDebugging.AddSnapshot(probeId, snapshot);
         }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedStackFrameNode.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedStackFrameNode.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
         public TrackedStackFrameNode? Parent => _parent;
 
-        public Exception? LeavingException { get; private set; }
+        public Exception? LeavingException { get; set; }
 
         public string Snapshot
         {
@@ -180,9 +180,9 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             Members.AddMember(new ScopeMember(name, type, value, memberKind));
         }
 
-        private IEnumerable<Exception> FlattenException(Exception exception)
+        private IEnumerable<Exception?> FlattenException(Exception? exception)
         {
-            var exceptionList = new Stack<Exception>();
+            var exceptionList = new Stack<Exception?>();
 
             exceptionList.Push(exception);
 
@@ -334,14 +334,9 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             }
         }
 
-        public bool HasChildException(Exception exception)
+        public bool HasChildException(Exception? exception)
         {
-            if (LeavingException == null)
-            {
-                return false;
-            }
-
-            if (LeavingException == exception || LeavingException == exception.InnerException)
+            if (LeavingException == exception || LeavingException == exception?.InnerException)
             {
                 return true;
             }


### PR DESCRIPTION
## Summary of changes
- Post PR #5163 fixes. There was a minor bug slipped in as part of the [nullability fixes](https://github.com/DataDog/dd-trace-dotnet/pull/5163/commits/f329904824d2708fcb112699455e5a60e9ee0b2f) done in that PR prior merging.
- Adding Exception Debugging tags to the _local_ root span when the log level is set to debug to assist in diagnostics.

## Reason for change
The fixes of nullability introduced a minor bug where unwinding from a method with an exception was not matched correctly with it's child frames to find the correct downward call path to pick up.