### PR TITLE
Disabling ASM Throughput Job 

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4027,7 +4027,7 @@ stages:
 
   - job: AsmLinux64
     timeoutInMinutes: 60
-    pool: Throughput
+    pool: Throughput-AppSec
 
     steps:
       - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3891,7 +3891,7 @@ stages:
 
   - job: Linux64
     timeoutInMinutes: 60
-    pool: Throughput
+    pool: Throughput-Appsec
 
     steps:
     - template: steps/clone-repo.yml
@@ -4028,12 +4028,6 @@ stages:
   - job: AsmLinux64
     timeoutInMinutes: 60
     pool: Throughput
-    condition: >
-      or(
-        eq(variables.isMainBranch, true),
-        eq(variables.force_appsec_throughput_run, 'true'),
-        eq(variables.isAppSecChanged, 'True')
-      )
 
     steps:
     - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3887,11 +3887,11 @@ stages:
     parameters:
       jobs: [Linux64, Windows64, LinuxArm64, AsmLinux64]
       allowSkipped: true
-  #### Throughput Linux 64, Windows 64, Linux Arm 64, Linux 64 for ASM
+  #### Throughput Linux 64, Windows 64, Linux arm 64, AsmLinux64
 
   - job: Linux64
     timeoutInMinutes: 60
-    pool: Throughput-Appsec
+    pool: Throughput
 
     steps:
     - template: steps/clone-repo.yml
@@ -4028,42 +4028,48 @@ stages:
   - job: AsmLinux64
     timeoutInMinutes: 60
     pool: Throughput
+    condition: >
+      or(
+        eq(variables.isMainBranch, true),
+        eq(variables.force_appsec_throughput_run, 'true'),
+        eq(variables.isAppSecChanged, 'True')
+      )
 
     steps:
-    - template: steps/clone-repo.yml
-      parameters:
-        targetShaId: $(targetShaId)
-        targetBranch: $(targetBranch)
-    - task: DownloadPipelineArtifact@2
-      displayName: Download linux native binary
-      inputs:
-        artifact: linux-monitoring-home-linux-x64
-        path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
+      - template: steps/clone-repo.yml
+        parameters:
+          targetShaId: $(targetShaId)
+          targetBranch: $(targetBranch)
+      - task: DownloadPipelineArtifact@2
+        displayName: Download linux native binary
+        inputs:
+          artifact: linux-monitoring-home-linux-x64
+          path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
 
-    - script: |
-        test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
-        test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
-        test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-        mkdir -p $(CrankDir)/results/logs
-        cd $(CrankDir)
-        chmod +x ./run-appsec.sh
-        ./run-appsec.sh "linux"
-      displayName: Crank
-      env:
-        DD_SERVICE: dd-trace-dotnet
-        DD_ENV: CI
+      - script: |
+          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
+          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
+          test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
+          mkdir -p $(CrankDir)/results/logs
+          cd $(CrankDir)
+          chmod +x ./run-appsec.sh
+          ./run-appsec.sh "linux"
+        displayName: Crank
+        env:
+          DD_SERVICE: dd-trace-dotnet
+          DD_ENV: CI
 
