### PR TITLE
[Tracer] support 128-bit trace ids in logs injection

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -650,7 +650,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/SocketsHttpHan
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/HttpClient/WinHttpHandler/WinHttpHandlerIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/IExternalScopeProvider.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/DirectSubmission/ILoggerFactory.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/DatadogLoggingScope.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/LoggerExternalScopeProviderForEachScopeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/LoggerFactoryScopeProviderForEachScopeIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/LoggerIntegrationCommon.cs

--- a/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
+++ b/tracer/src/Datadog.Trace.MSBuild/DatadogLogger.cs
@@ -12,6 +12,7 @@ using System.Text;
 using Datadog.Trace.Ci;
 using Datadog.Trace.Ci.CiEnvironment;
 using Datadog.Trace.Ci.Tags;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -356,9 +357,8 @@ namespace Datadog.Trace.MSBuild
                 }
                 else
                 {
-                    var traceId = span.GetTraceIdStringForLogs();
-                    var spanId = span.SpanId.ToString(CultureInfo.InvariantCulture);
-
+                    var use128Bits = span.Context.TraceContext?.Tracer.Settings.TraceId128BitGenerationEnabled ?? false;
+                    LogContext.TryGetValues(span.Context, out var traceId, out var spanId, use128Bits);
                     _context = new Context(traceId, spanId, span.Context.Origin);
                 }
             }

--- a/tracer/src/Datadog.Trace/Ci/Logging/DirectSubmission/CIVisibilityLogEvent.cs
+++ b/tracer/src/Datadog.Trace/Ci/Logging/DirectSubmission/CIVisibilityLogEvent.cs
@@ -16,9 +16,9 @@ namespace Datadog.Trace.Ci.Logging.DirectSubmission
         private readonly string _source;
         private readonly string? _logLevel;
         private readonly string _message;
-        private readonly ISpan? _span;
+        private readonly Span? _span;
 
-        public CIVisibilityLogEvent(string source, string? logLevel, string message, ISpan? span)
+        public CIVisibilityLogEvent(string source, string? logLevel, string message, Span? span)
         {
             _source = source;
             _logLevel = logLevel;

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -466,7 +466,7 @@ public sealed class Test
         _scope.Span.ResetStartTime();
     }
 
