### PR TITLE
Add try/finally to Msmq integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MsmqCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/MsmqCommon.cs
@@ -36,17 +36,27 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
                 tags.Command = command;
                 try
                 {
-                    tags.Path = messageQueue.Path;
-                    tags.Host = messageQueue.MachineName;
-                    tags.IsTransactionalQueue = messageQueue.Transactional.ToString();
                 }
-                catch
+                finally
                 {
-                    // Depending on the permissions available, messageQueue.Transactional may throw
-                    // a MessageQueueException. The Path and machine name are apparently fraught
-                    // with potential issues too, so playing it safe and swallowing any issues here
-                    // We could consider diving into the internals to fish out the value, but not
-                    // worth it IMO, especially as that would effectively bypass a "security" feature
+                    // MessageQueue.Path and MessageQueue.MachineName are not resilient to ThreadAbortException
+                    // This is technically not *our* problem, but at the same time maybe those methods wouldn't
+                    // be called at all if it wasn't for us. So let's play safe.
+
+                    try
+                    {
+                        tags.Path = messageQueue.Path;
+                        tags.Host = messageQueue.MachineName;
+                        tags.IsTransactionalQueue = messageQueue.Transactional.ToString();
+                    }
+                    catch
+                    {
+                        // Depending on the permissions available, messageQueue.Transactional may throw
+                        // a MessageQueueException. The Path and machine name are apparently fraught
+                        // with potential issues too, so playing it safe and swallowing any issues here
+                        // We could consider diving into the internals to fish out the value, but not
+                        // worth it IMO, especially as that would effectively bypass a "security" feature
+                    }
                 }
 
                 if (isMessagePartOfTransaction.HasValue)
@@ -58,7 +68,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq
 
                 var span = scope.Span;
                 span.Type = SpanTypes.Queue;
-                span.ResourceName = $"{command} {messageQueue.Path}";
+                span.ResourceName = $"{command} {tags.Path}";
 
                 // TODO: PBT: I think this span should be measured when span kind is consumer or producer
                 tracer.CurrentTraceSettings.Schema.RemapPeerService(tags);


### PR DESCRIPTION
## Summary of changes

Move `MessageQueue.Path` and `MessageQueue.MachineName` in a finally block.

## Reason for change

`MessageQueue.Path` and `MessageQueue.MachineName` and up calling [GenerateQueueProperties](https://referencesource.microsoft.com/System.Messaging/R/77ec140bf934299e.html) which is an odd method because the call to `Properties.Unlock` is not wrapped in a finally block, making it vulnerable to ThreadAbortException. In the `Receive` and `Send` method, the call to unlock *is* in a finally block.

I have no evidence that it could actually be a problem, but I have seen a memory dump with ThreadAbortExceptions and traces of leaked memory in MSMQ, so it clicked together. We don't have anything to lose by doing it, anyway.

We could argue that it's not really our problem if somebody is aborting threads, but at the same time it's very unlikely that our customers would call those properties themselves, so we're making their aborts more unsafe.

## Implementation details

We were also calling `MessageQueue.Path` outside of the try/catch block so I fixed that.
