### PR TITLE
Exclude known error from smoke tests

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2424,6 +2424,8 @@ partial class Build
            knownPatterns.Add(new(@".*Profiler call failed with result Unspecified-Failure \(80131351\): pInfo..GetModuleInfo\(moduleId, nullptr, 0, nullptr, nullptr, .assemblyId\)", RegexOptions.Compiled));
            // avoid any issue with CLR events that are not supported before 5.1 or .NET Framework
            knownPatterns.Add(new(@".*Event-based profilers \(Allocation, LockContention\) are not supported for", RegexOptions.Compiled));
+           // There's a race in the profiler where unwinding when the thread is running
+           knownPatterns.Add(new(@".*Failed to walk \d+ stacks for sampled exception", RegexOptions.Compiled));
 
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2425,7 +2425,7 @@ partial class Build
            // avoid any issue with CLR events that are not supported before 5.1 or .NET Framework
            knownPatterns.Add(new(@".*Event-based profilers \(Allocation, LockContention\) are not supported for", RegexOptions.Compiled));
            // There's a race in the profiler where unwinding when the thread is running
-           knownPatterns.Add(new(@".*Failed to walk \d+ stacks for sampled exception", RegexOptions.Compiled));
+           knownPatterns.Add(new(@".*Failed to walk \d+ stacks for sampled exception:\s+CORPROF_E_STACKSNAPSHOT_UNSAFE", RegexOptions.Compiled));
 
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });


### PR DESCRIPTION
## Summary of changes

Ignore a known Continuous Profiler error in the smoke tests

## Reason for change

This error is a known issue in the profiler that occurs due to unwinding when the thread is running, which is a race due to a slow machine

## Implementation details

Just filter the error

## Test coverage

Meh

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
