### PR TITLE
[Dynamic Instrumentation] Fix `System.ArgumentNullException` while processing span decoration probes with empty tags

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -1596,7 +1596,6 @@ Global
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{bc44a41f-1bed-4438-9f66-0ea5607906d5}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{cb56ac5a-d2c1-40de-99d5-dcf9f44c9482}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{deacde01-95fe-4777-b70a-f20a96aabea7}*SharedItemsImports = 5
-		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{ed3d82c5-021a-415a-a3d3-811ad85cd93c}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{f5582f54-e911-4258-b419-5e894d338c5b}*SharedItemsImports = 4
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{fab2b108-e5be-4647-869b-1dc5d362252e}*SharedItemsImports = 4
 	EndGlobalSection

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -591,10 +591,8 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/RabbitMQConstants.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/Common.cs
 src/Datadog.Trace/Debugger/Configurations/Models/Capture.cs
 src/Datadog.Trace/Debugger/Configurations/Models/DebuggerExpression.cs
-src/Datadog.Trace/Debugger/Configurations/Models/Decoration.cs
 src/Datadog.Trace/Debugger/Configurations/Models/EvaluateAt.cs
 src/Datadog.Trace/Debugger/Configurations/Models/FilterList.cs
-src/Datadog.Trace/Debugger/Configurations/Models/LogProbe.cs
 src/Datadog.Trace/Debugger/Configurations/Models/MetricKind.cs
 src/Datadog.Trace/Debugger/Configurations/Models/MetricProbe.cs
 src/Datadog.Trace/Debugger/Configurations/Models/OpsConfiguration.cs
@@ -604,7 +602,6 @@ src/Datadog.Trace/Debugger/Configurations/Models/SnapshotSegment.cs
 src/Datadog.Trace/Debugger/Configurations/Models/SpanDecorationProbe.cs
 src/Datadog.Trace/Debugger/Configurations/Models/SpanProbe.cs
 src/Datadog.Trace/Debugger/Configurations/Models/Tag.cs
-src/Datadog.Trace/Debugger/Configurations/Models/Where.cs
 src/Datadog.Trace/Debugger/Instrumentation/Collections/EverGrowingCollection.cs
 src/Datadog.Trace/Debugger/Instrumentation/Collections/MethodMetadataCollection.cs
 src/Datadog.Trace/Debugger/Instrumentation/Collections/MethodMetadataInfo.cs

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Decoration.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Decoration.cs
@@ -5,27 +5,28 @@
 
 #pragma warning disable SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially
 
+#nullable enable
 namespace Datadog.Trace.Debugger.Configurations.Models;
 
 internal record Decoration
 {
-    public SnapshotSegment When { get; set; }
+    public SnapshotSegment? When { get; set; }
 
-    public Tags[] Tags { get; set; }
+    public Tags[]? Tags { get; set; }
 }
 
 internal record Tags
 {
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
-    public TagValue Value { get; set; }
+    public TagValue? Value { get; set; }
 }
 
 internal record TagValue
 {
-    public string Template { get; set; }
+    public string? Template { get; set; }
 
-    public SnapshotSegment[] Segments { get; set; }
+    public SnapshotSegment[]? Segments { get; set; }
 }
 
 #pragma warning restore SA1402 // FileMayOnlyContainASingleType - StyleCop did not enforce this for records initially

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/LogProbe.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/LogProbe.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
 using System;
 using Datadog.Trace.Debugger.Helpers;
 
@@ -16,13 +17,13 @@ namespace Datadog.Trace.Debugger.Configurations.Models
 
         public Sampling? Sampling { get; set; }
 
-        public string Template { get; set; }
+        public string? Template { get; set; }
 
-        public SnapshotSegment[] Segments { get; set; }
+        public SnapshotSegment[]? Segments { get; set; }
 
-        public SnapshotSegment When { get; set; }
+        public SnapshotSegment? When { get; set; }
 
-        public bool Equals(LogProbe other)
+        public bool Equals(LogProbe? other)
         {
             if (ReferenceEquals(null, other))
             {
@@ -37,7 +38,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
             return base.Equals(other) && Equals(Capture, other.Capture) && Equals(Sampling, other.Sampling) && Template == other.Template && CaptureSnapshot == other.CaptureSnapshot && Segments.NullableSequentialEquals(other.Segments) && Equals(When, other.When);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Where.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Configurations/Models/Where.cs
@@ -3,25 +3,25 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
 using System;
-using System.Linq;
 using Datadog.Trace.Debugger.Helpers;
 
 namespace Datadog.Trace.Debugger.Configurations.Models
 {
     internal class Where : IEquatable<Where>
     {
-        public string TypeName { get; set; }
+        public string? TypeName { get; set; }
 
-        public string MethodName { get; set; }
+        public string? MethodName { get; set; }
 
-        public string SourceFile { get; set; }
+        public string? SourceFile { get; set; }
 
-        public string Signature { get; set; }
+        public string? Signature { get; set; }
 
-        public string[] Lines { get; set; }
+        public string[]? Lines { get; set; }
 
-        public bool Equals(Where other)
+        public bool Equals(Where? other)
         {
             if (ReferenceEquals(null, other))
             {
@@ -36,7 +36,7 @@ namespace Datadog.Trace.Debugger.Configurations.Models
             return TypeName == other.TypeName && MethodName == other.MethodName && SourceFile == other.SourceFile && Signature == other.Signature && Lines.NullableSequentialEquals(other.Lines);
         }
 
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
             {

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Datadog.Trace.Debugger.Configurations.Models;
 using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Debugger.Expressions
 {
@@ -47,6 +48,7 @@ namespace Datadog.Trace.Debugger.Expressions
             catch (Exception e)
             {
                 Log.Error(e, "Failed to create probe processor for probe: {Id}", probe.Id);
+                Log.Debug("Probe definition is {Probe}", JsonConvert.SerializeObject(probe));
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LineProbeResolver.cs
@@ -114,7 +114,13 @@ namespace Datadog.Trace.Debugger
             location = null;
             try
             {
-                if (!TryFindAssemblyContainingFile(probe.Where.SourceFile, out var filePathFromPdb, out var assembly))
+                var sourceFile = probe.Where?.SourceFile;
+                if (sourceFile == null)
+                {
+                    return new LineProbeResolveResult(LiveProbeResolveStatus.Error, "Source file is empty.");
+                }
+
+                if (!TryFindAssemblyContainingFile(sourceFile, out var filePathFromPdb, out var assembly))
                 {
                     return new LineProbeResolveResult(LiveProbeResolveStatus.Unbound, "Source file location for probe was not found, possibly because the relevant assembly was not yet loaded.");
                 }
@@ -125,7 +131,7 @@ namespace Datadog.Trace.Debugger
                     return new LineProbeResolveResult(LiveProbeResolveStatus.Error, "Failed to read from PDB");
                 }
 
-                if (probe.Where.Lines?.Length != 1 || !int.TryParse(probe.Where.Lines[0], out var lineNum))
+                if (probe.Where?.Lines?.Length != 1 || !int.TryParse(probe.Where.Lines[0], out var lineNum))
                 {
                     return new LineProbeResolveResult(LiveProbeResolveStatus.Error, "Failed to parse line number.");
                 }


### PR DESCRIPTION
## Summary of changes
Enable nullable types for certain models.
Validate the log probe path for null before processing.
Overhaul span decoration processing to address issues with missing tags.

## Reason for change
Previously, missing tags during span decoration processing led to `System.ArgumentNullException`. This PR fixes that issue.