-    internal ISpan GetInternalSpan()
+    internal Span GetInternalSpan()
     {
         return _scope.Span;
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/DatadogLoggingScope.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/DatadogLoggingScope.cs
@@ -54,6 +54,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
                     1 => new KeyValuePair<string, object>("dd_env", _env),
                     2 => new KeyValuePair<string, object>("dd_version", _version),
 
+                    // We want to get trace id and span id separately here,
+                    // hence the separate TryGetTraceId() and TryGetSpanId() methods in LogContext.
                     3 => new KeyValuePair<string, object>(
                         "dd_trace_id",
                         _tracer.DistributedSpanContext is { } context && LogContext.TryGetTraceId(context, _use128Bits, out var traceId) ? traceId : "0"),

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/DatadogLoggingScope.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/ILogger/LogsInjection/DatadogLoggingScope.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -16,6 +18,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
         private readonly string _env;
         private readonly string _version;
         private readonly Tracer _tracer;
+        private readonly bool _use128Bits;
         private readonly string _cachedFormat;
 
         public DatadogLoggingScope()
@@ -29,6 +32,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
             _service = tracer.DefaultServiceName ?? string.Empty;
             _env = tracer.Settings.Environment ?? string.Empty;
             _version = tracer.Settings.ServiceVersion ?? string.Empty;
+            _use128Bits = _tracer.Settings.TraceId128BitLoggingEnabled;
+
             _cachedFormat = string.Format(
                 CultureInfo.InvariantCulture,
                 "dd_service:\"{0}\", dd_env:\"{1}\", dd_version:\"{2}\"",
@@ -43,15 +48,20 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
         {
             get
             {
-                // For mismatch version support we need to keep requesting old keys.
-                var distContext = _tracer.DistributedSpanContext;
                 return index switch
                 {
                     0 => new KeyValuePair<string, object>("dd_service", _service),
                     1 => new KeyValuePair<string, object>("dd_env", _env),
                     2 => new KeyValuePair<string, object>("dd_version", _version),
-                    3 => new KeyValuePair<string, object>("dd_trace_id", distContext?[SpanContext.Keys.TraceId] ?? distContext?[HttpHeaderNames.TraceId] ?? "0"),
-                    4 => new KeyValuePair<string, object>("dd_span_id", distContext?[SpanContext.Keys.ParentId] ?? distContext?[HttpHeaderNames.ParentId] ?? "0"),
+
+                    3 => new KeyValuePair<string, object>(
+                        "dd_trace_id",
+                        _tracer.DistributedSpanContext is { } context && LogContext.TryGetTraceId(context, _use128Bits, out var traceId) ? traceId : "0"),
+
+                    4 => new KeyValuePair<string, object>(
+                        "dd_span_id",
+                        _tracer.DistributedSpanContext is { } context && LogContext.TryGetSpanId(context, out var spanId) ? spanId : "0"),
+
                     _ => throw new ArgumentOutOfRangeException(nameof(index))
                 };
             }
@@ -59,23 +69,15 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
 
         public override string ToString()
         {
-            var spanContext = _tracer.DistributedSpanContext;
-            if (spanContext is not null)
+            if (_tracer.DistributedSpanContext is { } context &&
+                LogContext.TryGetValues(context, out var traceId, out var spanId, _use128Bits))
             {
-                // For mismatch version support we need to keep requesting old keys.
-                var hasTraceId = spanContext.TryGetValue(SpanContext.Keys.TraceId, out string traceId) ||
-                                 spanContext.TryGetValue(HttpHeaderNames.TraceId, out traceId);
-                var hasSpanId = spanContext.TryGetValue(SpanContext.Keys.ParentId, out string spanId) ||
-                                spanContext.TryGetValue(HttpHeaderNames.ParentId, out spanId);
-                if (hasTraceId && hasSpanId)
-                {
-                    return string.Format(
-                        CultureInfo.InvariantCulture,
-                        "{0}, dd_trace_id:\"{1}\", dd_span_id:\"{2}\"",
-                        _cachedFormat,
-                        traceId,
-                        spanId);
-                }
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0}, dd_trace_id:\"{1}\", dd_span_id:\"{2}\"",
+                    _cachedFormat,
+                    traceId,
+                    spanId);
             }
 
             return _cachedFormat;
@@ -87,20 +89,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.ILogger
             yield return new KeyValuePair<string, object>("dd_env", _env);
             yield return new KeyValuePair<string, object>("dd_version", _version);
 
-            var spanContext = _tracer.DistributedSpanContext;
-            if (spanContext is not null)
+            if (_tracer.DistributedSpanContext is { } context &&
+                LogContext.TryGetValues(context, out var traceId, out var spanId, _use128Bits))
             {
-                // For mismatch version support we need to keep requesting old keys.
-                var hasTraceId = spanContext.TryGetValue(SpanContext.Keys.TraceId, out string traceId) ||
-                                 spanContext.TryGetValue(HttpHeaderNames.TraceId, out traceId);
-                var hasSpanId = spanContext.TryGetValue(SpanContext.Keys.ParentId, out string spanId) ||
-                                spanContext.TryGetValue(HttpHeaderNames.ParentId, out spanId);
-
-                if (hasTraceId && hasSpanId)
-                {
-                    yield return new KeyValuePair<string, object>("dd_trace_id", traceId);
-                    yield return new KeyValuePair<string, object>("dd_span_id", spanId);
-                }
+                yield return new KeyValuePair<string, object>("dd_trace_id", traceId);
+                yield return new KeyValuePair<string, object>("dd_span_id", spanId);
             }
         }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Log4Net/LogsInjection/AppenderAttachedImplIntegration.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.ComponentModel;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging;
 using Datadog.Trace.ClrProfiler.CallTarget;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
@@ -45,20 +46,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Log4Net
                 loggingEvent.Properties[CorrelationIdentifier.VersionKey] = tracer.Settings.ServiceVersion ?? string.Empty;
                 loggingEvent.Properties[CorrelationIdentifier.EnvKey] = tracer.Settings.Environment ?? string.Empty;
 
-                var spanContext = tracer.DistributedSpanContext;
-                if (spanContext is not null)
+                if (tracer.DistributedSpanContext is { } context &&
+                    LogContext.TryGetValues(context, out var traceId, out var spanId, tracer.Settings.TraceId128BitLoggingEnabled))
                 {
-                    // For mismatch version support we need to keep requesting old keys.
-                    var hasTraceId = spanContext.TryGetValue(SpanContext.Keys.TraceId, out string traceId) ||
-                                     spanContext.TryGetValue(HttpHeaderNames.TraceId, out traceId);
-                    var hasSpanId = spanContext.TryGetValue(SpanContext.Keys.ParentId, out string spanId) ||
-                                    spanContext.TryGetValue(HttpHeaderNames.ParentId, out spanId);
-
-                    if (hasTraceId && hasSpanId)
-                    {
-                        loggingEvent.Properties[CorrelationIdentifier.TraceIdKey] = traceId;
-                        loggingEvent.Properties[CorrelationIdentifier.SpanIdKey] = spanId;
-                    }
+                    loggingEvent.Properties[CorrelationIdentifier.TraceIdKey] = traceId;
+                    loggingEvent.Properties[CorrelationIdentifier.SpanIdKey] = spanId;
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/LogContext.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/LogContext.cs
@@ -13,7 +13,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging;
 internal static class LogContext
 {
     private static string GetTraceId(SpanContext context, bool use128Bits) =>
-        use128Bits ?
+        use128Bits && context.TraceId128.Upper > 0 ?
             context.RawTraceId :
             context.TraceId128.Lower.ToString(CultureInfo.InvariantCulture);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/LogContext.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/LogContext.cs
@@ -1,0 +1,88 @@
+﻿// <copyright file="LogContext.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging;
+
+internal static class LogContext
+{
+    private static string GetTraceId(SpanContext context, bool use128Bits) =>
+        use128Bits ?
+            context.RawTraceId :
+            context.TraceId128.Lower.ToString(CultureInfo.InvariantCulture);
+
+    private static string GetSpanId(SpanContext context) =>
+        context.SpanId.ToString(CultureInfo.InvariantCulture);
+
+    public static bool TryGetValues(
+        IReadOnlyDictionary<string, string> context,
+        out string traceId,
+        out string spanId,
+        bool use128Bits)
+    {
+        if (context is SpanContext spanContext)
+        {
+            traceId = GetTraceId(spanContext, use128Bits);
+            spanId = GetSpanId(spanContext);
+            return true;
+        }
+
+        if (TryGetTraceId(context, use128Bits, out traceId) &&
+            TryGetSpanId(context, out spanId))
+        {
+            return true;
+        }
+
+        traceId = string.Empty;
+        spanId = string.Empty;
+        return false;
+    }
+
+    public static bool TryGetTraceId(IReadOnlyDictionary<string, string> context, bool use128Bits, out string traceId)
+    {
+        if (context is SpanContext spanContext)
+        {
+            traceId = GetTraceId(spanContext, use128Bits);
+            return true;
+        }
+
+        var traceIdKey = use128Bits ? SpanContext.Keys.RawTraceId : SpanContext.Keys.TraceId;
+
+        // For mismatch version support we need to keep requesting old HttpHeaderNames keys.
+        if (context.TryGetValue(traceIdKey, out var value) ||
+            context.TryGetValue(HttpHeaderNames.TraceId, out value))
+        {
+            traceId = value;
+            return true;
+        }
+
+        traceId = string.Empty;
+        return false;
+    }
+
+    public static bool TryGetSpanId(IReadOnlyDictionary<string, string> context, out string spanId)
+    {
+        if (context is SpanContext spanContext)
+        {
+            spanId = GetSpanId(spanContext);
+            return true;
+        }
+
+        // For mismatch version support we need to keep requesting old HttpHeaderNames keys.
+        if (context.TryGetValue(SpanContext.Keys.ParentId, out var value) ||
+            context.TryGetValue(HttpHeaderNames.ParentId, out value))
+        {
+            spanId = value;
+            return true;
+        }
+
+        spanId = string.Empty;
+        return false;
+    }
+}

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/DiagnosticContextHelper.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/NLog/LogsInjection/DiagnosticContextHelper.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Reflection;
 using Datadog.Trace.DuckTyping;
 using Datadog.Trace.Logging;
@@ -115,38 +114,31 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.NLog.LogsInjecti
             }
         }
 
-        private static IReadOnlyList<KeyValuePair<string, object>> CreateEntriesList(Tracer tracer, out bool hasTraceIds)
+        private static KeyValuePair<string, object>[] CreateEntriesList(Tracer tracer, out bool hasTraceIds)
         {
             hasTraceIds = false;
-            var spanContext = tracer.DistributedSpanContext;
 
-            if (spanContext is not null)
+            if (tracer.DistributedSpanContext is { } context &&
+                LogContext.TryGetValues(context, out var traceId, out var spanId, tracer.Settings.TraceId128BitLoggingEnabled))
             {
-                // For mismatch version support we need to keep requesting old keys.
-                var hasTraceId = spanContext.TryGetValue(SpanContext.Keys.TraceId, out string traceId) ||
-                                 spanContext.TryGetValue(HttpHeaderNames.TraceId, out traceId);
-                var hasSpanId = spanContext.TryGetValue(SpanContext.Keys.ParentId, out string spanId) ||
-                                spanContext.TryGetValue(HttpHeaderNames.ParentId, out spanId);
-                if (hasTraceId && hasSpanId)
-                {
-                    hasTraceIds = true;
-                    return new[]
-                    {
-                        new KeyValuePair<string, object>(CorrelationIdentifier.ServiceKey, tracer.DefaultServiceName ?? string.Empty),
-                        new KeyValuePair<string, object>(CorrelationIdentifier.VersionKey, tracer.Settings.ServiceVersion ?? string.Empty),
-                        new KeyValuePair<string, object>(CorrelationIdentifier.EnvKey, tracer.Settings.Environment ?? string.Empty),
-                        new KeyValuePair<string, object>(CorrelationIdentifier.TraceIdKey, traceId),
-                        new KeyValuePair<string, object>(CorrelationIdentifier.SpanIdKey, spanId)
-                    };
-                }
+                hasTraceIds = true;
+
+                return
+                [
+                    new KeyValuePair<string, object>(CorrelationIdentifier.ServiceKey, tracer.DefaultServiceName ?? string.Empty),
+                    new KeyValuePair<string, object>(CorrelationIdentifier.VersionKey, tracer.Settings.ServiceVersion ?? string.Empty),
+                    new KeyValuePair<string, object>(CorrelationIdentifier.EnvKey, tracer.Settings.Environment ?? string.Empty),
+                    new KeyValuePair<string, object>(CorrelationIdentifier.TraceIdKey, traceId),
+                    new KeyValuePair<string, object>(CorrelationIdentifier.SpanIdKey, spanId)
+                ];
             }
 
-            return new[]
-            {
+            return
+            [
                 new KeyValuePair<string, object>(CorrelationIdentifier.ServiceKey, tracer.DefaultServiceName ?? string.Empty),
                 new KeyValuePair<string, object>(CorrelationIdentifier.VersionKey, tracer.Settings.ServiceVersion ?? string.Empty),
                 new KeyValuePair<string, object>(CorrelationIdentifier.EnvKey, tracer.Settings.Environment ?? string.Empty)
-            };
+            ];
         }
 
         internal static class Cache<TMarker>

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/Serilog/LogsInjection/LoggerDispatchInstrumentation.cs
@@ -55,19 +55,11 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging.Serilog.LogsInje
                 AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogVersionKey, tracer.Settings.ServiceVersion);
                 AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogEnvKey, tracer.Settings.Environment);
 
