### PR TITLE
Don't specify port for Yarp test to avoid flake

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs
@@ -38,10 +38,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // http.request => aspnet_core.request => http.request => aspnet_core.request
             const int expectedSpans = 4;
 
-            int aspnetCorePort = TcpPortProvider.GetOpenPort();
-
             using (var agent = EnvironmentHelper.GetMockAgent())
-            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: aspnetCorePort))
+            using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion, aspNetCorePort: 0))
             {
                 var spans = agent.WaitForSpans(expectedSpans, 1_000);
                 spans.Count.Should().Be(expectedSpans);


### PR DESCRIPTION
## Summary of changes

Use port 0 for YARP ASP.NET Core test

## Reason for change

There's a race condition when we specify the port ourselves, which [can lead to the app failing to start](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=155475&view=logs&j=92b69a2f-267f-5f77-ef71-bac5079306c6&t=48cd9012-b199-57ab-0677-b1fd41c41668):

```
System.IO.IOException: Failed to bind to address http://127.0.0.1:37627/: address already in use.
10:44:24 [DBG]         ---> Microsoft.AspNetCore.Connections.AddressInUseException: Address in use
10:44:24 [DBG]         ---> System.Net.Sockets.SocketException (98): Address in use
```

If you specify port 0, ASP.NET Core takes care of assigning a free port itself. We should always do this where possible.

## Implementation details

Instead of trying to get a free port ourselves, let ASP.NET Core assign it itself by setting `ASPNET_CORE_URLS` to use port 0

## Test coverage

Covered by existing tests

## Other details


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
