### PR TITLE
workaround to fix ddsketch issue temporarily

### DIFF
--- a/tracer/build/_build/docker/test-agent.windows.dockerfile
+++ b/tracer/build/_build/docker/test-agent.windows.dockerfile
@@ -2,6 +2,6 @@
 
 WORKDIR /
 
-RUN pip install --no-cache-dir ddapm-test-agent
+RUN pip install --no-cache-dir ddapm-test-agent ddsketch[serialization]
 
 ENTRYPOINT [ "ddapm-test-agent", "--port=8126" ]


### PR DESCRIPTION
## Summary of changes
Installs ddsketch[serialization] explicitly in dd-apm-test-agent docker

## Reason for change
Temporary workaround while the fix is applied upstream in dd-apm-test-agent

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
