### PR TITLE
Include the libunwind double-free fix

### DIFF
--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -1,4 +1,4 @@
-SET(LIBUNWIND_VERSION "v1.8.1-custom")
+SET(LIBUNWIND_VERSION "v1.8.1-custom-2")
 
 SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunwind-build)
 

--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -4,7 +4,7 @@ SET(LIBUNWIND_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libunwind-prefix/src/libunw
 
 ExternalProject_Add(libunwind
     GIT_REPOSITORY https://github.com/DataDog/libunwind.git
-    GIT_TAG gleocadie/v1.8.1-custom
+    GIT_TAG kevin/v1.8.1-custom-2
     GIT_PROGRESS true
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""


### PR DESCRIPTION
## Summary of changes

Change the libunwind branch to include https://github.com/DataDog/libunwind/commit/cc1d07281b9e034c9e088733aeb4b94ffd91db9e

It fixes a double-free in libunwind-ptrace.

## Reason for change

The double-free caused a crash in crashtracking.
