### PR TITLE
[Test] Running AspNetCore5IastTestsFullSampling Tests Serially

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -406,6 +406,8 @@ public class AspNetCore5IastTestsFullSamplingRedactionEnabled : AspNetCore5IastT
     }
 }
 
+[Collection(nameof(AspNetCore5IastTestsFullSampling))]
+[CollectionDefinition(nameof(AspNetCore5IastTestsFullSampling), DisableParallelization = true)]
 public abstract class AspNetCore5IastTestsFullSampling : AspNetCore5IastTests
 {
     public AspNetCore5IastTestsFullSampling(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableIast, string testName, bool? isIastDeduplicationEnabled = null, int? vulnerabilitiesPerRequest = null, bool redactionEnabled = false)


### PR DESCRIPTION
## Summary of changes
Updated AspNetCore5IastTestsFullSampling class to run serially and try to prevent flakes due to timeout.
