### PR TITLE
[Tracer] Support remote config for `DD_TRACE_SAMPLING_RULES` and Adaptive Sampling

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.Configuration.ConfigurationSources
             // { ConfigurationKeys.ServiceNameMappings, "tracing_service_mapping" },
             { ConfigurationKeys.LogsInjectionEnabled, "log_injection_enabled" },
             { ConfigurationKeys.GlobalSamplingRate, "tracing_sampling_rate" },
-            // { ConfigurationKeys.CustomSamplingRules, "tracing_sampling_rules" },
+            { ConfigurationKeys.CustomSamplingRules, "tracing_sampling_rules" },
             // { ConfigurationKeys.SpanSamplingRules, "span_sampling_rules" },
             // { ConfigurationKeys.DataStreamsMonitoring.Enabled, "data_streams_enabled" },
             { ConfigurationKeys.GlobalTags, "tracing_tags" }

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.Configuration
                 TraceEnabled = settings.WithKeys(ConfigurationKeys.TraceEnabled).AsBool(),
                 // RuntimeMetricsEnabled = settings.WithKeys(ConfigurationKeys.RuntimeMetricsEnabled).AsBool(),
                 // DataStreamsMonitoringEnabled = settings.WithKeys(ConfigurationKeys.DataStreamsMonitoring.Enabled).AsBool(),
-                // CustomSamplingRules = settings.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString(),
+                CustomSamplingRules = settings.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString(),
                 GlobalSamplingRate = settings.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDouble(),
                 // SpanSamplingRules = settings.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString(),
                 LogsInjectionEnabled = settings.WithKeys(ConfigurationKeys.LogsInjectionEnabled).AsBool(),

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -46,6 +46,7 @@ namespace Datadog.Trace.Configuration
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingLogsInjection, true);  // 13
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingSampleRate, true);     // 12
                 _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingTracingEnabled, true); // 19
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingSampleRules, true);    // 29
             }
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Configuration
                 TraceEnabled = settings.WithKeys(ConfigurationKeys.TraceEnabled).AsBool(),
                 // RuntimeMetricsEnabled = settings.WithKeys(ConfigurationKeys.RuntimeMetricsEnabled).AsBool(),
                 // DataStreamsMonitoringEnabled = settings.WithKeys(ConfigurationKeys.DataStreamsMonitoring.Enabled).AsBool(),
-                CustomSamplingRules = settings.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString(),
+                SamplingRules = settings.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString(),
                 GlobalSamplingRate = settings.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDouble(),
                 // SpanSamplingRules = settings.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString(),
                 LogsInjectionEnabled = settings.WithKeys(ConfigurationKeys.LogsInjectionEnabled).AsBool(),

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Configuration
         {
             if (dictionary1 == null || dictionary2 == null)
             {
-                return dictionary1 == dictionary2;
+                return ReferenceEquals(dictionary1, dictionary2);
             }
 
             if (dictionary1.Count != dictionary2.Count)

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Configuration
 
         public double? GlobalSamplingRate { get; init; }
 
-        public string? SpanSamplingRules { get; init; }
+        public string? CustomSamplingRules { get; init; }
 
         public bool? LogsInjectionEnabled { get; init; }
 
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Configuration
              && RuntimeMetricsEnabled == other.RuntimeMetricsEnabled
              && DataStreamsMonitoringEnabled == other.DataStreamsMonitoringEnabled
              && Nullable.Equals(GlobalSamplingRate, other.GlobalSamplingRate)
-             && SpanSamplingRules == other.SpanSamplingRules
+             && CustomSamplingRules == other.CustomSamplingRules
              && LogsInjectionEnabled == other.LogsInjectionEnabled
              && AreEqual(HeaderTags, other.HeaderTags)
              && AreEqual(ServiceNameMappings, other.ServiceNameMappings)
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Configuration
                 RuntimeMetricsEnabled,
                 DataStreamsMonitoringEnabled,
                 GlobalSamplingRate,
-                SpanSamplingRules,
+                CustomSamplingRules,
                 LogsInjectionEnabled);
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableDynamicSettings.cs
@@ -20,7 +20,7 @@ namespace Datadog.Trace.Configuration
 
         public double? GlobalSamplingRate { get; init; }
 
-        public string? CustomSamplingRules { get; init; }
+        public string? SamplingRules { get; init; }
 
         public bool? LogsInjectionEnabled { get; init; }
 
@@ -47,7 +47,7 @@ namespace Datadog.Trace.Configuration
              && RuntimeMetricsEnabled == other.RuntimeMetricsEnabled
              && DataStreamsMonitoringEnabled == other.DataStreamsMonitoringEnabled
              && Nullable.Equals(GlobalSamplingRate, other.GlobalSamplingRate)
-             && CustomSamplingRules == other.CustomSamplingRules
+             && SamplingRules == other.SamplingRules
              && LogsInjectionEnabled == other.LogsInjectionEnabled
              && AreEqual(HeaderTags, other.HeaderTags)
              && AreEqual(ServiceNameMappings, other.ServiceNameMappings)
@@ -81,7 +81,7 @@ namespace Datadog.Trace.Configuration
                 RuntimeMetricsEnabled,
                 DataStreamsMonitoringEnabled,
                 GlobalSamplingRate,
-                CustomSamplingRules,
+                SamplingRules,
                 LogsInjectionEnabled);
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -300,7 +300,8 @@ namespace Datadog.Trace.Configuration
 
         /// <summary>
         /// Gets the trace sampling rules from remote config.
-        /// These will be merged with local sampling rules.
+        /// These contain custom remote rules and dynamic (aka adaptive) rules.
+        /// They will be merged with local sampling rules.
         /// </summary>
         internal string? RemoteSamplingRules => DynamicSettings.SamplingRules;
 

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -38,7 +38,6 @@ namespace Datadog.Trace.Configuration
         private readonly IReadOnlyDictionary<string, string> _globalTags;
         private readonly double? _globalSamplingRate;
         private readonly bool _runtimeMetricsEnabled;
-        private readonly string? _spanSamplingRules;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableTracerSettings"/> class
@@ -99,7 +98,7 @@ namespace Datadog.Trace.Configuration
             MaxTracesSubmittedPerSecondInternal = settings.MaxTracesSubmittedPerSecondInternal;
             CustomSamplingRulesInternal = settings.CustomSamplingRulesInternal;
             CustomSamplingRulesFormat = settings.CustomSamplingRulesFormat;
-            _spanSamplingRules = settings.SpanSamplingRules;
+            SpanSamplingRules = settings.SpanSamplingRules;
             _globalSamplingRate = settings.GlobalSamplingRateInternal;
             IntegrationsInternal = new ImmutableIntegrationSettingsCollection(settings.IntegrationsInternal, settings.DisabledIntegrationNamesInternal);
             _headerTags = new ReadOnlyDictionary<string, string>(settings.HeaderTagsInternal);
@@ -300,6 +299,12 @@ namespace Datadog.Trace.Configuration
         internal string? CustomSamplingRulesInternal { get; }
 
         /// <summary>
+        /// Gets the trace sampling rules from remote config.
+        /// These will be merged with local sampling rules.
+        /// </summary>
+        internal string? RemoteSamplingRules => DynamicSettings.CustomSamplingRules;
+
+        /// <summary>
         /// Gets a value indicating the format for custom sampling rules ("regex" or "glob").
         /// </summary>
         /// <seealso cref="ConfigurationKeys.CustomSamplingRulesFormat"/>
@@ -309,7 +314,7 @@ namespace Datadog.Trace.Configuration
         /// Gets a value indicating the span sampling rules.
         /// </summary>
         /// <seealso cref="ConfigurationKeys.SpanSamplingRules"/>
-        internal string? SpanSamplingRules => DynamicSettings.SpanSamplingRules ?? _spanSamplingRules;
+        internal string? SpanSamplingRules { get; }
 
         /// <summary>
         /// Gets a value indicating a global rate for sampling.

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -302,7 +302,7 @@ namespace Datadog.Trace.Configuration
         /// Gets the trace sampling rules from remote config.
         /// These will be merged with local sampling rules.
         /// </summary>
