### PR TITLE
Update some packages

### DIFF
--- a/tracer/src/Datadog.Trace.Annotations/Datadog.Trace.Annotations.csproj
+++ b/tracer/src/Datadog.Trace.Annotations/Datadog.Trace.Annotations.csproj
@@ -19,8 +19,4 @@
       <None Include="..\..\..\docs\Datadog.Trace.Annotations\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    </ItemGroup>
-  
   </Project>

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -26,7 +26,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />

--- a/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -16,7 +16,6 @@
     <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
 
     <PackageReference Include="OpenTracing" Version="0.12.1" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet.SourceGenerators/Datadog.Trace.Tools.dd_dotnet.SourceGenerators.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet.SourceGenerators/Datadog.Trace.Tools.dd_dotnet.SourceGenerators.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet.SourceGenerators/Datadog.Trace.Tools.dd_dotnet.SourceGenerators.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet.SourceGenerators/Datadog.Trace.Tools.dd_dotnet.SourceGenerators.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <IsRoslynComponent>true</IsRoslynComponent>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <EnforceExtendedAnalyzerRules>false</EnforceExtendedAnalyzerRules>
     <!--  Using the root namespace so generators are all in the root + we can control how they're written to disk  -->
     <RootNamespace></RootNamespace> 
   </PropertyGroup>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -55,7 +55,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="InlineIL.Fody" Version="1.7.4" PrivateAssets="All" />
+    <PackageReference Include="InlineIL.Fody" Version="1.8.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -56,7 +56,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="InlineIL.Fody" Version="1.7.4" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
+++ b/tracer/test/test-applications/integrations/LogsInjection.Log4Net/LogsInjection.Log4Net.csproj
@@ -14,7 +14,6 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="$(ApiVersion)" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(ApiVersion)' &gt;= '2.0.8'">

--- a/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
+++ b/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31/Samples.AspNetCoreMvc31.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!--Files shared with AspNetCoreMvc21 -->

--- a/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
+++ b/tracer/test/test-applications/integrations/Samples.Owin.WebApi2/Samples.Owin.WebApi2.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.OwinSelfHost" Version="5.2.7" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
   <!--Files shared with aspnet/Samples.AspNetMvc5 -->

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Samples.AspNetCoreSimpleController.csproj
@@ -18,8 +18,4 @@
   <ItemGroup Condition="'$(MANUAL_INSTRUMENTATION)' == 'true' AND '$(VERSION_MISMATCH)' == 'true'">
     <PackageReference Include="Datadog.Trace" Version="2.22.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary of changes

- Updates Microsoft.CodeAnalysis.CSharp used in dd_dotnet source generators to latest
- Removed unnecessary references to Microsoft.SourceLink.GitHub
- Bump version of `InlineIL.Fody`

## Reason for change

- `dd_dotnet` is using an older version than the other source generators
- Microsoft.SourceLink.GitHub is injected automatically by the .NET 8 SDK, so this just causes unnecessary dependabot alerts
- New version of InlineIL.Fody, which supports Fody v6.8.0, which is what we're _already_ using, so seems like a good idea

Release notes:
- Updated Fody to v6.8.0, which supports RVA field alignment
- Added warnings for unused locals
- Changed parameter of IL.PushInRef to use ref readonly instead of in, to make the reference usage stand out at the call site

## Implementation details

Bumped some versions

## Test coverage

Hopefully we have enough test coverage for this stuff... _Particularly_ the vendored code

## Other details

Should resolve a few dependabot alerts

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
