### PR TITLE
Don't deploy `latest` lib injection images from `release/2.x`

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2260,7 +2260,7 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables.isMainBranch, true),
+        eq(variables.isMainOrReleaseBranch, true),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
       )
     )
@@ -2334,7 +2334,7 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables.isMainBranch, true),
+        eq(variables.isMainOrReleaseBranch, true),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
       )
     )
@@ -4030,7 +4030,7 @@ stages:
     pool: Throughput-AppSec
     condition: >
       or(
-        eq(variables.isMainBranch, true),
+        eq(variables.isMainOrReleaseBranch, true),
         eq(variables.force_appsec_throughput_run, 'true'),
         eq(variables.isAppSecChanged, 'True')
       )
@@ -4076,7 +4076,7 @@ stages:
     and(succeeded(), 
         eq(variables.isMainRepository, true),
         or(
-          eq(variables.isMainBranch, true),
+          eq(variables.isMainOrReleaseBranch, true),
           eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')))
   dependsOn: [package_linux, generate_variables, build_windows_tracer, merge_commit_id]
   variables:
@@ -6057,7 +6057,7 @@ stages:
     and(
       failed(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(variables['isMainBranch'], true)
+      eq(variables['isMainOrReleaseBranch'], true)
     )
   dependsOn: [trace_pipeline] # so it runs last
   jobs:

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - main
-      - release/1.x
+      - release/**
     types: [closed]
 
 jobs:

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -7,11 +7,13 @@ on:
 jobs:
   bump_version:
     # If this is a 1.x release, do the version bump in the release/1.x branch
-    # If this is a 2.x.0 release, do the version bump on master
-    # If this is a 2.x.x hotfix release, _don't_ do a version bump
+    # If this is a 2.x release, do the version bump in the release/2.x branch
+    # If this is a 3.x.0 release, do the version bump on master
+    # If this is a 3.x.x hotfix release, _don't_ do a version bump
     if: |
       startsWith(github.event.release.tag_name, 'v1.')
-      || (startsWith(github.event.release.tag_name, 'v2.')
+      || startsWith(github.event.release.tag_name, 'v2.')
+      || (startsWith(github.event.release.tag_name, 'v3.')
         && endsWith(github.event.release.tag_name, '.0'))
 
     runs-on: windows-latest
@@ -27,6 +29,9 @@ jobs:
         run: |
           if( "${{ github.event.release.tag_name}}".StartsWith("v1.")) {
             echo "::set-output name=ref::release/1.x"
+          # TODO: Uncomment the following once we cut the release/2.x branch and merge v3
+          # } elseif("${{ github.event.release.tag_name}}".StartsWith("v2.")) {
+            # echo "::set-output name=ref::release/2.x"
           } else {
             echo "::set-output name=ref::master"
           }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -117,44 +117,6 @@ deploy_musl_tag_to_docker_registries:
     IMG_DESTINATIONS: dd-lib-dotnet-init:$CI_COMMIT_TAG-musl
     IMG_SIGNING: "false"
 
-deploy_latest_tag_to_docker_registries:
-  stage: deploy
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: never
-    # Don't deploy latest tag if prerelease
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: always
-    - when: manual
-      allow_failure: true
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
-  variables:
-    IMG_SOURCES: ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:$CI_COMMIT_SHA
-    IMG_DESTINATIONS: dd-lib-dotnet-init:latest
-    IMG_SIGNING: "false"
-
-deploy_latest_musl_tag_to_docker_registries:
-  stage: deploy
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: never
-      # Don't deploy latest tag if prerelease
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: always
-    - when: manual
-      allow_failure: true
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
-  variables:
-    IMG_SOURCES: ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:$CI_COMMIT_SHA-musl
-    IMG_DESTINATIONS: dd-lib-dotnet-init:latest-musl
-    IMG_SIGNING: "false"
-
 package:
   extends: .package
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -122,7 +122,8 @@ deploy_latest_tag_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+    # Don't deploy latest tag if prerelease
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: always
     - when: manual
       allow_failure: true
@@ -140,7 +141,8 @@ deploy_latest_musl_tag_to_docker_registries:
   rules:
     - if: '$POPULATE_CACHE'
       when: never
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+(-prerelease)?$/'
+      # Don't deploy latest tag if prerelease
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
       when: always
     - when: manual
       allow_failure: true

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1341,7 +1341,12 @@ partial class Build
 
     private async Task<Milestone> GetOrCreateVNextMilestone(GitHubClient gitHubClient)
     {
-        var milestoneName = Version.StartsWith("1.") ? "vNext-v1" : "vNext";
+        var milestoneName = Version switch
+        {
+            null or { Length: 0 } => throw new Exception("Version was unexpectedly null!"),
+            { } v => $"vNext-v{v[0]}",
+        };
+
         var milestone = await GetMilestone(gitHubClient, milestoneName);
         if (milestone is not null)
         {


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR should be rebased onto `release/2.x` once that branch is created. It should _not_ be merged into `master`

## Summary of changes

Removes the "deploy latest" stage for lib-injection when we're in the `release/2.x` branch

## Reason for change

We don't want to mark v2 releases as "latest" once we start releasing v3

## Implementation details

Remove those stages

## Test coverage

Not much to 

## Other details

Needs to rebased onto `release/2.x`

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