-        internal string? RemoteSamplingRules => DynamicSettings.CustomSamplingRules;
+        internal string? RemoteSamplingRules => DynamicSettings.SamplingRules;
 
         /// <summary>
         /// Gets a value indicating the format for custom sampling rules ("regex" or "glob").

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.Configuration
                                                    converter: value =>
                                                    {
                                                        // We intentionally report invalid values as "valid" in the converter,
-                                                       // because we don't want to automatically fallback to the
+                                                       // because we don't want to automatically fall back to the
                                                        // default value.
                                                        if (!SamplingRulesFormat.IsValid(value, out var normalizedFormat))
                                                        {

--- a/tracer/src/Datadog.Trace/Sampling/AgentSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/AgentSamplingRule.cs
@@ -28,11 +28,6 @@ namespace Datadog.Trace.Sampling
                                             Datadog.Trace.Sampling.SamplingMechanism.Default :
                                             Datadog.Trace.Sampling.SamplingMechanism.AgentRate;
 
-        /// <summary>
-        /// Gets the lowest possible priority
-        /// </summary>
-        public int Priority => int.MinValue;
-
         public bool IsMatch(Span span) => true;
 
         public float GetSamplingRate(Span span)

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -82,7 +82,7 @@ namespace Datadog.Trace.Sampling
             try
             {
                 if (!string.IsNullOrWhiteSpace(configuration) &&
-                    JsonConvert.DeserializeObject<List<CustomRuleConfig>>(configuration) is { Count: > 0 } rules)
+                    JsonConvert.DeserializeObject<List<LocalSamplingRuleConfig>>(configuration) is { Count: > 0 } rules)
                 {
                     var samplingRules = new List<CustomSamplingRule>(rules.Count);
 
@@ -162,7 +162,7 @@ namespace Datadog.Trace.Sampling
         }
 
         // ReSharper disable once ClassNeverInstantiated.Local
-        private class CustomRuleConfig
+        private class LocalSamplingRuleConfig
         {
             // ReSharper disable UnusedAutoPropertyAccessor.Local
             [JsonProperty(PropertyName = "provenance")]

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -146,9 +146,13 @@ namespace Datadog.Trace.Sampling
 
         public override string ToString()
         {
-            // later this will return different values depending on the rule's provenance:
-            // local, customer (remote), or dynamic (remote)
-            return "LocalSamplingRule";
+            return _provenance switch
+            {
+                SamplingRuleProvenance.Local => "LocalSamplingRule",
+                SamplingRuleProvenance.Remote => "RemoteUserSamplingRule",
+                SamplingRuleProvenance.Automatic => "RemoteAdaptiveSamplingRule",
+                _ => "UnknownSamplingRule"
+            };
         }
 
         // ReSharper disable once ClassNeverInstantiated.Local

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Sampling
             _ => 0
         };
 
-        public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(string configuration, string patternFormat, TimeSpan timeout)
+        public static IEnumerable<CustomSamplingRule> BuildFromLocalConfigurationString(string configuration, string patternFormat, TimeSpan timeout)
         {
             try
             {

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -57,13 +57,24 @@ namespace Datadog.Trace.Sampling
             }
         }
 
-        public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.TraceSamplingRule;
+        public int SamplingMechanism => _provenance switch
+        {
+            SamplingRuleProvenance.Local => Datadog.Trace.Sampling.SamplingMechanism.TraceSamplingRule,
+            SamplingRuleProvenance.Remote => Datadog.Trace.Sampling.SamplingMechanism.RemoteUserSamplingRule,
+            SamplingRuleProvenance.Automatic => Datadog.Trace.Sampling.SamplingMechanism.RemoteAdaptiveSamplingRule,
+            _ => Datadog.Trace.Sampling.SamplingMechanism.Default
+        };
 
         /// <summary>
         /// Gets the priority of the rule.
-        /// Configuration rules will default to 1 as a priority and rely on order of specification.
         /// </summary>
-        public int Priority => 1;
+        public int Priority => _provenance switch
+        {
+            SamplingRuleProvenance.Local => 1,
+            SamplingRuleProvenance.Remote => 2,
+            SamplingRuleProvenance.Automatic => 3,
+            _ => 0
+        };
 
         public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(string configuration, string patternFormat, TimeSpan timeout)
         {

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -19,6 +19,7 @@ namespace Datadog.Trace.Sampling
 
         private readonly float _samplingRate;
         private readonly bool _alwaysMatch;
+        private readonly string _provenance;
 
         // TODO consider moving toward these https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/SimpleRegex.cs
         private readonly Regex? _serviceNameRegex;
@@ -30,6 +31,7 @@ namespace Datadog.Trace.Sampling
 
         public CustomSamplingRule(
             float rate,
+            string provenance,
             string patternFormat,
             string? serviceNamePattern,
             string? operationNamePattern,
@@ -38,6 +40,7 @@ namespace Datadog.Trace.Sampling
             TimeSpan timeout)
         {
             _samplingRate = rate;
+            _provenance = provenance;
 
             _serviceNameRegex = RegexBuilder.Build(serviceNamePattern, patternFormat, timeout);
             _operationNameRegex = RegexBuilder.Build(operationNamePattern, patternFormat, timeout);
@@ -76,6 +79,7 @@ namespace Datadog.Trace.Sampling
                         samplingRules.Add(
                             new CustomSamplingRule(
                                 rate: r.SampleRate,
+                                provenance: r.Provenance,
                                 patternFormat: patternFormat,
                                 serviceNamePattern: r.Service,
                                 operationNamePattern: r.OperationName,
@@ -139,6 +143,10 @@ namespace Datadog.Trace.Sampling
         // ReSharper disable once ClassNeverInstantiated.Local
         private class CustomRuleConfig
         {
+            [JsonRequired]
+            [JsonProperty(PropertyName = "provenance")]
+            public string Provenance { get; set; } = SamplingRuleProvenance.Local;
+
             [JsonRequired]
             [JsonProperty(PropertyName = "sample_rate")]
             public float SampleRate { get; set; }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -60,8 +60,8 @@ namespace Datadog.Trace.Sampling
         public int SamplingMechanism => _provenance switch
         {
             SamplingRuleProvenance.Local => Datadog.Trace.Sampling.SamplingMechanism.TraceSamplingRule,
-            SamplingRuleProvenance.Remote => Datadog.Trace.Sampling.SamplingMechanism.RemoteUserSamplingRule,
-            SamplingRuleProvenance.Automatic => Datadog.Trace.Sampling.SamplingMechanism.RemoteAdaptiveSamplingRule,
+            SamplingRuleProvenance.RemoteCustomer => Datadog.Trace.Sampling.SamplingMechanism.RemoteUserSamplingRule,
+            SamplingRuleProvenance.RemoteDynamic => Datadog.Trace.Sampling.SamplingMechanism.RemoteAdaptiveSamplingRule,
             _ => Datadog.Trace.Sampling.SamplingMechanism.Default
         };
 
@@ -70,9 +70,10 @@ namespace Datadog.Trace.Sampling
         /// </summary>
         public int Priority => _provenance switch
         {
+            // TODO: fix the order of these, larger values mean higher priority
             SamplingRuleProvenance.Local => 1,
-            SamplingRuleProvenance.Remote => 2,
-            SamplingRuleProvenance.Automatic => 3,
+            SamplingRuleProvenance.RemoteCustomer => 2,
+            SamplingRuleProvenance.RemoteDynamic => 3,
             _ => 0
         };
 
@@ -149,8 +150,8 @@ namespace Datadog.Trace.Sampling
             return _provenance switch
             {
                 SamplingRuleProvenance.Local => "LocalSamplingRule",
-                SamplingRuleProvenance.Remote => "RemoteUserSamplingRule",
-                SamplingRuleProvenance.Automatic => "RemoteAdaptiveSamplingRule",
+                SamplingRuleProvenance.RemoteCustomer => "RemoteUserSamplingRule",
+                SamplingRuleProvenance.RemoteDynamic => "RemoteAdaptiveSamplingRule",
                 _ => "UnknownSamplingRule"
             };
         }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -59,7 +59,7 @@ namespace Datadog.Trace.Sampling
 
         public int SamplingMechanism => _provenance switch
         {
-            SamplingRuleProvenance.Local => Datadog.Trace.Sampling.SamplingMechanism.TraceSamplingRule,
+            SamplingRuleProvenance.Local => Datadog.Trace.Sampling.SamplingMechanism.LocalTraceSamplingRule,
             SamplingRuleProvenance.RemoteCustomer => Datadog.Trace.Sampling.SamplingMechanism.RemoteUserSamplingRule,
             SamplingRuleProvenance.RemoteDynamic => Datadog.Trace.Sampling.SamplingMechanism.RemoteAdaptiveSamplingRule,
             _ => Datadog.Trace.Sampling.SamplingMechanism.Default

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -121,4 +121,5 @@ namespace Datadog.Trace.Sampling
                 _ => "UnknownSamplingRule"
             };
         }
+    }
 }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -91,7 +91,7 @@ namespace Datadog.Trace.Sampling
                         samplingRules.Add(
                             new CustomSamplingRule(
                                 rate: r.SampleRate,
-                                provenance: r.Provenance,
+                                provenance: r.Provenance ?? SamplingRuleProvenance.Local,
                                 patternFormat: patternFormat,
                                 serviceNamePattern: r.Service,
                                 operationNamePattern: r.OperationName,
@@ -159,9 +159,8 @@ namespace Datadog.Trace.Sampling
         // ReSharper disable once ClassNeverInstantiated.Local
         private class CustomRuleConfig
         {
-            [JsonRequired]
             [JsonProperty(PropertyName = "provenance")]
-            public string Provenance { get; set; } = SamplingRuleProvenance.Local;
+            public string? Provenance { get; set; }
 
             [JsonRequired]
             [JsonProperty(PropertyName = "sample_rate")]

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -161,13 +161,12 @@ namespace Datadog.Trace.Sampling
             };
         }
 
-        // ReSharper disable once ClassNeverInstantiated.Local
+        {
+
+        // ReSharper disable ClassNeverInstantiated.Local
+        // ReSharper disable UnusedAutoPropertyAccessor.Local
         private class LocalSamplingRuleConfig
         {
-            // ReSharper disable UnusedAutoPropertyAccessor.Local
-            [JsonProperty(PropertyName = "provenance")]
-            public string? Provenance { get; set; }
-
             [JsonRequired]
             [JsonProperty(PropertyName = "sample_rate")]
             public float SampleRate { get; set; }
@@ -183,7 +182,40 @@ namespace Datadog.Trace.Sampling
 
             [JsonProperty(PropertyName = "tags")]
             public Dictionary<string, string?>? Tags { get; set; }
-            // ReSharper restore UnusedAutoPropertyAccessor.Local
         }
+
+        private class RemoteSamplingRuleConfig
+        {
+            [JsonRequired]
+            [JsonProperty(PropertyName = "sample_rate")]
+            public float SampleRate { get; set; }
+
+            [JsonProperty(PropertyName = "provenance")]
+            public string? Provenance { get; set; }
+
+            [JsonProperty(PropertyName = "name")]
+            public string? OperationName { get; set; }
+
+            [JsonProperty(PropertyName = "service")]
+            public string? Service { get; set; }
+
+            [JsonProperty(PropertyName = "resource")]
+            public string? Resource { get; set; }
+
+            [JsonProperty(PropertyName = "tags")]
+            public List<Tag>? Tags { get; set; }
+
+            internal class Tag
+            {
+                [JsonProperty(PropertyName = "key")]
+                public string? Name { get; set; }
+
+                [JsonProperty(PropertyName = "value_glob")]
+                public string? Value { get; set; }
+            }
+        }
+
+        // ReSharper disable UnusedAutoPropertyAccessor.Local
+        // ReSharper disable ClassNeverInstantiated.Local
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -65,18 +65,6 @@ namespace Datadog.Trace.Sampling
             _ => Datadog.Trace.Sampling.SamplingMechanism.Default
         };
 
-        /// <summary>
-        /// Gets the priority of the rule.
-        /// </summary>
-        public int Priority => _provenance switch
-        {
-            // TODO: fix the order of these, larger values mean higher priority
-            SamplingRuleProvenance.Local => 1,
-            SamplingRuleProvenance.RemoteCustomer => 2,
-            SamplingRuleProvenance.RemoteDynamic => 3,
-            _ => 0
-        };
-
         public bool IsMatch(Span span)
         {
             if (span == null!)

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -111,6 +111,11 @@ namespace Datadog.Trace.Sampling
             return [];
         }
 
+        public static IEnumerable<CustomSamplingRule> BuildFromRemoteConfigurationString(string configuration, TimeSpan timeout)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsMatch(Span span)
         {
             if (span == null!)

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -164,6 +164,7 @@ namespace Datadog.Trace.Sampling
         // ReSharper disable once ClassNeverInstantiated.Local
         private class CustomRuleConfig
         {
+            // ReSharper disable UnusedAutoPropertyAccessor.Local
             [JsonProperty(PropertyName = "provenance")]
             public string? Provenance { get; set; }
 
@@ -182,6 +183,7 @@ namespace Datadog.Trace.Sampling
 
             [JsonProperty(PropertyName = "tags")]
             public Dictionary<string, string?>? Tags { get; set; }
+            // ReSharper restore UnusedAutoPropertyAccessor.Local
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRateRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRateRule.cs
@@ -1,4 +1,4 @@
-// <copyright file="GlobalSamplingRule.cs" company="Datadog">
+// <copyright file="GlobalSamplingRateRule.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -7,11 +7,11 @@
 
 namespace Datadog.Trace.Sampling
 {
-    internal class GlobalSamplingRule : ISamplingRule
+    internal class GlobalSamplingRateRule : ISamplingRule
     {
         private readonly float _globalRate;
 
-        public GlobalSamplingRule(float rate)
+        public GlobalSamplingRateRule(float rate)
         {
             _globalRate = rate;
         }

--- a/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRateRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRateRule.cs
@@ -16,11 +16,6 @@ namespace Datadog.Trace.Sampling
             _globalRate = rate;
         }
 
-        /// <summary>
-        /// Gets the priority which is one beneath custom rules.
-        /// </summary>
-        public int Priority => 0;
-
         public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.LocalTraceSamplingRule;
 
         public bool IsMatch(Span span) => true;

--- a/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
@@ -21,7 +21,7 @@ namespace Datadog.Trace.Sampling
         /// </summary>
         public int Priority => 0;
 
-        public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.TraceSamplingRule;
+        public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.LocalTraceSamplingRule;
 
         public bool IsMatch(Span span) => true;
 

--- a/tracer/src/Datadog.Trace/Sampling/ISamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ISamplingRule.cs
@@ -9,13 +9,6 @@ namespace Datadog.Trace.Sampling
 {
     internal interface ISamplingRule
     {
-        /// <summary>
-        /// Gets the rule priority.
-        /// Higher number means higher priority.
-        /// Not related to sampling priority.
-        /// </summary>
-        int Priority { get; }
-
         int SamplingMechanism { get; }
 
         bool IsMatch(Span span);

--- a/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
@@ -1,0 +1,94 @@
+﻿// <copyright file="LocalCustomSamplingRule.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Sampling;
+
+internal class LocalCustomSamplingRule : CustomSamplingRule
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LocalCustomSamplingRule>();
+
+    public LocalCustomSamplingRule(
+        float rate,
+        string patternFormat,
+        string? serviceNamePattern,
+        string? operationNamePattern,
+        string? resourceNamePattern,
+        ICollection<KeyValuePair<string, string?>>? tagPatterns,
+        TimeSpan timeout)
+        : base(
+            rate,
+            SamplingRuleProvenance.Local, // hard-coded, not present in local config json
+            patternFormat,
+            serviceNamePattern,
+            operationNamePattern,
+            resourceNamePattern,
+            tagPatterns,
+            timeout)
+    {
+    }
+
+    public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(
+        string configuration,
+        string patternFormat,
+        TimeSpan timeout)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(configuration) &&
+                JsonConvert.DeserializeObject<List<LocalSamplingRuleJsonModel>>(configuration) is { Count: > 0 } rules)
+            {
+                var samplingRules = new List<CustomSamplingRule>(rules.Count);
+
+                foreach (var r in rules)
+                {
+                    var samplingRule = new LocalCustomSamplingRule(
+                        rate: r.SampleRate,
+                        patternFormat: patternFormat, // from DD_TRACE_SAMPLING_RULES_FORMAT
+                        serviceNamePattern: r.Service,
+                        operationNamePattern: r.OperationName,
+                        resourceNamePattern: r.Resource,
+                        tagPatterns: r.Tags,
+                        timeout: timeout);
+
+                    samplingRules.Add(samplingRule);
+                }
+
+                return samplingRules;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Unable to parse the trace sampling rules.");
+        }
+
+        return [];
+    }
+
+    internal class LocalSamplingRuleJsonModel
+    {
+        [JsonRequired]
+        [JsonProperty(PropertyName = "sample_rate")]
+        public float SampleRate { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string? OperationName { get; set; }
+
+        [JsonProperty(PropertyName = "service")]
+        public string? Service { get; set; }
+
+        [JsonProperty(PropertyName = "resource")]
+        public string? Resource { get; set; }
+
+        [JsonProperty(PropertyName = "tags")]
+        public Dictionary<string, string?>? Tags { get; set; }
+    }
+}

--- a/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
@@ -44,7 +44,7 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
         try
         {
             if (!string.IsNullOrWhiteSpace(configuration) &&
-                JsonConvert.DeserializeObject<List<LocalSamplingRuleJsonModel>>(configuration) is { Count: > 0 } ruleModels)
+                JsonConvert.DeserializeObject<List<RuleConfigJsonModel>>(configuration) is { Count: > 0 } ruleModels)
             {
                 var samplingRules = new LocalCustomSamplingRule[ruleModels.Count];
 
@@ -75,7 +75,7 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
         return [];
     }
 
-    internal class LocalSamplingRuleJsonModel
+    internal class RuleConfigJsonModel
     {
         [JsonRequired]
         [JsonProperty(PropertyName = "sample_rate")]

--- a/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
@@ -36,7 +36,7 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
     {
     }
 
-    public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(
+    public static LocalCustomSamplingRule[] BuildFromConfigurationString(
         string configuration,
         string patternFormat,
         TimeSpan timeout)
@@ -44,12 +44,14 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
         try
         {
             if (!string.IsNullOrWhiteSpace(configuration) &&
-                JsonConvert.DeserializeObject<List<LocalSamplingRuleJsonModel>>(configuration) is { Count: > 0 } rules)
+                JsonConvert.DeserializeObject<List<LocalSamplingRuleJsonModel>>(configuration) is { Count: > 0 } ruleModels)
             {
-                var samplingRules = new List<CustomSamplingRule>(rules.Count);
+                var samplingRules = new LocalCustomSamplingRule[ruleModels.Count];
 
-                foreach (var r in rules)
+                for (var i = 0; i < ruleModels.Count; i++)
                 {
+                    var r = ruleModels[i];
+
                     var samplingRule = new LocalCustomSamplingRule(
                         rate: r.SampleRate,
                         patternFormat: patternFormat, // from DD_TRACE_SAMPLING_RULES_FORMAT
@@ -59,7 +61,7 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
                         tagPatterns: r.Tags,
                         timeout: timeout);
 
-                    samplingRules.Add(samplingRule);
+                    samplingRules[i] = samplingRule;
                 }
 
                 return samplingRules;

--- a/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
@@ -25,14 +25,14 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
         ICollection<KeyValuePair<string, string?>>? tagPatterns,
         TimeSpan timeout)
         : base(
-            rate,
-            SamplingRuleProvenance.Local, // hard-coded, not present in local config json
-            patternFormat,
-            serviceNamePattern,
-            operationNamePattern,
-            resourceNamePattern,
-            tagPatterns,
-            timeout)
+            rate: rate,
+            provenance: SamplingRuleProvenance.Local, // hard-coded, not present in local config json
+            patternFormat: patternFormat,
+            serviceNamePattern: serviceNamePattern,
+            operationNamePattern: operationNamePattern,
+            resourceNamePattern: resourceNamePattern,
+            tagPatterns: tagPatterns,
+            timeout: timeout)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/LocalCustomSamplingRule.cs
@@ -12,7 +12,7 @@ using Datadog.Trace.Vendors.Newtonsoft.Json;
 
 namespace Datadog.Trace.Sampling;
 
-internal class LocalCustomSamplingRule : CustomSamplingRule
+internal sealed class LocalCustomSamplingRule : CustomSamplingRule
 {
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LocalCustomSamplingRule>();
 
@@ -26,7 +26,6 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
         TimeSpan timeout)
         : base(
             rate: rate,
-            provenance: SamplingRuleProvenance.Local, // hard-coded, not present in local config json
             patternFormat: patternFormat,
             serviceNamePattern: serviceNamePattern,
             operationNamePattern: operationNamePattern,
@@ -35,6 +34,10 @@ internal class LocalCustomSamplingRule : CustomSamplingRule
             timeout: timeout)
     {
     }
+
+    public override string Provenance => SamplingRuleProvenance.Local;
+
+    public override int SamplingMechanism => Sampling.SamplingMechanism.LocalTraceSamplingRule;
 
     public static LocalCustomSamplingRule[] BuildFromConfigurationString(
         string configuration,

--- a/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
@@ -25,14 +25,14 @@ internal class RemoteCustomSamplingRule : CustomSamplingRule
         ICollection<KeyValuePair<string, string?>>? tagPatterns,
         TimeSpan timeout)
         : base(
-            rate,
-            provenance,
-            SamplingRulesFormat.Glob, // hard-coded, always "glob" for remote config rules
-            serviceNamePattern,
-            operationNamePattern,
-            resourceNamePattern,
-            tagPatterns,
-            timeout)
+            rate: rate,
+            provenance: provenance,
+            patternFormat: SamplingRulesFormat.Glob, // hard-coded, always "glob" for remote config rules
+            serviceNamePattern: serviceNamePattern,
+            operationNamePattern: operationNamePattern,
+            resourceNamePattern: resourceNamePattern,
+            tagPatterns: tagPatterns,
+            timeout: timeout)
     {
     }
 

--- a/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
@@ -36,17 +36,19 @@ internal class RemoteCustomSamplingRule : CustomSamplingRule
     {
     }
 
-    public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(string configuration, TimeSpan timeout)
+    public static RemoteCustomSamplingRule[] BuildFromConfigurationString(string configuration, TimeSpan timeout)
     {
         try
         {
             if (!string.IsNullOrWhiteSpace(configuration) &&
-                JsonConvert.DeserializeObject<List<RemoteSamplingRuleJsonModel>>(configuration) is { Count: > 0 } rules)
+                JsonConvert.DeserializeObject<List<RemoteSamplingRuleJsonModel>>(configuration) is { Count: > 0 } ruleModels)
             {
-                var samplingRules = new List<CustomSamplingRule>(rules.Count);
+                var samplingRules = new RemoteCustomSamplingRule[ruleModels.Count];
 
-                foreach (var r in rules)
+                for (var i = 0; i < ruleModels.Count; i++)
                 {
+                    var r = ruleModels[i];
+
                     // "tags" has different json schema between local and remote config
                     var tags = ConvertToLocalTags(r.Tags);
 
@@ -59,7 +61,7 @@ internal class RemoteCustomSamplingRule : CustomSamplingRule
                         tagPatterns: tags,
                         timeout: timeout);
 
-                    samplingRules.Add(samplingRule);
+                    samplingRules[i] = samplingRule;
                 }
 
                 return samplingRules;

--- a/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
@@ -1,0 +1,130 @@
+﻿// <copyright file="RemoteCustomSamplingRule.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Vendors.Newtonsoft.Json;
+
+namespace Datadog.Trace.Sampling;
+
+internal class RemoteCustomSamplingRule : CustomSamplingRule
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<RemoteCustomSamplingRule>();
+
+    public RemoteCustomSamplingRule(
+        float rate,
+        string provenance,
+        string? serviceNamePattern,
+        string? operationNamePattern,
+        string? resourceNamePattern,
+        ICollection<KeyValuePair<string, string?>>? tagPatterns,
+        TimeSpan timeout)
+        : base(
+            rate,
+            provenance,
+            SamplingRulesFormat.Glob, // hard-coded, always "glob" for remote config rules
+            serviceNamePattern,
+            operationNamePattern,
+            resourceNamePattern,
+            tagPatterns,
+            timeout)
+    {
+    }
+
+    public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(string configuration, TimeSpan timeout)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(configuration) &&
+                JsonConvert.DeserializeObject<List<RemoteSamplingRuleJsonModel>>(configuration) is { Count: > 0 } rules)
+            {
+                var samplingRules = new List<CustomSamplingRule>(rules.Count);
+
+                foreach (var r in rules)
+                {
+                    // "tags" has different json schema between local and remote config
+                    var tags = ConvertToLocalTags(r.Tags);
+
+                    var samplingRule = new RemoteCustomSamplingRule(
+                        rate: r.SampleRate,
+                        provenance: r.Provenance!, // never null for remote config rules
+                        serviceNamePattern: r.Service,
+                        operationNamePattern: r.OperationName,
+                        resourceNamePattern: r.Resource,
+                        tagPatterns: tags,
+                        timeout: timeout);
+
+                    samplingRules.Add(samplingRule);
+                }
+
+                return samplingRules;
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Unable to parse the trace sampling rules.");
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Convert a list of tags in the remote configuration format ("tags": [{"key": "{key1}", "value_glob": "{value1}"}, ...])
+    /// into the local configuration format ({"{key1}": "{value1}", ...}).
+    /// </summary>
+    internal static Dictionary<string, string?>? ConvertToLocalTags(List<RemoteSamplingRuleJsonModel.Tag>? remoteTags)
+    {
+        if (remoteTags == null)
+        {
+            return null;
+        }
+
+        var localTags = new Dictionary<string, string?>(remoteTags.Count);
+
+        foreach (var tag in remoteTags)
+        {
+            if (tag is { Name: not null, Value: not null })
+            {
+                localTags[tag.Name] = tag.Value;
+            }
+        }
+
+        return localTags;
+    }
+
+    internal class RemoteSamplingRuleJsonModel
+    {
+        [JsonRequired]
+        [JsonProperty(PropertyName = "sample_rate")]
+        public float SampleRate { get; set; }
+
+        [JsonProperty(PropertyName = "provenance")]
+        public string? Provenance { get; set; }
+
+        [JsonProperty(PropertyName = "name")]
+        public string? OperationName { get; set; }
+
+        [JsonProperty(PropertyName = "service")]
+        public string? Service { get; set; }
+
+        [JsonProperty(PropertyName = "resource")]
+        public string? Resource { get; set; }
+
+        [JsonProperty(PropertyName = "tags")]
+        public List<Tag>? Tags { get; set; }
+
+        internal class Tag
+        {
+            [JsonProperty(PropertyName = "key")]
+            public string? Name { get; set; }
+
+            [JsonProperty(PropertyName = "value_glob")]
+            public string? Value { get; set; }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RemoteCustomSamplingRule.cs
@@ -41,7 +41,7 @@ internal class RemoteCustomSamplingRule : CustomSamplingRule
         try
         {
             if (!string.IsNullOrWhiteSpace(configuration) &&
-                JsonConvert.DeserializeObject<List<RemoteSamplingRuleJsonModel>>(configuration) is { Count: > 0 } ruleModels)
+                JsonConvert.DeserializeObject<List<RuleConfigJsonModel>>(configuration) is { Count: > 0 } ruleModels)
             {
                 var samplingRules = new RemoteCustomSamplingRule[ruleModels.Count];
 
@@ -79,7 +79,7 @@ internal class RemoteCustomSamplingRule : CustomSamplingRule
     /// Convert a list of tags in the remote configuration format ("tags": [{"key": "{key1}", "value_glob": "{value1}"}, ...])
     /// into the local configuration format ({"{key1}": "{value1}", ...}).
     /// </summary>
-    internal static Dictionary<string, string?>? ConvertToLocalTags(List<RemoteSamplingRuleJsonModel.Tag>? remoteTags)
+    internal static Dictionary<string, string?>? ConvertToLocalTags(List<RuleConfigJsonModel.TagJsonModel>? remoteTags)
     {
         if (remoteTags == null)
         {
@@ -99,7 +99,7 @@ internal class RemoteCustomSamplingRule : CustomSamplingRule
         return localTags;
     }
 
-    internal class RemoteSamplingRuleJsonModel
+    internal class RuleConfigJsonModel
     {
         [JsonRequired]
         [JsonProperty(PropertyName = "sample_rate")]
@@ -118,9 +118,9 @@ internal class RemoteCustomSamplingRule : CustomSamplingRule
         public string? Resource { get; set; }
 
         [JsonProperty(PropertyName = "tags")]
-        public List<Tag>? Tags { get; set; }
+        public List<TagJsonModel>? Tags { get; set; }
 
-        internal class Tag
+        internal class TagJsonModel
         {
             [JsonProperty(PropertyName = "key")]
             public string? Name { get; set; }

--- a/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
@@ -42,7 +42,7 @@ internal static class SamplingMechanism
     /// The available sampling priorities are <see cref="SamplingPriorityValues.UserReject"/> (-1)
     /// and <see cref="SamplingPriorityValues.UserKeep"/> (2).
     /// </summary>
-    public const int TraceSamplingRule = 3;
+    public const int LocalTraceSamplingRule = 3;
 
     /// <summary>
     /// A sampling decision was made manually by the user.
@@ -115,7 +115,7 @@ internal static class SamplingMechanism
             Default => "-0",
             AgentRate => "-1",
             // RemoteRateAuto => "-2",
-            TraceSamplingRule => "-3",
+            LocalTraceSamplingRule => "-3",
             Manual => "-4",
             Asm => "-5",
             // RemoteRateUser => "-6",

--- a/tracer/src/Datadog.Trace/Sampling/SamplingRuleProvenance.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingRuleProvenance.cs
@@ -1,0 +1,32 @@
+// <copyright file="SamplingRuleProvenance.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+namespace Datadog.Trace.Sampling;
+
+/// <summary>
+/// The provenance of a sampling rule.
+/// </summary>
+internal static class SamplingRuleProvenance
+{
+    /// <summary>
+    /// Sampling rule is from local configuration,
+    /// such as <c>DD_TRACE_SAMPLING_RULES</c> or <c>DD_TRACE_SAMPLE_RATE</c>.
+    /// </summary>
+    public const string Local = "local";
+
+    /// <summary>
+    /// Sampling rule is a manual user override
+    /// sent via remote configuration (RCM).
+    /// </summary>
+    public const string Remote = "customer";
+
+    /// <summary>
+    /// Sampling rule was automatically computed by Datadog
+    /// and sent via remote configuration (RCM).
+    /// </summary>
+    public const string Automatic = "dynamic";
+}

--- a/tracer/src/Datadog.Trace/Sampling/SamplingRuleProvenance.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingRuleProvenance.cs
@@ -22,11 +22,11 @@ internal static class SamplingRuleProvenance
     /// Sampling rule is a manual user override
     /// sent via remote configuration (RCM).
     /// </summary>
-    public const string Remote = "customer";
+    public const string RemoteCustomer = "customer";
 
     /// <summary>
     /// Sampling rule was automatically computed by Datadog
     /// and sent via remote configuration (RCM).
     /// </summary>
-    public const string Automatic = "dynamic";
+    public const string RemoteDynamic = "dynamic";
 }

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -61,15 +61,6 @@ namespace Datadog.Trace.Sampling
                 _agentSamplingRule = agentSamplingRule;
             }
 
-            for (var i = 0; i < _rules.Count; i++)
-            {
-                if (_rules[i].Priority < rule.Priority)
-                {
-                    _rules.Insert(i, rule);
-                    return;
-                }
-            }
-
             // No items or this is the last priority
             _rules.Add(rule);
         }

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -62,6 +62,14 @@ namespace Datadog.Trace.Sampling
             _rules.Add(rule);
         }
 
+        /// <summary>
+        /// Register a new agent sampling rule. This rule should be registered last,
+        /// after any calls to <see cref="RegisterRule"/> or <see cref="RegisterRules"/>.
+        /// </summary>
+        /// <remarks>
+        /// The order that rules are registered is important, as they are evaluated in order.
+        /// The first rule that matches will be used to determine the sampling rate.
+        /// </remarks>
         public void RegisterAgentSamplingRule(AgentSamplingRule rule)
         {
             // only register the one AgentSamplingRule

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -49,10 +49,13 @@ namespace Datadog.Trace.Sampling
         }
 
         /// <summary>
-        /// Will insert a rule according to how high the Priority field is set.
-        /// If the priority is equal to other rules, the new rule will be the last in that priority group.
+        /// Register a new sampling rule. To register a <see cref="AgentSamplingRule"/>,
+        /// use <see cref="RegisterAgentSamplingRule"/> instead.
         /// </summary>
-        /// <param name="rule">The new rule being registered.</param>
+        /// <remarks>
+        /// The order that rules are registered is important, as they are evaluated in order.
+        /// The first rule that matches will be used to determine the sampling rate.
+        /// </remarks>
         public void RegisterRule(ISamplingRule rule)
         {
             _rules.Add(rule);

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -55,13 +55,16 @@ namespace Datadog.Trace.Sampling
         /// <param name="rule">The new rule being registered.</param>
         public void RegisterRule(ISamplingRule rule)
         {
-            if (rule is AgentSamplingRule agentSamplingRule)
-            {
-                // keep a reference so we can call SetDefaultSampleRates() later
-                _agentSamplingRule = agentSamplingRule;
-            }
-
             _rules.Add(rule);
+        }
+
+        public void RegisterAgentSamplingRule(AgentSamplingRule rule)
+        {
+            // keep a reference to this rule so we can call SetDefaultSampleRates() later
+            // to update the agent sampling rates
+            _agentSamplingRule = rule;
+
+            RegisterRule(rule);
         }
 
         // used for testing

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -64,6 +64,12 @@ namespace Datadog.Trace.Sampling
             _rules.Add(rule);
         }
 
+        // used for testing
+        internal IReadOnlyList<ISamplingRule> GetRules()
+        {
+            return _rules;
+        }
+
         private SamplingDecision MakeSamplingDecision(Span span, float rate, int mechanism)
         {
             // make a sampling decision as a function of traceId and sampling rate.

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -63,6 +63,19 @@ namespace Datadog.Trace.Sampling
         }
 
         /// <summary>
+        /// Register new sampling rules. To register a <see cref="AgentSamplingRule"/>,
+        /// use <see cref="RegisterAgentSamplingRule"/> instead.
+        /// </summary>
+        /// <remarks>
+        /// The order that rules are registered is important, as they are evaluated in order.
+        /// The first rule that matches will be used to determine the sampling rate.
+        /// </remarks>
+        public void RegisterRules(IEnumerable<ISamplingRule> rules)
+        {
+            _rules.AddRange(rules);
+        }
+
+        /// <summary>
         /// Register a new agent sampling rule. This rule should be registered last,
         /// after any calls to <see cref="RegisterRule"/> or <see cref="RegisterRules"/>.
         /// </summary>

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -16,18 +16,18 @@ namespace Datadog.Trace.Sampling
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TraceSampler>();
 
         private readonly IRateLimiter _limiter;
-        private readonly AgentSamplingRule _defaultRule = new();
+        private readonly AgentSamplingRule _agentSamplingRule = new();
         private readonly List<ISamplingRule> _rules = [];
 
         public TraceSampler(IRateLimiter limiter)
         {
             _limiter = limiter;
-            RegisterRule(_defaultRule);
+            RegisterRule(_agentSamplingRule);
         }
 
         public void SetDefaultSampleRates(IReadOnlyDictionary<string, float> sampleRates)
         {
-            _defaultRule.SetDefaultSampleRates(sampleRates);
+            _agentSamplingRule.SetDefaultSampleRates(sampleRates);
         }
 
         public SamplingDecision MakeSamplingDecision(Span span)

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -61,7 +61,6 @@ namespace Datadog.Trace.Sampling
                 _agentSamplingRule = agentSamplingRule;
             }
 
-            // No items or this is the last priority
             _rules.Add(rule);
         }
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -407,6 +407,9 @@ namespace Datadog.Trace
                     writer.WritePropertyName("sampling_rules");
                     writer.WriteValue(instanceSettings.CustomSamplingRulesInternal);
 
+                    writer.WritePropertyName("remote_sampling_rules");
+                    writer.WriteValue(instanceSettings.RemoteSamplingRules);
+
                     writer.WritePropertyName("tags");
                     WriteDictionary(instanceSettings.GlobalTagsInternal);
 

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -81,7 +81,7 @@ namespace Datadog.Trace
             DirectLogSubmission = directLogSubmission;
             Telemetry = telemetry;
             DiscoveryService = discoveryService;
-            TraceProcessors = traceProcessors ?? Array.Empty<ITraceProcessor>();
+            TraceProcessors = traceProcessors ?? [];
             QueryStringManager = new(settings.QueryStringReportingEnabled, settings.ObfuscationQueryStringRegexTimeout, settings.QueryStringReportingSize, settings.ObfuscationQueryStringRegex);
             var lstTagProcessors = new List<ITagProcessor>(TraceProcessors.Length);
             foreach (var traceProcessor in TraceProcessors)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -262,7 +262,7 @@ namespace Datadog.Trace
 
             if (patternFormatIsValid && !string.IsNullOrWhiteSpace(localSamplingRules))
             {
-                foreach (var rule in CustomSamplingRule.BuildFromLocalConfigurationString(localSamplingRules, samplingRulesFormat, RegexBuilder.DefaultTimeout))
+                foreach (var rule in LocalCustomSamplingRule.BuildFromConfigurationString(localSamplingRules, samplingRulesFormat, RegexBuilder.DefaultTimeout))
                 {
                     sampler.RegisterRule(rule);
                 }
@@ -273,7 +273,7 @@ namespace Datadog.Trace
 
             if (!string.IsNullOrWhiteSpace(remoteSamplingRules))
             {
-                foreach (var rule in CustomSamplingRule.BuildFromRemoteConfigurationString(remoteSamplingRules, RegexBuilder.DefaultTimeout))
+                foreach (var rule in RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRules, RegexBuilder.DefaultTimeout))
                 {
                     sampler.RegisterRule(rule);
                 }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -290,7 +290,7 @@ namespace Datadog.Trace
                 }
                 else
                 {
-                    sampler.RegisterRule(new GlobalSamplingRule(globalRate));
+                    sampler.RegisterRule(new GlobalSamplingRateRule(globalRate));
                 }
             }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -256,6 +256,17 @@ namespace Datadog.Trace
             // unlike most settings, remote sampling rules don't simply override local ones.
             // instead, they are combined with local rules, with remote rules taking precedence.
 
+            // remote sampling rules
+            var remoteSamplingRules = settings.RemoteSamplingRules;
+
+            if (!string.IsNullOrWhiteSpace(remoteSamplingRules))
+            {
+                foreach (var rule in RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRules, RegexBuilder.DefaultTimeout))
+                {
+                    sampler.RegisterRule(rule);
+                }
+            }
+
             // local sampling rules
             var patternFormatIsValid = SamplingRulesFormat.IsValid(settings.CustomSamplingRulesFormat, out var samplingRulesFormat);
             var localSamplingRules = settings.CustomSamplingRulesInternal;
@@ -268,18 +279,7 @@ namespace Datadog.Trace
                 }
             }
 
-            // remote sampling rules
-            var remoteSamplingRules = settings.RemoteSamplingRules;
-
-            if (!string.IsNullOrWhiteSpace(remoteSamplingRules))
-            {
-                foreach (var rule in RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRules, RegexBuilder.DefaultTimeout))
-                {
-                    sampler.RegisterRule(rule);
-                }
-            }
-
-            // global sampling rate (remote overrides local)
+            // global sampling rate (remote value overrides local value)
             if (settings.GlobalSamplingRateInternal is { } globalSamplingRate)
             {
                 if (globalSamplingRate is < 0f or > 1f)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -276,12 +276,11 @@ namespace Datadog.Trace
             if (!string.IsNullOrWhiteSpace(remoteSamplingRulesJson))
             {
                 var remoteSamplingRules =
-                    RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRulesJson, RegexBuilder.DefaultTimeout);
+                    RemoteCustomSamplingRule.BuildFromConfigurationString(
+                        remoteSamplingRulesJson,
+                        RegexBuilder.DefaultTimeout);
 
-                foreach (var remoteSamplingRule in remoteSamplingRules)
-                {
-                    sampler.RegisterRule(remoteSamplingRule);
-                }
+                sampler.RegisterRules(remoteSamplingRules);
             }
 
             // local sampling rules
@@ -291,12 +290,12 @@ namespace Datadog.Trace
             if (patternFormatIsValid && !string.IsNullOrWhiteSpace(localSamplingRulesJson))
             {
                 var localSamplingRules =
-                    LocalCustomSamplingRule.BuildFromConfigurationString(localSamplingRulesJson, samplingRulesFormat, RegexBuilder.DefaultTimeout);
+                    LocalCustomSamplingRule.BuildFromConfigurationString(
+                        localSamplingRulesJson,
+                        samplingRulesFormat,
+                        RegexBuilder.DefaultTimeout);
 
-                foreach (var localSamplingRule in localSamplingRules)
-                {
-                    sampler.RegisterRule(localSamplingRule);
-                }
+                sampler.RegisterRules(localSamplingRules);
             }
 
             // global sampling rate (remote value overrides local value)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -317,7 +317,7 @@ namespace Datadog.Trace
 
             // AgentSamplingRule handles all sampling rates received from the agent as a single "rule".
             // This rule is always present, even if the agent has not yet provided any sampling rates.
-            sampler.RegisterRule(new AgentSamplingRule());
+            sampler.RegisterAgentSamplingRule(new AgentSamplingRule());
 
             return sampler;
         }

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -292,6 +292,9 @@ namespace Datadog.Trace
                 }
             }
 
