### PR TITLE
[Profiler] Move GetAppDomain to ManagedThreadInfo

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -115,13 +115,12 @@ void AllocationsProvider::OnAllocation(uint32_t allocationKind,
     }
 
     result->SetUnixTimeUtc(GetCurrentTimestamp());
-    result->DetermineAppDomain(threadInfo->GetClrThreadId(), _pCorProfilerInfo);
 
     RawAllocationSample rawSample;
     rawSample.Timestamp = result->GetUnixTimeUtc();
     rawSample.LocalRootSpanId = result->GetLocalRootSpanId();
     rawSample.SpanId = result->GetSpanId();
-    rawSample.AppDomainId = result->GetAppDomainId();
+    rawSample.AppDomainId = threadInfo->GetAppDomainId();
     result->CopyInstructionPointers(rawSample.Stack);
     rawSample.ThreadInfo = threadInfo;
     rawSample.AllocationSize = objectSize;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -128,11 +128,10 @@ void ContentionProvider::AddContentionSample(uint64_t timestamp, uint32_t thread
         }
 
         result->SetUnixTimeUtc(GetCurrentTimestamp());
-        result->DetermineAppDomain(threadInfo->GetClrThreadId(), _pCorProfilerInfo);
 
         rawSample.LocalRootSpanId = result->GetLocalRootSpanId();
         rawSample.SpanId = result->GetSpanId();
-        rawSample.AppDomainId = result->GetAppDomainId();
+        rawSample.AppDomainId = threadInfo->GetAppDomainId();
         rawSample.Timestamp = result->GetUnixTimeUtc();
         result->CopyInstructionPointers(rawSample.Stack);
         rawSample.ThreadInfo = threadInfo;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
@@ -155,14 +155,13 @@ bool ExceptionsProvider::OnExceptionThrown(ObjectID thrownObjectId)
     }
 
     result->SetUnixTimeUtc(GetCurrentTimestamp());
-    result->DetermineAppDomain(threadInfo->GetClrThreadId(), _pCorProfilerInfo);
 
     RawExceptionSample rawSample;
 
     rawSample.Timestamp = result->GetUnixTimeUtc();
     rawSample.LocalRootSpanId = result->GetLocalRootSpanId();
     rawSample.SpanId = result->GetSpanId();
-    rawSample.AppDomainId = result->GetAppDomainId();
+    rawSample.AppDomainId = threadInfo->GetAppDomainId();
     result->CopyInstructionPointers(rawSample.Stack);
     rawSample.ThreadInfo = threadInfo;
     rawSample.ExceptionMessage = std::move(message);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
@@ -19,12 +19,12 @@ std::uint32_t ManagedThreadInfo::GenerateProfilerThreadInfoId()
     return newId;
 }
 
-ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId) :
-    ManagedThreadInfo(clrThreadId, 0, static_cast<HANDLE>(0), shared::WSTRING())
+ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, ICorProfilerInfo4* pCorProfilerInfo) :
+    ManagedThreadInfo(clrThreadId,pCorProfilerInfo, 0, static_cast<HANDLE>(0), shared::WSTRING())
 {
 }
 
-ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle, shared::WSTRING pThreadName) :
+ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, ICorProfilerInfo4* pCorProfilerInfo, DWORD osThreadId, HANDLE osThreadHandle, shared::WSTRING pThreadName) :
     _profilerThreadInfoId{GenerateProfilerThreadInfoId()},
     _clrThreadId(clrThreadId),
     _osThreadId(osThreadId),
@@ -43,6 +43,7 @@ ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, DWORD osThreadId, HAN
     _stackWalkLock(1),
     _isThreadDestroyed{false},
     _traceContextTrackingInfo{},
