### PR TITLE
Set the obfuscation querystring regex to something large to avoid flake in integration tests

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -66,9 +66,6 @@ namespace Datadog.Trace.Security.IntegrationTests
             _httpClient.DefaultRequestHeaders.ConnectionClose = true;
 #endif
             _jsonSerializerSettingsOrderProperty = new JsonSerializerSettings { ContractResolver = new OrderedContractResolver() };
-            EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_WAF_TIMEOUT", 10_000_000.ToString());
-            EnvironmentHelper.CustomEnvironmentVariables.Add("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_TIMEOUT", 10_000_000.ToString());
-            EnvironmentHelper.CustomEnvironmentVariables.Add("DD_IAST_REGEXP_TIMEOUT", 10_000_000.ToString());
         }
 
         protected bool IncludeAllHttpSpans { get; set; } = false;

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -237,6 +237,22 @@ namespace Datadog.Trace.TestHelpers
                 environmentVariables[ConfigurationKeys.AppSec.Rules] = externalRulesFile;
             }
 
+            // set the querystring regex to something stupidly large, as it can introduce random flake into snapshots
+            if (!environmentVariables.ContainsKey("DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_TIMEOUT"))
+            {
+                environmentVariables["DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_TIMEOUT"] = 10_000_000.ToString();
+            }
+
+            if (!environmentVariables.ContainsKey("DD_IAST_REGEXP_TIMEOUT"))
+            {
+                environmentVariables["DD_IAST_REGEXP_TIMEOUT"] = 10_000_000.ToString();
+            }
+
+            if (!environmentVariables.ContainsKey("DD_APPSEC_WAF_TIMEOUT"))
+            {
+                environmentVariables["DD_APPSEC_WAF_TIMEOUT"] = 10_000_000.ToString();
+            }
+
             foreach (var name in new[] { "SERVICESTACK_REDIS_HOST", "STACKEXCHANGE_REDIS_HOST" })
             {
                 var value = Environment.GetEnvironmentVariable(name);


### PR DESCRIPTION
## Summary of changes

Set the obfuscation querystring regex, waf timeout, and iast timeout to something stupidly large in tests

## Reason for change

We're still seeing [occasional flake](https://ddstaging.datadoghq.com/ci/test-runs?query=test_level%3Atest%20%40test.service%3Add-trace-dotnet%20%40test.full_name%3ADatadog.Trace.ClrProfiler.IntegrationTests.Datadog.Trace.ClrProfiler.IntegrationTests.ManualInstrumentationTests.ManualAndAutomatic%20%40git.branch%3Amaster%20%40test.status%3Afail&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1711642866822&end=1712247666822&paused=false) due to the querystring regex timing out. 


## Implementation details

Set the variables globally (unless they're explicitly set). Added all 3 timeout ones for good measure.

## Test coverage

All covered by existing

## Other details

#5297 did this already for ASM ASP.NET tests - this just does it globally