-                var spanContext = tracer.DistributedSpanContext;
-                if (spanContext is not null)
+                if (tracer.DistributedSpanContext is { } context &&
+                    LogContext.TryGetValues(context, out var traceId, out var spanId, tracer.Settings.TraceId128BitLoggingEnabled))
                 {
-                    // For mismatch version support we need to keep requesting old keys.
-                    var hasTraceId = spanContext.TryGetValue(SpanContext.Keys.TraceId, out string traceId) ||
-                                     spanContext.TryGetValue(HttpHeaderNames.TraceId, out traceId);
-                    var hasSpanId = spanContext.TryGetValue(SpanContext.Keys.ParentId, out string spanId) ||
-                                    spanContext.TryGetValue(HttpHeaderNames.ParentId, out spanId);
-                    if (hasTraceId && hasSpanId)
-                    {
-                        AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogTraceIdKey, traceId);
-                        AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogSpanIdKey, spanId);
-                    }
+                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogTraceIdKey, traceId);
+                    AddPropertyIfAbsent(dict, CorrelationIdentifier.SerilogSpanIdKey, spanId);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Selenium/SeleniumCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Selenium/SeleniumCommon.cs
@@ -72,7 +72,7 @@ internal static class SeleniumCommon
         {
             var span = test.GetInternalSpan();
             var tags = test.GetTags();
-            var traceId = span.Context.TraceId;
+            var traceId = span.TraceId128.Lower;
 
             // Create a cookie with the traceId to be used by the RUM library
             if (Activator.CreateInstance(_seleniumCookieType, CookieName, traceId.ToString()) is { } cookieInstance)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -735,7 +735,7 @@ namespace Datadog.Trace.Configuration
             /// Enables generating 128-bit trace ids instead of 64-bit trace ids.
             /// Note that a 128-bit trace id may be received from an upstream service or from
             /// an Activity even if we are not generating them ourselves.
-            /// Default value is <c>false</c> (disabled).
+            /// Default value is <c>true</c> (enabled).
             /// </summary>
             public const string TraceId128BitGenerationEnabled = "DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED";
 

--- a/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/SpanExtensions.cs
@@ -132,26 +132,6 @@ namespace Datadog.Trace.ExtensionMethods
             }
         }
 