+            // agent sampling rule handles all sampling rates received from the agent as a single "rule"
+            sampler.RegisterRule(new AgentSamplingRule());
+
             return sampler;
         }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -280,17 +280,15 @@ namespace Datadog.Trace
             }
 
             // global sampling rate (remote overrides local)
-            if (settings.GlobalSamplingRateInternal != null)
+            if (settings.GlobalSamplingRateInternal is { } globalSamplingRate)
             {
-                var globalRate = (float)settings.GlobalSamplingRateInternal.Value;
-
-                if (globalRate < 0f || globalRate > 1f)
+                if (globalSamplingRate is < 0f or > 1f)
                 {
                     Log.Warning("{ConfigurationKey} configuration of {ConfigurationValue} is out of range", ConfigurationKeys.GlobalSamplingRate, settings.GlobalSamplingRateInternal);
                 }
                 else
                 {
-                    sampler.RegisterRule(new GlobalSamplingRateRule(globalRate));
+                    sampler.RegisterRule(new GlobalSamplingRateRule((float)globalSamplingRate));
                 }
             }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -276,9 +276,9 @@ namespace Datadog.Trace
 
             if (!string.IsNullOrWhiteSpace(remoteSamplingRules))
             {
-                foreach (var rule in RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRules, RegexBuilder.DefaultTimeout))
+                foreach (var remoteSamplingRule in RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRules, RegexBuilder.DefaultTimeout))
                 {
-                    sampler.RegisterRule(rule);
+                    sampler.RegisterRule(remoteSamplingRule);
                 }
             }
 
