### PR TITLE
_Really_ clean up before doing anything

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -134,7 +134,7 @@ steps:
     displayName: clean
     condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
 
-  - powershell: rm "$env:BUILD_REPOSITORY_LOCALPATH/*"" -r -fo
+  - powershell: rm "$env:BUILD_REPOSITORY_LOCALPATH/*" -r -fo
     displayName: clean
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -12,7 +12,7 @@ steps:
       # Azure devops _doesn't_ clean up the contents of the repo after the pipeline has finished
       # So we do it manually
       echo "Cleaning up source directories ..."
-      rm -rf $BUILD_REPOSITORY_LOCALPATH/*
+      sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/*
       
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
@@ -129,5 +129,14 @@ steps:
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - ${{ else }}:
+    # The clean doesn't always work, so sudo rm -rf it
+  - bash: sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/*
+    displayName: clean
+    condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
+
+  - powershell: rm "$env:BUILD_REPOSITORY_LOCALPATH/*"" -r -fo
+    displayName: clean
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
   - checkout: self
     clean: true


### PR DESCRIPTION
## Summary of changes

Cleans the workspace in preparation for re-using agents

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/5309 we added a step to "clean" the workspace before checking out, so that we can start to re-use runners without tearing them down.

That PR only fixed the "running tests for a PR" scenario. We need to clean in the "doing an explicit run against a branch" scenario too.

## Implementation details

`sudo rm -rf` your way to glory

## Test coverage

I'll do an explicit run to make sure it doesn't complain. We won't know if it's the last piece to enable agent reuse until this is merged to master

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
