### PR TITLE
[Dynamic Instrumentation] Consider 3rd party assemblies on SymDB

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
@@ -43,7 +43,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
             Log.Information("Initializing Exception Debugging");
 
-            if (!ThirdPartyModules.PopulateFromConfig())
+            if (!ThirdPartyModules.IsValid)
             {
                 Log.Warning("Third party modules load has failed. Disabling Exception Debugging.");
                 _isDisabled = true;

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -18,6 +18,7 @@ using Datadog.Trace.Debugger.PInvoke;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Sink.Models;
 using Datadog.Trace.Debugger.Snapshots;
+using Datadog.Trace.Debugger.Symbols;
 using Datadog.Trace.Logging;
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
 using Datadog.Trace.Vendors.Serilog.Events;
@@ -552,7 +553,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 var assembly = method.Module.Assembly;
                 var assemblyName = assembly.GetName().Name;
 
-                if (assemblyName != null && FrameFilter.IsDatadogAssembly(assemblyName))
+                if (assemblyName != null && AssemblyFilter.IsDatadogAssembly(assemblyName))
                 {
                     continue;
                 }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyModules.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyModules.cs
@@ -4,7 +4,7 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
+using Datadog.Trace.VendoredMicrosoftCode.System.Collections.Immutable;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty
@@ -12,14 +12,14 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty
     internal class ThirdPartyModules
     {
         private static readonly Lazy<bool> IsModulesPopulated = new(PopulateFromConfig);
-        private static HashSet<string>? _thirdPartyModuleNames;
+        private static ImmutableHashSet<string> _thirdPartyModuleNames = ImmutableHashSet<string>.Empty;
 
         internal static bool IsValid => IsModulesPopulated.Value;
 
         private static bool PopulateFromConfig()
         {
             _thirdPartyModuleNames = ThirdPartyConfigurationReader.GetModules();
-            return _thirdPartyModuleNames?.Count > 0;
+            return _thirdPartyModuleNames.Count > 0;
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty
                 return true;
             }
 
-            return _thirdPartyModuleNames?.Contains(moduleName!) == true;
+            return _thirdPartyModuleNames.Contains(moduleName!);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyModules.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ThirdParty/ThirdPartyModules.cs
@@ -3,25 +3,38 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
-using Datadog.Trace.Logging;
 
 #nullable enable
 namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty
 {
     internal class ThirdPartyModules
     {
+        private static readonly Lazy<bool> IsModulesPopulated = new(PopulateFromConfig);
         private static HashSet<string>? _thirdPartyModuleNames;
 
-        internal static bool PopulateFromConfig()
+        internal static bool IsValid => IsModulesPopulated.Value;
+
+        private static bool PopulateFromConfig()
         {
             _thirdPartyModuleNames = ThirdPartyConfigurationReader.GetModules();
-            return _thirdPartyModuleNames.Count > 0;
+            return _thirdPartyModuleNames?.Count > 0;
         }
 
-        internal static bool Contains(string moduleName)
+        /// <summary>
+        /// Check if a module is a 3rd party module
+        /// </summary>
+        /// <param name="moduleName">module name to check if it's a 3rd party module</param>
+        /// <returns>true if the 3rd party list contains the moduleName or if the list fail to initialized</returns>
+        internal static bool Contains(string? moduleName)
         {
-            return _thirdPartyModuleNames?.Contains(moduleName) == true;
+            if (string.IsNullOrEmpty(moduleName) || !IsValid)
+            {
+                return true;
+            }
+
+            return _thirdPartyModuleNames?.Contains(moduleName!) == true;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsUploader.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.ExceptionAutoInstrumentation.ThirdParty;
 using Datadog.Trace.Debugger.Sink;
 using Datadog.Trace.Debugger.Symbols.Model;
 using Datadog.Trace.ExtensionMethods;
@@ -116,6 +117,12 @@ namespace Datadog.Trace.Debugger.Symbols
 
         public static ISymbolsUploader Create(IBatchUploadApi api, IDiscoveryService discoveryService, IRcmSubscriptionManager remoteConfigurationManager, DebuggerSettings settings, ImmutableTracerSettings tracerSettings, string serviceName)
         {
+            if (!ThirdPartyModules.IsValid)
+            {
+                Log.Warning("Third party modules load has failed. Disabling Symbol Uploader.");
+                return new NoOpUploader();
+            }
+
             if (api is not NoOpSymbolBatchUploadApi &&
                (EnvironmentHelpers.GetEnvironmentVariable(ConfigurationKeys.Debugger.SymbolDatabaseUploadEnabledInternal, "false")?.ToBoolean() ?? false))
             {


### PR DESCRIPTION
## Summary of changes
We don't want to upload symbol database for certain assemblies, including list of 3rd party code assemblies. This PR handle that.

## Implementation details
Use a predefine assembly list to check of a specific assembly is 3rd party or not.
