### PR TITLE
[Dynamic Instrumentation] Introduce diagnostics endpoint

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -19,10 +19,12 @@ internal record AgentConfiguration
         string? eventPlatformProxyEndpoint,
         string? telemetryProxyEndpoint,
         string? tracerFlareEndpoint,
-        bool clientDropP0)
+        bool clientDropP0,
+        string? diagnosticsEndpoint)
     {
         ConfigurationEndpoint = configurationEndpoint;
         DebuggerEndpoint = debuggerEndpoint;
+        DiagnosticsEndpoint = diagnosticsEndpoint;
         SymbolDbEndpoint = symbolDbEndpoint;
         AgentVersion = agentVersion;
         StatsEndpoint = statsEndpoint;
@@ -36,6 +38,8 @@ internal record AgentConfiguration
     public string? ConfigurationEndpoint { get; }
 
     public string? DebuggerEndpoint { get; }
+
+    public string? DiagnosticsEndpoint { get; }
 
     public string? SymbolDbEndpoint { get; }
 

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -20,6 +20,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
     internal class DiscoveryService : IDiscoveryService
     {
         private const string SupportedDebuggerEndpoint = "debugger/v1/input";
+        private const string SupportedDiagnosticsEndpoint = "debugger/v1/diagnostics";
         private const string SupportedSymbolDbEndpoint = "symdb/v1/input";
         private const string SupportedConfigurationEndpoint = "v0.7/config";
         private const string SupportedStatsEndpoint = "v0.6/stats";
@@ -65,6 +66,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
             new[]
             {
                 SupportedDebuggerEndpoint,
+                SupportedDiagnosticsEndpoint,
                 SupportedSymbolDbEndpoint,
                 SupportedConfigurationEndpoint,
                 SupportedStatsEndpoint,
@@ -219,6 +221,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
             var discoveredEndpoints = (jObject["endpoints"] as JArray)?.Values<string>().ToArray();
             string? configurationEndpoint = null;
             string? debuggerEndpoint = null;
+            string? diagnosticsEndpoint = null;
             string? symbolDbEndpoint = null;
             string? statsEndpoint = null;
             string? dataStreamsMonitoringEndpoint = null;
@@ -240,6 +243,10 @@ namespace Datadog.Trace.Agent.DiscoveryService
                     if (endpoint.Equals(SupportedDebuggerEndpoint, StringComparison.OrdinalIgnoreCase))
                     {
                         debuggerEndpoint = endpoint;
+                    }
+                    else if (endpoint.Equals(SupportedDiagnosticsEndpoint, StringComparison.OrdinalIgnoreCase))
+                    {
+                        diagnosticsEndpoint = endpoint;
                     }
                     else if (endpoint.Equals(SupportedSymbolDbEndpoint, StringComparison.OrdinalIgnoreCase))
                     {
@@ -281,6 +288,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
             var newConfig = new AgentConfiguration(
                 configurationEndpoint: configurationEndpoint,
                 debuggerEndpoint: debuggerEndpoint,
+                diagnosticsEndpoint: diagnosticsEndpoint ?? debuggerEndpoint,
                 symbolDbEndpoint: symbolDbEndpoint,
                 agentVersion: agentVersion,
                 statsEndpoint: statsEndpoint,

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
@@ -81,17 +81,11 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             var snapshotBatchUploadApi = AgentBatchUploadApi.Create(apiFactory, discoveryService, gitMetadataTagsProvider, false);
             var snapshotBatchUploader = BatchUploader.Create(snapshotBatchUploadApi);
 
-            var diagnosticsBatchUploadApi = AgentBatchUploadApi.Create(apiFactory, discoveryService, gitMetadataTagsProvider, true);
-            var diagnosticsBatchUploader = BatchUploader.Create(diagnosticsBatchUploadApi);
-
-            var batchApi = AgentBatchUploadApi.Create(apiFactory, discoveryService, gitMetadataTagsProvider, false);
-            var batchUploader = BatchUploader.Create(batchApi);
-
             _sink = DebuggerSink.Create(
-                snapshotStatusSink,
-                new NopProbeStatusSink(),
+                snapshotSink: snapshotStatusSink,
+                probeStatusSink: new NopProbeStatusSink(),
                 snapshotBatchUploader: snapshotBatchUploader,
-                diagnosticsBatchUploader: diagnosticsBatchUploader,
+                diagnosticsBatchUploader: new NonBatchUploader(),
                 debuggerSettings);
 
             Task.Run(async () => await _sink.StartFlushingAsync().ConfigureAwait(false));

--- a/tracer/src/Datadog.Trace/Debugger/Sink/AgentBatchUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/AgentBatchUploadApi.cs
@@ -25,22 +25,28 @@ namespace Datadog.Trace.Debugger.Sink
 
         private readonly IApiRequestFactory _apiRequestFactory;
         private readonly IGitMetadataTagsProvider? _gitMetadataTagsProvider;
+
         private string? _endpoint = null;
         private string? _tags = null;
 
         private AgentBatchUploadApi(
             IApiRequestFactory apiRequestFactory,
             IDiscoveryService discoveryService,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            bool isDiagnostics)
         {
             _apiRequestFactory = apiRequestFactory;
             _gitMetadataTagsProvider = gitMetadataTagsProvider;
-            discoveryService.SubscribeToChanges(c => _endpoint = c.DebuggerEndpoint);
+            discoveryService.SubscribeToChanges(c => _endpoint = isDiagnostics ? c.DiagnosticsEndpoint : c.DebuggerEndpoint);
         }
 
-        public static AgentBatchUploadApi Create(IApiRequestFactory apiRequestFactory, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider)
+        public static AgentBatchUploadApi Create(
+            IApiRequestFactory apiRequestFactory,
+            IDiscoveryService discoveryService,
+            IGitMetadataTagsProvider gitMetadataTagsProvider,
+            bool isDiagnostics)
         {
-            return new AgentBatchUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider);
+            return new AgentBatchUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, isDiagnostics);
         }
 
         public async Task<bool> SendBatchAsync(ArraySegment<byte> data)

--- a/tracer/src/Datadog.Trace/Debugger/Sink/BatchUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/BatchUploader.cs
@@ -11,7 +11,7 @@ using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Debugger.Sink
 {
-    internal class BatchUploader
+    internal class BatchUploader : IBatchUploader
     {
         private const int MaxSinglePayloadSize = 1 * 1024 * 1024;
         private const int MaxTotalPayloadSize = 5 * 1024 * 1024;

--- a/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerSink.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/DebuggerSink.cs
@@ -32,14 +32,14 @@ namespace Datadog.Trace.Debugger.Sink
         private readonly ProbeStatusSink _probeStatusSink;
         private readonly int _uploadFlushInterval;
         private readonly int _initialFlushInterval;
-        private readonly BatchUploader _snapshotBatchUploader;
-        private readonly BatchUploader _diagnosticsBatchUploader;
+        private readonly IBatchUploader _snapshotBatchUploader;
+        private readonly IBatchUploader _diagnosticsBatchUploader;
 
         private DebuggerSink(
             SnapshotSink snapshotSink,
             ProbeStatusSink probeStatusSink,
-            BatchUploader snapshotBatchUploader,
-            BatchUploader diagnosticsBatchUploader,
+            IBatchUploader snapshotBatchUploader,
+            IBatchUploader diagnosticsBatchUploader,
             int uploadFlushInterval,
             int initialFlushInterval)
         {
@@ -54,7 +54,7 @@ namespace Datadog.Trace.Debugger.Sink
             _cancellationSource = new CancellationTokenSource();
         }
 
-        public static DebuggerSink Create(SnapshotSink snapshotSink, ProbeStatusSink probeStatusSink, BatchUploader snapshotBatchUploader, BatchUploader diagnosticsBatchUploader, DebuggerSettings settings)
+        public static DebuggerSink Create(SnapshotSink snapshotSink, ProbeStatusSink probeStatusSink, IBatchUploader snapshotBatchUploader, IBatchUploader diagnosticsBatchUploader, DebuggerSettings settings)
         {
             var uploadInterval = settings.UploadFlushIntervalMilliseconds;
             var initialInterval =

--- a/tracer/src/Datadog.Trace/Debugger/Sink/IBatchUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/IBatchUploader.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/tracer/src/Datadog.Trace/Debugger/Sink/IBatchUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/IBatchUploader.cs
@@ -1,0 +1,14 @@
+// <copyright file="IBatchUploader.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Debugger.Sink;
+
+internal interface IBatchUploader
+{
+    Task Upload(IEnumerable<string> payloads);
+}

--- a/tracer/src/Datadog.Trace/Debugger/Sink/NonBatchUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/NonBatchUploader.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
 using System.Collections.Generic;
 using System.Threading.Tasks;
 

--- a/tracer/src/Datadog.Trace/Debugger/Sink/NonBatchUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/NonBatchUploader.cs
@@ -1,0 +1,17 @@
+// <copyright file="NonBatchUploader.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Datadog.Trace.Debugger.Sink;
+
+internal class NonBatchUploader : IBatchUploader
+{
+    public Task Upload(IEnumerable<string> payloads)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -492,7 +492,7 @@ namespace Datadog.Trace.TestHelpers
                 response = JsonConvert.SerializeObject(Configuration);
                 responseType = MockTracerResponseType.Info;
             }
-            else if (request.PathAndQuery.StartsWith("/debugger/v1/input"))
+            else if (request.PathAndQuery.StartsWith("/debugger"))
             {
                 HandlePotentialDebuggerData(request);
                 responseType = MockTracerResponseType.Debugger;

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
@@ -17,6 +17,7 @@ internal class DiscoveryServiceMock : IDiscoveryService
     public void TriggerChange(
         string configurationEndpoint = "configurationEndpoint",
         string debuggerEndpoint = "debuggerEndpoint",
+        string diagnosticsEndpoint = "diagnosticsEndpoint",
         string symbolDbEndpoint = "symbolDbEndpoint",
         string agentVersion = "agentVersion",
         string statsEndpoint = "traceStatsEndpoint",
@@ -29,6 +30,7 @@ internal class DiscoveryServiceMock : IDiscoveryService
             new AgentConfiguration(
                 configurationEndpoint: configurationEndpoint,
                 debuggerEndpoint: debuggerEndpoint,
+                diagnosticsEndpoint: diagnosticsEndpoint,
                 symbolDbEndpoint: symbolDbEndpoint,
                 agentVersion: agentVersion,
                 statsEndpoint: statsEndpoint,

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -65,6 +65,7 @@ public class DiscoveryServiceTests
         config.AgentVersion.Should().Be(version);
         config.ConfigurationEndpoint.Should().NotBeNullOrEmpty();
         config.DebuggerEndpoint.Should().NotBeNullOrEmpty();
+        config.DiagnosticsEndpoint.Should().NotBeNullOrEmpty();
         config.SymbolDbEndpoint.Should().NotBeNullOrEmpty();
         config.ClientDropP0s.Should().Be(clientDropP0s);
         config.StatsEndpoint.Should().NotBeNullOrEmpty();
@@ -254,6 +255,7 @@ public class DiscoveryServiceTests
         var config1 = new AgentConfiguration(
             configurationEndpoint: "ConfigurationEndpoint",
             debuggerEndpoint: "DebuggerEndpoint",
+            diagnosticsEndpoint: "DiagnosticsEndpoint",
             symbolDbEndpoint: "symbolDbEndpoint",
             agentVersion: "AgentVersion",
             statsEndpoint: "StatsEndpoint",
@@ -267,6 +269,7 @@ public class DiscoveryServiceTests
         var config2 = new AgentConfiguration(
             configurationEndpoint: "ConfigurationEndpoint",
             debuggerEndpoint: "DebuggerEndpoint",
+            diagnosticsEndpoint: "DiagnosticsEndpoint",
             symbolDbEndpoint: "symbolDbEndpoint",
             agentVersion: "AgentVersion",
             statsEndpoint: "StatsEndpoint",
@@ -280,6 +283,7 @@ public class DiscoveryServiceTests
         var config3 = new AgentConfiguration(
             configurationEndpoint: "DIFFERENT",
             debuggerEndpoint: "DebuggerEndpoint",
+            diagnosticsEndpoint: "DiagnosticsEndpoint",
             symbolDbEndpoint: "symbolDbEndpoint",
             agentVersion: "AgentVersion",
             statsEndpoint: "StatsEndpoint",

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -447,6 +447,7 @@ namespace Datadog.Trace.Tests.Agent
                 callback(new AgentConfiguration(
                              configurationEndpoint: "configurationEndpoint",
                              debuggerEndpoint: "debuggerEndpoint",
+                             diagnosticsEndpoint: "diagnosticsEndpoint",
                              symbolDbEndpoint: "symbolDbEndpoint",
                              agentVersion: "agentVersion",
                              statsEndpoint: "traceStatsEndpoint",

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -85,6 +85,7 @@ public class LiveDebuggerTests
                 new AgentConfiguration(
                     configurationEndpoint: "configurationEndpoint",
                     debuggerEndpoint: "debuggerEndpoint",
+                    diagnosticsEndpoint: "diagnosticsEndpoint",
                     symbolDbEndpoint: "symbolDbEndpoint",
                     agentVersion: "agentVersion",
                     statsEndpoint: "traceStatsEndpoint",


### PR DESCRIPTION
## Summary of Changes
Introduce diagnostics endpoint.
Sends snapshots to `input` and probe statuses to `diagnostics` endpoint.

## Reason for Change
Previously, we sent all debugger data to the endpoint `/debugger/v1/input`. Then, the `/debugger/v1/diagnostics` endpoint was introduced. This PR acknowledges this endpoint. 