### PR TITLE
Try working around missing Docker Compose v1 in hosted runners

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -13,6 +13,10 @@ parameters:
     type: string
     default: ''
 
+  - name: 'dockerComposePath'
+    type: string
+    default: ''
+
 steps:
 - bash: |
     echo "##vso[task.setvariable variable=TOKEN]$(System.JobId)"
@@ -102,6 +106,7 @@ steps:
     dockerComposeCommand: logs $(TEST_AGENT_TARGET)
     projectName: ddtrace_$(Build.BuildNumber)
     dockerComposeFile: $(COMPOSE_PATH)
+    dockerComposePath: ${{ parameters.dockerComposePath }}
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
   condition: succeededOrFailed()
@@ -114,6 +119,7 @@ steps:
     dockerComposeCommand: down
     projectName: ddtrace_$(Build.BuildNumber)
     dockerComposeFile: $(COMPOSE_PATH)
+    dockerComposePath: ${{ parameters.dockerComposePath }}
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
   condition: succeededOrFailed()

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -13,10 +13,6 @@ parameters:
     type: string
     default: ''
 
-  - name: 'dockerComposePath'
-    type: string
-    default: ''
-
 steps:
 - bash: |
     echo "##vso[task.setvariable variable=TOKEN]$(System.JobId)"
@@ -106,7 +102,6 @@ steps:
     dockerComposeCommand: logs $(TEST_AGENT_TARGET)
     projectName: ddtrace_$(Build.BuildNumber)
     dockerComposeFile: $(COMPOSE_PATH)
-    dockerComposePath: ${{ parameters.dockerComposePath }}
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
   condition: succeededOrFailed()
@@ -119,7 +114,6 @@ steps:
     dockerComposeCommand: down
     projectName: ddtrace_$(Build.BuildNumber)
     dockerComposeFile: $(COMPOSE_PATH)
-    dockerComposePath: ${{ parameters.dockerComposePath }}
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
   condition: succeededOrFailed()

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4649,6 +4649,19 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
+    # Install docker-compose v1
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
+    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
+    - task: Bash@3
+      displayName: "Install docker-compose v1"
+      inputs:
+        targetType: 'inline'
+        script: |
+          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          mkdir -p $DOCKER_CONFIG/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -4700,6 +4713,8 @@ stages:
       parameters:
         target: 'dd-dotnet-smoke-tests'
         snapshotPrefix: "smoke_test"
+        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
+
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
@@ -4733,6 +4748,19 @@ stages:
         vmImage: ubuntu-latest
       
       steps:
+        # Install docker-compose v1
+        # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
+        # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
+        - task: Bash@3
+          displayName: "Install docker-compose v1"
+          inputs:
+            targetType: 'inline'
+            script: |
+              DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+              mkdir -p $DOCKER_CONFIG/cli-plugins
+              curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+              chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
         - template: steps/clone-repo.yml
           parameters:
             targetShaId: $(targetShaId)
@@ -4785,6 +4813,7 @@ stages:
           parameters:
             target: 'dd-dotnet-chiseled-smoke-tests'
             snapshotPrefix: "smoke_test"
+            dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -4812,6 +4841,19 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
+    # Install docker-compose v1
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
+    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
+    - task: Bash@3
+      displayName: "Install docker-compose v1"
+      inputs:
+        targetType: 'inline'
+        script: |
+          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          mkdir -p $DOCKER_CONFIG/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -4851,6 +4893,7 @@ stages:
       parameters:
         target: 'nuget-smoke-tests'
         snapshotPrefix: "smoke_test"
+        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - script: |
         docker-compose -p ddtrace_$(Build.BuildNumber) build \
@@ -4869,6 +4912,7 @@ stages:
       parameters:
         target: 'nuget-dddotnet-smoke-tests'
         snapshotPrefix: "smoke_test"
