### PR TITLE
Bump the macos timeout

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1091,7 +1091,7 @@ stages:
       jobs: [managed]
 
   - job: managed
-    timeoutInMinutes: 60 #default value
+    timeoutInMinutes: 90
     pool:
       vmImage: macos-11
     steps:


### PR DESCRIPTION
## Summary of changes

Bumps the timeout for macos unit tests from 60 -> 90

## Reason for change

Saw it timeout on master [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=155934&view=results)

## Implementation details

Bump it

## Test coverage

N/A

## Other details

Can look at splitting by tfm later if we need to bring this down


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
