### PR TITLE
Enable `RestoreUseStaticGraphEvaluation` to speed up `Restore` stage

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -217,23 +217,13 @@ partial class Build
                 return;
             }
 
-            if (IsWin)
-            {
-                NuGetTasks.NuGetRestore(s => s
-                    .SetTargetPath(Solution)
-                    .SetVerbosity(NuGetVerbosity.Normal)
-                    .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
-                        o.SetPackagesDirectory(NugetPackageDirectory)));
-            }
-            else
-            {
-                DotNetRestore(s => s
-                    .SetProjectFile(Solution)
-                    .SetVerbosity(DotNetVerbosity.Normal)
-                    .SetProperty("configuration", BuildConfiguration.ToString())
-                    .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
-                        o.SetPackageDirectory(NugetPackageDirectory)));
-            }
+            DotNetRestore(s => s
+                                .SetProjectFile(Solution)
+                                .SetVerbosity(DotNetVerbosity.Normal)
+                                .SetProperty("configuration", BuildConfiguration.ToString())
+                                .SetProperty("RestoreUseStaticGraphEvaluation", "true")
+                                .When(!string.IsNullOrEmpty(NugetPackageDirectory), o =>
+                                    o.SetPackageDirectory(NugetPackageDirectory)));
         });
 
     Target CompileNativeSrcWindows => _ => _

--- a/tracer/src/Datadog.InstrumentedAssemblyGenerator/Datadog.InstrumentedAssemblyGenerator.csproj
+++ b/tracer/src/Datadog.InstrumentedAssemblyGenerator/Datadog.InstrumentedAssemblyGenerator.csproj
@@ -6,7 +6,6 @@
     <Copyright>Copyright 2022 Datadog, Inc.</Copyright>
     
     <LangVersion>latest</LangVersion>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <RunAnalyzersDuringBuild>False</RunAnalyzersDuringBuild>
     <AnalysisLevel>none</AnalysisLevel>
     <RunAnalyzersDuringLiveAnalysis>False</RunAnalyzersDuringLiveAnalysis>

--- a/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/AssemblyProcessor.cs
@@ -842,8 +842,8 @@ namespace Datadog.Trace.Coverage.Collector
                         break;
                 }
 
-                var datadogTraceDllPath = Path.Combine(_settings.TracerHome, targetFolder, "Datadog.Trace.dll");
-                var datadogTracePdbPath = Path.Combine(_settings.TracerHome, targetFolder, "Datadog.Trace.pdb");
+                var datadogTraceDllPath = Path.Combine(_settings.TracerHome!, targetFolder, "Datadog.Trace.dll");
+                var datadogTracePdbPath = Path.Combine(_settings.TracerHome!, targetFolder, "Datadog.Trace.pdb");
 
                 // Global lock for copying the Datadog.Trace assembly to the output folder
                 lock (PadLock)

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageSettings.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageSettings.cs
@@ -102,9 +102,14 @@ internal class CoverageSettings
         if (xmlNodeList is { } nodeList)
         {
             var lstElements = (List<string>)elements;
-            foreach (XmlElement element in nodeList)
+            foreach (XmlElement? element in nodeList)
             {
-                var item = element.InnerText;
+                if (element is null)
+                {
+                    continue;
+                }
+
+                var item = element!.InnerText;
                 if (string.IsNullOrWhiteSpace(item))
                 {
                     continue;

--- a/tracer/src/Datadog.Trace.Coverage.collector/Datadog.Trace.Coverage.collector.csproj
+++ b/tracer/src/Datadog.Trace.Coverage.collector/Datadog.Trace.Coverage.collector.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <ImplicitUsings>false</ImplicitUsings>
         <Nullable>enable</Nullable>
         <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>

--- a/tracer/src/Datadog.Trace.Coverage.collector/FiltersHelper.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/FiltersHelper.cs
@@ -87,7 +87,7 @@ internal static class FiltersHelper
                             }
                         }
 
-                        instance.AddInclude(Path.IsPathRooted(filter) ? filter.Substring(Path.GetPathRoot(filter).Length) : filter);
+                        instance.AddInclude(Path.IsPathRooted(filter) ? filter.Substring(Path.GetPathRoot(filter)!.Length) : filter);
                     }
 
                     return Tuple.Create(instance, (IReadOnlyList<Regex>)lstRegex);
@@ -95,7 +95,7 @@ internal static class FiltersHelper
 
             var matcher = value.Item1;
             // https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.filesystemglobbing.matcher?view=dotnet-plat-ext-6.0
-            var globbingResult = matcher.Match(Path.IsPathRooted(sourcePath) ? sourcePath.Substring(Path.GetPathRoot(sourcePath).Length) : sourcePath).HasMatches;
+            var globbingResult = matcher.Match(Path.IsPathRooted(sourcePath) ? sourcePath.Substring(Path.GetPathRoot(sourcePath)!.Length) : sourcePath).HasMatches;
             if (globbingResult)
             {
                 return true;


### PR DESCRIPTION
## Summary of changes

This enables the usage of `RestoreUseStaticGraphEvaluation` during the NuGet `Restore` stage to speed up the build (slightly).

Doc: https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#restoring-with-msbuild-static-graph-evaluation

The restore usually takes me ~45 seconds to ~60 seconds per build, this change brings that down to ~10 seconds to ~25 seconds.

## Reason for change

Just trying various things to speed up the build process.

## Implementation details

Add `RestoreUseStaticGraphEvaluation` as a property to the `dotnet` call.

No longer use `NuGetTasks` for Windows restoring - unsure if that is important or not?

Had to remove specific `<TargetFramework>netstandard2.0</TargetFramework>` as it was causing the following build error:

```
C:\Program Files\dotnet\sdk\8.0.103\NuGet.RestoreEx.targets(19,5): error : Invalid restore input. Duplicate frameworks found: 'netstandard2.0, netstandard2.0, netstandard2.0, netstandard2.0'. Input files: \Datadog.Trace.Coverage.collector\Datadog.Trace.Coverage.collector.csproj.
```

Had to ignore some `null` issues with `Coverage.Collector`

I also noticed this message that pops up with the `Restore` now and after looking into what it means I don't really know what to do with it, but I can't tell if it is an issue:

```
The solution contains '22' project(s) 'Solution Items,src,test,test-applications,regression,dependency-libs,integrations,aspnet,dependency-libs,build,artifacts,benchmarks,instrumentation,crank,shared,shared,security,aspnet,azure-functions,Samples.Shared,debugger,dependency-libs' that are not known to MSBuild. Ensure that all projects are known to be MSBuild before running restore on the solution.
```

I've also noticed that there is a `FastDevLoop` option that was added to our Nuke build process that completely bypasses the Restore stage, as an alternative we could just do use I suppose and close this PR.

## Test coverage

- If it works on the CI is the test.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