+        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -4902,6 +4946,19 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
+    # Install docker-compose v1
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
+    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
+    - task: Bash@3
+      displayName: "Install docker-compose v1"
+      inputs:
+        targetType: 'inline'
+        script: |
+          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          mkdir -p $DOCKER_CONFIG/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -4933,6 +4990,7 @@ stages:
       parameters:
         target: 'dotnet-tool-nuget-smoke-tests'
         snapshotPrefix: "smoke_test"
+        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -4966,6 +5024,19 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
+    # Install docker-compose v1
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
+    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
+    - task: Bash@3
+      displayName: "Install docker-compose v1"
+      inputs:
+        targetType: 'inline'
+        script: |
+          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          mkdir -p $DOCKER_CONFIG/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -5001,6 +5072,7 @@ stages:
       parameters:
         target: 'dotnet-tool-smoke-tests'
         snapshotPrefix: "smoke_test"
+        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -5038,6 +5110,19 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
+    # Install docker-compose v1
+    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
+    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
+    - task: Bash@3
+      displayName: "Install docker-compose v1"
+      inputs:
+        targetType: 'inline'
+        script: |
+          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
+          mkdir -p $DOCKER_CONFIG/cli-plugins
+          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
+          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
+
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -5079,6 +5164,7 @@ stages:
       parameters:
         target: 'dotnet-tool-self-instrument-smoke-tests'
         snapshotPrefix: "smoke_test"
+        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4646,7 +4646,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-latest
+      name: azure-linux-smoke-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -4730,7 +4730,7 @@ stages:
       variables:
         smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
       pool:
-        vmImage: ubuntu-latest
+        name: azure-linux-smoke-scale-set
       
       steps:
         - template: steps/clone-repo.yml
@@ -4809,7 +4809,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-latest
+      name: azure-linux-smoke-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -4899,7 +4899,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-latest
+      name: azure-linux-smoke-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -4963,7 +4963,7 @@ stages:
     variables:
       smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
     pool:
-      vmImage: ubuntu-latest
+      name: azure-linux-smoke-scale-set
 
     steps:
     - template: steps/clone-repo.yml
@@ -5035,7 +5035,7 @@ stages:
       installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb"
       linuxArtifacts: "linux-packages-linux-x64"
     pool:
-      vmImage: ubuntu-latest
+      name: azure-linux-smoke-scale-set
 
     steps:
     - template: steps/clone-repo.yml

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4649,19 +4649,6 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
-    # Install docker-compose v1
-    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
-    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
-    - task: Bash@3
-      displayName: "Install docker-compose v1"
-      inputs:
-        targetType: 'inline'
-        script: |
-          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-          mkdir -p $DOCKER_CONFIG/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
-          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -4713,8 +4700,6 @@ stages:
       parameters:
         target: 'dd-dotnet-smoke-tests'
         snapshotPrefix: "smoke_test"
-        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
-
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
       condition: succeededOrFailed()
@@ -4748,19 +4733,6 @@ stages:
         vmImage: ubuntu-latest
       
       steps:
-        # Install docker-compose v1
-        # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
-        # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
-        - task: Bash@3
-          displayName: "Install docker-compose v1"
-          inputs:
-            targetType: 'inline'
-            script: |
-              DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-              mkdir -p $DOCKER_CONFIG/cli-plugins
-              curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
-              chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-
         - template: steps/clone-repo.yml
           parameters:
             targetShaId: $(targetShaId)
@@ -4813,7 +4785,6 @@ stages:
           parameters:
             target: 'dd-dotnet-chiseled-smoke-tests'
             snapshotPrefix: "smoke_test"
-            dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -4841,19 +4812,6 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
-    # Install docker-compose v1
-    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
-    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
-    - task: Bash@3
-      displayName: "Install docker-compose v1"
-      inputs:
-        targetType: 'inline'
-        script: |
-          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-          mkdir -p $DOCKER_CONFIG/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
-          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -4893,7 +4851,6 @@ stages:
       parameters:
         target: 'nuget-smoke-tests'
         snapshotPrefix: "smoke_test"
