### PR TITLE
[Debugger][Test] skip `SymbolExtractorTest` tests in `DEBUG` mode

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractorTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractorTest.cs
@@ -31,9 +31,17 @@ public class SymbolExtractorTest
     [MemberData(nameof(TestSamples))]
     private async Task Test(Type type)
     {
-#if NETFRAMEWORK
+#if DEBUG
+        // silence compiler warnings
         _ = type;
         await Task.Yield();
+
+        throw new SkipException("This test requires RELEASE mode and will always fail in DEBUG mode");
+#elif NETFRAMEWORK
+        // silence compiler warnings
+        _ = type;
+        await Task.Yield();
+
         throw new SkipException("This test is flaky - The .NET Framework snapshots produced are different in CI and locally");
 #else
         if (!EnvironmentTools.IsWindows())


### PR DESCRIPTION
## Summary of changes

Skip tests in `DEBUG` mode because they require `RELEASE` mode of they will fail.

## Reason for change

To allow dev to run tests in `DEBUG` mode.

## Implementation details

`#if DEBUG`...

## Test coverage

The test itself is the test.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
