### PR TITLE
[Tracing] Add `IsRemote` to `SpanContext`

### DIFF
--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Propagators
 
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.B3Multi);
             var samplingPriority = ParseUtility.ParseInt32(carrier, carrierGetter, Sampled);
-            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId) { IsRemote = true };
+            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId, isRemote: true);
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Propagators
 
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.B3Multi);
             var samplingPriority = ParseUtility.ParseInt32(carrier, carrierGetter, Sampled);
-            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId);
+            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId) { IsRemote = true };
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Propagators
                 }
 
                 var samplingPriority = rawSampled == '1' ? 1 : 0;
-                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId.ToString(), rawSpanId.ToString()) { IsRemote = true };
+                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId.ToString(), rawSpanId.ToString(), isRemote: true);
 #else
                 string? rawTraceId;
                 string? rawSpanId;
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Propagators
                 }
 
                 var samplingPriority = rawSampled == '1' ? 1 : 0;
-                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId) { IsRemote = true };
+                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId, isRemote: true);
 #endif
 
                 TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.B3SingleHeader);

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Propagators
                 }
 
                 var samplingPriority = rawSampled == '1' ? 1 : 0;
-                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId.ToString(), rawSpanId.ToString());
+                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId.ToString(), rawSpanId.ToString()) { IsRemote = true };
 #else
                 string? rawTraceId;
                 string? rawSpanId;
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Propagators
                 }
 
                 var samplingPriority = rawSampled == '1' ? 1 : 0;
-                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId);
+                spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, null, rawTraceId, rawSpanId) { IsRemote = true };
 #endif
 
                 TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.B3SingleHeader);

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -86,7 +86,8 @@ namespace Datadog.Trace.Propagators
 
             spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin)
                           {
-                              PropagatedTags = traceTags
+                              PropagatedTags = traceTags,
+                              IsRemote = true,
                           };
 
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.Datadog);

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -84,10 +84,9 @@ namespace Datadog.Trace.Propagators
             // and the upper 64 bits in "_dd.p.tid"
             var traceId = GetFullTraceId((ulong)traceIdLower, traceTags);
 
-            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin)
+            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, isRemote: true)
                           {
                               PropagatedTags = traceTags,
-                              IsRemote = true,
                           };
 
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleExtracted(MetricTags.ContextHeaderStyle.Datadog);

--- a/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
@@ -59,11 +59,11 @@ namespace Datadog.Trace.Propagators
                 traceId = GetFullTraceId((ulong)traceIdLower, traceTags);
             }
 
-            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, rawTraceId, rawSpanId)
+            // we don't consider contexts coming from this as "remote" as it could be from a version conflict scenario crossing an AppDomain boundary
+            spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, rawTraceId, rawSpanId, isRemote: false)
                           {
                               PropagatedTags = traceTags,
                               AdditionalW3CTraceState = w3CTraceState,
-                              IsRemote = true,
                           };
 
             return true;

--- a/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
@@ -63,6 +63,7 @@ namespace Datadog.Trace.Propagators
                           {
                               PropagatedTags = traceTags,
                               AdditionalW3CTraceState = w3CTraceState,
+                              IsRemote = true,
                           };
 
             return true;

--- a/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DistributedContextExtractor.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Propagators
                 traceId = GetFullTraceId((ulong)traceIdLower, traceTags);
             }
 
-            // we don't consider contexts coming from this as "remote" as it could be from a version conflict scenario crossing an AppDomain boundary
+            // we don't consider contexts coming from this as "remote" as it could be from a version conflict scenario
             spanContext = new SpanContext(traceId, parentId, samplingPriority, serviceName: null, origin, rawTraceId, rawSpanId, isRemote: false)
                           {
                               PropagatedTags = traceTags,

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -633,11 +633,11 @@ namespace Datadog.Trace.Propagators
                 serviceName: null,
                 origin: traceState.Origin,
                 rawTraceId: traceParent.RawTraceId,
-                rawSpanId: traceParent.RawParentId);
+                rawSpanId: traceParent.RawParentId,
+                isRemote: true);
 
             spanContext.PropagatedTags = traceTags;
             spanContext.AdditionalW3CTraceState = traceState.AdditionalValues;
-            spanContext.IsRemote = true;
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -637,6 +637,7 @@ namespace Datadog.Trace.Propagators
 
             spanContext.PropagatedTags = traceTags;
             spanContext.AdditionalW3CTraceState = traceState.AdditionalValues;