-    _sharedMemoryArea{nullptr}
+    _sharedMemoryArea{nullptr},
+    _info{pCorProfilerInfo}
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -421,7 +421,11 @@ inline void ManagedThreadInfo::SetSharedMemory(volatile int* memoryArea)
 
 inline AppDomainID ManagedThreadInfo::GetAppDomainId()
 {
-    AppDomainID appDomainId{NULL};
+    // This function will be called in the signal handler.
+    // As far as I saw, this function is safe'ish to be called from a signal handler.
+    // If at some point, it's not safe anymore, we will have to rethink how we get
+    // the AppDomainID from a signal handler.
+    AppDomainID appDomainId{0};
     HRESULT hr = _info->GetThreadAppDomain(_clrThreadId, &appDomainId);
     return appDomainId;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<ManagedThreadInfo> ManagedThreadList::GetOrCreate(ThreadID clrTh
     auto pInfo = FindByClrId(clrThreadId);
     if (pInfo == nullptr)
     {
-        pInfo = std::make_shared<ManagedThreadInfo>(clrThreadId);
+        pInfo = std::make_shared<ManagedThreadInfo>(clrThreadId, _pCorProfilerInfo);
         _threads.push_back(pInfo);
 
         _lookupByClrThreadId[clrThreadId] = pInfo;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -489,7 +489,6 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             if (isStackSnapshotSuccessful)
             {
                 UpdateSnapshotInfos(pStackSnapshotResult, duration, thisSampleTimestampNanosecs);
-                pStackSnapshotResult->DetermineAppDomain(pThreadInfo->GetClrThreadId(), _pCorProfilerInfo);
             }
 
             // If we got here, then either target thread == sampler thread (we are sampling the current thread),
@@ -580,7 +579,7 @@ void StackSamplerLoop::PersistStackSnapshotResults(
         rawSample.Timestamp = pSnapshotResult->GetUnixTimeUtc();
         rawSample.LocalRootSpanId = pSnapshotResult->GetLocalRootSpanId();
         rawSample.SpanId = pSnapshotResult->GetSpanId();
-        rawSample.AppDomainId = pSnapshotResult->GetAppDomainId();
+        rawSample.AppDomainId = pThreadInfo->GetAppDomainId();
         pSnapshotResult->CopyInstructionPointers(rawSample.Stack);
         rawSample.ThreadInfo = pThreadInfo;
         rawSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();
@@ -594,7 +593,7 @@ void StackSamplerLoop::PersistStackSnapshotResults(
         rawCpuSample.Timestamp = pSnapshotResult->GetUnixTimeUtc();
         rawCpuSample.LocalRootSpanId = pSnapshotResult->GetLocalRootSpanId();
         rawCpuSample.SpanId = pSnapshotResult->GetSpanId();
-        rawCpuSample.AppDomainId = pSnapshotResult->GetAppDomainId();
+        rawCpuSample.AppDomainId = pThreadInfo->GetAppDomainId();
         pSnapshotResult->CopyInstructionPointers(rawCpuSample.Stack);
         rawCpuSample.ThreadInfo = pThreadInfo;
         rawCpuSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.cpp
@@ -6,7 +6,6 @@
 StackSnapshotResultBuffer::StackSnapshotResultBuffer() :
     _unixTimeUtc{0},
     _representedDurationNanoseconds{0},
-    _appDomainId{0},
     _instructionPointers{},
     _currentFramesCount{0},
     _localRootSpanId{0},
@@ -18,7 +17,6 @@ StackSnapshotResultBuffer::~StackSnapshotResultBuffer()
 {
     _unixTimeUtc = 0;
     _representedDurationNanoseconds = 0;
-    _appDomainId = static_cast<AppDomainID>(0);
     _currentFramesCount = 0;
     _localRootSpanId = 0;
     _spanId = 0;
@@ -30,7 +28,6 @@ void StackSnapshotResultBuffer::Reset()
     _spanId = 0;
 
     _currentFramesCount = 0;
-    _appDomainId = static_cast<AppDomainID>(0);
     _representedDurationNanoseconds = 0;
     _unixTimeUtc = 0;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSnapshotResultBuffer.h
@@ -29,9 +29,6 @@ public:
     inline std::uint64_t GetRepresentedDurationNanoseconds() const;
     inline std::uint64_t SetRepresentedDurationNanoseconds(std::uint64_t value);
 
-    inline AppDomainID GetAppDomainId() const;
-    inline AppDomainID SetAppDomainId(AppDomainID appDomainId);
-
     inline std::uint64_t GetLocalRootSpanId() const;
     inline std::uint64_t SetLocalRootSpanId(std::uint64_t value);
 
@@ -41,8 +38,6 @@ public:
     inline std::size_t GetFramesCount() const;
     inline void SetFramesCount(std::uint16_t count);
     inline void CopyInstructionPointers(std::vector<std::uintptr_t>& ips) const;
-
-    inline void DetermineAppDomain(ThreadID threadId, ICorProfilerInfo4* pCorProfilerInfo);
 
     void Reset();
 
@@ -58,7 +53,6 @@ protected:
 
     std::uint64_t _unixTimeUtc;
     std::uint64_t _representedDurationNanoseconds;
-    AppDomainID _appDomainId;
     std::array<uintptr_t, MaxSnapshotStackDepth_Limit> _instructionPointers;
     std::uint16_t _currentFramesCount;
 
@@ -89,18 +83,6 @@ inline std::uint64_t StackSnapshotResultBuffer::SetRepresentedDurationNanosecond
 {
     std::uint64_t prevValue = _representedDurationNanoseconds;
     _representedDurationNanoseconds = value;
-    return prevValue;
-}
-
-inline AppDomainID StackSnapshotResultBuffer::GetAppDomainId() const
-{
-    return _appDomainId;
-}
-
-inline AppDomainID StackSnapshotResultBuffer::SetAppDomainId(AppDomainID value)
-{
-    AppDomainID prevValue = _appDomainId;
-    _appDomainId = value;
     return prevValue;
 }
 
@@ -144,35 +126,6 @@ inline void StackSnapshotResultBuffer::CopyInstructionPointers(std::vector<std::
 
     // copy the instruction pointer to the out-parameter
     ips.insert(ips.end(), _instructionPointers.begin(), _instructionPointers.begin() + _currentFramesCount);
-}
-
-inline void StackSnapshotResultBuffer::DetermineAppDomain(ThreadID threadId, ICorProfilerInfo4* pCorProfilerInfo)
-{
-    // Determine the AppDomain currently running the sampled thread:
-    //
-    // (Note: On Windows, the target thread is still suspended and the AddDomain ID will be correct.
-    // However, on Linux the signal handler that performed the stack walk has finished and the target
-    // thread is making progress again.
-    // So, it is possible that since we walked the stack, the thread's AppDomain changed and the AppDomain ID we
-    // read here does not correspond to the stack sample. In practice we expect this to occur very rarely,
-    // so we accept this for now.
-    // If, however, this is observed frequently enough to present a problem, we will need to move the AppDomain
-    // ID read logic into _pStackFramesCollector->CollectStackSample(). Collectors that suspend the target thread
-    // will be able to read the ID at any time, but non-suspending collectors (e.g. Linux) will need to do it from
-    // within the signal handler. An example for this is the
-    // StackFramesCollectorBase::TryApplyTraceContextDataFromCurrentCollectionThreadToSnapshot() API which exists
-    // to address the same synchronization issue with TraceContextTracking-related data.
-    // There is an additional complexity with the AppDomain case, because it is likely not safe to call
-    // _pCorProfilerInfo->GetThreadAppDomain() from the collector's signal handler directly (needs to be investigated).
-    // To address this, we will need to do it via a SynchronousOffThreadWorkerBase-based mechanism, similar to how
-    // the SymbolsResolver uses a Worker and synchronously waits for results to avoid calling
-    // symbol resolution APIs on a CLR thread.)
-    AppDomainID appDomainId;
-    HRESULT hr = pCorProfilerInfo->GetThreadAppDomain(threadId, &appDomainId);
-    if (SUCCEEDED(hr))
-    {
-        SetAppDomainId(appDomainId);
-    }
 }
 
 // ----------- ----------- ----------- ----------- ----------- ----------- ----------- ----------- -----------

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -304,7 +304,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckSamplingThreadCollectCallStack)
 
     auto collector = LinuxStackFramesCollector(signalManager, configuration.get());
 
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)GetWorkerThreadId(), (HANDLE)0);
 
     std::uint32_t hr;
@@ -328,7 +328,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckSamplingThreadCollectCallStackWith
 
     auto collector = LinuxStackFramesCollector(signalManager, configuration.get());
 
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)GetWorkerThreadId(), (HANDLE)0);
 
     std::uint32_t hr;
@@ -354,7 +354,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckCollectionAbortIfInPthreadCreateCa
 
     auto collector = LinuxStackFramesCollector(signalManager, configuration.get());
 
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)GetWorkerThreadId(), (HANDLE)0);
 
     std::uint32_t hr;
