### PR TITLE
Ensure we also clean hidden folders

### DIFF
--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -11,11 +11,11 @@ steps:
   - bash: |
       # Azure devops _doesn't_ clean up the contents of the repo after the pipeline has finished
       # So we do it manually
-      echo "Cleaning up source directory $BUILD_REPOSITORY_LOCALPATH/"
-      sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/
-      # Have to recreate the directory because the above deletes it entirely (to ensure we also delete . files)
-      mkdir $BUILD_REPOSITORY_LOCALPATH/
-      
+      echo "Cleaning $BUILD_REPOSITORY_LOCALPATH/ directory"
+      # This deletes everything in the folder _except the .git folder
+      # Deleting the git folder causes weird issues with git lfs
+      sudo find $BUILD_REPOSITORY_LOCALPATH/. -name . -o -prune -not \( -path $BUILD_REPOSITORY_LOCALPATH/./.git -prune \) -exec rm -rf -- {} +
+
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
       prBranch=$SYSTEM_PULLREQUEST_SOURCEBRANCH
@@ -68,7 +68,7 @@ steps:
   - powershell: |
       echo "Cleaning up source directories ..."
       $localPath=$env:BUILD_REPOSITORY_LOCALPATH
-      rm $localPath/* -r -fo
+      rm $localPath/* -r -fo -Exclude ".git"
 
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
@@ -133,14 +133,14 @@ steps:
 - ${{ else }}:
     # The clean doesn't always work, so sudo rm -rf it
   - bash: |
-      echo "Deleting $BUILD_REPOSITORY_LOCALPATH/ with sudo rm -rf"
-      sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/
-      # Have to recreate the directory because the above deletes it entirely (to ensure we also delete . files)
-      mkdir $BUILD_REPOSITORY_LOCALPATH/
+      echo "Cleaning $BUILD_REPOSITORY_LOCALPATH/ directory"
+      # This deletes everything in the folder _except the .git folder
+      # Deleting the git folder causes weird issues with git lfs
+      sudo find $BUILD_REPOSITORY_LOCALPATH/. -name . -o -prune -not \( -path $BUILD_REPOSITORY_LOCALPATH/./.git -prune \) -exec rm -rf -- {} +
     displayName: clean
     condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
 
-  - powershell: rm "$env:BUILD_REPOSITORY_LOCALPATH/*" -r -fo
+  - powershell: rm "$env:BUILD_REPOSITORY_LOCALPATH/*" -r -fo -Exclude ".git"
     displayName: clean
     condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -11,8 +11,10 @@ steps:
   - bash: |
       # Azure devops _doesn't_ clean up the contents of the repo after the pipeline has finished
       # So we do it manually
-      echo "Cleaning up source directories ..."
-      sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/*
+      echo "Cleaning up source directory $BUILD_REPOSITORY_LOCALPATH/"
+      sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/
+      # Have to recreate the directory because the above deletes it entirely (to ensure we also delete . files)
+      mkdir $BUILD_REPOSITORY_LOCALPATH/
       
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
@@ -130,7 +132,11 @@ steps:
 
 - ${{ else }}:
     # The clean doesn't always work, so sudo rm -rf it
-  - bash: sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/*
+  - bash: |
+      echo "Deleting $BUILD_REPOSITORY_LOCALPATH/ with sudo rm -rf"
+      sudo rm -rf $BUILD_REPOSITORY_LOCALPATH/
+      # Have to recreate the directory because the above deletes it entirely (to ensure we also delete . files)
+      mkdir $BUILD_REPOSITORY_LOCALPATH/
     displayName: clean
     condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
 

--- a/.azure-pipelines/steps/clone-repo.yml
+++ b/.azure-pipelines/steps/clone-repo.yml
@@ -12,9 +12,8 @@ steps:
       # Azure devops _doesn't_ clean up the contents of the repo after the pipeline has finished
       # So we do it manually
       echo "Cleaning $BUILD_REPOSITORY_LOCALPATH/ directory"
-      # This deletes everything in the folder _except the .git folder
-      # Deleting the git folder causes weird issues with git lfs
-      sudo find $BUILD_REPOSITORY_LOCALPATH/. -name . -o -prune -not \( -path $BUILD_REPOSITORY_LOCALPATH/./.git -prune \) -exec rm -rf -- {} +
+      # This deletes everything in the folder, including hidden `.` folders
+      sudo find $BUILD_REPOSITORY_LOCALPATH/. -name . -o -prune -exec rm -rf -- {} +
 
       # As this is a pull request, we need to do a fake merge
       # uses similar process to existing checkout task
@@ -136,7 +135,7 @@ steps:
       echo "Cleaning $BUILD_REPOSITORY_LOCALPATH/ directory"
       # This deletes everything in the folder _except the .git folder
       # Deleting the git folder causes weird issues with git lfs
-      sudo find $BUILD_REPOSITORY_LOCALPATH/. -name . -o -prune -not \( -path $BUILD_REPOSITORY_LOCALPATH/./.git -prune \) -exec rm -rf -- {} +
+      sudo find $BUILD_REPOSITORY_LOCALPATH/. -name . -o -prune -exec rm -rf -- {} +
     displayName: clean
     condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
 


### PR DESCRIPTION
## Summary of changes

Update the "clean" step to delete hidden e.g. `.nuke` files and folders

## Reason for change

`rm -rf *` doesn't delete "hidden" folders/files like `.nuke` or `.github` so the clean steps weren't working, and meant that subsequent checkout steps were failing

## Implementation details

Delete the whole directory and recreate it. I looked at other options, but this was just the easiest and the easiest to understand

## Test coverage

Tested against the branch manually

## Other details

Third time lucky...
- https://github.com/DataDog/dd-trace-dotnet/pull/5387
- https://github.com/DataDog/dd-trace-dotnet/pull/5309

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
