### PR TITLE
Update GitHub token to one that's not about to expire

### DIFF
--- a/.github/workflows/auto-trigger-aas-release.yml
+++ b/.github/workflows/auto-trigger-aas-release.yml
@@ -13,6 +13,6 @@ jobs:
         run: |
           curl -X POST \
           -H "Accept: application/vnd.github.v3+json" \
-          -H "Authorization: Bearer ${{ secrets.GH_TOKEN_PIERO }}" \
+          -H "Authorization: Bearer ${{ secrets.GH_EXTERNAL_TOKEN }}" \
           https://api.github.com/repos/DataDog/datadog-aas-extension/dispatches \
           -d '{"event_type": "dd-trace-dotnet-release", "client_payload": {"is_prerelease":"${{github.event.release.prerelease}}", "version":"${{github.event.release.tag_name}}" } }'

--- a/.github/workflows/auto_deploy_aas_test_apps.yml
+++ b/.github/workflows/auto_deploy_aas_test_apps.yml
@@ -47,4 +47,4 @@ jobs:
         name: 'Trigger AAS deploy'
         if: env.stop != 'true'
         with:
-          aas_github_token: ${{ secrets.GH_TOKEN_PIERO }}
+          aas_github_token: ${{ secrets.GH_EXTERNAL_TOKEN }}

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -57,4 +57,4 @@ jobs:
       - uses: ./.github/actions/deploy-aas-dev-apps
         name: 'Trigger AAS deploy'
         with:
-          aas_github_token: ${{ secrets.GH_TOKEN_PIERO }}
+          aas_github_token: ${{ secrets.GH_EXTERNAL_TOKEN }}


### PR DESCRIPTION
## Summary of changes

Rename `GH_TOKEN_PIERO` to `GH_EXTERNAL_TOKEN` to make it more obvious what it does

## Reason for change

The `GH_TOKEN_PIERO` is about to expire. To avoid linking the name of the secret to a specific person, renamed it to `GH_EXTERNAL_TOKEN` (as it's used to call external workflows, in cases where you _can't_ use the "built-in" token).

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/b279a8db-65fb-449c-b22f-010f59ff38c1)


## Implementation details

Already added a new token called `GH_EXTERNAL_TOKEN`. This PR changes the usages to the new token.

## Test coverage

We'll find out soon enough whether it works..

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
