### PR TITLE
[Profiler] Fix bug in case of Agent error with .NET Framework

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
@@ -30,7 +30,7 @@ EtwEventsManager::EtwEventsManager(
     _pAllocationListener(pAllocationListener),
     _pContentionListener(pContentionListener)
 {
-    _isDebugLogEnabled = pConfiguration->IsDebugLogEnabled();
+    _isDebugLogEnabled = pConfiguration->IsEtwLoggingEnabled();
 
     _threadsInfo.reserve(256);
     _parser = std::make_unique<ClrEventsParser>(
@@ -149,7 +149,6 @@ void EtwEventsManager::OnEvent(
     }
     else if (keyword == KEYWORD_GC)
     {
-
         if (id == EVENT_ALLOCATION_TICK)
         {
             if (_isDebugLogEnabled)
@@ -171,9 +170,21 @@ void EtwEventsManager::OnEvent(
         }
         else
         {
+            if (_isDebugLogEnabled)
+            {
+                std::cout << "GC event: " << keyword << " - " << id << std::endl;
+            }
+
             // reuse GC events parser
             auto timestamp = TimestampToEpochNS(systemTimestamp);
             _parser->ParseEvent(timestamp, version, keyword, id, cbEventData, pEventData);
+        }
+    }
+    else
+    {
+        if (_isDebugLogEnabled)
+        {
+            std::cout << "Unknown event: " << keyword << " - " << id << std::endl;
         }
     }
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
@@ -303,17 +303,23 @@ void EtwEventsManager::Stop()
         Log::Warn("Fail to unregister from the Datadog Agent...");
     }
 
-    if (_IpcClient->Disconnect())
+    if (_IpcClient != nullptr)
     {
-        Log::Info("Disconnected from the Datadog Agent named pipe");
-    }
-    else
-    {
-        Log::Warn("Failed to disconnect from the Datadog Agent named pipe...");
+        if (_IpcClient->Disconnect())
+        {
+            Log::Info("Disconnected from the Datadog Agent named pipe");
+        }
+        else
+        {
+            Log::Warn("Failed to disconnect from the Datadog Agent named pipe...");
+        }
     }
 
     // stop listening to incoming ETW events
-    _IpcServer->Stop();
+    if (_IpcServer != nullptr)
+    {
+        _IpcServer->Stop();
+    }
 }
 
 static void LogLastError(const char* msg, DWORD error = ::GetLastError())

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -89,7 +89,8 @@ Configuration::Configuration()
     }
 
     _isEtwEnabled = GetEnvironmentValue(EnvironmentVariables::EtwEnabled, false);
-     ExtractSsiState(_isSsiDeployed, _isSsiActivated);
+    ExtractSsiState(_isSsiDeployed, _isSsiActivated);
+    _isEtwLoggingEnabled = GetEnvironmentValue(EnvironmentVariables::EtwLoggingEnabled, false);
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -547,6 +548,14 @@ bool Configuration::IsSsiActivated() const
     return _isSsiActivated;
 }
 
+bool Configuration::IsEtwLoggingEnabled() const
+{
+#ifdef LINUX
+    return false;
+#else
+    return _isEtwLoggingEnabled;
+#endif
+}
 
 bool convert_to(shared::WSTRING const& s, bool& result)
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -69,7 +69,7 @@ public:
     bool IsEtwEnabled() const override;
     bool IsSsiDeployed() const override;
     bool IsSsiActivated() const override;
-
+    bool IsEtwLoggingEnabled() const override;
 
 
 private:
@@ -157,4 +157,5 @@ private:
     bool _isEtwEnabled;
     bool _isSsiDeployed;
     bool _isSsiActivated;
+    bool _isEtwLoggingEnabled;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -62,6 +62,7 @@ public:
     inline static const shared::WSTRING SystemCallsShieldEnabled    = WStr("DD_INTERNAL_SYSTEM_CALLS_SHIELD_ENABLED");
     inline static const shared::WSTRING EtwEnabled                  = WStr("DD_INTERNAL_PROFILING_ETW_ENABLED");
     inline static const shared::WSTRING SsiDeployed                 = WStr("DD_INJECTION_ENABLED");
+    inline static const shared::WSTRING EtwLoggingEnabled           = WStr("DD_INTERNAL_ETW_LOGGING_ENABLED");
 
     inline static const shared::WSTRING CIVisibilityEnabled         = WStr("DD_CIVISIBILITY_ENABLED");
     inline static const shared::WSTRING InternalCIVisibilitySpanId  = WStr("DD_INTERNAL_CIVISIBILITY_SPANID");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -67,4 +67,5 @@ public:
     virtual bool IsEtwEnabled() const = 0;
     virtual bool IsSsiDeployed() const = 0;
     virtual bool IsSsiActivated() const = 0;
+    virtual bool IsEtwLoggingEnabled() const = 0;
 };

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -27,5 +27,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string GcThreadsCpuTimeEnabled = "DD_INTERNAL_GC_THREADS_CPUTIME_ENABLED";
         public const string ThreadLifetimeEnabled = "DD_INTERNAL_THREAD_LIFETIME_ENABLED";
         public const string SsiDeployed = "DD_INJECTION_ENABLED";
+        public const string EtwEnabled = "DD_INTERNAL_PROFILING_ETW_ENABLED";
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/EtwEventsTests.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/WindowsOnly/EtwEventsTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="EtwEventsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System.IO;
+using System.Linq;
+using Datadog.Profiler.IntegrationTests.Helpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.WindowsOnly
+{
+    [Trait("Category", "WindowsOnly")]
+
+    public class EtwEventsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public EtwEventsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01", new[] { "net462" })]
+        public void CheckErrorWhenNoAgentIsAvailable(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: "--scenario 1");
+
+            // Overwrite the one set in EnvironmentHelper
+            runner.Environment.SetVariable(EnvironmentVariables.EtwEnabled, "1");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(_output);
+
+            runner.Run(agent);
+
+            var logFile = Directory.GetFiles(runner.Environment.LogDir)
+                .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
+
+            var lines = File.ReadAllLines(logFile);
+
+            lines.Should().ContainMatch("*Impossible to connect to the Datadog Agent named pipe*");
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -905,3 +905,22 @@ TEST(ConfigurationTest, CheckSsiIsNotActivatedIfEnvVarIsEmpty)
     auto expectedValue = false;
     ASSERT_THAT(configuration.IsSsiActivated(), expectedValue);
 }
+
+TEST(ConfigurationTest, CheckEtwLoggingIsDisabledByDefault)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.IsEtwLoggingEnabled(), false);
+}
+
+TEST(ConfigurationTest, CheckEtwLoggingIsEnabledIfEnvVarSetToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::EtwLoggingEnabled, WStr("1"));
+    auto configuration = Configuration{};
+    auto expectedValue =
+#ifdef LINUX
+        false;
+#else
+        true;
+#endif
+    ASSERT_THAT(configuration.IsEtwLoggingEnabled(), expectedValue);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -72,6 +72,7 @@ public:
     MOCK_METHOD(bool, IsEtwEnabled, (), (const override));
     MOCK_METHOD(bool, IsSsiDeployed, (), (const override));
     MOCK_METHOD(bool, IsSsiActivated, (), (const override));
+    MOCK_METHOD(bool, IsEtwLoggingEnabled, (), (const override));
 };
 
 class MockExporter : public IExporter


### PR DESCRIPTION
## Summary of changes
Check non initialized IPC client and server in case of error to connect to the Agent for .NET Framework

## Reason for change
Possible crash

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
