### PR TITLE
add test for DSM context reuse in async context

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DataStreamsMonitoring/DataStreamsManagerTests.cs
@@ -237,6 +237,36 @@ public class DataStreamsManagerTests
     }
 
     [Fact]
+    public async Task WhenEnabled_AsyncConsumeThenProduceKeepsPathway()
+    {
+        var dsm = GetDataStreamManager(enabled: true, out var writer);
+
+        async Task Receive()
+        {
+            await Task.Delay(millisecondsDelay: 15);
+            dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Consume, new[] { "in" }, payloadSizeBytes: 100, timeInQueueMs: 100);
+        }
+
+        async Task Send()
+        {
+            dsm.SetCheckpoint(parentPathway: null, CheckpointKind.Produce, new[] { "out" }, payloadSizeBytes: 100, timeInQueueMs: 100);
+            await Task.Delay(millisecondsDelay: 15);
+        }
+
+        // simulate an async consume followed by an async produce
+        await Receive();
+        await Send();
+
+        await dsm.DisposeAsync();
+
+        writer.Points.Should().HaveCount(expected: 2);
+        var points = writer.Points.ToArray();
+        points[0].EdgeTags.Should().Contain("in");
+        points[1].EdgeTags.Should().Contain("out");
+        points[1].ParentHash.Should().BeEquivalentTo(points[0].Hash); // pathway from consume should be used in produce
+    }
+
+    [Fact]
     public async Task DisposeAsync_DisablesDsm()
     {
         var dsm = GetDataStreamManager(true, out _);


### PR DESCRIPTION
This PR is currently just demonstrating a failing test.

It's testing roughly the same thing as the test just above (that consuming and then producing keeps the chain unbroken in DSM), but with async methods.

The context is currently saved in an `AsyncLocal` variable
https://github.com/DataDog/dd-trace-dotnet/blob/b5a855bffe6c0b2ae5d150fb6ad674363464c816/tracer/src/Datadog.Trace/DataStreamsMonitoring/DataStreamsManager.cs#L27
but my understanding is that this only has the scope of the `await consume()`, and it's lost once we open a new async context for the produce.

The alternatives I see are:
 - using a `ThreadLocal` variable instead
 - using a regular variable instead (not static ?)
 - ???
 
and I'm not sure what's the right choice here.