### PR TITLE
[Profiler] Pass memory_resource around

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.cpp
@@ -36,7 +36,8 @@ AllocationsProvider::AllocationsProvider(
     IConfiguration* pConfiguration,
     ISampledAllocationsListener* pListener,
     MetricsRegistry& metricsRegistry,
-    CallstackProvider pool)
+    CallstackProvider pool,
+    shared::pmr::memory_resource* memoryResource)
     :
     AllocationsProvider(
         valueTypeProvider.GetOrRegister(SampleTypeDefinitions),
@@ -45,7 +46,8 @@ AllocationsProvider::AllocationsProvider(
         pConfiguration,
         pListener,
         metricsRegistry,
-        std::move(pool))
+        std::move(pool),
+        memoryResource)
 {
 }
 
@@ -60,8 +62,9 @@ AllocationsProvider::AllocationsProvider(
     IConfiguration* pConfiguration,
     ISampledAllocationsListener* pListener,
     MetricsRegistry& metricsRegistry,
-    CallstackProvider pool) :
-    CollectorBase<RawAllocationSample>("AllocationsProvider", std::move(valueTypes), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore),
+    CallstackProvider pool,
+    shared::pmr::memory_resource* memoryResource) :
+    CollectorBase<RawAllocationSample>("AllocationsProvider", std::move(valueTypes), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource),
     _pCorProfilerInfo(pCorProfilerInfo),
     _pManagedThreadList(pManagedThreadList),
     _pFrameStore(pFrameStore),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsProvider.h
@@ -13,6 +13,8 @@
 #include "RawAllocationSample.h"
 #include "SumMetric.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 #include <memory>
 
 class IConfiguration;
@@ -42,7 +44,8 @@ public:
         IConfiguration* pConfiguration,
         ISampledAllocationsListener* pListener,
         MetricsRegistry& metricsRegistry,
-        CallstackProvider callstackProvider);
+        CallstackProvider callstackProvider,
+        shared::pmr::memory_resource* memoryResource);
 
     AllocationsProvider(
         std::vector<SampleValueTypeProvider::Offset> valueTypeProvider,
@@ -55,7 +58,8 @@ public:
         IConfiguration* pConfiguration,
         ISampledAllocationsListener* pListener,
         MetricsRegistry& metricsRegistry,
-        CallstackProvider callstackProvider);
+        CallstackProvider callstackProvider,
+        shared::pmr::memory_resource* memoryResource);
 
     void OnAllocation(uint32_t allocationKind,
                       ClassID classId,

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CollectorBase.h
@@ -2,14 +2,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #pragma once
-#include <list>
-#include <mutex>
-#include <string>
-#include <thread>
-#include <vector>
-
-#include "Log.h"
-#include "OpSysTools.h"
 
 #include "IAppDomainStore.h"
 #include "ICollector.h"
@@ -18,13 +10,22 @@
 #include "IRuntimeIdStore.h"
 #include "IService.h"
 #include "IThreadsCpuManager.h"
+#include "Log.h"
+#include "OpSysTools.h"
 #include "ProviderBase.h"
 #include "RawSample.h"
 #include "RawSamples.hpp"
 #include "SamplesEnumerator.h"
 #include "SampleValueTypeProvider.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
 #include "shared/src/native-src/string.h"
+
+#include <list>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
 
 // forward declarations
 class IConfiguration;
@@ -57,14 +58,15 @@ public:
         IThreadsCpuManager* pThreadsCpuManager,
         IFrameStore* pFrameStore,
         IAppDomainStore* pAppDomainStore,
-        IRuntimeIdStore* pRuntimeIdStore)
+        IRuntimeIdStore* pRuntimeIdStore,
+        shared::pmr::memory_resource* memoryResource)
         :
         ProviderBase(name),
         _pFrameStore{pFrameStore},
         _pAppDomainStore{pAppDomainStore},
         _pRuntimeIdStore{pRuntimeIdStore},
         _pThreadsCpuManager{pThreadsCpuManager},
