### PR TITLE
Try again to fix dd-trace build

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3311,7 +3311,13 @@ stages:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
     - template: steps/install-latest-dotnet-sdk.yml
-    - template: steps/restore-working-directory.yml
+    # download _everything_ not just the bin/obj/package files
+    - task: DownloadPipelineArtifact@2
+      displayName: Download working dir
+      inputs:
+        artifact: build-windows-working-directory
+        path: $(System.DefaultWorkingDirectory)
+      retryCountOnTaskFailure: 5
 
     # Download everything to monitoring home
     # BuildBundleNuget moves everything to the required folders


### PR DESCRIPTION
## Summary of changes

Restore the entire working directory, not just bin/obj/pacakages

## Reason for change

The `v3-main` build of the `dd-trace` tool is still failing even after #5424. After some trial and error, I've discovered this fixes it.

## Implementation details

Don't use the built in steps/restore-working-directory.yml, as apparently something weird happens when we build the tool, and it tries to rebuild too much. Restoring everything resolves it. No, I don't know why. Yes, it is weird. Yes, it is frustrating. No, I don't have a better idea right now.

## Test coverage

Will do a comparison of the packages again, but initial outlook looks good

## Other details

Maybe we should skip the `clone` step entirely in these post-build stages, and _always_ do a full working directory restore. I'll give it a try and see what the impact is

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