-        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - script: |
         docker-compose -p ddtrace_$(Build.BuildNumber) build \
@@ -4912,7 +4869,6 @@ stages:
       parameters:
         target: 'nuget-dddotnet-smoke-tests'
         snapshotPrefix: "smoke_test"
-        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -4946,19 +4902,6 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
-    # Install docker-compose v1
-    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
-    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
-    - task: Bash@3
-      displayName: "Install docker-compose v1"
-      inputs:
-        targetType: 'inline'
-        script: |
-          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-          mkdir -p $DOCKER_CONFIG/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
-          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -4990,7 +4933,6 @@ stages:
       parameters:
         target: 'dotnet-tool-nuget-smoke-tests'
         snapshotPrefix: "smoke_test"
-        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -5024,19 +4966,6 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
-    # Install docker-compose v1
-    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
-    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
-    - task: Bash@3
-      displayName: "Install docker-compose v1"
-      inputs:
-        targetType: 'inline'
-        script: |
-          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-          mkdir -p $DOCKER_CONFIG/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
-          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -5072,7 +5001,6 @@ stages:
       parameters:
         target: 'dotnet-tool-smoke-tests'
         snapshotPrefix: "smoke_test"
-        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -5110,19 +5038,6 @@ stages:
       vmImage: ubuntu-latest
 
     steps:
-    # Install docker-compose v1
-    # https://github.com/microsoft/azure-pipelines-tasks/issues/19711
-    # We can't use docker-compose v2 universally yet (our custom runners and the DockerCompose@0 task don't support it)
-    - task: Bash@3
-      displayName: "Install docker-compose v1"
-      inputs:
-        targetType: 'inline'
-        script: |
-          DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker}
-          mkdir -p $DOCKER_CONFIG/cli-plugins
-          curl -SL https://github.com/docker/compose/releases/download/1.29.2/docker-compose-Linux-x86_64 -o $DOCKER_CONFIG/cli-plugins/docker-compose
-          chmod +x $DOCKER_CONFIG/cli-plugins/docker-compose
-
     - template: steps/clone-repo.yml
       parameters:
         targetShaId: $(targetShaId)
@@ -5164,7 +5079,6 @@ stages:
       parameters:
         target: 'dotnet-tool-self-instrument-smoke-tests'
         snapshotPrefix: "smoke_test"
-        dockerComposePath: '/home/vsts/.docker/cli-plugins/docker-compose'
 
     - publish: tracer/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)


### PR DESCRIPTION
## Summary of changes

Run installer tests on a separate "smoke test" pool

## Reason for change

Microsoft, have decided to break 30k pipelines by removing docker compose v1 from their hosted pipelines, installing v2 only instead:  https://github.com/actions/runner-images/issues/9557

What's more, their own Azure Devops `DockerCompose@0` task doesn't even support v2: https://github.com/microsoft/azure-pipelines-tasks/issues/19711

## Implementation details

As a workaround, set up a separate Azure VMSS and use that for the smoke tests instead of the hosted runners.

Alternatives include:
- Switching everything to use v2. This would also require dropping usage of the built-in task `DockerCompose@0`. Also, Microsoft don't provide arm64 hosted runners, so we have to self host, and those images are using v2, so we'd have to duplicate a bunch of tasks and/or update the runners etc.
- Install Docker compose v1 on the hosted runners, [as described here](https://github.com/microsoft/azure-pipelines-tasks/issues/19711#issuecomment-2033737296). I tried that, and it didn't work, primarily because we don't _just_ use the `DockerCompose@v0` task.
- Switch to managing this with test containers, so there's only one abstraction to handle. I think we should look into this in the future, if nothing else it would reduce the amount of YAML we have, aiding transitions to other CI systems if necessary

## Test coverage

This is the test. I'll also do a "[run all installer tests](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=155336&view=results)" run to be sure.

## Other details

:azure-chaos:

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