-        _collectedSamples{}
+        _collectedSamples{memoryResource}
     {
         _valueOffsets = std::move(valueOffsets);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.cpp
@@ -37,9 +37,10 @@ ContentionProvider::ContentionProvider(
     IRuntimeIdStore* pRuntimeIdStore,
     IConfiguration* pConfiguration,
     MetricsRegistry& metricsRegistry,
-    CallstackProvider callstackProvider)
+    CallstackProvider callstackProvider,
+    shared::pmr::memory_resource* memoryResource)
     :
-    CollectorBase<RawContentionSample>("ContentionProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore),
+    CollectorBase<RawContentionSample>("ContentionProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource),
     _pCorProfilerInfo{pCorProfilerInfo},
     _pManagedThreadList{pManagedThreadList},
     _sampler(pConfiguration->ContentionSampleLimit(), pConfiguration->GetUploadInterval(), false),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -16,6 +16,8 @@
 #include "MetricsRegistry.h"
 #include "RawContentionSample.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 #include <memory>
 
 class IConfiguration;
@@ -43,7 +45,8 @@ public:
         IRuntimeIdStore* pRuntimeIdStore,
         IConfiguration* pConfiguration,
         MetricsRegistry& metricsRegistry,
-        CallstackProvider callstackProvider);
+        CallstackProvider callstackProvider,
+        shared::pmr::memory_resource* memoryResource);
 
     // IContentionListener implementation
     void OnContention(double contentionDurationNs) override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -156,17 +156,18 @@ bool CorProfilerCallback::InitializeServices()
             _pThreadsCpuManager,
             _pAppDomainStore.get(),
             pRuntimeIdStore,
-            _pConfiguration.get());
+            _pConfiguration.get(),
+            MemoryResourceManager::GetDefault());
     }
 
     if (_pConfiguration->IsWallTimeProfilingEnabled())
     {
-        _pWallTimeProvider = RegisterService<WallTimeProvider>(valueTypeProvider, _pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore, _pConfiguration.get());
+        _pWallTimeProvider = RegisterService<WallTimeProvider>(valueTypeProvider, _pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore, _pConfiguration.get(), MemoryResourceManager::GetDefault());
     }
 
     if (_pConfiguration->IsCpuProfilingEnabled())
     {
-        _pCpuTimeProvider = RegisterService<CpuTimeProvider>(valueTypeProvider, _pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore, _pConfiguration.get());
+        _pCpuTimeProvider = RegisterService<CpuTimeProvider>(valueTypeProvider, _pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore, _pConfiguration.get(), MemoryResourceManager::GetDefault());
     }
 
     if (_pConfiguration->IsExceptionProfilingEnabled())
@@ -181,7 +182,8 @@ bool CorProfilerCallback::InitializeServices()
             _pAppDomainStore.get(),
             pRuntimeIdStore,
             _metricsRegistry,
-            CallstackProvider(_memoryResourceManager.GetDefault()));
+            CallstackProvider(_memoryResourceManager.GetDefault()),
+            MemoryResourceManager::GetDefault());
     }
 
     // _pCorProfilerInfoEvents must have been set for any .NET 5+ CLR events-based profiler to work
@@ -214,7 +216,8 @@ bool CorProfilerCallback::InitializeServices()
                     _pConfiguration.get(),
                     _pLiveObjectsProvider,
                     _metricsRegistry,
-                    CallstackProvider(_memoryResourceManager.GetDefault())
+                    CallstackProvider(_memoryResourceManager.GetDefault()),
+                    MemoryResourceManager::GetDefault()
                     );
 
                 if (!_pConfiguration->IsAllocationProfilingEnabled())
@@ -242,7 +245,8 @@ bool CorProfilerCallback::InitializeServices()
                 _pConfiguration.get(),
                 nullptr, // no listener
                 _metricsRegistry,
-                CallstackProvider(_memoryResourceManager.GetDefault())
+                CallstackProvider(_memoryResourceManager.GetDefault()),
+                MemoryResourceManager::GetDefault()
                 );
         }
 
@@ -258,7 +262,8 @@ bool CorProfilerCallback::InitializeServices()
                 pRuntimeIdStore,
                 _pConfiguration.get(),
                 _metricsRegistry,
