### PR TITLE
read variable responsible for enabling SCA

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -284,7 +284,7 @@ partial class Build
             DeleteDirectory(NativeTracerProject.Directory / "build");
 
             var finalArchs = FastDevLoop ? new[]  { "arm64" } : OsxArchs;
-            
+
             var lstNativeBinaries = new List<string>();
             foreach (var arch in finalArchs)
             {
@@ -2221,7 +2221,7 @@ partial class Build
                     if (line.Contains("#nullable enable"))
                     {
                         missingNullability = false;
-                        break;        
+                        break;
                     }
                 }
 

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -115,6 +115,10 @@ namespace Datadog.Trace.AppSec
             WafDebugEnabled = config
                              .WithKeys(ConfigurationKeys.AppSec.WafDebugEnabled)
                              .AsBool(defaultValue: false);
+
+            ScaEnabled = config
+                             .WithKeys(ConfigurationKeys.AppSec.ScaEnabled)
+                             .AsBool();
         }
 
         public double ApiSecuritySampleDelay { get; set; }
@@ -199,6 +203,11 @@ namespace Datadog.Trace.AppSec
         /// Gets a value indicating whether or not api security is enabled, defaults to false.
         /// </summary>
         public bool ApiSecurityEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not sca is enabled, defaults to null.
+        /// </summary>
+        public bool? ScaEnabled { get; }
 
         public static SecuritySettings FromDefaultSources()
         {

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -205,7 +205,8 @@ namespace Datadog.Trace.AppSec
         public bool ApiSecurityEnabled { get; }
 
         /// <summary>
-        /// Gets a value indicating whether or not sca is enabled, defaults to null.
+        /// Gets a value indicating whether or not SCA (Software Composition Analysis) is enabled, defaults to null.
+        /// It is not use locally, but ready by the backend.
         /// </summary>
         public bool? ScaEnabled { get; }
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -114,6 +114,11 @@ namespace Datadog.Trace.Configuration
             /// Activate debug logs for the WAF
             /// </summary>
             internal const string WafDebugEnabled = "DD_APPSEC_WAF_DEBUG";
+
+            /// <summary>
+            /// Activate debug logs for the WAF
+            /// </summary>
+            internal const string ScaEnabled = "DD_APPSEC_SCA_ENABLED";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -116,7 +116,7 @@ namespace Datadog.Trace.Configuration
             internal const string WafDebugEnabled = "DD_APPSEC_WAF_DEBUG";
 
             /// <summary>
-            /// Activate debug logs for the WAF
+            /// Activate SCA (Software Composition Analysis), used in the backend
             /// </summary>
             internal const string ScaEnabled = "DD_APPSEC_SCA_ENABLED";
         }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -8,12 +8,15 @@
 using System;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Telemetry
 {
     internal class TelemetrySettings
     {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TelemetrySettings));
+
         public TelemetrySettings(
             bool telemetryEnabled,
             string? configurationError,

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetrySettings.cs
@@ -15,8 +15,6 @@ namespace Datadog.Trace.Telemetry
 {
     internal class TelemetrySettings
     {
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(TelemetrySettings));
-
         public TelemetrySettings(
             bool telemetryEnabled,
             string? configurationError,

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
@@ -14,6 +14,7 @@ using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
+using Xunit.Abstractions;
 using Xunit.Sdk;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests;
@@ -23,8 +24,9 @@ public class TelemetryHelperTests
     private readonly ApplicationTelemetryData _app;
     private readonly HostTelemetryData _host;
     private readonly TelemetryDataBuilder _dataBuilder = new();
+    private readonly ITestOutputHelper _output;
 
-    public TelemetryHelperTests()
+    public TelemetryHelperTests(ITestOutputHelper output)
     {
         _app = new ApplicationTelemetryData(
             "service",
@@ -36,6 +38,7 @@ public class TelemetryHelperTests
             runtimeName: "dotnet",
             runtimeVersion: "7.0.1");
         _host = new HostTelemetryData("MY_HOST", "Windows", "x64");
+        _output = output;
     }
 
     [Fact]
@@ -120,6 +123,7 @@ public class TelemetryHelperTests
             { ConfigurationKeys.FeatureFlags.RouteTemplateResourceNamesEnabled, "1" },
             { ConfigurationKeys.TraceEnabled, "0" },
             { ConfigurationKeys.AppSec.Enabled, "1" },
+            { ConfigurationKeys.AppSec.ScaEnabled, "1" },
         });
 
         _ = new ImmutableTracerSettings(new TracerSettings(config, collector));
@@ -136,6 +140,8 @@ public class TelemetryHelperTests
         TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.TraceEnabled, false);
         TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.AppSec.Enabled);
         TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.AppSec.Enabled, true);
+        TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.AppSec.ScaEnabled);
+        TelemetryHelper.AssertConfiguration(telemetryData, ConfigurationKeys.AppSec.ScaEnabled, true);
     }
 
     private TelemetryData BuildTelemetryData(


### PR DESCRIPTION
## Summary of changes

Reads an environment variable from so that it is placed into the libraries configuration telemetry and can be consumed by the backend.

## Test coverage

Added a unit test, it will be covered by systems tests once adapted in this PR: https://github.com/DataDog/system-tests/pull/2417

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