+            spanContext.IsRemote = true;
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -82,12 +82,14 @@ namespace Datadog.Trace
         /// <param name="samplingPriority">The propagated sampling priority.</param>
         /// <param name="serviceName">The service name to propagate to child spans.</param>
         /// <param name="origin">The propagated origin of the trace.</param>
-        internal SpanContext(TraceId traceId, ulong spanId, int? samplingPriority, string serviceName, string origin)
+        /// <param name="isRemote">Whether this <see cref="SpanContext"/> was from a distributed context.</param>
+        internal SpanContext(TraceId traceId, ulong spanId, int? samplingPriority, string serviceName, string origin, bool isRemote = false)
             : this(traceId, serviceName)
         {
             SpanId = spanId;
             SamplingPriority = samplingPriority;
             Origin = origin;
+            IsRemote = isRemote;
         }
 
         /// <summary>
@@ -102,7 +104,8 @@ namespace Datadog.Trace
         /// <param name="origin">The propagated origin of the trace.</param>
         /// <param name="rawTraceId">The raw propagated trace id</param>
         /// <param name="rawSpanId">The raw propagated span id</param>
-        internal SpanContext(TraceId traceId, ulong spanId, int? samplingPriority, string serviceName, string origin, string rawTraceId, string rawSpanId)
+        /// <param name="isRemote">Whether this <see cref="SpanContext"/> was from a distributed context.</param>
+        internal SpanContext(TraceId traceId, ulong spanId, int? samplingPriority, string serviceName, string origin, string rawTraceId, string rawSpanId, bool isRemote = false)
             : this(traceId, serviceName)
         {
             SpanId = spanId;
@@ -110,6 +113,7 @@ namespace Datadog.Trace
             Origin = origin;
             _rawTraceId = rawTraceId;
             _rawSpanId = rawSpanId;
+            IsRemote = isRemote;
         }
 
         /// <summary>
@@ -123,7 +127,8 @@ namespace Datadog.Trace
         /// <param name="spanId">The propagated span id.</param>
         /// <param name="rawTraceId">Raw trace id value</param>
         /// <param name="rawSpanId">Raw span id value</param>
-        internal SpanContext(ISpanContext parent, TraceContext traceContext, string serviceName, TraceId traceId = default, ulong spanId = 0, string rawTraceId = null, string rawSpanId = null)
+        /// <param name="isRemote">Whether this <see cref="SpanContext"/> was from a distributed context.</param>
+        internal SpanContext(ISpanContext parent, TraceContext traceContext, string serviceName, TraceId traceId = default, ulong spanId = 0, string rawTraceId = null, string rawSpanId = null, bool isRemote = false)
             : this(GetTraceId(parent, traceId), serviceName)
         {
             // if 128-bit trace ids are enabled, also use full uint64 for span id,
@@ -145,6 +150,7 @@ namespace Datadog.Trace
             }
 
             _rawSpanId = rawSpanId;
+            IsRemote = isRemote;
         }
 
         private SpanContext(TraceId traceId, string serviceName)
@@ -258,9 +264,9 @@ namespace Datadog.Trace
         internal PathwayContext? PathwayContext { get; private set; }
 
         /// <summary>
-        ///  Gets or sets a value indicating whether this <see cref="SpanContext"/> was propagated from a remote parent.
+        ///  Gets a value indicating whether this <see cref="SpanContext"/> was propagated from a remote parent.
         /// </summary>
-        internal bool IsRemote { get; set; }
+        internal bool IsRemote { get; }
 
         /// <inheritdoc/>
         int IReadOnlyCollection<KeyValuePair<string, string>>.Count => KeyNames.Length;

--- a/tracer/src/Datadog.Trace/SpanContext.cs
+++ b/tracer/src/Datadog.Trace/SpanContext.cs
@@ -257,6 +257,11 @@ namespace Datadog.Trace
 
         internal PathwayContext? PathwayContext { get; private set; }
 
+        /// <summary>
+        ///  Gets or sets a value indicating whether this <see cref="SpanContext"/> was propagated from a remote parent.
+        /// </summary>
+        internal bool IsRemote { get; set; }
+
         /// <inheritdoc/>
         int IReadOnlyCollection<KeyValuePair<string, string>>.Count => KeyNames.Length;
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -167,6 +167,7 @@ namespace Datadog.Trace.Tests.Propagators
                            RawSpanId = rawSpanId,
                            Origin = null,
                            SamplingPriority = samplingPriority,
