### PR TITLE
Don't re-build everything when building the runner in CI

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -436,9 +436,9 @@ partial class Build : NukeBuild
         .Executes(() =>
         {
             DotNetPack(x => x
-                // we have to restore and build dependencies to make sure we remove the pdb and xml files
                 .SetProject(Solution.GetProject(Projects.DdTrace))
                 .SetConfiguration(BuildConfiguration)
+                .EnableNoDependencies()
                 .SetNoWarnDotNetCore3()
                 .SetDDEnvironmentVariables("dd-trace-dotnet-runner-tool")
                 .SetProperty("PackageOutputPath", ArtifactsDirectory / "nuget" / "dd-trace")
@@ -471,7 +471,7 @@ partial class Build : NukeBuild
                 .SetProject(Solution.GetProject(Projects.DdTrace))
                 // Have to do a restore currently as we're specifying specific runtime
                 // .EnableNoRestore()
-                // .EnableNoDependencies()
+                .EnableNoDependencies()
                 .SetFramework(TargetFramework.NET7_0)
                 .SetConfiguration(BuildConfiguration)
                 .SetNoWarnDotNetCore3()


### PR DESCRIPTION
## Summary of changes

Add `EnableNoDependencies` to the `PackRunnerToolNuget` and `BuildStandaloneTool` targets

## Reason for change

There's some weird interactions happening in the `v3-main` branch related to Fody, the coverage collector, and the runner tool. I can't figure out exactly what's going on there, but enabling these resolves it and I _hope_ doesn't have an impact on the build so let's try it

## Implementation details

Add `EnableNoDependencies`. I tried adding `NoRestore`, `NoBuild`, and that _does_ work for `PackRunnerToolNuget`, but we end up with the pdbs and xml files in the tool output. [`PublishReferencesDocumentationFiles` may solve the XML issue](https://learn.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#publishreferencesdocumentationfiles), but we'd still be stuck with the pdb. And if this works, why not.

## Test coverage

We have integration tests obviously, but I've done a manual comparison of the final runner tool artifact to make sure it's ok. Comparing the build from this branch to master shows things are mostly the same. There's some minor changes in assembly size for some assemblies I can't fully account for, but I'm not too concerned...

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/103176bd-11a1-49d3-8f0f-f2f8cffb7056)

Can't do that for the standalone tool, but the file size is identical, so I suspect we're ok 🤞 


## Other details

The build is so complicated it makes me sad.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
