### PR TITLE
Don't print snapshots diff unless running in CI

### DIFF
--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -317,6 +317,7 @@ partial class Build
     Target PrintSnapshotsDiff  => _ => _
       .Description("Prints snapshots differences from the current tests")
       .AssuredAfterFailure()
+      .OnlyWhenStatic(() => IsServerBuild)
       .Executes(() =>
       {
           var snapshotsDirectory = TestsDirectory / "snapshots";


### PR DESCRIPTION
## Summary of changes

Only prints the snapshot diff at the end of the run if running in CI

## Reason for change

It adds quite a lot of noise and confusion when running locally, and consensus seems to be to disable it

## Implementation details

Check `IsServerBuild` variable (I'm assuming that works as expected 😅)

## Test coverage

I'll check this build and make sure it runs. Already tested locally that it _doesn't_ run.

## Other details
Alternative approach was here:
- https://github.com/DataDog/dd-trace-dotnet/pull/5045

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