-        internal static string GetTraceIdStringForLogs(this ISpan span)
-        {
-            if (span is not Span s)
-            {
-                return span?.TraceId.ToString(CultureInfo.InvariantCulture);
-            }
-
-            var context = s.Context;
-            var use128Bits = context.TraceContext?.Tracer?.Settings?.TraceId128BitLoggingEnabled ?? false;
-
-            if (use128Bits && context.TraceId128.Upper > 0)
-            {
-                // encode all 128 bits of the trace id as a hex string
-                return context.RawTraceId;
-            }
-
-            // encode only the lower 64 bits of the trace ids as decimal (not hex)
-            return context.TraceId128.Lower.ToString(CultureInfo.InvariantCulture);
-        }
-
         private static string ConvertStatusCodeToString(int statusCode)
         {
             if (statusCode == 200)

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -324,7 +324,7 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             writer.WriteEndObject();
         }
 
-        internal void FormatCIVisibilityLog(StringBuilder sb, string source, string? logLevel, string message, ISpan? span)
+        internal void FormatCIVisibilityLog(StringBuilder sb, string source, string? logLevel, string message, Span? span)
         {
             using var writer = GetJsonWriter(sb);
 

--- a/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
+++ b/tracer/src/Datadog.Trace/Logging/DirectSubmission/Formatting/LogFormatter.cs
@@ -10,6 +10,7 @@ using System.Globalization;
 using System.IO;
 using System.Text;
 using Datadog.Trace.Ci.Tags;
+using Datadog.Trace.ClrProfiler.AutoInstrumentation.Logging;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Util;
@@ -34,8 +35,9 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
         private readonly string? _env;
         private readonly string? _version;
         private readonly IGitMetadataTagsProvider _gitMetadataTagsProvider;
-        private bool _gitMetadataAdded;
+        private readonly bool _use128Bits;
 
+        private bool _gitMetadataAdded;
         private string? _ciVisibilityDdTags;
 
         public LogFormatter(
@@ -47,16 +49,16 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
             string version,
             IGitMetadataTagsProvider gitMetadataTagsProvider)
         {
-            _gitMetadataTagsProvider = gitMetadataTagsProvider;
             _source = string.IsNullOrEmpty(directLogSettings.Source) ? null : directLogSettings.Source;
             _service = string.IsNullOrEmpty(serviceName) ? null : serviceName;
             _host = string.IsNullOrEmpty(directLogSettings.Host) ? null : directLogSettings.Host;
-
-            var globalTags = directLogSettings.GlobalTags is { Count: > 0 } ? directLogSettings.GlobalTags : settings.GlobalTags;
-
-            Tags = EnrichTagsWithAasMetadata(StringifyGlobalTags(globalTags), aasSettings);
             _env = string.IsNullOrEmpty(env) ? null : env;
             _version = string.IsNullOrEmpty(version) ? null : version;
+            _gitMetadataTagsProvider = gitMetadataTagsProvider;
+            _use128Bits = settings.TraceId128BitLoggingEnabled;
+
+            var globalTags = directLogSettings.GlobalTags is { Count: > 0 } ? directLogSettings.GlobalTags : settings.GlobalTags;
+            Tags = EnrichTagsWithAasMetadata(StringifyGlobalTags(globalTags), aasSettings);
         }
 
         internal delegate LogPropertyRenderingDetails FormatDelegate<T>(JsonTextWriter writer, in T state);
@@ -375,14 +377,14 @@ namespace Datadog.Trace.Logging.DirectSubmission.Formatting
                     service = span.ServiceName;
                 }
 
