### PR TITLE
[Exception Replay] Better communicate non-captured exceptions

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/CachedDoneExceptions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/CachedDoneExceptions.cs
@@ -7,54 +7,32 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 {
-    internal class CachedDoneExceptions
+    /// <summary>
+    /// Acts as a proxy to a static `CachedItems` object to make the Exception that are in done cases easily accesible, throughout the codebase
+    /// without references detouring.
+    /// </summary>
+    internal static class CachedDoneExceptions
     {
-        private static readonly HashSet<string> DoneExceptions = new();
-        private static readonly ReaderWriterLockSlim DoneExceptionsLocker = new();
+        private static readonly CachedItems _cachedDoneExceptions = new CachedItems();
 
-        internal static void Add(string exceptionToString)
+        internal static void Add(string item)
         {
-            DoneExceptionsLocker.EnterWriteLock();
-            try
-            {
-                DoneExceptions.Add(exceptionToString);
-            }
-            finally
-            {
-                DoneExceptionsLocker.ExitWriteLock();
-            }
+            _cachedDoneExceptions.Add(item);
         }
 
-        internal static bool Remove(string exceptionToString)
+        internal static bool Remove(string item)
         {
-            DoneExceptionsLocker.EnterWriteLock();
-            try
-            {
-                return DoneExceptions.Remove(exceptionToString);
-            }
-            finally
-            {
-                DoneExceptionsLocker.ExitWriteLock();
-            }
+            return _cachedDoneExceptions.Remove(item);
         }
 
-        internal static bool Contains(string exceptionToString)
+        internal static bool Contains(string item)
         {
-            DoneExceptionsLocker.EnterReadLock();
-            try
-            {
-                return DoneExceptions.Contains(exceptionToString);
-            }
-            finally
-            {
-                DoneExceptionsLocker.ExitReadLock();
-            }
+            return _cachedDoneExceptions.Contains(item);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/CachedItems.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/CachedItems.cs
@@ -1,0 +1,65 @@
+// <copyright file="CachedItems.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Vendors.MessagePack;
+using Fnv1aHash = Datadog.Trace.VendoredMicrosoftCode.System.Reflection.Internal.Hash;
+
+#nullable enable
+namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
+{
+    internal class CachedItems
+    {
+        private readonly HashSet<int> cache = new();
+        private readonly ReaderWriterLockSlim cacheLocker = new();
+
+        internal void Add(string item)
+        {
+            cacheLocker.EnterWriteLock();
+            try
+            {
+                cache.Add(Hash(item));
+            }
+            finally
+            {
+                cacheLocker.ExitWriteLock();
+            }
+        }
+
+        internal bool Remove(string item)
+        {
+            cacheLocker.EnterWriteLock();
+            try
+            {
+                return cache.Remove(Hash(item));
+            }
+            finally
+            {
+                cacheLocker.ExitWriteLock();
+            }
+        }
+
+        internal bool Contains(string item)
+        {
+            cacheLocker.EnterReadLock();
+            try
+            {
+                return cache.Contains(Hash(item));
+            }
+            finally
+            {
+                cacheLocker.ExitReadLock();
+            }
+        }
+
+        private int Hash(string item) => Fnv1aHash.GetFNVHashCode(StringEncoding.UTF8.GetBytes(item));
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionCollectionState.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionCollectionState.cs
@@ -18,6 +18,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         Initializing,
         Collecting,
         Finalizing,
+        Invalidated,
         None
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedExceptionCase.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/TrackedExceptionCase.cs
@@ -41,6 +41,8 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
         public bool IsDone => TrackingExceptionCollectionState == ExceptionCollectionState.Finalizing || TrackingExceptionCollectionState == ExceptionCollectionState.Done;
 
+        public bool IsInvalidated => TrackingExceptionCollectionState == ExceptionCollectionState.Invalidated;
+
         public DateTime StartCollectingTime { get; private set; }
 
         public ExceptionCase ExceptionCase { get; private set; }
@@ -95,6 +97,11 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             }
 
             return false;
+        }
+
+        public void InvalidateCase()
+        {
+            EndInProgressState(ExceptionCollectionState.Invalidated);
         }
 
         private bool BeginTeardown()


### PR DESCRIPTION
## Summary of changes
In Exception Replay we may fail to capture all the frames of an exception. The reasons vary and could be instrumentation failure (native level), blocklisting, .NET 6+ with non-optimized code, etc - of all the participating frames in the exception stack trace.

To communicate that, a new tag was introduced - `_dd.debug.error.<FRAME_NUMBER>.no_capture_reason:<REASON>`.
In this PR, I've added this tag for every frame we've failed to capture.

## Reason for change
Communicating to the customers why there are no frame data for a given exception.