-                CallstackProvider(_memoryResourceManager.GetDefault())
+                CallstackProvider(_memoryResourceManager.GetDefault()),
+                MemoryResourceManager::GetDefault()
                 );
         }
 
@@ -270,7 +275,8 @@ bool CorProfilerCallback::InitializeServices()
                 _pThreadsCpuManager,
                 _pAppDomainStore.get(),
                 pRuntimeIdStore,
-                _pConfiguration.get()
+                _pConfiguration.get(),
+                MemoryResourceManager::GetDefault()
                 );
             _pGarbageCollectionProvider = RegisterService<GarbageCollectionProvider>(
                 valueTypeProvider,
@@ -279,7 +285,8 @@ bool CorProfilerCallback::InitializeServices()
                 _pAppDomainStore.get(),
                 pRuntimeIdStore,
                 _pConfiguration.get(),
-                _metricsRegistry
+                _metricsRegistry,
+                MemoryResourceManager::GetDefault()
                 );
         }
         else
@@ -322,7 +329,8 @@ bool CorProfilerCallback::InitializeServices()
                 _pConfiguration.get(),
                 nullptr, // no listener
                 _metricsRegistry,
-                CallstackProvider(_memoryResourceManager.GetDefault()));
+                CallstackProvider(_memoryResourceManager.GetDefault()),
+                MemoryResourceManager::GetDefault());
         }
 
         if (_pConfiguration->IsContentionProfilingEnabled())
@@ -337,7 +345,8 @@ bool CorProfilerCallback::InitializeServices()
                 pRuntimeIdStore,
                 _pConfiguration.get(),
                 _metricsRegistry,
-                CallstackProvider(_memoryResourceManager.GetDefault()));
+                CallstackProvider(_memoryResourceManager.GetDefault()),
+                MemoryResourceManager::GetDefault());
         }
 
         if (_pConfiguration->IsGarbageCollectionProfilingEnabled())
@@ -348,7 +357,8 @@ bool CorProfilerCallback::InitializeServices()
                 _pThreadsCpuManager,
                 _pAppDomainStore.get(),
                 pRuntimeIdStore,
