### PR TITLE
Start pushing `latest_snapshot` images for lib-injection images

### DIFF
--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -125,6 +125,19 @@ jobs:
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-arm64v8.outputs.digest}}"
         docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}-musl
 
+        # We also create latest_snapshot images
+        docker manifest create \
+          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:latest_snapshot \
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-amd64.outputs.digest}}" \
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-arm64v8.outputs.digest}}"
+        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:latest_snapshot
+
+        docker manifest create \
+          ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:latest_snapshot-musl \
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-amd64.outputs.digest}}" \
+          --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-arm64v8.outputs.digest}}"
+        docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:latest_snapshot-musl
+
   lib-injection-image-test:
     needs:
       - build-and-publish-init-image


### PR DESCRIPTION
## Summary of changes

Adds the `latest_snapshot` and `latest_snapshot-musl` tags to the lib-injection images.

## Reason for change

System tests want to use them for testing against master

## Implementation details

Push another tag in the lib-injection GitHub Action

## Test coverage

Ran it, and it worked

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
