### PR TITLE
Add Onboarding tests on gitlab pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,6 +156,16 @@ deploy_latest_musl_tag_to_docker_registries:
     IMG_DESTINATIONS: dd-lib-dotnet-init:latest-musl
     IMG_SIGNING: "false"
 
+package-snapshot:
+  extends: .package
+  rules:
+    - if: $CI_COMMIT_BRANCH == 'robertomonteromiguel/add_onboarding_tests'
+      when: on_success
+  script:
+    - ../.gitlab/build-deb-rpm-snapshot.sh
+  variables:
+    ARCH: amd64
+
 package:
   extends: .package
   rules:

--- a/.gitlab/build-deb-rpm-snapshot.sh
+++ b/.gitlab/build-deb-rpm-snapshot.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+source common_build_functions.sh
+
+
+if [ -z "$ARCH" ]; then
+  ARCH=amd64
+fi
+
+
+export DOTNET_PACKAGE_VERSION="2.5.0.dev.1"
+echo -n $DOTNET_PACKAGE_VERSION > auto_inject-dotnet.version
+
+cp auto_inject-dotnet.version datadog-dotnet-apm.dir/opt/datadog/version
+
+# Build packages
+fpm_wrapper "datadog-apm-library-dotnet" "$DOTNET_PACKAGE_VERSION" \
+  --input-type dir \
+  --chdir=datadog-dotnet-apm.dir/opt/datadog \
+  --prefix "$LIBRARIES_INSTALL_BASE/dotnet" \
+  --after-install datadog-dotnet-apm.dir/opt/datadog/createLogPath.sh \
+  --url "https://github.com/DataDog/dd-trace-dotnet" \
+  --license "Apache License 2.0" \
+  --description "Datadog APM client library for .NET" \
+  .=.


### PR DESCRIPTION
## Summary of changes
Add the onboarding tests on gitlab pipeline. These tests will be executed after deb and rpm packages generation.


## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