@@ -374,7 +374,7 @@ TEST_F(LinuxStackFramesCollectorFixture, MustNotCollectIfUnknownThreadId)
 
     auto collector = LinuxStackFramesCollector(signalManager, configuration.get());
 
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo(0, (HANDLE)0);
 
     std::uint32_t hr;
@@ -397,7 +397,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerSignalHandlerIsRestoredIfA
 
     // Validate the profiler is working correctly
     auto threadId = (DWORD)GetWorkerThreadId();
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo(threadId, (HANDLE)0);
 
     std::uint32_t hr;
@@ -459,7 +459,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerHandlerIsInstalledCorrectl
     std::uint32_t hr;
     StackSnapshotResultBuffer* buffer;
     auto threadId = GetWorkerThreadId();
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)threadId, (HANDLE)0);
 
     // validate it's working
@@ -502,7 +502,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerHandlerIsInstalledCorrectl
     std::uint32_t hr;
     StackSnapshotResultBuffer* buffer;
     auto threadId = GetWorkerThreadId();
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)threadId, (HANDLE)0);
 
     // validate it's working
@@ -546,7 +546,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckProfilerHandlerIsInstalledCorrectl
     StackSnapshotResultBuffer* buffer;
 
     auto threadId = GetWorkerThreadId();
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)threadId, (HANDLE)0);
 
     // validate it's working
