### PR TITLE
Avoid more flake in smoke tests

### DIFF
--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -34,7 +34,7 @@ namespace Samples.StackExchangeRedis
             catch (Exception ex)
                 when (ex.GetType().Name == "RedisConnectionException"
                    && (ex.Message.Contains("No connection is available to service this operation")
-                      || ex.Message.Contains("It was not possible to connect to the redis server"))
+                      || ex.Message.Contains("It was not possible to connect to the redis server")))
             {
                 // If the redis server is being too slow in responding, we can end up with timeouts
                 // We could do retries, but then we risk butting up against timeout limits etc

--- a/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.StackExchange.Redis/Program.cs
@@ -33,7 +33,8 @@ namespace Samples.StackExchangeRedis
             }
             catch (Exception ex)
                 when (ex.GetType().Name == "RedisConnectionException"
-                   && ex.Message.Contains("No connection is available to service this operation"))
+                   && (ex.Message.Contains("No connection is available to service this operation")
+                      || ex.Message.Contains("It was not possible to connect to the redis server"))
             {
                 // If the redis server is being too slow in responding, we can end up with timeouts
                 // We could do retries, but then we risk butting up against timeout limits etc

--- a/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -18,7 +18,7 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
             catch (Exception ex)
                 when (ex.GetType().Name == "RedisConnectionException"
                    && (ex.Message.Contains("No connection is available to service this operation")
-                      || ex.Message.Contains("It was not possible to connect to the redis server"))
+                      || ex.Message.Contains("It was not possible to connect to the redis server")))
             {
                 // If the redis server is being too slow in responding, we can end up with timeouts
                 // We could do retries, but then we risk butting up against timeout limits etc

--- a/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
+++ b/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs
@@ -17,7 +17,8 @@ namespace StackExchange.Redis.AssemblyConflict.SdkProject
             }
             catch (Exception ex)
                 when (ex.GetType().Name == "RedisConnectionException"
-                 &&  ex.Message.Contains("No connection is available to service this operation"))
+                   && (ex.Message.Contains("No connection is available to service this operation")
+                      || ex.Message.Contains("It was not possible to connect to the redis server"))
             {
                 // If the redis server is being too slow in responding, we can end up with timeouts
                 // We could do retries, but then we risk butting up against timeout limits etc


### PR DESCRIPTION
## Summary of changes

- Ignores a benign exception in the smoke tests

## Reason for change

Occasionally Redis flakes out (docker reasons), which manifests as flake in our integration tests. I think it's fine to ignore it.

## Implementation details

Add another exception to ignore (these were the logs in a recent unrelated PR)

```
08:44:20 [DBG]  Unhandled exception. StackExchange.Redis.RedisConnectionException: It was not possible to connect to the redis server(s); to create a disconnected multiplexer, disable AbortOnConnectFail. SocketFailure on PING
08:44:20 [DBG]     at StackExchange.Redis.ConnectionMultiplexer.ConnectImpl(Func`1 multiplexerFactory, TextWriter log) in c:\code\StackExchange.Redis\StackExchange.Redis\StackExchange\Redis\ConnectionMultiplexer.cs:line 888
08:44:20 [DBG]     at StackExchange.Redis.ConnectionMultiplexer.Connect(String configuration, TextWriter log) in c:\code\StackExchange.Redis\StackExchange.Redis\StackExchange\Redis\ConnectionMultiplexer.cs:line 855
08:44:20 [DBG]     at Datadog.StackExchange.Redis.StrongName.RedisStrongNameClient..ctor(String configuration) in /project/tracer/test/test-applications/regression/dependency-libs/Datadog.StackExchange.Redis.StrongName/RedisStrongNameClient.cs:line 15
08:44:20 [DBG]     at StackExchange.Redis.AssemblyConflict.SdkProject.Program.RunTest() in /project/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs:line 61
08:44:20 [DBG]     at StackExchange.Redis.AssemblyConflict.SdkProject.Program.Main() in /project/tracer/test/test-applications/regression/StackExchange.Redis.AssemblyConflict.SdkProject/Program.cs:line 16
08:44:20 [DBG]     at StackExchange.Redis.AssemblyConflict.SdkProject.Program.<Main>()
08:44:20 [DBG]  
```

## Test coverage

I'm pretty comfortable this isn't an instrumentation issue and it's just a benign Redis issue, but there's obviously a tiny chance this isn't benign and we're ignoring a real issue. Seems pretty unlikely to me though?

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
