### PR TITLE
Fix sending `Content-Length: 0` when using chunked-encoding

### DIFF
--- a/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/PushStreamContent.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/HttpContent/PushStreamContent.cs
@@ -31,7 +31,8 @@ internal class PushStreamContent : IHttpContent
         _onStreamAvailable = onStreamAvailable;
     }
 
-    public long? Length => 0;
+    // We don't know the length, so don't send a content-length header
+    public long? Length => null;
 
     public async Task CopyToAsync(Stream destination)
     {

--- a/tracer/src/Datadog.Trace/HttpOverStreams/HttpHeaderHelperBase.cs
+++ b/tracer/src/Datadog.Trace/HttpOverStreams/HttpHeaderHelperBase.cs
@@ -16,8 +16,9 @@ namespace Datadog.Trace.HttpOverStreams
 
         public Task WriteLeadingHeaders(HttpRequest request, TextWriter writer)
         {
-            var leadingHeaders =
-                $"{request.Verb} {request.Path} HTTP/1.1{DatadogHttpValues.CrLf}Host: {request.Host}{DatadogHttpValues.CrLf}Accept-Encoding: identity{DatadogHttpValues.CrLf}Content-Length: {request.Content?.Length ?? 0}{DatadogHttpValues.CrLf}{MetadataHeaders}";
+            var leadingHeaders = request.Content?.Length is { } contentLength
+                                     ? $"{request.Verb} {request.Path} HTTP/1.1{DatadogHttpValues.CrLf}Host: {request.Host}{DatadogHttpValues.CrLf}Accept-Encoding: identity{DatadogHttpValues.CrLf}Content-Length: {contentLength}{DatadogHttpValues.CrLf}{MetadataHeaders}"
+                                     : $"{request.Verb} {request.Path} HTTP/1.1{DatadogHttpValues.CrLf}Host: {request.Host}{DatadogHttpValues.CrLf}Accept-Encoding: identity{DatadogHttpValues.CrLf}{MetadataHeaders}";
             return writer.WriteAsync(leadingHeaders);
         }
 

--- a/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockHttpParser.cs
@@ -75,7 +75,9 @@ namespace Datadog.Trace.TestHelpers
             }
             while (true);
 
-            var length = long.TryParse(headers.GetValue(ContentLengthHeaderKey), out var headerValue) ? headerValue : (long?)null;
+            var length = headers.GetValue(ContentLengthHeaderKey) is { } contentLength
+                             ? long.Parse(contentLength)
+                             : (long?)null;
             var body = headers.GetValue("Transfer-Encoding") is "chunked"
                            ? new ChunkedEncodingReadContent(stream)
                            : new StreamContent(stream, length);


### PR DESCRIPTION
## Summary of changes

- If we don't have a known content length, don't send `Content-Length: 0`
- For `PushStreamContent` don't explicitly set `Content-Length: 0`

## Reason for change

In some cases, we don't know the content-length ahead of time (e.g. if we have a stream). In those situations we use `Transfer-Encoding: chunked` which is correct. However `HttpHeaderHelperBase` is also sending a fixed `Content-Length: 0` in that situation, which is incorrect.

## Implementation details

Only set `Content-Length` if we actually have a _known_ length when sending the request. Fix `PushStreamContent` which was incorrectly hard-coding to `0`.

## Test coverage

Covered by existing tests

## Other details

Part of a PR stack.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
