### PR TITLE
Temporarily disable profiler CppCheck

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1621,6 +1621,8 @@ stages:
     pool:
       name: azure-windows-scale-set
     timeoutInMinutes: 60 #default value
+    # Temporarily disabled, as current Cppcheck does not support macros
+    condition: "false"
 
     steps:
     - powershell: |


### PR DESCRIPTION
## Summary of changes

Temporarily disabled the profiler Cppcheck on Windows

## Reason for change

The existing CppCheck version does not support macros that are currently in use, so it fails every single run.

## Implementation details

Temporarily disable the job 

## Test coverage

Less

## Other details

@gleocadie is going to look at reinstating this soon!

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
