### PR TITLE
Split the macos build into 2 jobs and parallelise

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1104,6 +1104,13 @@ stages:
         parameters:
           artifact: build-macos-working-directory
 
+      # The native tracer is built and uploaded separately for perf reasons, so needs to be explicitly downloaded here
+      - task: DownloadPipelineArtifact@2
+        displayName: Download native tracer
+        inputs:
+          artifact: build-macos-native_tracer
+          path: $(monitoringHome)
+
       - script: ./tracer/build.sh BuildAndRunManagedUnitTests --code-coverage $(runCodeCoverage)
         displayName: Build and Test
         retryCountOnTaskFailure: 1

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -652,9 +652,9 @@ stages:
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [build]
+      jobs: [native_tracer, native_loader_and_managed, upload_artifacts]
 
-  - job: build
+  - job: native_tracer
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
@@ -666,17 +666,62 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/install-latest-dotnet-sdk.yml
 
-    - script: ./tracer/build.sh BuildTracerHome BuildNativeLoader
-      displayName: Build tracer home
+    - script: ./tracer/build.sh CreateRequiredDirectories CompileManagedLoader CompileNativeSrc PublishNativeTracer
+      displayName: Build native-tracer
       retryCountOnTaskFailure: 1
 
     - publish: $(monitoringHome)
-      displayName: Uploading macos profiler artifact
-      artifact: macos-tracer-home
+      displayName: Uploading macos native tracer artifact
+      artifact: build-macos-native_tracer
+
+  - job: native_loader_and_managed
+    timeoutInMinutes: 60 #default value
+    dependsOn: [ ]
+    pool:
+      vmImage: macos-11
+    steps:
+    - template: steps/clone-repo.yml
+      parameters:
+        targetShaId: $(targetShaId)
+        targetBranch: $(targetBranch)
+    - template: steps/install-latest-dotnet-sdk.yml
+
+    # The CreateRootDescriptorsFile tasks expects the native loader but we build that in the other stage
+    - script: ./tracer/build.sh BuildManagedTracerHome BuildNativeLoader --skip CreateRootDescriptorsFile
+      displayName: Build managed tracer + native loader
+      retryCountOnTaskFailure: 1
+
+    - publish: $(monitoringHome)
+      displayName: Uploading macos native tracer artifact
+      artifact: build-macos-native_loader
 
     - publish: $(System.DefaultWorkingDirectory)
       displayName: Upload working directory after the build
       artifact: build-macos-working-directory
+
+  - job: upload_artifacts
+    timeoutInMinutes: 60 #default value
+    dependsOn: [native_tracer, native_loader_and_managed ]
+    pool:
+      vmImage: macos-11
+    steps:
+    - checkout: none
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download native tracer
+      inputs:
+        artifact: build-macos-native_tracer
+        path: $(monitoringHome)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download native loader and managed
+      inputs:
+        artifact: build-macos-native_loader
+        path: $(monitoringHome)
+
+    - publish: $(monitoringHome)
+      displayName: Uploading combined macos profiler artifact
+      artifact: macos-tracer-home
 
 - stage: package_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))


### PR DESCRIPTION
## Summary of changes

Splits the `build_macos` stage into 2 jobs and runs them in parallel

## Reason for change

The `build_macos` job is _slow_, _over-an-hour_ slow. And it's a prerequisite for the `dd-trace` tool build, which is in turn a prerequisite for the tool artifact tests and the tool installer tests.

## Implementation details

Similar to how we _had_ to do with the linux tracer (though we didn't parallelise there currently, we could consider it). Splits the build into two separate jobs:

- Build the managed loader and the native tracer. The native tracer takes ~25-30 mins to build.
- Build the managed code (up to 15 mins) and the native loader (~10 mins).

We then add a third job that recombines the artifacts to give the same "existing" artifacts as we currently produce, namely the tracer home ~~and the "current build directory"~~ I didn't bother downloading the whole mac directory and re-uploading it in the end. As the macos unit tests are the only place we need this currently, just re-downloading them there instead

## Test coverage

If it works, we're good

## Other details

Even with this, the stage is still the slowest build stage by a factor of 2, but I'm not sure there's much more we can do to improve that.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
