### PR TITLE
[v3] Remove unnecessary System.Net.Http dependency from v3

### DIFF
--- a/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -20,10 +20,6 @@
     <PackageReference Include="OpenTracing" Version="0.12.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETFramework' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' ">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/tracer/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
+++ b/tracer/test/Datadog.Trace.OpenTracing.Tests/Datadog.Trace.OpenTracing.Tests.csproj
@@ -12,7 +12,6 @@
   </ItemGroup>
 
   <ItemGroup Condition=" !$(TargetFramework.StartsWith('net4')) ">
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
 
     <!-- These are only required because we load Datadog.Trace using reflection  -->
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" PrivateAssets="All" />


### PR DESCRIPTION
## Summary of changes

Removes the NuGet reference to System.Net.Http

## Reason for change

This reference isn't necessary, as System.Net.Http.HttpHeaders is available in all versions of .NET Standard and .NET Core.

## Implementation details

Just removed the reference. This makes no change to the referenced assemblies, and it has no impact on application that reference Datadog.Trace.OpenTracing because the library is only ever copied if it's required.

## Test coverage

I did a manual test, adding Datadog.Trace.OpenTracing to a console app, and confirmed the output doesn't _currently_ include any extra dlls etc

## Other details
Fixes https://github.com/DataDog/dd-trace-dotnet/issues/5377

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