-                _pConfiguration.get());
+                _pConfiguration.get(),
+                MemoryResourceManager::GetDefault());
 
             _pGarbageCollectionProvider = RegisterService<GarbageCollectionProvider>(
                 valueTypeProvider,
@@ -357,7 +367,8 @@ bool CorProfilerCallback::InitializeServices()
                 _pAppDomainStore.get(),
                 pRuntimeIdStore,
                 _pConfiguration.get(),
-                _metricsRegistry);
+                _metricsRegistry,
+                MemoryResourceManager::GetDefault());
         }
         else
         {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.cpp
@@ -8,6 +8,7 @@
 #include "IRuntimeIdStore.h"
 #include "RawCpuSample.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
 
 std::vector<SampleValueType> CpuTimeProvider::SampleTypeDefinitions(
     {
@@ -22,9 +23,10 @@ CpuTimeProvider::CpuTimeProvider(
     IFrameStore* pFrameStore,
     IAppDomainStore* pAppDomainStore,
     IRuntimeIdStore* pRuntimeIdStore,
-    IConfiguration* pConfiguration
+    IConfiguration* pConfiguration,
+    shared::pmr::memory_resource* memoryResource
     )
     :
-    CollectorBase<RawCpuSample>("CpuTimeProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore)
+    CollectorBase<RawCpuSample>("CpuTimeProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource)
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuTimeProvider.h
@@ -6,6 +6,8 @@
 #include "CollectorBase.h"
 #include "RawCpuSample.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 // forward declarations
 class IConfiguration;
 class IFrameStore;
@@ -25,7 +27,8 @@ public:
         IFrameStore* pFrameStore,
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
-        IConfiguration* pConfiguration
+        IConfiguration* pConfiguration,
+        shared::pmr::memory_resource* memoryResource
         );
 
 private:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp
@@ -30,9 +30,10 @@ ExceptionsProvider::ExceptionsProvider(
     IAppDomainStore* pAppDomainStore,
     IRuntimeIdStore* pRuntimeIdStore,
     MetricsRegistry& metricsRegistry,
-    CallstackProvider callstackProvider)
+    CallstackProvider callstackProvider,
+    shared::pmr::memory_resource* memoryResource)
     :
-    CollectorBase<RawExceptionSample>("ExceptionsProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore),
+    CollectorBase<RawExceptionSample>("ExceptionsProvider", valueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource),
     _pCorProfilerInfo(pCorProfilerInfo),
     _pManagedThreadList(pManagedThreadList),
     _pFrameStore(pFrameStore),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.h
@@ -18,6 +18,8 @@
 #include "CounterMetric.h"
 #include "IUpscaleProvider.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 #include <memory>
 
 class IConfiguration;
@@ -38,7 +40,8 @@ public:
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
         MetricsRegistry& metricsRegistry,
-        CallstackProvider pool);
+        CallstackProvider pool,
+        shared::pmr::memory_resource* memoryResource);
 
     bool OnModuleLoaded(ModuleID moduleId);
     bool OnExceptionThrown(ObjectID thrownObjectId);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.cpp
@@ -13,9 +13,10 @@ GarbageCollectionProvider::GarbageCollectionProvider(
     IAppDomainStore* pAppDomainStore,
     IRuntimeIdStore* pRuntimeIdStore,
     IConfiguration* pConfiguration,
-    MetricsRegistry& metricsRegistry)
+    MetricsRegistry& metricsRegistry,
+    shared::pmr::memory_resource* memoryResource)
     :
-    CollectorBase<RawGarbageCollectionSample>("GarbageCollectorProvider", valueTypeProvider.GetOrRegister(TimelineSampleType::Definitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore)
+    CollectorBase<RawGarbageCollectionSample>("GarbageCollectorProvider", valueTypeProvider.GetOrRegister(TimelineSampleType::Definitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource)
 {
     _gen0CountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_gc_gen0");
     _gen1CountMetric = metricsRegistry.GetOrRegister<CounterMetric>("dotnet_gc_gen1");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
@@ -11,6 +11,8 @@
 #include "CounterMetric.h"
 #include "MeanMaxMetric.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 class SampleValueTypeProvider;
 
 class GarbageCollectionProvider
@@ -25,7 +27,8 @@ public:
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
         IConfiguration* pConfiguration,
-        MetricsRegistry& metricsRegistry);
+        MetricsRegistry& metricsRegistry,
+        shared::pmr::memory_resource* memoryResource);
 
     // Inherited via IGarbageCollectionsListener
     void OnGarbageCollectionStart(

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LinkedList.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LinkedList.hpp
@@ -21,7 +21,7 @@ template <class T>
 class LinkedList
 {
 public:
-    LinkedList(shared::pmr::memory_resource* allocator = shared::pmr::get_default_resource()) noexcept :
+    LinkedList(shared::pmr::memory_resource* allocator) noexcept :
         _head{nullptr}, _tail{&_head}, _nbElements{0}, _allocator{allocator}
     {
     }
@@ -43,7 +43,7 @@ public:
     LinkedList(LinkedList const&) = delete;
     LinkedList& operator=(LinkedList const&) = delete;
 
-    LinkedList(LinkedList&& other) NOEXCEPT : LinkedList()
+    LinkedList(LinkedList&& other) NOEXCEPT : LinkedList(shared::pmr::get_default_resource())
     {
         *this = std::move(other);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -49,7 +49,8 @@ LiveObjectsProvider::LiveObjectsProvider(
         pConfiguration,
         nullptr,
         metricsRegistry,
-        CallstackProvider(shared::pmr::null_memory_resource())); // safe to pass nullptr for the provider. This provider does not collect callstack
+        CallstackProvider(shared::pmr::null_memory_resource()), // safe to pass the null memory resource for the provider. This provider does not collect callstack
+        shared::pmr::null_memory_resource()); // safe to pass null memory resource for the provider. This provider is only used to transform RawSamples
 }
 
 const char* LiveObjectsProvider::GetName()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.cpp
@@ -26,9 +26,10 @@ StopTheWorldGCProvider::StopTheWorldGCProvider(
     IThreadsCpuManager* pThreadsCpuManager,
     IAppDomainStore* pAppDomainStore,
     IRuntimeIdStore* pRuntimeIdStore,
-    IConfiguration* pConfiguration)
+    IConfiguration* pConfiguration,
+    shared::pmr::memory_resource* memoryResource)
     :
-    CollectorBase<RawStopTheWorldSample>("StopTheWorldGCProvider", valueTypeProvider.GetOrRegister(TimelineSampleType::Definitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore)
+    CollectorBase<RawStopTheWorldSample>("StopTheWorldGCProvider", valueTypeProvider.GetOrRegister(TimelineSampleType::Definitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource)
 {
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StopTheWorldGCProvider.h
@@ -7,6 +7,8 @@
 #include "IGCSuspensionsListener.h"
 #include "RawStopTheWorldSample.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 class IFrameStore;
 class IThreadsCpuManager;
 class IAppDomainStore;
@@ -27,7 +29,8 @@ public:
         IThreadsCpuManager* pThreadsCpuManager,
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
-        IConfiguration* pConfiguration);
+        IConfiguration* pConfiguration,
+        shared::pmr::memory_resource* memoryResource);
 
     // Inherited via IGCSuspensionsListener
     void OnSuspension(uint64_t timestamp, int32_t number, uint32_t generation, uint64_t pauseDuration) override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.cpp
@@ -13,12 +13,13 @@ ThreadLifetimeProvider::ThreadLifetimeProvider(
     IThreadsCpuManager* pThreadsCpuManager,
     IAppDomainStore* pAppDomainStore,
     IRuntimeIdStore* pRuntimeIdStore,
-    IConfiguration* pConfiguration)
+    IConfiguration* pConfiguration,
+    shared::pmr::memory_resource* memoryResource)
     :
     CollectorBase<RawThreadLifetimeSample>(
         "ThreadLifetimeProvider",
         valueTypeProvider.GetOrRegister(TimelineSampleType::Definitions),
-        pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore)
+        pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource)
 {
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.h
@@ -9,6 +9,8 @@
 #include "IThreadLifetimeListener.h"
 #include "RawThreadLifetimeSample.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 class IFrameStore;
 class IThreadsCpuManager;
 class IAppDomainStore;
@@ -28,7 +30,8 @@ public:
         IThreadsCpuManager* pThreadsCpuManager,
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
-        IConfiguration* pConfiguration);
+        IConfiguration* pConfiguration,
+        shared::pmr::memory_resource* memoryResource);
 
     // Inherited via IThreadLifetimeListener
     void OnThreadStart(std::shared_ptr<ManagedThreadInfo> threadInfo) override;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.cpp
