### PR TITLE
[Profiler] Fix possible crash when Agent does not answer namedpipe connection

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/EtwEventsHandler.cpp
@@ -65,7 +65,7 @@ void EtwEventsHandler::OnConnect(HANDLE hPipe)
         readSize = 0;
         if (!ReadEvents(hPipe, buffer.get(), bufferSize, readSize))
         {
-            _logger->Warn("Stop reading events");
+            _logger->Info("Stop reading events");
             break;
         }
 
@@ -155,7 +155,7 @@ bool EtwEventsHandler::ReadEvents(HANDLE hPipe, uint8_t* pBuffer, DWORD bufferSi
             {
                 if (lastError == ERROR_BROKEN_PIPE)
                 {
-                    _logger->Warn("Disconnected named pipe client...");
+                    _logger->Info("Disconnected named pipe client...");
                 }
                 else
                 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.cpp
@@ -207,39 +207,6 @@ void CALLBACK IpcServer::StartCallback(PTP_CALLBACK_INSTANCE instance, PVOID con
     ::DisconnectNamedPipe(pThis->_hNamedPipe);
     ::CloseHandle(pThis->_hNamedPipe);
     pThis->_hNamedPipe = nullptr;
-
-    //auto pServerInfo = new ServerInfo();
-    //pServerInfo->pThis = pThis;
-    //pServerInfo->hPipe = pThis->_hNamedPipe;
-
-    //// TODO: we don't really need to use a threadpool thread because we are already in a threadpool thread
-    //if (!::TrySubmitThreadpoolCallback(ConnectCallback, pServerInfo, nullptr))
-    //{
-    //    delete pServerInfo;
-
-    //    pThis->ShowLastError("Impossible to add the Connect callback into the threadpool...");
-    //    pThis->_pHandler->OnStartError();
-
-    //    ::CloseHandle(pThis->_hNamedPipe);
-    //    pThis->_hNamedPipe = nullptr;
-
-    //    return;
-    //}
-}
-
-void CALLBACK IpcServer::ConnectCallback(PTP_CALLBACK_INSTANCE instance, PVOID context)
-{
-    ServerInfo* pInfo = reinterpret_cast<ServerInfo*>(context);
-    IpcServer* pThis = pInfo->pThis;
-    HANDLE hPipe = pInfo->hPipe;
-    delete pInfo;
-
-    // this is a blocking call until the communication ends on this named pipe
-    pThis->_pHandler->OnConnect(hPipe);
-
-    // cleanup
-    ::DisconnectNamedPipe(hPipe);
-    ::CloseHandle(hPipe);
 }
 
 void IpcServer::ShowLastError(const char* message, uint32_t lastError)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.h
@@ -40,8 +40,6 @@ public:
 
 private:
     static void CALLBACK StartCallback(PTP_CALLBACK_INSTANCE instance, PVOID context);
-    static void CALLBACK StartCallbackEx(PTP_CALLBACK_INSTANCE instance, PVOID context);
-    static void CALLBACK ConnectCallback(PTP_CALLBACK_INSTANCE instance, PVOID context);
     void ShowLastError(const char* message, uint32_t lastError = ::GetLastError());
 
 private:

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/ETW/IpcServer.h
@@ -26,6 +26,7 @@ public:
               uint32_t timeoutMS);
     ~IpcServer();
 
+    // TODO: remove this method and use Start instead in the sample application
     static std::unique_ptr<IpcServer> StartAsync(
         IIpcLogger* pLogger,
         const std::string& portName,
@@ -34,10 +35,12 @@ public:
         uint32_t outBufferSize,
         uint32_t maxInstances = PIPE_UNLIMITED_INSTANCES,
         uint32_t timeoutMS = NMPWAIT_USE_DEFAULT_WAIT);
+    void WaitForNamedPipe(DWORD timeoutMS);
     void Stop();
 
 private:
     static void CALLBACK StartCallback(PTP_CALLBACK_INSTANCE instance, PVOID context);
+    static void CALLBACK StartCallbackEx(PTP_CALLBACK_INSTANCE instance, PVOID context);
     static void CALLBACK ConnectCallback(PTP_CALLBACK_INSTANCE instance, PVOID context);
     void ShowLastError(const char* message, uint32_t lastError = ::GetLastError());
 
@@ -50,8 +53,11 @@ private:
     uint32_t _timeoutMS;
     INamedPipeHandler* _pHandler;
     IIpcLogger* _pLogger;
+    HANDLE _hNamedPipe;
 
-    uint32_t _serverCount;
+    // will be set when the server is initialized
+    HANDLE _hInitializedEvent;
+
     std::atomic<bool> _stopRequested = false;
 };
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/EtwEventsManager.cpp
@@ -271,7 +271,6 @@ bool EtwEventsManager::Start()
     std::string pipeName = buffer.str();
     Log::Info("Exposing ", pipeName);
 
-    // create the client part to send the registration command
     _eventsHandler = std::make_unique<EtwEventsHandler>(_logger.get(), this);
     _IpcServer = IpcServer::StartAsync(
         _logger.get(),
@@ -279,7 +278,7 @@ bool EtwEventsManager::Start()
         _eventsHandler.get(),
         (1 << 16) + sizeof(IpcHeader),  // in buffer size = 64K + header
         sizeof(SuccessResponse),        // out buffer contains only the response
-        MaxInstances,                   // max number of instances (2 = the Agent + one pending)
+        1,                              // only one instance
         TimeoutMS);
     if (_IpcServer == nullptr)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -645,11 +645,6 @@ void CorProfilerCallback::DisposeInternal()
         ProfilerEngineStatus::WriteIsProfilerEngineActive(false);
         _isInitialized.store(false);
 
-        // From that time, we need to ensure that ALL native threads are stop and don't call back to managed world
-        // So, don't sleep before stopping the threads
-
-        DisposeServices();
-
         // Don't forget to stop the CLR events session if any
         auto* pInfo = _pCorProfilerInfoEvents;
         if (pInfo != nullptr)
@@ -669,6 +664,8 @@ void CorProfilerCallback::DisposeInternal()
         {
             _pEtwEventsManager->Stop();
         }
+
+        DisposeServices();
 
         ICorProfilerInfo5* pCorProfilerInfo = _pCorProfilerInfo;
         if (pCorProfilerInfo != nullptr)
@@ -1424,7 +1421,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadCreated(ThreadID threadId)
         auto success = _pEtwEventsManager->Start();
         if (!success)
         {
-            Log::Error("Failed to the contact Datadog Agent named pipe dedicated to profiling. Try to install the latest version for lock contention and GC profiling.");
+            Log::Error("Failed to the contact Datadog Agent named pipe dedicated to profiling. Try to install the latest version.");
 
             _pEtwEventsManager->Stop();
             _pEtwEventsManager = nullptr;


### PR DESCRIPTION
## Summary of changes
- Handle Agent connection error to stop the server 
- Stop listening to events before stopping the services
 
## Reason for change
Possible crash in CI

## Implementation details

## Test coverage
Crashing test should be valid now

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
