### PR TITLE
[Dynamic Instrumentation] Comment resolve for 5373

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
@@ -78,14 +78,14 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             var discoveryService = tracer.TracerManager.DiscoveryService;
             var gitMetadataTagsProvider = tracer.TracerManager.GitMetadataTagsProvider;
 
-            var snapshotBatchUploadApi = AgentBatchUploadApi.Create(apiFactory, discoveryService, gitMetadataTagsProvider, false);
+            var snapshotBatchUploadApi = AgentBatchUploadApi.CreateSnapshotApi(apiFactory, discoveryService, gitMetadataTagsProvider, isDiagnostics: false);
             var snapshotBatchUploader = BatchUploader.Create(snapshotBatchUploadApi);
 
             _sink = DebuggerSink.Create(
                 snapshotSink: snapshotStatusSink,
                 probeStatusSink: new NopProbeStatusSink(),
                 snapshotBatchUploader: snapshotBatchUploader,
-                diagnosticsBatchUploader: new NonBatchUploader(),
+                diagnosticsBatchUploader: new NopBatchUploader(),
                 debuggerSettings);
 
             Task.Run(async () => await _sink.StartFlushingAsync().ConfigureAwait(false));

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             var discoveryService = tracer.TracerManager.DiscoveryService;
             var gitMetadataTagsProvider = tracer.TracerManager.GitMetadataTagsProvider;
 
-            var snapshotBatchUploadApi = AgentBatchUploadApi.CreateSnapshotApi(apiFactory, discoveryService, gitMetadataTagsProvider, isDiagnostics: false);
+            var snapshotBatchUploadApi = AgentBatchUploadApi.CreateSnapshotApi(apiFactory, discoveryService, gitMetadataTagsProvider);
             var snapshotBatchUploader = BatchUploader.Create(snapshotBatchUploadApi);
 
             _sink = DebuggerSink.Create(

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebuggerFactory.cs
@@ -47,10 +47,10 @@ internal class LiveDebuggerFactory
             () => new MinimalAgentHeaderHelper(),
             uri => uri);
 
-        var snapshotBatchUploadApi = AgentBatchUploadApi.Create(apiFactory, discoveryService, gitMetadataTagsProvider, false);
+        var snapshotBatchUploadApi = AgentBatchUploadApi.CreateSnapshotApi(apiFactory, discoveryService, gitMetadataTagsProvider);
         var snapshotBatchUploader = BatchUploader.Create(snapshotBatchUploadApi);
 
-        var diagnosticsBatchUploadApi = AgentBatchUploadApi.Create(apiFactory, discoveryService, gitMetadataTagsProvider, true);
+        var diagnosticsBatchUploadApi = AgentBatchUploadApi.CreateDiagnosticsApi(apiFactory, discoveryService, gitMetadataTagsProvider);
         var diagnosticsBatchUploader = BatchUploader.Create(diagnosticsBatchUploadApi);
 
         var debuggerSink = DebuggerSink.Create(

--- a/tracer/src/Datadog.Trace/Debugger/Sink/AgentBatchUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/AgentBatchUploadApi.cs
@@ -40,13 +40,20 @@ namespace Datadog.Trace.Debugger.Sink
             discoveryService.SubscribeToChanges(c => _endpoint = isDiagnostics ? c.DiagnosticsEndpoint : c.DebuggerEndpoint);
         }
 
-        public static AgentBatchUploadApi Create(
+        public static AgentBatchUploadApi CreateDiagnosticsApi(
             IApiRequestFactory apiRequestFactory,
             IDiscoveryService discoveryService,
-            IGitMetadataTagsProvider gitMetadataTagsProvider,
-            bool isDiagnostics)
+            IGitMetadataTagsProvider gitMetadataTagsProvider)
         {
-            return new AgentBatchUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, isDiagnostics);
+            return new AgentBatchUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, true);
+        }
+
+        public static AgentBatchUploadApi CreateSnapshotApi(
+            IApiRequestFactory apiRequestFactory,
+            IDiscoveryService discoveryService,
+            IGitMetadataTagsProvider gitMetadataTagsProvider)
+        {
+            return new AgentBatchUploadApi(apiRequestFactory, discoveryService, gitMetadataTagsProvider, false);
         }
 
         public async Task<bool> SendBatchAsync(ArraySegment<byte> data)

--- a/tracer/src/Datadog.Trace/Debugger/Sink/NopBatchUploader.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Sink/NopBatchUploader.cs
@@ -1,4 +1,4 @@
-// <copyright file="NonBatchUploader.cs" company="Datadog">
+// <copyright file="NopBatchUploader.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace Datadog.Trace.Debugger.Sink;
 
-internal class NonBatchUploader : IBatchUploader
+internal class NopBatchUploader : IBatchUploader
 {
     public Task Upload(IEnumerable<string> payloads)
     {


### PR DESCRIPTION
## Summary of changes
Split method `CreateUploader` to `CreateSnapshotApi` and `CreateDiagnosticsApi`
Rename `NonBatchUploader` to `NopBatchUploader`

## Reason for change
Comment resolve for PR https://github.com/DataDog/dd-trace-dotnet/pull/5373