@@ -611,7 +611,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckThatProfilerHandlerAndOtherHandler
 
     // Validate the profiler is still working correctly
     auto threadId = (DWORD)GetWorkerThreadId();
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo(threadId, (HANDLE)0);
 
     std::uint32_t hr;
@@ -664,7 +664,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckTheProfilerStopWorkingIfSignalHand
     auto collector = LinuxStackFramesCollector(signalManager, configuration.get());
 
     const auto threadId = GetWorkerThreadId();
-    auto threadInfo = ManagedThreadInfo((ThreadID)0);
+    auto threadInfo = ManagedThreadInfo((ThreadID)0, nullptr);
     threadInfo.SetOsInfo((DWORD)threadId, (HANDLE)0);
     std::uint32_t hr;
     StackSnapshotResultBuffer* buffer;

--- a/profiler/test/Datadog.Profiler.Native.Tests/ManagedThreadListTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ManagedThreadListTest.cpp
@@ -291,7 +291,7 @@ TEST(ManagedThreadListTest, CheckMultipleIterators)
 TEST(ManagedThreadListTest, CheckRegisterThreadTwice)
 {
     ManagedThreadList threads(nullptr);
-    auto thread = std::make_shared<ManagedThreadInfo>(1);
+    auto thread = std::make_shared<ManagedThreadInfo>(1, nullptr);
 
     ASSERT_TRUE(threads.RegisterThread(thread));
     ASSERT_FALSE(threads.RegisterThread(thread));


### PR DESCRIPTION
## Summary of changes

Move `GetAppDomain` to `ManagedThreadInfo` class.

## Reason for change

In the next Cpu Profiler, we won't use `StackSnapshotResultBuffer` and we will have to retrieve the thread AppDomain.
So we have to move it to the `ManagedThreadInfo` class.

## Implementation details

Move the code.

## Test coverage

Current tests must not fail.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
