### PR TITLE
Add an explicit "clean docker" step

### DIFF
--- a/.azure-pipelines/steps/clean-docker-containers.yml
+++ b/.azure-pipelines/steps/clean-docker-containers.yml
@@ -1,0 +1,3 @@
+steps:
+- script: docker rm -f $(docker ps -q -a)
+  displayName: Clean docker containers

--- a/.azure-pipelines/steps/clean-docker-containers.yml
+++ b/.azure-pipelines/steps/clean-docker-containers.yml
@@ -1,3 +1,16 @@
 steps:
-- script: docker rm -f $(docker ps -q -a)
-  displayName: Clean docker containers
+- bash: |
+    ids=$(docker ps -q -a)
+    if [ ! -z "$VAR" ]; then
+      docker rm -f $ids
+    fi
+  displayName: Clean docker
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+
+- powershell: |
+    $ids = $(docker ps -q -a)
+    if ($ids) {
+      docker rm -f $ids
+    }
+  displayName: Clean Windows docker
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/.azure-pipelines/steps/clean-docker-containers.yml
+++ b/.azure-pipelines/steps/clean-docker-containers.yml
@@ -1,7 +1,7 @@
 steps:
 - bash: |
     ids=$(docker ps -q -a)
-    if [ ! -z "$VAR" ]; then
+    if [ ! -z "$ids" ]; then
       docker rm -f $ids
     fi
   displayName: Clean docker

--- a/.azure-pipelines/steps/clean-docker-containers.yml
+++ b/.azure-pipelines/steps/clean-docker-containers.yml
@@ -5,7 +5,7 @@ steps:
       docker rm -f $ids
     fi
   displayName: Clean docker
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+  condition: and(succeeded(), not(eq(variables['Agent.OS'], 'Windows_NT')))
 
 - powershell: |
     $ids = $(docker ps -q -a)

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -14,12 +14,7 @@ parameters:
     default: ''
 
 steps:
-- ${{ if eq(parameters.isLinux, true) }}:
-  - bash: docker rm -f $(docker ps -qa)
-    displayName: Clean docker containers
-- ${{ else }}:
-  - powershell: docker rm -f $(docker ps -a -q)
-    displayName: Clean docker containers
+- template: ./clean-docker-containers.yml
 
 - bash: |
     echo "##vso[task.setvariable variable=TOKEN]$(System.JobId)"

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -14,6 +14,13 @@ parameters:
     default: ''
 
 steps:
+- ${{ if eq(parameters.isLinux, true) }}:
+  - bash: docker rm -f $(docker ps -qa)
+    displayName: Clean docker containers
+- ${{ else }}:
+  - powershell: docker rm -f $(docker ps -a -q)
+    displayName: Clean docker containers
+
 - bash: |
     echo "##vso[task.setvariable variable=TOKEN]$(System.JobId)"
     echo "##vso[task.setvariable variable=START_ENDPOINT]/test/session/start?test_session_token=$(System.JobId)"


### PR DESCRIPTION
## Summary of changes

Explicitly tear down any docker container sbefore running smoke tests

## Reason for change

I've been trialing not tearing down VMs after runs, and we've seen occasional issues where the stage smoke test stage fails due to "left-over" agent containers (I think). 

```
Creating network "ddtrace_2024040474_default" with the default driver
Creating ddtrace_2024040474_test-agent_1 ... 
Host is already in use by another container
Creating ddtrace_2024040474_test-agent_1 ... error

ERROR: for ddtrace_2024040474_test-agent_1  Cannot start service test-agent: driver failed programming external connectivity on endpoint ddtrace_2024040474_test-agent_1 (8b5625ae1ffd15a50e0210593a68d66f544eb285256c98c1bdd73ab3a829aebd): Bind for 0.0.0.0:8126 failed: port is already allocated

ERROR: for test-agent  Cannot start service test-agent: driver failed programming external connectivity on endpoint ddtrace_2024040474_test-agent_1 (8b5625ae1ffd15a50e0210593a68d66f544eb285256c98c1bdd73ab3a829aebd): Bind for 0.0.0.0:8126 failed: port is already allocated
Encountered errors while bringing up the project.


```


This is attempting to clean _before_ we run, in case there's an issue with the post-run cleanup

## Implementation details

- `docker ps -q -a` - List all docker containers, including stopped, only show their IDs
- `docker rm -f <ids>` - Nuke those containers

Created as a helper template as I envisage using this elsewhere when we try not tearing down other VMs too (if this whole experiment works)

## Test coverage

This is the test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
