### PR TITLE
K8s Lib Injection: Migration

### DIFF
--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -14,15 +14,11 @@ jobs:
       packages: write
     strategy:
       matrix:
-        lib-injection-connection: ['network','uds']
-        lib-injection-use-admission-controller: [false, true]
         runtime: ['bullseye-slim','alpine']
       fail-fast: false
     uses: ./.github/workflows/lib-injection-test.yml
     with:
       commit_id: ${{ github.event.inputs.forced_commit_id || github.sha }}
-      lib_injection_connection: ${{ matrix.lib-injection-connection }}
-      lib_injection_use_admission_controller: ${{ matrix.lib-injection-use-admission-controller }}
       runtime: ${{ matrix.runtime }}
     secrets:
       DOCKER_REGISTRY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lib-injection-test.yml
+++ b/.github/workflows/lib-injection-test.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Install runner
         uses: ./.github/actions/install_runner 
 
-      - name: Build weblog latest base images
+      - name: Build weblog base images
         env:
-          APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}
+          APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ env.WEBLOG_VARIANT }}
         run: |
           cd lib-injection/build/docker/$TEST_LIBRARY/$WEBLOG_VARIANT 
-          LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
+          LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:$DOCKER_IMAGE_WEBLOG_TAG ./build.sh
           cd ..
 
       - name: Run K8s Lib Injection Tests
@@ -57,5 +57,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: logs_k8s_lib_injection
+          name: logs_k8s_lib_injection_${{ env.WEBLOG_VARIANT }}_${{ env.RUNTIME }}
           path: artifact.tar.gz

--- a/.github/workflows/lib-injection-test.yml
+++ b/.github/workflows/lib-injection-test.yml
@@ -9,14 +9,6 @@ on:
         description: 'The commit ID to run the test against'
         required: true
         type: string
-      lib_injection_connection:
-        description: 'The connection type to use for the lib-injection test (e.g. network, uds)'
-        required: true
-        type: string
-      lib_injection_use_admission_controller:
-        description: 'Whether to use the admission controller'
-        type: boolean
-        required: true
       runtime:
         description: 'The runtime to use to run the tests (e.g. bullseye-slim, alpine)'
         required: true
@@ -31,20 +23,39 @@ jobs:
     env:
       TEST_LIBRARY: dotnet
       WEBLOG_VARIANT: 'dd-lib-dotnet-init-test-app'
-      LIBRARY_INJECTION_CONNECTION: ${{ inputs.lib_injection_connection }}
-      LIBRARY_INJECTION_ADMISSION_CONTROLLER: ${{ inputs.lib_injection_use_admission_controller == true && 'use-admission-controller' || '' }}
       DOCKER_REGISTRY_IMAGES_PATH: ghcr.io/datadog
       DOCKER_IMAGE_TAG: ${{ inputs.commit_id }}${{ inputs.runtime == 'alpine' && '-musl' || '' }}
       DOCKER_IMAGE_WEBLOG_TAG: ${{ inputs.commit_id }}-${{ inputs.runtime }}
       RUNTIME: ${{ inputs.runtime }}
       BUILDX_PLATFORMS: linux/amd64
-      MODE: manual
     steps:
-      - name: lib-injection test runner
-        id: lib-injection-test-runner
-        uses: DataDog/system-tests/lib-injection/runner@main
+      - name: Checkout system tests
+        uses: actions/checkout@v2
         with:
-          docker-registry: ghcr.io
-          docker-registry-username: ${{ github.repository_owner }}
-          docker-registry-password: ${{ secrets.DOCKER_REGISTRY_GITHUB_TOKEN }}
-          test-script: ./lib-injection/run-manual-lib-injection.sh
+            repository: 'DataDog/system-tests'
+
+      - name: Install runner
+        uses: ./.github/actions/install_runner 
+
+      - name: Build weblog latest base images
+        env:
+          APP_DOCKER_IMAGE_REPO: ghcr.io/datadog/system-tests/${{ matrix.variant.weblog-variant }}
+        run: |
+          cd lib-injection/build/docker/$TEST_LIBRARY/$WEBLOG_VARIANT 
+          LIBRARY_INJECTION_TEST_APP_IMAGE=$APP_DOCKER_IMAGE_REPO:latest ./build.sh
+          cd ..
+
+      - name: Run K8s Lib Injection Tests
+        run: ./run.sh K8S_LIB_INJECTION_BASIC
+
+      - name: Compress logs
+        id: compress_logs
+        if: always()
+        run: tar -czvf artifact.tar.gz $(ls | grep logs)
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs_k8s_lib_injection
+          path: artifact.tar.gz

--- a/.github/workflows/lib-injection-test.yml
+++ b/.github/workflows/lib-injection-test.yml
@@ -34,6 +34,25 @@ jobs:
         with:
             repository: 'DataDog/system-tests'
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+    
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+          config-inline: |
+            [worker.oci]
+              max-parallelism = 1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # 3.0.0
+        with:
+          registry: ghcr.io/datadog
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
       - name: Install runner
         uses: ./.github/actions/install_runner 
 

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -146,15 +146,11 @@ jobs:
       packages: write
     strategy:
       matrix:
-        lib-injection-connection: ['network','uds']
-        lib-injection-use-admission-controller: [false, true]
         runtime: ['bullseye-slim','alpine']
       fail-fast: false
     uses: ./.github/workflows/lib-injection-test.yml
     with:
       commit_id: ${{ github.event.inputs.commit_id || github.sha }}
-      lib_injection_connection: ${{ matrix.lib-injection-connection }}
-      lib_injection_use_admission_controller: ${{ matrix.lib-injection-use-admission-controller }}
       runtime: ${{ matrix.runtime }}
     secrets:
       DOCKER_REGISTRY_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary of changes
Migrate the system-tests lib injection test to the new approach
## Reason for change
Lib Injection tests were build using bash scripting, new tests use kubernetes python client
## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
