### PR TITLE
Only publish `:latest` lib-injection container images on merges to master

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3853,7 +3853,7 @@ stages:
             -H "Authorization: token $GITHUB_TOKEN"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/DataDog/dd-trace-dotnet/actions/workflows/lib-injection.yml/dispatches \
-            -d '{"ref":"$(Build.SourceBranch)","inputs":{"azdo_build_id":"$(Build.BuildId)"}}'
+            -d '{"ref":"$(Build.SourceBranch)","inputs":{"azdo_build_id":"$(Build.BuildId)","is_latest":"$(isMainBranch)"}}'
         displayName: Start lib-injection GitHub Actions worfklow
         env:
           GITHUB_TOKEN: $(GITHUB_TOKEN)

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -10,6 +10,10 @@ on:
         description: 'Use a specific commit? If provided, this commit will be checked out, and the github images will be tagged with this commit'
         required: false
         default: ''
+      is_latest:
+        description: 'Does this commit represent a build that should be tagged as latest?'
+        required: false
+        default: false
 
 jobs:
   build-and-publish-init-image:
@@ -125,6 +129,10 @@ jobs:
           --amend "ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init@${{steps.build-image-musl-arm64v8.outputs.digest}}"
         docker manifest push ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:${{ env.COMMIT_SHA }}-musl
 
+    - name: Publish latest multiarch images with all platforms
+      if: github.event.inputs.is_latest == true
+      shell: bash
+      run: |
         # We also create latest_snapshot images
         docker manifest create \
           ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet-init:latest_snapshot \


### PR DESCRIPTION
## Summary of changes

Limits the _building_ of lib-injection images to merges to master

## Reason for change

We shouldn't be pushing these for _all_ commits 😬 

## Implementation details

Send an `is_latest` flag in the dispatch

## Test coverage

I'll check that this build _doesn't_ trigger the container build. When it's merged, I'll verify it does.

## Other details

Not that this means if we do releases from non-main branches that we want to be marked as latest (i.e. hotfix releases), we'll need to _manually_ trigger this workflow to create the container images. 

I think that's a reasonable tradeoff, and will add it to the release process.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
