### PR TITLE
Increase the margin for the number of threads in RuntimeMetricsWriterTests

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -165,20 +165,8 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
                 actualNumberOfThreads.Should().NotBeNull();
 
-                if (actualNumberOfThreads > expectedNumberOfThreads + 100)
-                {
-                    // Too many thread, try to force a memory dump
-                    if (!MemoryDumpHelper.IsAvailable)
-                    {
-                        await MemoryDumpHelper.InitializeAsync(new Progress<string>(s => _output.WriteLine(s)));
-                    }
-
-                    var dumpResult = MemoryDumpHelper.CaptureMemoryDump(Process.GetCurrentProcess());
-                    Environment.FailFast(dumpResult.ToString());
-                }
-
-                // To future generations: if 100 is not enough, feel free to bump it up. We're really just checking that the value is "realistic".
-                actualNumberOfThreads.Should().NotBeNull().And.BeGreaterThan(0).And.BeInRange(expectedNumberOfThreads - 100, expectedNumberOfThreads + 100);
+                // A margin of 500 threads seem like a lot, but we have tests that spawn a large number of threads to try to find race conditions
+                actualNumberOfThreads.Should().NotBeNull().And.BeGreaterThan(0).And.BeInRange(expectedNumberOfThreads - 500, expectedNumberOfThreads + 500);
 
                 // CPU time and memory usage can vary wildly, so don't try too hard to validate
                 userCpuTime.Should().NotBeNull().And.BeGreaterThan(0);

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -157,6 +157,12 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
 
                 actualNumberOfThreads.Should().NotBeNull();
 
+                if (actualNumberOfThreads > expectedNumberOfThreads + 100)
+                {
+                    // Too many thread, try to force a memory dump
+                    Environment.FailFast("(╯°□°)╯︵ ┻━┻");
+                }
+
                 // To future generations: if 100 is not enough, feel free to bump it up. We're really just checking that the value is "realistic".
                 actualNumberOfThreads.Should().NotBeNull().And.BeGreaterThan(0).And.BeInRange(expectedNumberOfThreads - 100, expectedNumberOfThreads + 100);
 

--- a/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RuntimeMetrics/RuntimeMetricsWriterTests.cs
@@ -14,7 +14,6 @@ using Datadog.Trace.Vendors.StatsdClient;
 using FluentAssertions;
 using Moq;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Datadog.Trace.Tests.RuntimeMetrics
 {
@@ -22,13 +21,6 @@ namespace Datadog.Trace.Tests.RuntimeMetrics
     [Collection(nameof(RuntimeMetricsWriterTests))]
     public class RuntimeMetricsWriterTests
     {
-        private readonly ITestOutputHelper _output;
-
-        public RuntimeMetricsWriterTests(ITestOutputHelper output)
-        {
-            _output = output;
-        }
-
         [Fact]
         public void PushEvents()
         {


### PR DESCRIPTION
## Summary of changes

Increase the range of valid values for the number of threads in `RuntimeMetricsWriterTests.ShouldCaptureProcessMetrics`.

## Reason for change

I initially thought that 100 was plenty enough, but we have tests that create a large number of threads to stresstest things (`UnmanagedMemoryPoolTests` for instance). Let's hope that 500 is enough.