### PR TITLE
[CI] Minor cleanup

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -10,7 +10,6 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string ProfilingLogDir = "DD_TRACE_LOG_DIRECTORY";
         public const string ProfilingPprofDir = "DD_INTERNAL_PROFILING_OUTPUT_DIR";
         public const string CodeHotSpotsEnable = "DD_PROFILING_CODEHOTSPOTS_ENABLED";
-        public const string UseNativeLoader = "USE_NATIVE_LOADER";
         public const string CpuProfilerEnabled = "DD_PROFILING_CPU_ENABLED";
         public const string WallTimeProfilerEnabled = "DD_PROFILING_WALLTIME_ENABLED";
         public const string ExceptionProfilerEnabled = "DD_PROFILING_EXCEPTION_ENABLED";

--- a/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -4,8 +4,6 @@ imports:
 
 variables:
   commit_hash: 0
-  telemetry_v2: 0
-  enable_metrics: 0
 
 jobs:
   server:

--- a/tracer/build/crank/Security.Samples.AspNetCoreSimpleController.yml
+++ b/tracer/build/crank/Security.Samples.AspNetCoreSimpleController.yml
@@ -4,7 +4,6 @@
 
 variables:
   commit_hash: 0
-  enable_metrics: 0
 
 jobs:
   server:

--- a/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
+++ b/tracer/test/test-applications/throughput/Samples.AspNetCoreSimpleController/Program.cs
@@ -60,9 +60,6 @@ namespace Samples.AspNetCoreSimpleController
             }
 #endif
 
-            Console.WriteLine(" * DD_INTERNAL_TELEMETRY_V2_ENABLED: '{0}'",
-                              Environment.GetEnvironmentVariable("DD_INTERNAL_TELEMETRY_V2_ENABLED"));
-
             Console.WriteLine(" * DD_TELEMETRY_METRICS_ENABLED: '{0}'",
                               Environment.GetEnvironmentVariable("DD_TELEMETRY_METRICS_ENABLED"));
 


### PR DESCRIPTION
## Summary of changes

Remove references to unused variables

## Reason for change

I was cleaning up some unused variables in our pipeline [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_apps/hub/ms.vss-build-web.ci-designer-hub?pipelineId=54&nonce=8iK0gwFbocpoLdI5qlNi%2BA%3D%3D&name=andrewlock&branch=master) and these were the only references we had to them (so they're essentially unused)

## Implementation details

In addition to these changes, I removed the following (unused) variables from the pipeline definition:
- `enable_metrics`
- `enable_telemetry_v2`
- `push_artifacts_to_s3`
- `run_azure_functions_tests`
- `run_cosmos_integration_tests`
- `USE_NATIVE_LOADER`

Additionally, I changed the default for `run_extended_throughput_tests` from `true` to `false` (I'm not sure when this was changed, but we generally don't want to run those extra tests for all PRs etc).

## Test coverage

Meh

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
