### PR TITLE
Update libunwind to 1.8.1

### DIFF
--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -4,7 +4,7 @@ SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunw
 
 ExternalProject_Add(libunwind
     GIT_REPOSITORY https://github.com/DataDog/libunwind.git
-    GIT_TAG gleocadie/backtrace2_4
+    GIT_TAG gleocadie/v1.8.1-custom
     GIT_PROGRESS true
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""

--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -1,4 +1,4 @@
-SET(LIBUNWIND_VERSION "1.7.0-custom")
+SET(LIBUNWIND_VERSION "v1.8.1-custom")
 
 SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind-build)
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -259,7 +259,7 @@ std::int32_t LinuxStackFramesCollector::CollectStackWithBacktrace2(void* ctx)
 
     // Now walk the stack:
     auto [data, size] = Data();
-    auto count = unw_backtrace2((void**)data, size, context);
+    auto count = unw_backtrace2((void**)data, size, context, UNW_INIT_SIGNAL_FRAME);
 
     if (count == 0)
     {


### PR DESCRIPTION
## Summary of changes

Bump the libunwind version to 1.8.1.

## Reason for change

The previous version is struggling to walk threads remotely on a .NET 7+ app.

## Implementation details

The `UNW_INIT_SIGNAL_FRAME` flag is not hardcoded anymore and has to be passed explicitly to `unw_backtrace2`.

