### PR TITLE
Fix profiler integration tests

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -28,6 +28,9 @@
     <Compile Include="..\..\..\tracer\test\Datadog.Trace.TestHelpers\MockSpan.cs">
       <Link>Tracer\MockSpan.cs</Link>
     </Compile>
+    <Compile Include="..\..\..\tracer\test\Datadog.Trace.TestHelpers\MockSpanLink.cs">
+      <Link>Tracer\MockSpanLink.cs</Link>
+    </Compile>
     <Compile Include="..\..\..\tracer\src\Datadog.Trace\Tags.cs">
       <Link>Tracer\Tags.cs</Link>
     </Compile>


### PR DESCRIPTION
## Summary of changes

Add missing MockSpanLink for profiler integration tests

## Reason for change

The profiler integration tests are currently completely broken on master

## Implementation details

#5354 added support for span links. As part of that PR, the mock span definition was updated. Unfortunately, the profiler integration tests link in the `MockSpan`, so it was then missing the `MockSpanLink` definition

## Test coverage

Covered by existing

## Other details

IMO this is exactly the sort of coupling we _don't_ want between the different products, where a sipmle change in one breaks the other products, and results in broken master. That said, we probably _do_ want to have a unified specification for what a "span" looks like. Maybe the answer is a proper shared project, instead of simple linking?

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
