### PR TITLE
Ignore complaints from NuGet about out of support packages

### DIFF
--- a/tracer/test/test-applications/integrations/dependency-libs/Directory.Build.props
+++ b/tracer/test/test-applications/integrations/dependency-libs/Directory.Build.props
@@ -7,8 +7,11 @@
   <PropertyGroup>
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
-    <!-- Stop NuGet complaining about us targetting obsolete TFMs etc-->
+    <!-- Stop NuGet from complaining about vulnerable packages -->
     <NuGetAudit>false</NuGetAudit>
+    <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
+    <!-- Ignore complaints from NuGet about out of support packages-->
+    <NoWarn>NU1901;NU1902;NU1903;NU1904</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary of changes

Ignore obsolete package warnings in sample dependency-libraries

## Reason for change

Currently we get a bunch of warnings about using .NET Core and other packages e.g.

```
[WRN] CompileDependencyLib: C:\repos\dd-trace-dotnet\tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj : warning NU1903: Package 'Microsoft.NETCore.App' 2.1.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-2xjx-v99w-gqf3 [TargetFramework=netcoreapp2.1]
[WRN] CompileDependencyLib: C:\repos\dd-trace-dotnet\tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj : warning NU1902: Package 'Microsoft.NETCore.App' 2.1.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-3gp9-h8hw-pxpw [TargetFramework=netcoreapp2.1]
[WRN] CompileDependencyLib: C:\repos\dd-trace-dotnet\tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj : warning NU1903: Package 'Microsoft.NETCore.App' 2.1.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-3w5p-jhp5-c29q [TargetFramework=netcoreapp2.1]
[WRN] CompileDependencyLib: C:\repos\dd-trace-dotnet\tracer\test\test-applications\integrations\dependency-libs\LogsInjectionHelper.VersionConflict\LogsInjectionHelper.VersionConflict.csproj : warning NU1902: Package 'Microsoft.NETCore.App' 2.1.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-5633-f33j-c6f7 [TargetFramework=netcoreapp2.1]
12:18:14 [WRN] C:\repos\dd-trace-dotnet\tracer\test\test-applications\integrations\dependency-libs\Samples.SqlServer.Vb\Samples.SqlServer.Vb.vbproj : warning NU1902: Package 'System.Data.SqlClient' 4.1.0 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-8g2p-5pqh-5jmc [TargetFramework=netstandard2.0]
12:18:14 [WRN] C:\repos\dd-trace-dotnet\tracer\test\test-applications\integrations\dependency-libs\Samples.SqlServer.Vb\Samples.SqlServer.Vb.vbproj : warning NU1903: Package 'System.Data.SqlClient' 4.1.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-98g6-xh36-x2p7 [TargetFramework=netstandard2.0]
```

We want to use these versions for testing purposes, so they're just noise

## Implementation details

Ignore the warnings

## Test coverage

Tested locally, it works

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
