### PR TITLE
[v3] Update behavior of header tags parsing (AIT-8600)

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -34,6 +34,7 @@ In this section we describe the important breaking changes introduced in v3.0.0+
 #### Custom-only tracing is no longer supported
 
 **What changed?**
+
 In version 2.x.x of the tracer, you can add tracing to your application in two ways:
 - Using [automatic instrumentation](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/). You will automatically receive traces for common libraries and frameworks.
 - Using [custom instrumentation](https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core/?tab=windows#custom-instrumentation) by referencing the [_Datadog.Trace_ ](https://www.nuget.org/packages/Datadog.Trace) or [Datadog.Trace.OpenTracing](https://www.nuget.org/packages/Datadog.Trace.OpenTracing) NuGet packages.
@@ -93,6 +94,7 @@ Also note that the implementation types from all public APIs have changed. For e
 #### Changes to default settings
 
 **What changed and why?**
+
 Several settings have changed their default values:
 - `DD_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` now defaults to `true`. This setting provides a better experience in the majority of cases.
 - `DD_TRACE_WCF_WEB_HTTP_RESOURCE_NAMES_ENABLED` now defaults to `true`. This setting provides a better experience in the majority of cases.
@@ -104,7 +106,8 @@ We recommend using the new settings if possible. If this is not possible, you ca
 
 **What changed and why?**
 Some settings have changed their behavior, and there are some changes to reported tags
-- `DD_TRACE_HEADER_TAGS` [no longer replaces periods or spaces in names](https://github.com/DataDog/dd-trace-dotnet/pull/4599) . The new behavior is consistent with the behavior of other tracer languages.
+- `DD_TRACE_HEADER_TAGS` [no longer replaces periods or spaces in names](https://github.com/DataDog/dd-trace-dotnet/pull/4599). The new behavior is consistent with the behavior of other tracer languages.
+- `DD_TRACE_HEADER_TAGS` [now considers trailing `:` in entries as invalid, and splits key-value pairs on the last `:` in the entry](https://github.com/DataDog/dd-trace-dotnet/pull/5438). The new behavior is consistent with the behavior of other tracer languages.
 - The `language` tag is [now added to added to all spans](https://github.com/DataDog/dd-trace-dotnet/pull/4839) with the value `dotnet`. Previously, some spans were not tagged, but were subsequently tagged with the value `.NET`. This change removes the inconsistency
 - `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` now refers to an absolute file path instead of providing the template content directly. This makes it easier to provide custom values.
 - `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` now refers to an absolute file path instead of providing the template content directly. This makes it easier to provide custom values.
@@ -112,6 +115,8 @@ Some settings have changed their behavior, and there are some changes to reporte
 
 **What action should you take?**
 If you require the previous `DD_TRACE_HEADER_TAGS` normalization behavior, you must apply this normalization yourself, replacing periods and spaces with underscores in the value you pass to `DD_TRACE_HEADER_TAGS`.
+
+Review any cases where you are setting `DD_TRACE_HEADER_TAGS` with entries that end in `:` or which contain multiple `:` values. For example, in `key1:, key2:key3:value4`, `key1:` is considered an invalid value in v3.0.0 whereas it was valid in v2.x.x. The final entry will be split into `key2:key3` and `value4` in v3.0.0, whereas in v2.x.x it was split into `key2` and `key3:value4`.  
 
 If you are currently using `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` or `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML`, you should move that content to a file, and provide the absolute file path in the settings.
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
@@ -109,7 +109,7 @@ namespace Datadog.Trace.Configuration
                 else if (colonIndex > 0)
                 {
                     // if a colon is present with no value, we take the value to be empty (e.g. "key1:, key2: ").
-                    // note we already did TrimStart() on the key, so it only needs TrimEnd().
+                    // note we already did Trim() on the entire entry, so the key portion only needs TrimEnd().
                     var key = trimmedEntry.Substring(0, colonIndex).TrimEnd();
                     var value = trimmedEntry.Substring(colonIndex + 1).Trim();
                     dictionary[key] = value;

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
@@ -101,7 +101,7 @@ namespace Datadog.Trace.Configuration
 
                 if (colonIndex < 0 && enableHeaderTagsBehaviors)
                 {
-                    // entries with no colon are allowed (e.g. "key1, key2:value2, key3"),
+                    // entries with no colon are allowed (e.g. key1 and key3 in "key1, key2:value2, key3"),
                     // it's a key with no value.
                     var key = trimmedEntry;
                     dictionary[key] = string.Empty;

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
@@ -75,36 +75,44 @@ namespace Datadog.Trace.Configuration
                 return dictionary;
             }
 
+            bool enableHeaderTagsBehaviors = allowOptionalMappings;
             var entries = data.Split(DictionarySeparatorChars, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (var entry in entries)
             {
-                // we need TrimStart() before looking for ':' so we can skip entries with no key
+                // we need Trim() before looking for ':' so we can skip entries with no key
                 // (that is, entries with a leading ':', like "<empty or whitespace>:value")
-                var trimmedEntry = entry.TrimStart();
-
-                if (trimmedEntry.Length > 0)
+                var trimmedEntry = entry.Trim();
+                if (trimmedEntry.Length == 0 || trimmedEntry.StartsWith(":"))
                 {
-                    // colonIndex == 0 is a leading colon, not valid
-                    var colonIndex = trimmedEntry.IndexOf(':');
+                    continue;
+                }
+                else if (enableHeaderTagsBehaviors && trimmedEntry.EndsWith(":"))
+                {
+                    // When parsing header tags, any input trailing colons is invalid
+                    continue;
+                }
 
-                    if (colonIndex < 0 && allowOptionalMappings)
-                    {
-                        // entries with no colon are allowed (e.g. "key1, key2:value2, key3"),
-                        // it's a key with no value.
-                        // note we already did TrimStart(), so we only need TrimEnd().
-                        var key = trimmedEntry.TrimEnd();
-                        dictionary[key] = string.Empty;
-                    }
-                    else if (colonIndex > 0)
-                    {
-                        // split at the first colon only. any other colons are part of the value.
-                        // if a colon is present with no value, we take the value to be empty (e.g. "key1:, key2: ").
-                        // note we already did TrimStart() on the key, so it only needs TrimEnd().
-                        var key = trimmedEntry.Substring(0, colonIndex).TrimEnd();
-                        var value = trimmedEntry.Substring(colonIndex + 1).Trim();
-                        dictionary[key] = value;
-                    }
+                var colonIndex = enableHeaderTagsBehaviors switch
+                {
+                    false => trimmedEntry.IndexOf(':'), // In the general case, we split on the first colon
+                    true => trimmedEntry.LastIndexOf(':'), // However, for header tags parsing is recommended to split on last colon
+                };
+
+                if (colonIndex < 0 && enableHeaderTagsBehaviors)
+                {
+                    // entries with no colon are allowed (e.g. "key1, key2:value2, key3"),
+                    // it's a key with no value.
+                    var key = trimmedEntry;
+                    dictionary[key] = string.Empty;
+                }
+                else if (colonIndex > 0)
+                {
+                    // if a colon is present with no value, we take the value to be empty (e.g. "key1:, key2: ").
+                    // note we already did TrimStart() on the key, so it only needs TrimEnd().
+                    var key = trimmedEntry.Substring(0, colonIndex).TrimEnd();
+                    var value = trimmedEntry.Substring(colonIndex + 1).Trim();
+                    dictionary[key] = value;
                 }
             }
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.Tests.Configuration
         private static readonly Dictionary<string, string> TagsK1V1K2V2 = new() { { "k1", "v1" }, { "k2", "v2" } };
         private static readonly Dictionary<string, string> TagsK2V2 = new() { { "k2", "v2" } };
         private static readonly Dictionary<string, string> TagsWithColonsInValue = new() { { "k1", "v1" }, { "k2", "v2:with:colons" }, { "trailing", "colon:good:" } };
-        private static readonly Dictionary<string, string> HeaderTagsWithOptionalMappings = new() { { "header1", "tag1" }, { "header2", "Content-Type" }, { "header3", "Content-Type" }, { "header4", "C!!!ont_____ent----tYp!/!e" }, { "validheaderonly", string.Empty }, { "validheaderwithoutcolon", string.Empty } };
+        private static readonly Dictionary<string, string> HeaderTagsWithOptionalMappings = new() { { "header1", "tag1" }, { "header2", "Content-Type" }, { "header3", "Content-Type" }, { "header4", "C!!!ont_____ent----tYp!/!e" }, { "validheaderwithoutcolon", string.Empty } };
         private static readonly Dictionary<string, string> HeaderTagsWithDots = new() { { "header3", "my.header.with.dot" }, { "my.new.header.with.dot", string.Empty } };
         private static readonly Dictionary<string, string> HeaderTagsSameTag = new() { { "header1", "tag1" }, { "header2", "tag1" } };
 
@@ -116,7 +116,7 @@ namespace Datadog.Trace.Tests.Configuration
             yield return (ConfigurationKeys.GlobalAnalyticsEnabled, "false", s => s.AnalyticsEnabled, false);
 #pragma warning restore 618
 
-            yield return (ConfigurationKeys.HeaderTags, "header1:tag1,header2:Content-Type,header3: Content-Type ,header4:C!!!ont_____ent----tYp!/!e,header6:9invalidtagname,:invalidtagonly,validheaderonly:,validheaderwithoutcolon,:", s => s.HeaderTags, HeaderTagsWithOptionalMappings);
+            yield return (ConfigurationKeys.HeaderTags, "header1:tag1,header2:Content-Type,header3: Content-Type ,header4:C!!!ont_____ent----tYp!/!e,header6:9invalidtagname,:invalidtagonly,invalidheaderonly:,validheaderwithoutcolon,:", s => s.HeaderTags, HeaderTagsWithOptionalMappings);
             yield return (ConfigurationKeys.HeaderTags, "header1:tag1,header2:tag1", s => s.HeaderTags, HeaderTagsSameTag);
             yield return (ConfigurationKeys.HeaderTags, "header1:tag1,header1:tag2", s => s.HeaderTags.Count, 1);
             yield return (ConfigurationKeys.HeaderTags, "header3:my.header.with.dot,my.new.header.with.dot", s => s.HeaderTags, HeaderTagsWithDots);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -356,7 +356,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("k.e y?!1", false, new[] { "k.e y?!1|" })]
         [InlineData(":leadingcolon", false, new string[0])]
         [InlineData(":leadingcolon", true, new string[0])]
-        [InlineData("one:two:three", true, new[] { "one|two:three" })]
+        [InlineData("one:two:three", true, new[] { "one:two|three" })]
         public void HeaderTags(string value, bool normalizationFixEnabled, string[] expected)
         {
             var source = CreateConfigurationSource(

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -348,12 +348,15 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData("", true, new string[0])]
         [InlineData("   ", true, new string[0])]
         // nominal
-        [InlineData("key1:value1,key2:value2,key3", true, new[] { "key1:value1", "key2:value2", "key3:" })]
+        [InlineData("key1:value1,key2:value2,key3", true, new[] { "key1|value1", "key2|value2", "key3|" })]
         // trim whitespace
-        [InlineData(" key1 : value1 ", true, new[] { "key1:value1" })]
+        [InlineData(" key1 : value1 ", true, new[] { "key1|value1" })]
         // other normalization
-        [InlineData("key1:val.u e1?!", true, new[] { "key1:val.u e1?!" })]
-        [InlineData("k.e y?!1", false, new[] { "k.e y?!1:" })]
+        [InlineData("key1:val.u e1?!", true, new[] { "key1|val.u e1?!" })]
+        [InlineData("k.e y?!1", false, new[] { "k.e y?!1|" })]
+        [InlineData(":leadingcolon", false, new string[0])]
+        [InlineData(":leadingcolon", true, new string[0])]
+        [InlineData("one:two:three", true, new[] { "one|two:three" })]
         public void HeaderTags(string value, bool normalizationFixEnabled, string[] expected)
         {
             var source = CreateConfigurationSource(
@@ -361,7 +364,7 @@ namespace Datadog.Trace.Tests.Configuration
                 (ConfigurationKeys.FeatureFlags.HeaderTagsNormalizationFixEnabled, normalizationFixEnabled ? "1" : "0"));
             var settings = new TracerSettings(source);
 
-            settings.HeaderTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Split(':').First(), v => v.Split(':').Last()));
+            settings.HeaderTags.Should().BeEquivalentTo(expected.ToDictionary(v => v.Substring(0, v.IndexOf('|')), v => v.Substring(v.IndexOf('|') + 1)));
         }
 
         [Theory]


### PR DESCRIPTION
## Summary of changes
Updates the behavior of header tags parsing, which occurs in the tracer code when `StringConfigurationSource.ParseCustomKeyValues` is invoked with parameter `allowOptionalMappings=true`.

The new BREAKING behavior (again, limited to header tags parsing) is the following:
- Input strings that end in a colon are now considered invalid
- To create the key-value pair, the input string is split by the last `:` char in the string instead of the first one

## Reason for change
This behavior will be breaking for some inputs, so it would be best to include this in a major version update.

## Implementation details

## Test coverage
Updated the unit tests and ran the in-progress build against the following system-tests test cases with success:
- `test_library_conf.py::Test_HeaderTags_Colon_Trailing`
- `test_library_conf.py::Test_HeaderTags_Whitespace_Tag`

As a result of the system-tests updates, .NET will pass all of the HeaderTags tests in `test_library_conf.py`

## Other details
Fixes AIT-8600