+                           IsRemote = true,
                        });
         }
 
@@ -211,6 +212,7 @@ namespace Datadog.Trace.Tests.Propagators
                            RawSpanId = rawSpanId,
                            Origin = null,
                            SamplingPriority = samplingPriority,
+                           IsRemote = true,
                        });
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -133,6 +133,7 @@ namespace Datadog.Trace.Tests.Propagators
                            RawSpanId = rawSpanId,
                            Origin = null,
                            SamplingPriority = samplingPriority,
+                           IsRemote = true,
                        });
         }
 
@@ -162,6 +163,7 @@ namespace Datadog.Trace.Tests.Propagators
                            RawSpanId = rawSpanId,
                            Origin = null,
                            SamplingPriority = samplingPriority,
+                           IsRemote = true,
                        });
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DatadogPropagatorTests.cs
@@ -214,6 +214,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = Origin,
                            SamplingPriority = SamplingPriority,
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                        });
         }
 
@@ -238,6 +239,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = Origin,
                            SamplingPriority = SamplingPriority,
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                        });
         }
 
@@ -261,6 +263,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = Origin,
                            SamplingPriority = SamplingPriority,
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                        });
         }
 
@@ -291,6 +294,7 @@ namespace Datadog.Trace.Tests.Propagators
                            RawTraceId = RawTraceId,
                            RawSpanId = "0000000000000000",
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                        });
         }
 
@@ -355,6 +359,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = Origin,
                            SamplingPriority = SamplingPriority,
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                        });
         }
 
@@ -389,6 +394,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = Origin,
                            SamplingPriority = expectedSamplingPriority,
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                        });
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
@@ -91,7 +91,6 @@ public class DistributedPropagatorTests
                        SamplingPriority = SamplingPriority,
                        PropagatedTags = PropagatedTagsCollection,
                        AdditionalW3CTraceState = AdditionalW3CTraceState,
-                       IsRemote = true,
                    });
     }
 
@@ -127,7 +126,6 @@ public class DistributedPropagatorTests
                 RawTraceId = RawTraceId,
                 RawSpanId = "0000000000000000",
                 PropagatedTags = EmptyPropagatedTags,
-                IsRemote = true,
             });
     }
 
@@ -208,7 +206,6 @@ public class DistributedPropagatorTests
                        SamplingPriority = SamplingPriority,
                        PropagatedTags = PropagatedTagsCollection,
                        AdditionalW3CTraceState = AdditionalW3CTraceState,
-                       IsRemote = true,
                    });
     }
 
@@ -247,7 +244,6 @@ public class DistributedPropagatorTests
                        SamplingPriority = expectedSamplingPriority,
                        PropagatedTags = PropagatedTagsCollection,
                        AdditionalW3CTraceState = AdditionalW3CTraceState,
-                       IsRemote = true,
                    });
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/DistributedPropagatorTests.cs
@@ -91,6 +91,7 @@ public class DistributedPropagatorTests
                        SamplingPriority = SamplingPriority,
                        PropagatedTags = PropagatedTagsCollection,
                        AdditionalW3CTraceState = AdditionalW3CTraceState,
+                       IsRemote = true,
                    });
     }
 
@@ -126,6 +127,7 @@ public class DistributedPropagatorTests
                 RawTraceId = RawTraceId,
                 RawSpanId = "0000000000000000",
                 PropagatedTags = EmptyPropagatedTags,
+                IsRemote = true,
             });
     }
 
@@ -205,7 +207,8 @@ public class DistributedPropagatorTests
                        RawSpanId = RawSpanId,
                        SamplingPriority = SamplingPriority,
                        PropagatedTags = PropagatedTagsCollection,
-                       AdditionalW3CTraceState = AdditionalW3CTraceState
+                       AdditionalW3CTraceState = AdditionalW3CTraceState,
+                       IsRemote = true,
                    });
     }
 
@@ -244,6 +247,7 @@ public class DistributedPropagatorTests
                        SamplingPriority = expectedSamplingPriority,
                        PropagatedTags = PropagatedTagsCollection,
                        AdditionalW3CTraceState = AdditionalW3CTraceState,
+                       IsRemote = true,
                    });
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/MultiSpanContextPropagatorTests.cs
@@ -294,6 +294,7 @@ namespace Datadog.Trace.Tests.Propagators
                            RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
+                           IsRemote = true,
                        });
         }
 
