### PR TITLE
Fix smoke test issue and pin versions

### DIFF
--- a/tracer/build/_build/docker/test-agent.windows.dockerfile
+++ b/tracer/build/_build/docker/test-agent.windows.dockerfile
@@ -2,6 +2,7 @@
 
 WORKDIR /
 
-RUN pip install --no-cache-dir ddapm-test-agent
+# Pin to older test agent versions to try to avoid breakages in the future
+RUN pip install --no-cache-dir "ddapm-test-agent==1.16.0" "ddsketch==3.0.1" "ddsketch[serialization]==3.0.1"
 
 ENTRYPOINT [ "ddapm-test-agent", "--port=8126" ]


### PR DESCRIPTION
## Summary of changes

Fixes the failing build in ddapm-test-agent, and pins to the current versions to avoid issues in the future

## Reason for change

A recent major version update to ddsketch broke ddapm-test-agent, which in turn broke us. We don't want that to happen again

## Implementation details

Install the dependency, and also pin it so this doesn't happen again

## Test coverage

This is the test...

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