-    - script: |
-        cp $(CrankDir)/*.json $(CrankDir)/results
-      displayName: Copy the results to results dir
+      - script: |
+          cp $(CrankDir)/*.json $(CrankDir)/results
+        displayName: Copy the results to results dir
 
-    - publish: "$(CrankDir)/results"
-      displayName: Publish results
-      # We don't include the JobAttempt in this case, because we rely on a specific name
-      # and an error in the throughput tests probably means no usable data, so dont
-      # bother trying to upload these in case of failure, which means we can retry the
-      # stages without issue
-      artifact: crank_linux_x64_asm_1
+      - publish: "$(CrankDir)/results"
+        displayName: Publish results
+        # We don't include the JobAttempt in this case, because we rely on a specific name
+        # and an error in the throughput tests probably means no usable data, so dont
+        # bother trying to upload these in case of failure, which means we can retry the
+        # stages without issue
+        artifact: crank_linux_x64_asm_1
 
 - stage: throughput_profiler
   condition: >

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3885,9 +3885,9 @@ stages:
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [Linux64, Windows64, LinuxArm64, AsmLinux64]
+      jobs: [Linux64, Windows64, LinuxArm64]
       allowSkipped: true
-  #### Throughput Linux 64, Windows 64, Linux arm 64, AsmLinux64
+  #### Throughput Linux 64, Windows 64, Linux arm 64
 
   - job: Linux64
     timeoutInMinutes: 60
@@ -4022,54 +4022,6 @@ stages:
       # bother trying to upload these in case of failure, which means we can retry the
       # stages without issue
       artifact: crank_linux_arm64_1
-    
-    #### Throughput-AppSec Linux 64
-
-#  - job: AsmLinux64
-#    timeoutInMinutes: 60
-#    pool: Throughput-AppSec
-#    condition: >
-#      or(
-#        eq(variables.isMainBranch, true),
-#        eq(variables.force_appsec_throughput_run, 'true'),
-#        eq(variables.isAppSecChanged, 'True')
-#      )
-#
-#    steps:
-#      - template: steps/clone-repo.yml
-#        parameters:
-#          targetShaId: $(targetShaId)
-#          targetBranch: $(targetBranch)
-#      - task: DownloadPipelineArtifact@2
-#        displayName: Download linux native binary
-#        inputs:
-#          artifact: linux-monitoring-home-linux-x64
-#          path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
-#
-#      - script: |
-#          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
-#          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
-#          test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-#          mkdir -p $(CrankDir)/results/logs
-#          cd $(CrankDir)
-#          chmod +x ./run-appsec.sh
-#          ./run-appsec.sh "linux"
-#        displayName: Crank
-#        env:
-#          DD_SERVICE: dd-trace-dotnet
-#          DD_ENV: CI
-#
-#      - script: |
-#          cp $(CrankDir)/*.json $(CrankDir)/results
-#        displayName: Copy the results to results dir
-#
-#      - publish: "$(CrankDir)/results"
-#        displayName: Publish results
-#        # We don't include the JobAttempt in this case, because we rely on a specific name
-#        # and an error in the throughput tests probably means no usable data, so dont
-#        # bother trying to upload these in case of failure, which means we can retry the
-#        # stages without issue
-#        artifact: crank_linux_x64_asm_1
 
 - stage: throughput_profiler
   condition: >
@@ -5955,13 +5907,6 @@ stages:
       inputs:
         artifact: crank_linux_x64_1
         path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_linux_x64_1
-
-    - task: DownloadPipelineArtifact@2
-      displayName: Download crank_linux_x64_asm_1
-      continueOnError: true
-      inputs:
-        artifact: crank_linux_x64_asm_1
-        path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_linux_x64_asm_1
 
     - task: DownloadPipelineArtifact@2
       displayName: Download crank_windows_x64_1

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3988,7 +3988,6 @@ stages:
       parameters:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
-
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 native binary
       inputs:
@@ -4028,14 +4027,19 @@ stages:
 
   - job: AsmLinux64
     timeoutInMinutes: 60
-    pool: Throughput-AppSec
+    pool: Throughput
+    condition: >
+      or(
+        eq(variables.isMainBranch, true),
+        eq(variables.force_appsec_throughput_run, 'true'),
+        eq(variables.isAppSecChanged, 'True')
+      )
 
     steps:
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
-
     - task: DownloadPipelineArtifact@2
       displayName: Download linux native binary
       inputs:
@@ -4046,8 +4050,6 @@ stages:
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
         test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-        mkdir -p tracer/bin/netcoreapp3.1
-        cp tracer/tracer-home-linux/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll 
         mkdir -p $(CrankDir)/results/logs
         cd $(CrankDir)
         chmod +x ./run-appsec.sh
@@ -4056,8 +4058,6 @@ stages:
       env:
         DD_SERVICE: dd-trace-dotnet
         DD_ENV: CI
-        DD_CIVISIBILITY_AGENTLESS_ENABLED: true
-        DD_API_KEY: $(ddApiKey)
 
     - script: |
         cp $(CrankDir)/*.json $(CrankDir)/results
@@ -5959,7 +5959,6 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download crank_linux_x64_asm_1
       continueOnError: true
-      condition: succeededOrFailed()
       inputs:
         artifact: crank_linux_x64_asm_1
         path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_linux_x64_asm_1

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4025,46 +4025,51 @@ stages:
     
     #### Throughput-AppSec Linux 64
 
-  - job: AsmLinux64
-    timeoutInMinutes: 60
-    pool: Throughput-AppSec
-
-    steps:
-      - template: steps/clone-repo.yml
-        parameters:
-          targetShaId: $(targetShaId)
-          targetBranch: $(targetBranch)
-      - task: DownloadPipelineArtifact@2
-        displayName: Download linux native binary
-        inputs:
-          artifact: linux-monitoring-home-linux-x64
-          path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
-
-      - script: |
-          export AGENT_ALLOW_RUNASROOT=1
-          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
-          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
-          test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-          mkdir -p $(CrankDir)/results/logs
-          cd $(CrankDir)
-          chmod +x ./run-appsec.sh
-          ./run-appsec.sh "linux"
-        displayName: Crank
-        env:
-          DD_SERVICE: dd-trace-dotnet
-          DD_ENV: CI
-
-      - script: |
-          cp $(CrankDir)/*.json $(CrankDir)/results
-        displayName: Copy the results to results dir
-
-      - publish: "$(CrankDir)/results"
-        displayName: Publish results
-        # We don't include the JobAttempt in this case, because we rely on a specific name
-        # and an error in the throughput tests probably means no usable data, so dont
-        # bother trying to upload these in case of failure, which means we can retry the
-        # stages without issue
-        artifact: crank_linux_x64_asm_1
+#  - job: AsmLinux64
+#    timeoutInMinutes: 60
+#    pool: Throughput-AppSec
+#    condition: >
+#      or(
+#        eq(variables.isMainBranch, true),
+#        eq(variables.force_appsec_throughput_run, 'true'),
+#        eq(variables.isAppSecChanged, 'True')
+#      )
+#
+#    steps:
+#      - template: steps/clone-repo.yml
+#        parameters:
+#          targetShaId: $(targetShaId)
+#          targetBranch: $(targetBranch)
+#      - task: DownloadPipelineArtifact@2
+#        displayName: Download linux native binary
+#        inputs:
+#          artifact: linux-monitoring-home-linux-x64
+#          path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
+#
+#      - script: |
+#          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
+#          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
+#          test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
+#          mkdir -p $(CrankDir)/results/logs
+#          cd $(CrankDir)
+#          chmod +x ./run-appsec.sh
+#          ./run-appsec.sh "linux"
+#        displayName: Crank
+#        env:
+#          DD_SERVICE: dd-trace-dotnet
+#          DD_ENV: CI
+#
+#      - script: |
+#          cp $(CrankDir)/*.json $(CrankDir)/results
+#        displayName: Copy the results to results dir
+#
+#      - publish: "$(CrankDir)/results"
+#        displayName: Publish results
+#        # We don't include the JobAttempt in this case, because we rely on a specific name
+#        # and an error in the throughput tests probably means no usable data, so dont
+#        # bother trying to upload these in case of failure, which means we can retry the
+#        # stages without issue
+#        artifact: crank_linux_x64_asm_1
 
 - stage: throughput_profiler
   condition: >

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3887,7 +3887,7 @@ stages:
     parameters:
       jobs: [Linux64, Windows64, LinuxArm64, AsmLinux64]
       allowSkipped: true
-  #### Throughput Linux 64, windows 64, linux arm 64
+  #### Throughput Linux 64, Windows 64, Linux Arm 64, Linux 64 for ASM
 
   - job: Linux64
     timeoutInMinutes: 60
@@ -3988,6 +3988,7 @@ stages:
       parameters:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
+
     - task: DownloadPipelineArtifact@2
       displayName: Download arm64 native binary
       inputs:
@@ -4028,48 +4029,47 @@ stages:
   - job: AsmLinux64
     timeoutInMinutes: 60
     pool: Throughput-AppSec
-    condition: >
-      or(
-        eq(variables.isMainBranch, true),
-        eq(variables.force_appsec_throughput_run, 'true'),
-        eq(variables.isAppSecChanged, 'True')
-      )
 
     steps:
-      - template: steps/clone-repo.yml
-        parameters:
-          targetShaId: $(targetShaId)
-          targetBranch: $(targetBranch)
-      - task: DownloadPipelineArtifact@2
-        displayName: Download linux native binary
-        inputs:
-          artifact: linux-monitoring-home-linux-x64
-          path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
+    - template: steps/clone-repo.yml
+      parameters:
+        targetShaId: $(targetShaId)
+        targetBranch: $(targetBranch)
 
-      - script: |
-          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
-          test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
-          test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
-          mkdir -p $(CrankDir)/results/logs
-          cd $(CrankDir)
-          chmod +x ./run-appsec.sh
-          ./run-appsec.sh "linux"
-        displayName: Crank
-        env:
-          DD_SERVICE: dd-trace-dotnet
-          DD_ENV: CI
+    - task: DownloadPipelineArtifact@2
+      displayName: Download linux native binary
+      inputs:
+        artifact: linux-monitoring-home-linux-x64
+        path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
 
-      - script: |
-          cp $(CrankDir)/*.json $(CrankDir)/results
-        displayName: Copy the results to results dir
+    - script: |
+        test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
+        test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
+        test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1
+        mkdir -p tracer/bin/netcoreapp3.1
+        cp tracer/tracer-home-linux/netcoreapp3.1/Datadog.Trace.dll tracer/bin/netcoreapp3.1/Datadog.Trace.dll 
+        mkdir -p $(CrankDir)/results/logs
+        cd $(CrankDir)
+        chmod +x ./run-appsec.sh
+        ./run-appsec.sh "linux"
+      displayName: Crank
+      env:
+        DD_SERVICE: dd-trace-dotnet
+        DD_ENV: CI
+        DD_CIVISIBILITY_AGENTLESS_ENABLED: true
+        DD_API_KEY: $(ddApiKey)
 
-      - publish: "$(CrankDir)/results"
-        displayName: Publish results
-        # We don't include the JobAttempt in this case, because we rely on a specific name
-        # and an error in the throughput tests probably means no usable data, so dont
-        # bother trying to upload these in case of failure, which means we can retry the
-        # stages without issue
-        artifact: crank_linux_x64_asm_1
+    - script: |
+        cp $(CrankDir)/*.json $(CrankDir)/results
+      displayName: Copy the results to results dir
+
+    - publish: "$(CrankDir)/results"
+      displayName: Publish results
+      # We don't include the JobAttempt in this case, because we rely on a specific name
+      # and an error in the throughput tests probably means no usable data, so dont
+      # bother trying to upload these in case of failure, which means we can retry the
+      # stages without issue
+      artifact: crank_linux_x64_asm_1
 
 - stage: throughput_profiler
   condition: >
@@ -5959,6 +5959,7 @@ stages:
     - task: DownloadPipelineArtifact@2
       displayName: Download crank_linux_x64_asm_1
       continueOnError: true
+      condition: succeededOrFailed()
       inputs:
         artifact: crank_linux_x64_asm_1
         path: $(System.DefaultWorkingDirectory)/tracer/build_data/throughput/current/crank_linux_x64_asm_1

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4028,12 +4028,6 @@ stages:
   - job: AsmLinux64
     timeoutInMinutes: 60
     pool: Throughput
-    condition: >
-      or(
-        eq(variables.isMainBranch, true),
-        eq(variables.force_appsec_throughput_run, 'true'),
-        eq(variables.isAppSecChanged, 'True')
-      )
 
     steps:
       - template: steps/clone-repo.yml
@@ -4047,6 +4041,7 @@ stages:
           path: $(System.DefaultWorkingDirectory)/tracer/tracer-home-linux
 
       - script: |
+          export AGENT_ALLOW_RUNASROOT=1
           test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Trace.ClrProfiler.Native.so (native loader) does not exist" && exit 1
           test ! -s "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so" && echo "tracer/tracer-home-linux/linux-x64/Datadog.Tracer.Native.so does not exist" && exit 1
           test ! -s "tracer/tracer-home-linux/linux-x64/libddwaf.so" && echo "tracer/tracer-home-linux/linux-x64/libddwaf.so does not exist" && exit 1

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -38,9 +38,10 @@ namespace Samples.AspNetCoreSimpleController
 
                 if (!isAttached && tracerEnabled)
                 {
-                    Console.WriteLine("Error: Profiler is required and is not loaded.");
-                    Environment.Exit(1);
-                    return;
+                    Console.WriteLine("Error: Profiler is required and is not loaded!!!");
+                    Console.WriteLine(" * Running without profiler.");
+                    /*Environment.Exit(1);
+                    return;*/
                 }
 
                 nativeTracerVersion = SampleHelpers.GetNativeTracerVersion();

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -38,10 +38,9 @@ namespace Samples.AspNetCoreSimpleController
 
                 if (!isAttached && tracerEnabled)
                 {
-                    Console.WriteLine("Error: Profiler is required and is not loaded!!!");
-                    Console.WriteLine(" * Running without profiler.");
-                    /*Environment.Exit(1);
-                    return;*/
+                    Console.WriteLine("Error: Profiler is required and is not loaded.");
+                    Environment.Exit(1);
+                    return;
                 }
 
                 nativeTracerVersion = SampleHelpers.GetNativeTracerVersion();


### PR DESCRIPTION
## Summary of changes
Commented out the ASM Throughput Job so that we can collect data on other flaky stages/tests before the quarter ends to try addressing the underlaying issue with less pressure in the incoming Q2 weeks.