@@ -319,6 +320,7 @@ namespace Datadog.Trace.Tests.Propagators
                            RawSpanId = "000000003ade68b1",
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
+                           IsRemote = true,
                        });
         }
 
@@ -349,6 +351,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = null,
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                        });
         }
 
@@ -385,6 +388,7 @@ namespace Datadog.Trace.Tests.Propagators
                            PropagatedTags = PropagatedTagsCollection,
                            Parent = null,
                            ParentId = null,
+                           IsRemote = true,
                        });
         }
 
@@ -424,6 +428,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = "rum",
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                        });
         }
 
@@ -571,6 +576,7 @@ namespace Datadog.Trace.Tests.Propagators
                            AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
                            Parent = null,
                            ParentId = null,
+                           IsRemote = true,
                        });
         }
 
@@ -622,6 +628,7 @@ namespace Datadog.Trace.Tests.Propagators
                            AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
                            Parent = null,
                            ParentId = null,
+                           IsRemote = true,
                        });
         }
 
@@ -673,6 +680,7 @@ namespace Datadog.Trace.Tests.Propagators
                            AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
                            Parent = null,
                            ParentId = null,
+                           IsRemote = true,
                        });
         }
 
@@ -724,6 +732,7 @@ namespace Datadog.Trace.Tests.Propagators
                            AdditionalW3CTraceState = !extractFirst || w3CHeaderFirst ? "foo=1" : null,
                            Parent = null,
                            ParentId = null,
+                           IsRemote = true,
                        });
         }
 
@@ -777,6 +786,7 @@ namespace Datadog.Trace.Tests.Propagators
                            AdditionalW3CTraceState = w3CHeaderFirst ? "foo=1" : null,
                            Parent = null,
                            ParentId = null,
+                           IsRemote = true,
                        });
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/SpanContextMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/SpanContextMock.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SpanContextMock.cs" company="Datadog">
+// <copyright file="SpanContextMock.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -26,6 +26,8 @@ internal class SpanContextMock
     public TraceTagCollection PropagatedTags { get; set; }
 
     public string AdditionalW3CTraceState { get; set; }
+
+    public bool IsRemote { get; set; }
 
     public ISpanContext Parent { get; set; }
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -320,6 +320,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = SamplingPriorityValues.UserKeep,
                            Origin = "rum",
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -364,6 +365,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = 1,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -400,6 +402,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = SamplingPriorityValues.UserKeep,
                            Origin = "rum",
                            PropagatedTags = PropagatedTagsCollection,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -470,6 +473,7 @@ namespace Datadog.Trace.Tests.Propagators
                            Origin = "rum",
                            PropagatedTags = PropagatedTagsCollection,
                            AdditionalW3CTraceState = "abc=123,foo=bar",
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -506,6 +510,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = SamplingPriorityValues.AutoKeep,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -640,6 +645,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = samplingPriority,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -679,6 +685,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = samplingPriority,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -720,6 +727,7 @@ namespace Datadog.Trace.Tests.Propagators
                                    new("_dd.p.dm", "-0"),
                                },
                                cachedPropagationHeader: null),
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -761,6 +769,7 @@ namespace Datadog.Trace.Tests.Propagators
                                    new("_dd.p.dm", "-0"),
                                },
                                cachedPropagationHeader: null),
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -797,6 +806,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = 0,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -833,6 +843,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = 0,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -869,6 +880,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = 1,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });
@@ -905,6 +917,7 @@ namespace Datadog.Trace.Tests.Propagators
                            SamplingPriority = 0,
                            Origin = null,
                            PropagatedTags = EmptyPropagatedTags,
+                           IsRemote = true,
                            Parent = null,
                            ParentId = null,
                        });


### PR DESCRIPTION
## Summary of changes

This adds `IsRemote` to `SpanContext` that will be set to `true` whenever that context originated from some distributed context via some `IContextExtractor`.

## Reason for change

Needed a way to easily discern whether a `SpanContext` was originated from a remote context or from a local one and this seems to be a good way of doing it.

Alternatively, I _think_ it is intentional that creating a `SpanContext` without a parent `SpanContext` is intended to be a "remote" context, but that isn't actually guaranteed, so this seemed better (I think)

## Implementation details

Added `IsRemote` to `SpanContext`
For each of the `IContextExtractor`s, added a `IsRemote = true` to the `SpanContext` that is extracted in the `TryExtract` method.

## Test coverage

- Updated tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
