### PR TITLE
Try fix macos unit test crash

### DIFF
--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -9,8 +9,7 @@ using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests.Utils;
 
-[Collection(nameof(WafLibraryRequiredTest))]
-[CollectionDefinition(nameof(WafLibraryRequiredTest), DisableParallelization=true)]
+[Collection(nameof(SecuritySequentialTests))]
 public class WafLibraryRequiredTest
 {
     /// <summary>

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
@@ -21,7 +21,6 @@ using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests
 {
-    [Collection(nameof(SecuritySequentialTests))]
     public class WafMemoryTests : WafLibraryRequiredTest
     {
         public const int OverheadMargin = 40_000_000; // 40Mb margin


### PR DESCRIPTION
## Summary of changes

Avoid tests belonging to multiple `[Collection]`s

## Reason for change

We started seeing the crashes after this PR:
- https://github.com/DataDog/dd-trace-dotnet/pull/5346

So suspect it was the issue. According to https://github.com/xunit/xunit/issues/2497:

> Collections are a parallelization and context-sharing boundary. They aren't meant to be used this way.

so probably shouldn't do that

## Implementation details

Remove the duplicate Collection attribute by removing from the child and moving it to the base. The `[SecuritySequentialTests]` collection already disables serialization

## Test coverage

🤞 


## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
