### PR TITLE
Disable inlining for restsharp exploration tests

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -414,6 +414,8 @@ class ExplorationTestDescription
                 IsGitShallowCloneSupported = true,
                 PathToUnitTestProject = "test/RestSharp.Tests",
                 SupportedFrameworks = new[] { TargetFramework.NET6_0 },
+                // Workaround for https://github.com/dotnet/runtime/issues/95653
+                EnvironmentVariables = new[] { ("DD_CLR_ENABLE_INLINING", "0") },
             },
             ExplorationTestName.serilog => new ExplorationTestDescription()
             {


### PR DESCRIPTION
## Summary of changes

Disable inlining for restsharp exploration tests

## Reason for change

Random failures because of https://github.com/dotnet/runtime/issues/95653
