### PR TITLE
Running all WafLibraryRequiredTest tests serially

### DIFF
--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -5,9 +5,12 @@
 
 #nullable enable
 using Datadog.Trace.AppSec.Waf.NativeBindings;
+using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests.Utils;
 
+[Collection(nameof(WafLibraryRequiredTest))]
+[CollectionDefinition(nameof(WafLibraryRequiredTest), DisableParallelization=true)]
 public class WafLibraryRequiredTest
 {
     /// <summary>


### PR DESCRIPTION
## Summary of changes
Disables Parallelization for the WafLibraryRequiredTest class that the WAF tests inherit from.

## Reason for change
It was observed that the WAF tests created thousands of threads so trying to change the way they are ran to serially so that we can monitor the impact it has on the CI other runs if any.