@@ -288,9 +288,9 @@ namespace Datadog.Trace
 
             if (patternFormatIsValid && !string.IsNullOrWhiteSpace(localSamplingRules))
             {
-                foreach (var rule in LocalCustomSamplingRule.BuildFromConfigurationString(localSamplingRules, samplingRulesFormat, RegexBuilder.DefaultTimeout))
+                foreach (var localSamplingRule in LocalCustomSamplingRule.BuildFromConfigurationString(localSamplingRules, samplingRulesFormat, RegexBuilder.DefaultTimeout))
                 {
-                    sampler.RegisterRule(rule);
+                    sampler.RegisterRule(localSamplingRule);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.DiscoveryService;
@@ -251,8 +250,6 @@ namespace Datadog.Trace
 
         protected virtual ITraceSampler GetSampler(ImmutableTracerSettings settings)
         {
-            var sampler = new TraceSampler(new TracerRateLimiter(settings.MaxTracesSubmittedPerSecondInternal));
-
             // ISamplingRule is used to implement, in order of precedence:
             // - custom sampling rules
             //   - remote custom rules (provenance: "customer")
@@ -270,6 +267,8 @@ namespace Datadog.Trace
             // Unlike most settings, local custom sampling rules configuration (DD_TRACE_SAMPLING_RULES) is not
             // simply overriden with the remote configuration. Instead, remote rules are merged with local rules,
             // with remote rules taking precedence.
+
+            var sampler = new TraceSampler(new TracerRateLimiter(settings.MaxTracesSubmittedPerSecondInternal));
 
             // remote sampling rules
             var remoteSamplingRulesJson = settings.RemoteSamplingRules;

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -272,11 +272,14 @@ namespace Datadog.Trace
             // with remote rules taking precedence.
 
             // remote sampling rules
-            var remoteSamplingRules = settings.RemoteSamplingRules;
+            var remoteSamplingRulesJson = settings.RemoteSamplingRules;
 
-            if (!string.IsNullOrWhiteSpace(remoteSamplingRules))
+            if (!string.IsNullOrWhiteSpace(remoteSamplingRulesJson))
             {
-                foreach (var remoteSamplingRule in RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRules, RegexBuilder.DefaultTimeout))
+                var remoteSamplingRules =
+                    RemoteCustomSamplingRule.BuildFromConfigurationString(remoteSamplingRulesJson, RegexBuilder.DefaultTimeout);
+
+                foreach (var remoteSamplingRule in remoteSamplingRules)
                 {
                     sampler.RegisterRule(remoteSamplingRule);
                 }
@@ -284,11 +287,14 @@ namespace Datadog.Trace
 
             // local sampling rules
             var patternFormatIsValid = SamplingRulesFormat.IsValid(settings.CustomSamplingRulesFormat, out var samplingRulesFormat);
-            var localSamplingRules = settings.CustomSamplingRulesInternal;
+            var localSamplingRulesJson = settings.CustomSamplingRulesInternal;
 
-            if (patternFormatIsValid && !string.IsNullOrWhiteSpace(localSamplingRules))
+            if (patternFormatIsValid && !string.IsNullOrWhiteSpace(localSamplingRulesJson))
             {
-                foreach (var localSamplingRule in LocalCustomSamplingRule.BuildFromConfigurationString(localSamplingRules, samplingRulesFormat, RegexBuilder.DefaultTimeout))
+                var localSamplingRules =
+                    LocalCustomSamplingRule.BuildFromConfigurationString(localSamplingRulesJson, samplingRulesFormat, RegexBuilder.DefaultTimeout);
+
+                foreach (var localSamplingRule in localSamplingRules)
                 {
                     sampler.RegisterRule(localSamplingRule);
                 }
@@ -299,7 +305,10 @@ namespace Datadog.Trace
             {
                 if (globalSamplingRate is < 0f or > 1f)
                 {
-                    Log.Warning("{ConfigurationKey} configuration of {ConfigurationValue} is out of range", ConfigurationKeys.GlobalSamplingRate, settings.GlobalSamplingRateInternal);
+                    Log.Warning(
+                        "{ConfigurationKey} configuration of {ConfigurationValue} is out of range",
+                        ConfigurationKeys.GlobalSamplingRate,
+                        settings.GlobalSamplingRateInternal);
                 }
                 else
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         LogInjectionEnabled = true,
                         // SpanSamplingRules = "[{\"service\": \"cart*\"}]",
                         TraceSampleRate = .5,
-                        // CustomSamplingRules = "[{\"sample_rate\":0.1}]",
+                        TraceSamplingRules = "[{\"sample_rate\":0.1}]",
                         // ServiceNameMapping = "[{\"from_key\":\"foo\", \"to_name\":\"bar\"}]",
                         TraceHeaderTags = "[{ \"header\": \"User-Agent\", \"tag_name\": \"http.user_agent\" }]",
                         GlobalTags = "[\"foo1:bar1\",\"foo2:bar2\"]"
@@ -78,7 +78,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                         LogInjectionEnabled = true,
                         // SpanSamplingRules = "[{\"service\": \"cart*\"}]",
                         TraceSampleRate = .5,
-                        // CustomSamplingRules = "[{\"sample_rate\":0.1}]",
+                        TraceSamplingRules = "[{\"sample_rate\":0.1}]",
                         // ServiceNameMapping = "foo:bar",
                         TraceHeaderTags = "User-Agent:http.user_agent",
                         GlobalTags = "[\"foo1:bar1\",\"foo2:bar2\"]"
@@ -213,7 +213,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // json["debug"]?.Value<bool>().Should().Be(expectedConfig.DebugLogsEnabled);
                 json["log_injection_enabled"]?.Value<bool>().Should().Be(expectedConfig.LogInjectionEnabled);
                 json["sample_rate"]?.Value<double?>().Should().Be(expectedConfig.TraceSampleRate);
-                json["sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SamplingRules);
+                json["remote_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.TraceSamplingRules);
                 // json["span_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SpanSamplingRules);
                 // json["data_streams_enabled"]?.Value<bool>().Should().Be(expectedConfig.DataStreamsEnabled);
                 FlattenJsonArray(json["header_tags"]).Should().Be(expectedConfig.TraceHeaderTags ?? string.Empty);
@@ -255,7 +255,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // (ConfigurationKeys.DebugEnabled, config.DebugLogsEnabled),
                 (ConfigurationKeys.LogsInjectionEnabled, config.LogInjectionEnabled),
                 (ConfigurationKeys.GlobalSamplingRate, config.TraceSampleRate),
-                (ConfigurationKeys.CustomSamplingRules, config.SamplingRules),
+                (ConfigurationKeys.CustomSamplingRules, config.TraceSamplingRules),
                 // (ConfigurationKeys.SpanSamplingRules, config.SpanSamplingRules),
                 // (ConfigurationKeys.DataStreamsMonitoring.Enabled, config.DataStreamsEnabled),
                 (ConfigurationKeys.HeaderTags, config.TraceHeaderTags == null ? null : JToken.Parse(config.TraceHeaderTags).ToString()),
@@ -355,7 +355,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             public double? TraceSampleRate { get; init; }
 
             [JsonProperty("tracing_sampling_rules")]
-            public string SamplingRules { get; init; }
+            public string TraceSamplingRules { get; init; }
 
             // [JsonProperty("span_sampling_rules")]
             // public string SpanSamplingRules { get; init; }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -355,7 +355,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             public double? TraceSampleRate { get; init; }
 
             [JsonProperty("tracing_sampling_rules")]
-            public string CustomSamplingRules { get; init; }
+            public string SamplingRules { get; init; }
 
             // [JsonProperty("span_sampling_rules")]
             // public string SpanSamplingRules { get; init; }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -177,6 +177,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             capabilities[14].Should().BeTrue(); // APM_TRACING_HTTP_HEADER_TAGS
             capabilities[15].Should().BeTrue(); // APM_TRACING_CUSTOM_TAGS
             capabilities[19].Should().BeTrue(); // APM_TRACING_TRACING_ENABLED
+            capabilities[29].Should().BeTrue(); // APM_TRACING_SAMPLE_RULES
 
             request.Client.State.ConfigStates.Should().ContainSingle(f => f.Id == fileId)
                .Subject.ApplyState.Should().Be(ApplyStates.ACKNOWLEDGED);
@@ -353,8 +354,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             [JsonProperty("tracing_sampling_rate")]
             public double? TraceSampleRate { get; init; }
 
-            // [JsonProperty("tracing_sampling_rules")]
-            // public string CustomSamplingRules { get; init; }
+            [JsonProperty("tracing_sampling_rules")]
+            public string CustomSamplingRules { get; init; }
 
             // [JsonProperty("span_sampling_rules")]
             // public string SpanSamplingRules { get; init; }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // json["debug"]?.Value<bool>().Should().Be(expectedConfig.DebugLogsEnabled);
                 json["log_injection_enabled"]?.Value<bool>().Should().Be(expectedConfig.LogInjectionEnabled);
                 json["sample_rate"]?.Value<double?>().Should().Be(expectedConfig.TraceSampleRate);
-                // json["sampling_rules"]?.Value<string>().Should().Be(expectedConfig.CustomSamplingRules);
+                json["sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SamplingRules);
                 // json["span_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SpanSamplingRules);
                 // json["data_streams_enabled"]?.Value<bool>().Should().Be(expectedConfig.DataStreamsEnabled);
                 FlattenJsonArray(json["header_tags"]).Should().Be(expectedConfig.TraceHeaderTags ?? string.Empty);
@@ -255,7 +255,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // (ConfigurationKeys.DebugEnabled, config.DebugLogsEnabled),
                 (ConfigurationKeys.LogsInjectionEnabled, config.LogInjectionEnabled),
                 (ConfigurationKeys.GlobalSamplingRate, config.TraceSampleRate),
-                // (ConfigurationKeys.CustomSamplingRules, config.CustomSamplingRules),
+                (ConfigurationKeys.CustomSamplingRules, config.SamplingRules),
                 // (ConfigurationKeys.SpanSamplingRules, config.SpanSamplingRules),
                 // (ConfigurationKeys.DataStreamsMonitoring.Enabled, config.DataStreamsEnabled),
                 (ConfigurationKeys.HeaderTags, config.TraceHeaderTags == null ? null : JToken.Parse(config.TraceHeaderTags).ToString()),

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTags.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/TraceTags.cs
@@ -34,7 +34,7 @@ public class TraceTags
     [Theory]
     [InlineData(SamplingMechanism.Default)]
     [InlineData(SamplingMechanism.AgentRate)]
-    [InlineData(SamplingMechanism.TraceSamplingRule)]
+    [InlineData(SamplingMechanism.LocalTraceSamplingRule)]
     [InlineData(SamplingMechanism.Manual)]
     [InlineData(SamplingMechanism.Asm)]
     public async Task SerializeSamplingMechanismTag(int samplingMechanism)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -104,6 +104,20 @@ namespace Datadog.Trace.Tests.Configuration
             TracerManager.Instance.Settings.TraceEnabled.Should().BeTrue();
         }
 
+        [Fact]
+        public void SetSamplingRules()
+        {
+            var tracerSettings = new TracerSettings();
+            TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings), TracerManagerFactory.Instance);
+
+            // sampling rules is null by default
+            TracerManager.Instance.Settings.RemoteSamplingRules.Should().BeNull();
+
+            // set sampling rules "remotely"
+            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_sampling_rules", "test")));
+            TracerManager.Instance.Settings.RemoteSamplingRules.Should().Be("test");
+        }
+
         private static ConfigurationBuilder CreateConfig(params (string Key, object Value)[] settings)
         {
             using var stringWriter = new StringWriter();

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -3,10 +3,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.IO;
+using System.Threading;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Sampling;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Moq;
@@ -113,9 +116,55 @@ namespace Datadog.Trace.Tests.Configuration
             // sampling rules is null by default
             TracerManager.Instance.Settings.RemoteSamplingRules.Should().BeNull();
 
+            var traceSampler = TracerManager.Instance.PerTraceSettings.TraceSampler as TraceSampler;
+            traceSampler!.GetRules().Should().ContainSingle().And.AllBeOfType<AgentSamplingRule>();
+
+            const string samplingRulesJson = """
+                                             [{
+                                                "sample_rate": 0.5,
+                                                "provenance": "customer",
+                                                "service": "Service1",
+                                                "resource": "Resource1"
+                                             },
+                                             {
+                                                "sample_rate": 0.1,
+                                                "provenance": "dynamic",
+                                                "service": "Service2",
+                                                "resource": "Resource2"
+                                             }]
+                                             """;
+
             // set sampling rules "remotely"
-            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_sampling_rules", "test")));
-            TracerManager.Instance.Settings.RemoteSamplingRules.Should().Be("test");
+            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_sampling_rules", samplingRulesJson)));
+            TracerManager.Instance.Settings.RemoteSamplingRules.Should().Be(samplingRulesJson);
+
+            traceSampler = TracerManager.Instance.PerTraceSettings.TraceSampler as TraceSampler;
+            var rules = traceSampler!.GetRules();
+            rules.Should().HaveCount(3);
+
+            rules[0].Should()
+                    .BeEquivalentTo(
+                         new RemoteCustomSamplingRule(
+                             rate: 0.5f,
+                             provenance: SamplingRuleProvenance.RemoteCustomer,
+                             serviceNamePattern: "Service1",
+                             operationNamePattern: null,
+                             resourceNamePattern: "Resource1",
+                             tagPatterns: null,
+                             timeout: TimeSpan.FromSeconds(1)));
+
+            rules[1].Should()
+                    .BeEquivalentTo(
+                         new RemoteCustomSamplingRule(
+                             rate: 0.1f,
+                             provenance: SamplingRuleProvenance.RemoteDynamic,
+                             serviceNamePattern: "Service2",
+                             operationNamePattern: null,
+                             resourceNamePattern: "Resource2",
+                             tagPatterns: null,
+                             timeout: TimeSpan.FromSeconds(1)));
+
+            rules[2].Should().BeOfType<AgentSamplingRule>();
         }
 
         private static ConfigurationBuilder CreateConfig(params (string Key, object Value)[] settings)

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -140,31 +140,29 @@ namespace Datadog.Trace.Tests.Configuration
 
             traceSampler = TracerManager.Instance.PerTraceSettings.TraceSampler as TraceSampler;
             var rules = traceSampler!.GetRules();
-            rules.Should().HaveCount(3);
 
-            rules[0].Should()
-                    .BeEquivalentTo(
-                         new RemoteCustomSamplingRule(
-                             rate: 0.5f,
-                             provenance: SamplingRuleProvenance.RemoteCustomer,
-                             serviceNamePattern: "Service1",
-                             operationNamePattern: null,
-                             resourceNamePattern: "Resource1",
-                             tagPatterns: null,
-                             timeout: TimeSpan.FromSeconds(1)));
-
-            rules[1].Should()
-                    .BeEquivalentTo(
-                         new RemoteCustomSamplingRule(
-                             rate: 0.1f,
-                             provenance: SamplingRuleProvenance.RemoteDynamic,
-                             serviceNamePattern: "Service2",
-                             operationNamePattern: null,
-                             resourceNamePattern: "Resource2",
-                             tagPatterns: null,
-                             timeout: TimeSpan.FromSeconds(1)));
-
-            rules[2].Should().BeOfType<AgentSamplingRule>();
+            rules.Should()
+                 .BeEquivalentTo(
+                      new ISamplingRule[]
+                      {
+                          new RemoteCustomSamplingRule(
+                              rate: 0.5f,
+                              provenance: SamplingRuleProvenance.RemoteCustomer,
+                              serviceNamePattern: "Service1",
+                              operationNamePattern: null,
+                              resourceNamePattern: "Resource1",
+                              tagPatterns: null,
+                              timeout: TimeSpan.FromSeconds(1)),
+                          new RemoteCustomSamplingRule(
+                              rate: 0.1f,
+                              provenance: SamplingRuleProvenance.RemoteDynamic,
+                              serviceNamePattern: "Service2",
+                              operationNamePattern: null,
+                              resourceNamePattern: "Resource2",
+                              tagPatterns: null,
+                              timeout: TimeSpan.FromSeconds(1)),
+                          new AgentSamplingRule()
+                      });
         }
 
         private static ConfigurationBuilder CreateConfig(params (string Key, object Value)[] settings)

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
@@ -53,7 +53,7 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void Constructs_With_ResourceName()
+        public void Constructs_With_ResourceName_Local()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/*" }]""";
             var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
@@ -67,10 +67,57 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public void Constructs_With_Tags()
+        public void Constructs_With_ResourceName_Remote()
+        {
+            const string config = """[{ "sample_rate":0.3, resource: "/api/v1/*" }]""";
+            var rule = CustomSamplingRule.BuildFromRemoteConfigurationString(config, Timeout).Single();
+
+            var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
+            var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
+
+            VerifyRate(rule, 0.3f);
+            VerifySingleRule(rule, matchingSpan, isMatch: true);
+            VerifySingleRule(rule, nonMatchingSpan, isMatch: false);
+        }
+
+        [Fact]
+        public void Constructs_With_Tags_Local()
         {
             const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE?", "http.status_code": "200", "balance": "*" } }]""";
             var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+
+            var matchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
+            matchingSpan1.SetTag("http.method", "GET");
+            matchingSpan1.SetMetric("http.status_code", 200); // matches as string or int
+            matchingSpan1.SetMetric("balance", 12);           // "*" matches ints or floats
+
+            var matchingSpan2 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
+            matchingSpan2.SetTag("http.method", "GEX");      // "GE?" matches any single character
+            matchingSpan2.SetTag("http.status_code", "200"); // matches as string or int
+            matchingSpan2.SetMetric("balance", 12.34);       // "*" matches ints or floats
+
+            // missing "http.status_code" tag
+            var nonMatchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
+            nonMatchingSpan1.SetTag("http.method", "GET");
+            nonMatchingSpan1.SetMetric("balance", 12.34);
+
+            var nonMatchingSpan2 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
+            nonMatchingSpan2.SetTag("http.method", "POST"); // no match
+            nonMatchingSpan2.SetMetric("http.status_code", 200);
+            nonMatchingSpan2.SetMetric("balance", 12.34);
+
+            VerifyRate(rule, 0.3f);
+            VerifySingleRule(rule, matchingSpan1, isMatch: true);
+            VerifySingleRule(rule, matchingSpan2, isMatch: true);
+            VerifySingleRule(rule, nonMatchingSpan1, isMatch: false);
+            VerifySingleRule(rule, nonMatchingSpan2, isMatch: false);
+        }
+
+        [Fact]
+        public void Constructs_With_Tags_Remote()
+        {
+            const string config = """[{ "sample_rate":0.3, "tags": [{ "key":"http.method", "value_glob":"GE?" }, { "key":"http.status_code", "value_glob":"200"}, { "key":"balance", "value_glob":"*" }] }]""";
+            var rule = CustomSamplingRule.BuildFromRemoteConfigurationString(config, Timeout).Single();
 
             var matchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan1.SetTag("http.method", "GET");

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_ResourceName_Local()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/*" }]""";
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_ResourceName_Remote()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/*" }]""";
-            var rule = CustomSamplingRule.BuildFromRemoteConfigurationString(config, Timeout).Single();
+            var rule = RemoteCustomSamplingRule.BuildFromConfigurationString(config, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
@@ -84,7 +84,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_Tags_Local()
         {
             const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE?", "http.status_code": "200", "balance": "*" } }]""";
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
 
             var matchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan1.SetTag("http.method", "GET");
@@ -117,7 +117,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_Tags_Remote()
         {
             const string config = """[{ "sample_rate":0.3, "tags": [{ "key":"http.method", "value_glob":"GE?" }, { "key":"http.status_code", "value_glob":"200"}, { "key":"balance", "value_glob":"*" }] }]""";
-            var rule = CustomSamplingRule.BuildFromRemoteConfigurationString(config, Timeout).Single();
+            var rule = RemoteCustomSamplingRule.BuildFromConfigurationString(config, Timeout).Single();
 
             var matchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan1.SetTag("http.method", "GET");
@@ -158,7 +158,7 @@ namespace Datadog.Trace.Tests.Sampling
                                   ]
                                   """;
 
-            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).ToArray();
+            var rules = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).ToArray();
             rules.Should().HaveCount(4);
 
             var cartRule = rules[0];
@@ -202,7 +202,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void RuleShouldBeCaseInsensitive()
         {
             var config = "[{\"sample_rate\":0.5, \"service\":\"SHOPPING-cart-service\", \"name\":\"CHECKOUT\"}]";
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifySingleRule(rule, TestSpans.CartCheckoutSpan, true);
         }
 
@@ -213,13 +213,13 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData("""[{"sample_rate":0.3, "name":"["}]""", 1)] // invalid regex, but valid glob
         public void Malformed_Rules_Do_Not_Register_Or_Crash(string ruleConfig, int count)
         {
-            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(ruleConfig, SamplingRulesFormat.Glob, Timeout).ToArray();
+            var rules = LocalCustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Glob, Timeout).ToArray();
             rules.Should().HaveCount(count);
         }
 
         private static void VerifyRate(string config, float expectedRate)
         {
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifyRate(rule, expectedRate);
         }
 
@@ -230,7 +230,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static void VerifySingleRule(string config, Span span, bool isMatch)
         {
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifySingleRule(rule, span, isMatch);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_ResourceName()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/*" }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_Tags()
         {
             const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE?", "http.status_code": "200", "balance": "*" } }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
 
             var matchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan1.SetTag("http.method", "GET");
@@ -111,7 +111,7 @@ namespace Datadog.Trace.Tests.Sampling
                                   ]
                                   """;
 
-            var rules = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).ToArray();
+            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).ToArray();
             rules.Should().HaveCount(4);
 
             var cartRule = rules[0];
@@ -155,7 +155,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void RuleShouldBeCaseInsensitive()
         {
             var config = "[{\"sample_rate\":0.5, \"service\":\"SHOPPING-cart-service\", \"name\":\"CHECKOUT\"}]";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifySingleRule(rule, TestSpans.CartCheckoutSpan, true);
         }
 
@@ -166,13 +166,13 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData("""[{"sample_rate":0.3, "name":"["}]""", 1)] // invalid regex, but valid glob
         public void Malformed_Rules_Do_Not_Register_Or_Crash(string ruleConfig, int count)
         {
-            var rules = CustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Glob, Timeout).ToArray();
+            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(ruleConfig, SamplingRulesFormat.Glob, Timeout).ToArray();
             rules.Should().HaveCount(count);
         }
 
         private static void VerifyRate(string config, float expectedRate)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifyRate(rule, expectedRate);
         }
 
@@ -183,7 +183,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static void VerifySingleRule(string config, Span span, bool isMatch)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifySingleRule(rule, span, isMatch);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_ResourceName()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/.*" }]""";
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_Tags()
         {
             const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE.", "http.status_code": "200" } }]""";
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan.SetTag("http.method", "GET");
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tests.Sampling
                          ]
                          """;
 
-            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).ToArray();
+            var rules = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).ToArray();
             rules.Should().HaveCount(4);
 
             var cartRule = rules[0];
@@ -144,7 +144,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void RuleShouldBeCaseInsensitive()
         {
             var config = """[{"sample_rate":0.5, "service":"SHOPPING-cart-service", "name":"CHECKOUT"}]""";
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifySingleRule(rule, TestSpans.CartCheckoutSpan, true);
         }
 
@@ -158,13 +158,13 @@ namespace Datadog.Trace.Tests.Sampling
 
         public void Malformed_Rules_Do_Not_Register_Or_Crash(string ruleConfig)
         {
-            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(ruleConfig, SamplingRulesFormat.Regex, Timeout).ToArray();
+            var rules = LocalCustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Regex, Timeout).ToArray();
             Assert.Empty(rules);
         }
 
         private static void VerifyRate(string config, float expectedRate)
         {
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifyRate(rule, expectedRate);
         }
 
@@ -175,7 +175,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static void VerifySingleRule(string config, Span span, bool expected)
         {
-            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = LocalCustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifySingleRule(rule, span, expected);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_ResourceName()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/.*" }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
@@ -70,7 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_Tags()
         {
             const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE.", "http.status_code": "200" } }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan.SetTag("http.method", "GET");
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tests.Sampling
                          ]
                          """;
 
-            var rules = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).ToArray();
+            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).ToArray();
             rules.Should().HaveCount(4);
 
             var cartRule = rules[0];
@@ -144,7 +144,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void RuleShouldBeCaseInsensitive()
         {
             var config = """[{"sample_rate":0.5, "service":"SHOPPING-cart-service", "name":"CHECKOUT"}]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifySingleRule(rule, TestSpans.CartCheckoutSpan, true);
         }
 
@@ -158,13 +158,13 @@ namespace Datadog.Trace.Tests.Sampling
 
         public void Malformed_Rules_Do_Not_Register_Or_Crash(string ruleConfig)
         {
-            var rules = CustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Regex, Timeout).ToArray();
+            var rules = CustomSamplingRule.BuildFromLocalConfigurationString(ruleConfig, SamplingRulesFormat.Regex, Timeout).ToArray();
             Assert.Empty(rules);
         }
 
         private static void VerifyRate(string config, float expectedRate)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifyRate(rule, expectedRate);
         }
 
@@ -175,7 +175,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static void VerifySingleRule(string config, Span span, bool expected)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
+            var rule = CustomSamplingRule.BuildFromLocalConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifySingleRule(rule, span, expected);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
@@ -18,7 +18,7 @@ public class CustomSamplingRuleTests
     [Fact]
     public void ConvertToLocalTags()
     {
-        var remoteTags = new List<RemoteCustomSamplingRule.RemoteSamplingRuleJsonModel.Tag>
+        var remoteTags = new List<RemoteCustomSamplingRule.RuleConfigJsonModel.TagJsonModel>
         {
             new() { Name = "key1", Value = "value1" },
             new() { Name = "key2", Value = "value2" },

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
@@ -18,13 +18,13 @@ public class CustomSamplingRuleTests
     [Fact]
     public void ConvertToLocalTags()
     {
-        var remoteTags = new List<CustomSamplingRule.RemoteSamplingRuleJsonModel.Tag>
+        var remoteTags = new List<RemoteCustomSamplingRule.RemoteSamplingRuleJsonModel.Tag>
         {
             new() { Name = "key1", Value = "value1" },
             new() { Name = "key2", Value = "value2" },
         };
 
-        var localTags = CustomSamplingRule.ConvertToLocalTags(remoteTags);
+        var localTags = RemoteCustomSamplingRule.ConvertToLocalTags(remoteTags);
         localTags.Should().BeEquivalentTo(new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } });
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleTests.cs
@@ -1,0 +1,30 @@
+// <copyright file="CustomSamplingRuleTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Sampling;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Sampling;
+
+[Collection(nameof(Datadog.Trace.Tests.Sampling))]
+public class CustomSamplingRuleTests
+{
+    [Fact]
+    public void ConvertToLocalTags()
+    {
+        var remoteTags = new List<CustomSamplingRule.RemoteSamplingRuleJsonModel.Tag>
+        {
+            new() { Name = "key1", Value = "value1" },
+            new() { Name = "key2", Value = "value2" },
+        };
+
+        var localTags = CustomSamplingRule.ConvertToLocalTags(remoteTags);
+        localTags.Should().BeEquivalentTo(new Dictionary<string, string> { { "key1", "value1" }, { "key2", "value2" } });
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RemoteCustomSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RemoteCustomSamplingRuleTests.cs
@@ -1,11 +1,9 @@
-// <copyright file="CustomSamplingRuleTests.cs" company="Datadog">
+// <copyright file="RemoteCustomSamplingRuleTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using Datadog.Trace.Sampling;
 using FluentAssertions;
 using Xunit;
@@ -13,7 +11,7 @@ using Xunit;
 namespace Datadog.Trace.Tests.Sampling;
 
 [Collection(nameof(Datadog.Trace.Tests.Sampling))]
-public class CustomSamplingRuleTests
+public class RemoteCustomSamplingRuleTests
 {
     [Fact]
     public void ConvertToLocalTags()

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -46,6 +46,7 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 1,
+                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -69,6 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 1,
+                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -92,6 +94,7 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 0,
+                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -115,6 +118,7 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 0.5f,
+                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -134,6 +134,7 @@ namespace Datadog.Trace.Tests.Sampling
         public async Task No_Registered_Rules_Uses_Legacy_Rates()
         {
             var sampler = new TraceSampler(new NoLimits());
+            sampler.RegisterRule(new AgentSamplingRule());
             sampler.SetDefaultSampleRates(MockAgentRates);
 
             await RunSamplerTest(
@@ -155,6 +156,7 @@ namespace Datadog.Trace.Tests.Sampling
 
             var span = scope.Span;
             var sampler = new TraceSampler(new NoLimits());
+            sampler.RegisterRule(new AgentSamplingRule());
 
             // if there are no other rules, and before we have agent rates, mechanism is "Default"
             var (_, mechanism1) = sampler.MakeSamplingDecision(span);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -44,9 +44,8 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new TraceSampler(new DenyAll());
 
             sampler.RegisterRule(
-                new CustomSamplingRule(
+                new LocalCustomSamplingRule(
                     rate: 1,
-                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -68,9 +67,8 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new TraceSampler(new NoLimits());
 
             sampler.RegisterRule(
-                new CustomSamplingRule(
+                new LocalCustomSamplingRule(
                     rate: 1,
-                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -92,9 +90,8 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new TraceSampler(new NoLimits());
 
             sampler.RegisterRule(
-                new CustomSamplingRule(
+                new LocalCustomSamplingRule(
                     rate: 0,
-                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -116,9 +113,8 @@ namespace Datadog.Trace.Tests.Sampling
             var sampler = new TraceSampler(new NoLimits());
 
             sampler.RegisterRule(
-                new CustomSamplingRule(
+                new LocalCustomSamplingRule(
                     rate: 0.5f,
-                    SamplingRuleProvenance.Local,
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -134,7 +134,7 @@ namespace Datadog.Trace.Tests.Sampling
         public async Task No_Registered_Rules_Uses_Legacy_Rates()
         {
             var sampler = new TraceSampler(new NoLimits());
-            sampler.RegisterRule(new AgentSamplingRule());
+            sampler.RegisterAgentSamplingRule(new AgentSamplingRule());
             sampler.SetDefaultSampleRates(MockAgentRates);
 
             await RunSamplerTest(
@@ -156,7 +156,7 @@ namespace Datadog.Trace.Tests.Sampling
 
             var span = scope.Span;
             var sampler = new TraceSampler(new NoLimits());
-            sampler.RegisterRule(new AgentSamplingRule());
+            sampler.RegisterAgentSamplingRule(new AgentSamplingRule());
 
             // if there are no other rules, and before we have agent rates, mechanism is "Default"
             var (_, mechanism1) = sampler.MakeSamplingDecision(span);

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests_SetSamplingDecision.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests_SetSamplingDecision.cs
@@ -15,7 +15,7 @@ public class TraceContextTests_SetSamplingDecision
         [Theory]
         [InlineData(SamplingPriorityValues.AutoKeep, SamplingMechanism.Default)]
         [InlineData(SamplingPriorityValues.AutoKeep, SamplingMechanism.AgentRate)]
-        [InlineData(SamplingPriorityValues.AutoReject, SamplingMechanism.TraceSamplingRule)]
+        [InlineData(SamplingPriorityValues.AutoReject, SamplingMechanism.LocalTraceSamplingRule)]
         [InlineData(SamplingPriorityValues.UserReject, SamplingMechanism.Manual)]
         [InlineData(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm)]
         public void SetSamplingDecision(int samplingPriority, int samplingMechanism)


### PR DESCRIPTION
## Summary of changes

Add support for receiving sampling rules via remote configuration (RCM). Implements "Adaptive Sampling."

## Reason for change

New feature

## Implementation details

- subscribe to RCM capability 29.
- add `SamplingRules` to `DynamicSettings` and `ImmutableDynamicSettings`
- split `CustomSamplingRule` into `LocalCustomSamplingRule` and `RemoteCustomSamplingRule`
- parse `tracing_sampling_rules` from RCM into list of `RemoteCustomSamplingRule`

## Test coverage

- added several unit and integration tests
- expanded existing tests to include remote sampling rules

## Other details
- [RFC](https://docs.google.com/document/d/12lXVniuaYenanxnpt5gJJ76a1X7gFOfmCYVQVXlHNco/edit)
- [APMAPI-14](https://datadoghq.atlassian.net/browse/APMAPI-14)

PRs:
1. #5477
2. #5545
3. #5306
4. (this one) #5453

<!-- Fixes #{issue} -->



[APMAPI-14]: https://datadoghq.atlassian.net/browse/APMAPI-14?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