### PR TITLE
[v3] Changes to release process

### DIFF
--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -29,9 +29,8 @@ jobs:
         run: |
           if( "${{ github.event.release.tag_name}}".StartsWith("v1.")) {
             echo "::set-output name=ref::release/1.x"
-          # TODO: Uncomment the following once we cut the release/2.x branch and merge v3
-          # } elseif("${{ github.event.release.tag_name}}".StartsWith("v2.")) {
-            # echo "::set-output name=ref::release/2.x"
+          } elseif("${{ github.event.release.tag_name}}".StartsWith("v2.")) {
+            echo "::set-output name=ref::release/2.x"
           } else {
             echo "::set-output name=ref::master"
           }

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -6,9 +6,9 @@ on:
 
 jobs:
   update_benchmark_branches:
-    # only run on "normal" 2.0 branches
+    # only run on "normal" 3.0 branches
     if: |
-      startsWith(github.event.release.tag_name, 'v2.')
+      startsWith(github.event.release.tag_name, 'v3.')
       && !endsWith(github.event.release.tag_name, '-prerelease')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary of changes

Changes to the release process once v3 is merged

## Reason for change

After we merge the v3 branch
- We should create new benchmark branches for v3 only
- We should create v2 releases on the `release/2.x` branch

## Implementation details

Fiddle with some bits

## Test coverage

Yeah... we can't really test this unfortunately

## Other details
This can be merged into the v3-main branch once this is merged:
- https://github.com/DataDog/dd-trace-dotnet/pull/4811

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