@@ -23,9 +23,10 @@ WallTimeProvider::WallTimeProvider(
     IFrameStore* pFrameStore,
     IAppDomainStore* pAppDomainStore,
     IRuntimeIdStore* pRuntimeIdStore,
-    IConfiguration* pConfiguration
+    IConfiguration* pConfiguration,
+    shared::pmr::memory_resource* memoryResource
     )
     :
-    CollectorBase<RawWallTimeSample>("WallTimeProvider", sampleValueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore)
+    CollectorBase<RawWallTimeSample>("WallTimeProvider", sampleValueTypeProvider.GetOrRegister(SampleTypeDefinitions), pThreadsCpuManager, pFrameStore, pAppDomainStore, pRuntimeIdStore, memoryResource)
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/WallTimeProvider.h
@@ -6,6 +6,8 @@
 #include "CollectorBase.h"
 #include "RawWallTimeSample.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 // forward declarations
 class IConfiguration;
 class IFrameStore;
@@ -27,7 +29,8 @@ public:
         IFrameStore* pFrameStore,
         IAppDomainStore* pAppDomainStore,
         IRuntimeIdStore* pRuntimeIdStore,
-        IConfiguration* pConfiguration
+        IConfiguration* pConfiguration,
+        shared::pmr::memory_resource* memoryResource
         );
 
 private:

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinkedListTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinkedListTest.cpp
@@ -11,9 +11,11 @@
 
 #include "gtest/gtest.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 TEST(LinkedListTest, PushBack)
 {
-    LinkedList<int> x;
+    LinkedList<int> x(shared::pmr::get_default_resource());
 
     ASSERT_EQ(x.Size(), 0);
 
@@ -26,7 +28,7 @@ TEST(LinkedListTest, PushBack)
 
 TEST(LinkedListTest, ForEach)
 {
-    LinkedList<std::string> x;
+    LinkedList<std::string> x(shared::pmr::get_default_resource());
 
     ASSERT_TRUE(x.Append("1"));
     ASSERT_TRUE(x.Append("2"));
@@ -50,7 +52,7 @@ struct Person
 
 TEST(LinkedListTest, Move)
 {
-    LinkedList<Person> l;
+    LinkedList<Person> l(shared::pmr::get_default_resource());
 
     l.Append({.Name = "Georges", .Age = 42});
     l.Append({.Name = "Ralph", .Age = 101});
@@ -88,7 +90,7 @@ TEST(LinkedListTest, Move)
 
 TEST(LinkedListTest, Assign)
 {
-    LinkedList<Person> l;
+    LinkedList<Person> l(shared::pmr::get_default_resource());
 
     l.Append({.Name = "Georges", .Age = 42});
     l.Append({.Name = "Ralph", .Age = 101});
@@ -97,7 +99,7 @@ TEST(LinkedListTest, Assign)
 
     ASSERT_EQ(l.Size(), 4);
 
-    LinkedList<Person> other;
+    LinkedList<Person> other(shared::pmr::get_default_resource());
 
     other = std::move(l);
 
@@ -179,7 +181,7 @@ TEST(LinkedListTest, ObjectDtorCalled)
 
     bool dtorCalled = false;
     {
-        LinkedList<Dummy> l;
+        LinkedList<Dummy> l(shared::pmr::get_default_resource());
 
         l.Append({&dtorCalled});
 
@@ -220,10 +222,10 @@ TEST(LinkedListTest, CannotAllocate)
 TEST(LinkedListTest, EnsureMoveAssignementOperatorDoesNotLeakOrLeavesTheCollectionInInconsitentState)
 {
     {
-        LinkedList<int> l2;
+        LinkedList<int> l2(shared::pmr::get_default_resource());
         l2.Append(21);
 
-        LinkedList<int> ll;
+        LinkedList<int> ll(shared::pmr::get_default_resource());
         EXPECT_NO_THROW(ll = std::move(l2));
 
         ASSERT_EQ(l2.Size(), 0);
@@ -232,9 +234,9 @@ TEST(LinkedListTest, EnsureMoveAssignementOperatorDoesNotLeakOrLeavesTheCollecti
     }
 
     {
-        LinkedList<int> l2;
+        LinkedList<int> l2(shared::pmr::get_default_resource());
 
-        LinkedList<int> ll;
+        LinkedList<int> ll(shared::pmr::get_default_resource());
         ll.Append(21);
 
         EXPECT_NO_THROW(ll = std::move(l2));
@@ -245,8 +247,8 @@ TEST(LinkedListTest, EnsureMoveAssignementOperatorDoesNotLeakOrLeavesTheCollecti
     }
 
     {
-        LinkedList<int> l2;
-        LinkedList<int> ll;
+        LinkedList<int> l2(shared::pmr::get_default_resource());
+        LinkedList<int> ll(shared::pmr::get_default_resource());
 
         EXPECT_NO_THROW(ll = std::move(l2));
 
@@ -257,7 +259,7 @@ TEST(LinkedListTest, EnsureMoveAssignementOperatorDoesNotLeakOrLeavesTheCollecti
 
 __declspec(noinline) void SwapWithContent(LinkedList<int>& ll)
 {
-    LinkedList<int> l;
+    LinkedList<int> l(shared::pmr::get_default_resource());
     l.Append(41);
     l.Append(43);
     l.Swap(ll);
@@ -266,9 +268,9 @@ __declspec(noinline) void SwapWithContent(LinkedList<int>& ll)
 TEST(LinkedListTest, SwapAll)
 {
     {
-        LinkedList<int> l;
+        LinkedList<int> l(shared::pmr::get_default_resource());
 
-        LinkedList<int> ll;
+        LinkedList<int> ll(shared::pmr::get_default_resource());
         ll.Append(21);
 
         ll.Swap(l);
@@ -277,9 +279,9 @@ TEST(LinkedListTest, SwapAll)
         ASSERT_EQ(ll.Size(), 0);
     }
     {
-        LinkedList<int> l;
+        LinkedList<int> l(shared::pmr::get_default_resource());
 
-        LinkedList<int> ll;
+        LinkedList<int> ll(shared::pmr::get_default_resource());
         ll.Append(21);
 
         l.Swap(ll);
@@ -288,12 +290,12 @@ TEST(LinkedListTest, SwapAll)
         ASSERT_EQ(ll.Size(), 0);
     }
     {
-        LinkedList<int> l;
+        LinkedList<int> l(shared::pmr::get_default_resource());
         l.Append(1);
         l.Append(2);
         l.Append(3);
 
-        LinkedList<int> ll;
+        LinkedList<int> ll(shared::pmr::get_default_resource());
         ll.Append(21);
 
         ll.Swap(l);
@@ -303,7 +305,7 @@ TEST(LinkedListTest, SwapAll)
     }
 
     {
-        LinkedList<int> l;
+        LinkedList<int> l(shared::pmr::get_default_resource());
         SwapWithContent(l);
 
         ASSERT_EQ(l.Size(), 2);
@@ -312,8 +314,8 @@ TEST(LinkedListTest, SwapAll)
         ASSERT_EQ(l.Size(), 3);
     }
     {
-        LinkedList<double> l;
-        LinkedList<double> ll;
+        LinkedList<double> l(shared::pmr::get_default_resource());
+        LinkedList<double> ll(shared::pmr::get_default_resource());
 
         EXPECT_NO_THROW(l.Swap(ll));
     }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProviderTest.cpp
@@ -23,6 +23,8 @@
 #include "ThreadsCpuManagerHelper.h"
 #include "WallTimeProvider.h"
 
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
 using namespace std::chrono_literals;
 
 CallstackProvider callstackProvider(MemoryResourceManager::GetDefault());
@@ -94,7 +96,7 @@ TEST(WallTimeProviderTest, CheckNoMissingSample)
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration, shared::pmr::get_default_resource());
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -126,7 +128,7 @@ TEST(WallTimeProviderTest, CheckAppDomainInfoAndRuntimeId)
     std::string secondExpectedRuntimeId = "OtherRid";
     EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(2))).WillRepeatedly(::testing::Return(secondExpectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration, shared::pmr::get_default_resource());
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -207,7 +209,7 @@ TEST(WallTimeProviderTest, CheckFrames)
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(static_cast<AppDomainID>(1))).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration, shared::pmr::get_default_resource());
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -268,7 +270,7 @@ TEST(WallTimeProviderTest, CheckValuesAndTimestamp)
     std::string expectedRuntimeId = "MyRid";
     EXPECT_CALL(runtimeIdStore, GetId(::testing::_)).WillRepeatedly(::testing::Return(expectedRuntimeId.c_str()));
 
-    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    WallTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration, shared::pmr::get_default_resource());
     Sample::ValuesCount = 1;
     provider.Start();
 
@@ -312,7 +314,7 @@ TEST(CpuTimeProviderTest, CheckValuesAndTimestamp)
     RuntimeIdStoreHelper runtimeIdStore;
     auto [configuration, mockConfiguration] = CreateConfiguration();
 
-    CpuTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration);
+    CpuTimeProvider provider(valueTypeProvider, &threadscpuManager, &frameStore, &appDomainStore, &runtimeIdStore, &mockConfiguration, shared::pmr::get_default_resource());
     Sample::ValuesCount = 1;
     provider.Start();
 


### PR DESCRIPTION
## Summary of changes

Provide `memory_resource` instance to provider.

## Reason for change
This is mainly plumbing PR. The goal is to pass a memory_resource to the `LinkedList`.

For now we use the default one (new/delete).
In next PR(s), we may use Pooled resource memory instances.

## Implementation details

- Change Providers signature to pass a memory_resource to the `LinkedList`

## Test coverage
Current tests must pass
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
