### PR TITLE
Bump the timeout of the integration_tests_windows stage

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1286,7 +1286,7 @@ stages:
   - job: Win
     pool:
       name: azure-windows-scale-set
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
     strategy:
       matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_windows_matrix'] ]
 


### PR DESCRIPTION
## Summary of changes

Increase the timeout for the windows integration test stage to 90mins

## Reason for change

We made the tests slower by running serially, so now they sometimes timeout

## Implementation details

60 -> 90

## Test coverage

N/A

## Other details

There are other options. We could split each job into 3 parallel jobs, e.g. integration tests, security tests, clrprofiler tests. These currently take:
- clrprofiler = 23 mins
- Security = 15 mins
- other test libraries + regression tests adds up to ~7mins

So there may be value there in improving the throughput, but this first step side steps the issue for now

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