-                // encode all 128 bits of the trace id as a hex string, or
-                // encode only the lower 64 bits of the trace ids as decimal (not hex)
-                writer.WritePropertyName("dd.trace_id", escape: false);
-                writer.WriteValue(span.GetTraceIdStringForLogs());
+                if (LogContext.TryGetValues(span.Context, out var traceId, out var spanId, _use128Bits))
+                {
+                    writer.WritePropertyName("dd.trace_id", escape: false);
+                    writer.WriteValue(traceId);
 
-                // 64-bit span ids are always encoded as decimal (not hex)
-                writer.WritePropertyName("dd.span_id", escape: false);
-                writer.WriteValue(span.SpanId.ToString(CultureInfo.InvariantCulture));
+                    writer.WritePropertyName("dd.span_id", escape: false);
+                    writer.WriteValue(spanId);
+                }
 
                 if (span.GetTag(TestTags.Suite) is { } suite)
                 {

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Activity.Handlers;
@@ -202,6 +203,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the active span context dictionary by consulting DistributedTracer.Instance
         /// </summary>
+        [MaybeNull]
         internal IReadOnlyDictionary<string, string> DistributedSpanContext => DistributedTracer.Instance.GetSpanContextRaw() ?? InternalActiveScope?.Span?.Context;
 
         /// <summary>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs
@@ -154,7 +154,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         protected async Task RunDirectlyShipsLogs(bool filterStartupLogs, bool enable128BitInjection, string packageVersion)
         {
-            SetEnvironmentVariable("DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED", enable128BitInjection ? "true" : "false");
             SetEnvironmentVariable("DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED", enable128BitInjection ? "true" : "false");
             SetInstrumentationVerification();
             var hostName = "integration_ilogger_tests";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
@@ -175,7 +175,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 string traceIdRegex;
                 if (use128Bits)
                 {
-                    traceIdRegex = string.Format(test.RegexFormat, traceIdProperty, @"\""([0-9a-f]{32})\"""); // Match a string of digits or hex character - must be 32. Group 1 has ID
+                    traceIdRegex = string.Format(test.RegexFormat, traceIdProperty, @"("")?([0-9a-f]{32})(?(1)\1|)"); // Match a string of 32 hex characters surrounded by double quotes.
                 }
                 else
                 {
@@ -198,7 +198,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                .And.MatchRegex(traceIdRegex)
                                .And.MatchRegex(spanIdRegex);
 
-                            var logTraceId = use128Bits ? Regex.Match(log, traceIdRegex).Groups[1].Value : Regex.Match(log, traceIdRegex).Groups[2].Value;
+                            var logTraceId = Regex.Match(log, traceIdRegex).Groups[2].Value;
                             traceIdSet.Add(logTraceId);
                             var logSpanId = Regex.Match(log, spanIdRegex).Groups[2].Value;
                             spanIdSet.Add(logSpanId);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
@@ -122,30 +122,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // Ensure that all spans are represented (when correlated) or no spans are represented (when not correlated) in the traced logs
                 if (tracedLogs.Any())
                 {
-                    List<string> traceIds = new List<string>();
-                    if (use128Bits)
-                    {
-                        // reassemble 128 bit
-                        foreach (var span in spans)
-                        {
-                            var lower = span.TraceId;
-                            var upper = span.GetTag(Tags.Propagated.TraceIdUpper);
-
-                            if (string.IsNullOrEmpty(upper))
-                            {
-                                continue; // TODO: unsure exactly why some were empty, but I don't think it was an issue
-                            }
-
-                            var combined = upper + lower.ToString("x16");
-                            traceIds.Add(combined);
-                        }
-
-                        traceIds = traceIds.Distinct().ToList();
-                    }
-                    else
-                    {
-                        traceIds = spans.Select(x => x.TraceId.ToString()).Distinct().ToList();
-                    }
+                    var traceIds = use128Bits
+                        ? spans.Select(x => x.GetTag(Trace.Tags.TraceId)).Distinct().ToList()   // gets the RawTraceId
+                        : spans.Select(x => x.TraceId.ToString()).Distinct().ToList();          // gets the TraceId lower (64-bits)
 
                     if (traceIds.Any())
                     {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs
@@ -124,16 +124,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // Ensure that all spans are represented (when correlated) or no spans are represented (when not correlated) in the traced logs
                 if (tracedLogs.Any())
                 {
-                    List<string> traceIds = new List<string>();
+                    var traceIds = new List<string>();
                     if (use128Bits)
                     {
-                        // dumb but simple way of reassembling 128 bit trace ids
-                        // we first collect all spans that have a propagated trace id upper
-                        // we build a dictionary of {upper: lower} trace ids
-                        // then we go back through the spans and reassemble the 128 bit trace id
-                        // there isn't a clean way of getting the 128-bit id from the MockSpan
-                        // This could be converted to a LINQ query but...
-                        var lowerUpper = new Dictionary<string, string>();
                         foreach (var span in spans)
                         {
                             var lower = span.TraceId.ToString("x16");
@@ -141,27 +134,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                             if (string.IsNullOrEmpty(upper))
                             {
                                 continue;
-                            }
-
-                            if (lowerUpper.ContainsKey(lower))
-                            {
-                                continue;
-                            }
-                            else
-                            {
-                                lowerUpper.Add(lower, upper);
-                            }
-                        }
-
-                        // reassemble 128 bit
-                        foreach (var span in spans)
-                        {
-                            var lower = span.TraceId.ToString("x16");
-                            var upper = span.GetTag(Tags.Propagated.TraceIdUpper);
-
-                            if (string.IsNullOrEmpty(upper))
-                            {
-                                upper = lowerUpper[lower];
                             }
 
                             var combined = upper + lower;


### PR DESCRIPTION
## Summary of changes

Add support for injecting 128-bit trace ids using logs injection. This uses the existing `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED` setting, which is `false` (disabled) by default.

When `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=false` (default), there should be no change from today:
- inject all trace ids as a 64-bit decimal number
- use the lower 64 bits (`traceid.lower`) for 128-bit trace ids

When `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED=true`:
- 64-bit trace ids (`traceid.upper == 0`) should keep the previous decimal format (no change)
- 128-bit trace ids should be injected as lower-case hex string of length 32 (with left `0` padding if required)

## Reason for change

The `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED` setting already exists (and is disabled by default), but enabling it doesn't really do anything yet. Its behavior is defined in [the RFC that added support for 128-bit trace ids](https://docs.google.com/document/d/1h69s_dPWCJ2shqrnqPFGOw_cvpav9ZnWzfn8OiYrKBs/edit#heading=h.bwjbgaq1zmnr).

## Implementation details

Created a helper `LogContext` static class to consolidate code used to get trace id and span id strings in various places. The new methods take a `bool` parameter to determine if we should inject 64-bit trace ids as decimal strings (default) or 128-bit trace ids as hexadecimal strings. Span id are always injected as decimal strings, never hex.

The new implementation also detects `SpanContext` objects and accesses its properties directly instead of relying on the `IReadOnlyDictionary<string, string>` implementation used for version mismatch scenarios.

## Test coverage

Added all necessary tests to test both 64-bit and 128-bit injection.
Tested locally as well with various applications and can see the 128-bit IDs properly injected.

