### PR TITLE
Disable Inlining to 0 for both Cake & swashbuckle tests

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -385,6 +385,8 @@ class ExplorationTestDescription
                 IsGitShallowCloneSupported = true,
                 PathToUnitTestProject = "src/Cake.Common.Tests",
                 SupportedFrameworks = new[] { TargetFramework.NETCOREAPP3_1, TargetFramework.NET5_0, TargetFramework.NET6_0 },
+                // Workaround for https://github.com/dotnet/runtime/issues/95653
+                EnvironmentVariables = new[] { ("DD_CLR_ENABLE_INLINING", "0") },
             },
             ExplorationTestName.swashbuckle => new ExplorationTestDescription()
             {
@@ -394,6 +396,8 @@ class ExplorationTestDescription
                 IsGitShallowCloneSupported = true,
                 PathToUnitTestProject = "test/Swashbuckle.AspNetCore.SwaggerGen.Test",
                 SupportedFrameworks = new[] { TargetFramework.NET6_0 },
+                // Workaround for https://github.com/dotnet/runtime/issues/95653
+                EnvironmentVariables = new[] { ("DD_CLR_ENABLE_INLINING", "0") },
             },
             ExplorationTestName.paket => new ExplorationTestDescription()
             {


### PR DESCRIPTION
## Summary of changes
Setting `DD_CLR_ENABLE_INLINING ` to 0 for both tests to test the outcome of the next runs and if it still flakes.

## Reason for change
We got new errors in master this time for the debugger tests above so same as https://github.com/DataDog/dd-trace-dotnet/pull/5335 trying to disable it and check if the test does happen to fail again.