### PR TITLE
[ASM] Ensure new sample and agent are used on each test

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity;
 
 public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
-    private readonly AspNetCoreTestFixture _fixture;
+    private AspNetCoreTestFixture _fixture;
 
     protected AspNetCoreApiSecurity(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableApiSecurity, string sampleName)
         : base(sampleName, outputHelper, "/shutdown", testName: $"ApiSecurity.{sampleName}.{(enableApiSecurity ? "ApiSecOn" : "ApiSecOff")}")
@@ -74,6 +74,9 @@ public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCo
 
     private async Task TryStartApp()
     {
+        _fixture?.Dispose();
+        _fixture = new AspNetCoreTestFixture();
+        _fixture.SetOutput(Output);
         // we don't test with security off, but test with api security off, otherwise the matrix of tests would be too large
         await _fixture.TryStartApp(this, true);
         SetHttpPort(_fixture.HttpPort);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
@@ -23,7 +23,7 @@ namespace Datadog.Trace.Security.IntegrationTests.ApiSecurity;
 
 public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCoreTestFixture>
 {
-    private AspNetCoreTestFixture _fixture;
+    private readonly AspNetCoreTestFixture _fixture;
 
     protected AspNetCoreApiSecurity(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper, bool enableApiSecurity, string sampleName)
         : base(sampleName, outputHelper, "/shutdown", testName: $"ApiSecurity.{sampleName}.{(enableApiSecurity ? "ApiSecOn" : "ApiSecOff")}")
@@ -74,9 +74,6 @@ public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCo
 
     private async Task TryStartApp()
     {
-        _fixture?.Dispose();
-        _fixture = new AspNetCoreTestFixture();
-        _fixture.SetOutput(Output);
         // we don't test with security off, but test with api security off, otherwise the matrix of tests would be too large
         await _fixture.TryStartApp(this, true);
         SetHttpPort(_fixture.HttpPort);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -174,6 +174,51 @@ public abstract class AspNetCore5IastTestsVariableVulnerabilityPerRequestIastEna
     }
 }
 
+public class AspNetCore5IastTestsRestartedSampleIastEnabled : AspNetCore5IastTests
+{
+    public AspNetCore5IastTestsRestartedSampleIastEnabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
+        : base(fixture, outputHelper, enableIast: true, vulnerabilitiesPerRequest: 200, isIastDeduplicationEnabled: false, testName: "AspNetCore5IastTestsEnabled", redactionEnabled: true, samplingRate: 100)
+    {
+    }
+
+    [SkippableTheory]
+    [Trait("RunOnWindows", "True")]
+    [InlineData(-1, 10)]
+    [InlineData(-1, 15)]
+    [InlineData(15, 15)]
+    [InlineData(5, 15)]
+    public async Task TestMaxRanges(int maxRanges, int nbrRangesCreated)
+    {
+        // Set the configuration (use default configuration if -1 is passed)
+        var maxRangesConfiguration = maxRanges == -1 ? IastSettings.MaxRangeCountDefault : maxRanges;
+        SetEnvironmentVariable(ConfigurationKeys.Iast.MaxRangeCount, maxRangesConfiguration.ToString());
+
+        var filename = "Iast.MaxRanges.AspNetCore5.IastEnabled." + maxRangesConfiguration + "." + nbrRangesCreated;
+        var url = "/Iast/MaxRanges?count=" + nbrRangesCreated + "&tainted=taintedString|";
+
+        IncludeAllHttpSpans = true;
+
+        // Using a new fixture here to use a new process that applies
+        // correctly the new environment variable value that is changing between tests
+        var newFixture = new AspNetCoreTestFixture();
+        newFixture.SetOutput(Output);
+        await TryStartApp(newFixture);
+
+        var agent = newFixture.Agent;
+        var spans = await SendRequestsAsync(agent, [url]);
+        var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddIastScrubbing();
+        await VerifyHelper.VerifySpans(spansFiltered, settings)
+                          .UseFileName(filename)
+                          .DisableRequireUniquePrefix();
+
+        newFixture.Dispose();
+        newFixture.SetOutput(null);
+    }
+}
+
 public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsFullSampling
 {
     public AspNetCore5IastTestsFullSamplingIastEnabled(AspNetCoreTestFixture fixture, ITestOutputHelper outputHelper)
@@ -330,43 +375,6 @@ public class AspNetCore5IastTestsFullSamplingIastEnabled : AspNetCore5IastTestsF
         await VerifyHelper.VerifySpans(spansFiltered, settings)
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();
-    }
-
-    [SkippableTheory]
-    [Trait("RunOnWindows", "True")]
-    [InlineData(-1, 10)]
-    [InlineData(-1, 15)]
-    [InlineData(15, 15)]
-    [InlineData(5, 15)]
-    public async Task TestMaxRanges(int maxRanges, int nbrRangesCreated)
-    {
-        // Set the configuration (use default configuration if -1 is passed)
-        var maxRangesConfiguration = maxRanges == -1 ? IastSettings.MaxRangeCountDefault : maxRanges;
-        SetEnvironmentVariable(ConfigurationKeys.Iast.MaxRangeCount, maxRangesConfiguration.ToString());
-
-        var filename = "Iast.MaxRanges.AspNetCore5.IastEnabled." + maxRangesConfiguration + "." + nbrRangesCreated;
-        var url = "/Iast/MaxRanges?count=" + nbrRangesCreated + "&tainted=taintedString|";
-
-        IncludeAllHttpSpans = true;
-
-        // Using a new fixture here to use a new process that applies
-        // correctly the new environment variable value that is changing between tests
-        var newFixture = new AspNetCoreTestFixture();
-        newFixture.SetOutput(Output);
-        await TryStartApp(newFixture);
-
-        var agent = newFixture.Agent;
-        var spans = await SendRequestsAsync(agent, [url]);
-        var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
-
-        var settings = VerifyHelper.GetSpanVerifierSettings();
-        settings.AddIastScrubbing();
-        await VerifyHelper.VerifySpans(spansFiltered, settings)
-                          .UseFileName(filename)
-                          .DisableRequireUniquePrefix();
-
-        newFixture.Dispose();
-        newFixture.SetOutput(null);
     }
 
 #if !NETFRAMEWORK && NETCOREAPP3_1_OR_GREATER


### PR DESCRIPTION
## Summary of changes
Stop AspNetCore fixture and Sample reutilization on the same class

## Reason for change
Sample and agent reutilization causes frequent flakiness

