### PR TITLE
[APM] Add git reference to application telemetry

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -72,7 +72,7 @@ namespace Datadog.Trace.Ci
 
         protected override IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager, ITelemetryController telemetry)
         {
-            return new CIGitMetadataTagsProvider();
+            return new CIGitMetadataTagsProvider(telemetry);
         }
 
         protected override ITraceSampler GetSampler(ImmutableTracerSettings settings)

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -65,9 +65,9 @@ namespace Datadog.Trace.Ci
             }
         }
 
-        protected override ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService)
+        protected override ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider)
         {
-            return TelemetryFactory.Instance.CreateCiVisibilityTelemetryController(settings, discoveryService, isAgentAvailable: !_settings.Agentless);
+            return TelemetryFactory.Instance.CreateCiVisibilityTelemetryController(settings, discoveryService, isAgentAvailable: !_settings.Agentless, gitMetadataTagsProvider);
         }
 
         protected override IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager)

--- a/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/Ci/CITracerManagerFactory.cs
@@ -65,12 +65,12 @@ namespace Datadog.Trace.Ci
             }
         }
 
-        protected override ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider)
+        protected override ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService)
         {
-            return TelemetryFactory.Instance.CreateCiVisibilityTelemetryController(settings, discoveryService, isAgentAvailable: !_settings.Agentless, gitMetadataTagsProvider);
+            return TelemetryFactory.Instance.CreateCiVisibilityTelemetryController(settings, discoveryService, isAgentAvailable: !_settings.Agentless);
         }
 
-        protected override IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager)
+        protected override IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager, ITelemetryController telemetry)
         {
             return new CIGitMetadataTagsProvider();
         }

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIGitMetadataTagsProvider.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIGitMetadataTagsProvider.cs
@@ -7,16 +7,25 @@
 using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Ci.CiEnvironment;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Telemetry;
 
 namespace Datadog.Trace.Ci.Configuration;
 
 internal class CIGitMetadataTagsProvider : IGitMetadataTagsProvider
 {
+    private readonly ITelemetryController _telemetry;
+
+    public CIGitMetadataTagsProvider(ITelemetryController telemetry)
+    {
+        _telemetry = telemetry;
+    }
+
     public bool TryExtractGitMetadata([NotNullWhen(true)] out GitMetadata? gitMetadata)
     {
         if (CIEnvironmentValues.Instance is { Commit: { Length: > 0 } commit, Repository: { Length: > 0 } repository })
         {
             gitMetadata = new GitMetadata(commit, repository);
+            _telemetry.RecordGitMetadata(gitMetadata);
             return true;
         }
 

--- a/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
@@ -79,7 +79,6 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
             {
                 // we have everything
                 gitMetadata = _cachedGitTags = new GitMetadata(gitCommitSha, gitRespositoryUrl);
-                _telemetry.RecordGitMetadata(gitMetadata, false);
                 // For now, we do not need to call the profiler here. The profiler is able to get those information from the environment.
                 return true;
             }
@@ -95,7 +94,7 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
                 _cachedGitTags = gitMetadata;
                 // These tags could be GitMetadata.Empty but record it anyway, as it gives us an indication
                 // that we failed to extract the information
-                _telemetry.RecordGitMetadata(gitMetadata, true);
+                _telemetry.RecordGitMetadata(gitMetadata);
                 PropagateGitMetadataToTheProfiler(gitMetadata);
                 return true;
             }

--- a/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GitMetadataTagsProvider.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Pdb;
+using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
 
 #nullable enable
@@ -18,13 +19,13 @@ namespace Datadog.Trace.Configuration;
 
 internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
 {
-    private readonly IConfigurationTelemetry _telemetry;
+    private readonly ITelemetryController _telemetry;
     private readonly ImmutableTracerSettings _immutableTracerSettings;
     private readonly IScopeManager _scopeManager;
     private GitMetadata? _cachedGitTags = null;
     private int _tryCount = 0;
 
-    public GitMetadataTagsProvider(ImmutableTracerSettings immutableTracerSettings, IScopeManager scopeManager, IConfigurationTelemetry telemetry)
+    public GitMetadataTagsProvider(ImmutableTracerSettings immutableTracerSettings, IScopeManager scopeManager, ITelemetryController telemetry)
     {
         _immutableTracerSettings = immutableTracerSettings;
         _scopeManager = scopeManager;
@@ -78,6 +79,7 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
             {
                 // we have everything
                 gitMetadata = _cachedGitTags = new GitMetadata(gitCommitSha, gitRespositoryUrl);
+                _telemetry.RecordGitMetadata(gitMetadata, false);
                 // For now, we do not need to call the profiler here. The profiler is able to get those information from the environment.
                 return true;
             }
@@ -93,8 +95,7 @@ internal class GitMetadataTagsProvider : IGitMetadataTagsProvider
                 _cachedGitTags = gitMetadata;
                 // These tags could be GitMetadata.Empty but record it anyway, as it gives us an indication
                 // that we failed to extract the information
-                _telemetry.Record(ConfigurationKeys.GitRepositoryUrl, gitMetadata.RepositoryUrl, recordValue: true, ConfigurationOrigins.Calculated);
-                _telemetry.Record(ConfigurationKeys.GitCommitSha, gitMetadata.CommitSha, recordValue: true, ConfigurationOrigins.Calculated);
+                _telemetry.RecordGitMetadata(gitMetadata, true);
                 PropagateGitMetadataToTheProfiler(gitMetadata);
                 return true;
             }

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/ApplicationTelemetryCollector.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/ApplicationTelemetryCollector.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ApplicationTelemetryCollector.cs" company="Datadog">
+// <copyright file="ApplicationTelemetryCollector.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -18,8 +18,10 @@ internal class ApplicationTelemetryCollector
 
     public void RecordTracerSettings(
         ImmutableTracerSettings tracerSettings,
-        string defaultServiceName)
+        string defaultServiceName,
+        IGitMetadataTagsProvider gitMetadataTagsProvider)
     {
+        gitMetadataTagsProvider.TryExtractGitMetadata(out var gitMetadata);
         var frameworkDescription = FrameworkDescription.Instance;
         var application = new ApplicationTelemetryData(
             serviceName: defaultServiceName,
@@ -29,7 +31,9 @@ internal class ApplicationTelemetryCollector
             languageName: TracerConstants.Language,
             languageVersion: frameworkDescription.ProductVersion,
             runtimeName: frameworkDescription.Name,
-            runtimeVersion: frameworkDescription.ProductVersion);
+            runtimeVersion: frameworkDescription.ProductVersion,
+            commitSha: gitMetadata?.CommitSha,
+            repositoryUrl: gitMetadata?.RepositoryUrl);
 
         Interlocked.Exchange(ref _applicationData, application);
 

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ApplicationTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ApplicationTelemetryData.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ApplicationTelemetryData.cs" company="Datadog">
+// <copyright file="ApplicationTelemetryData.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -9,7 +9,7 @@ namespace Datadog.Trace.Telemetry;
 
 internal class ApplicationTelemetryData
 {
-    public ApplicationTelemetryData(string serviceName, string env, string serviceVersion, string tracerVersion, string languageName, string languageVersion, string runtimeName, string runtimeVersion)
+    public ApplicationTelemetryData(string serviceName, string env, string serviceVersion, string tracerVersion, string languageName, string languageVersion, string runtimeName, string runtimeVersion, string? commitSha, string? repositoryUrl)
     {
         ServiceName = serviceName;
         Env = env;
@@ -38,4 +38,8 @@ internal class ApplicationTelemetryData
     public string RuntimeVersion { get; set; }
 
     public string? RuntimePatches { get; set; }
+
+    public string? CommitSha { get; set; }
+
+    public string? SepositoryUrl { get; set; }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ApplicationTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ApplicationTelemetryData.cs
@@ -19,6 +19,8 @@ internal class ApplicationTelemetryData
         LanguageVersion = languageVersion;
         RuntimeName = runtimeName;
         RuntimeVersion = runtimeVersion;
+        CommitSha = commitSha;
+        RepositoryUrl = repositoryUrl;
     }
 
     public string ServiceName { get; set; }
@@ -41,5 +43,5 @@ internal class ApplicationTelemetryData
 
     public string? CommitSha { get; set; }
 
-    public string? SepositoryUrl { get; set; }
+    public string? RepositoryUrl { get; set; }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
@@ -63,6 +63,6 @@ namespace Datadog.Trace.Telemetry
         /// <summary>
         /// Updates Git metadata for telemetry
         /// </summary>
-        void RecordGitMetadata(GitMetadata gitMetadata, bool fromAssmbly);
+        void RecordGitMetadata(GitMetadata gitMetadata);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/ITelemetryController.cs
@@ -59,5 +59,10 @@ namespace Datadog.Trace.Telemetry
         /// Dumps the current telemetry state to the provided filename.
         /// </summary>
         Task DumpTelemetry(string filePath);
+
+        /// <summary>
+        /// Updates Git metadata for telemetry
+        /// </summary>
+        void RecordGitMetadata(GitMetadata gitMetadata, bool fromAssmbly);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
@@ -47,5 +47,9 @@ namespace Datadog.Trace.Telemetry
         }
 
         public Task DumpTelemetry(string filePath) => Task.CompletedTask;
+
+        public void RecordGitMetadata(GitMetadata gitMetadata, bool fromAssmbly)
+        {
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/NullTelemetryController.cs
@@ -48,7 +48,7 @@ namespace Datadog.Trace.Telemetry
 
         public Task DumpTelemetry(string filePath) => Task.CompletedTask;
 
-        public void RecordGitMetadata(GitMetadata gitMetadata, bool fromAssmbly)
+        public void RecordGitMetadata(GitMetadata gitMetadata)
         {
         }
     }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -94,15 +94,12 @@ internal class TelemetryController : ITelemetryController
         _queue.Enqueue(new WorkItem(WorkItem.ItemType.EnableSending, null));
     }
 
-    public void RecordGitMetadata(GitMetadata gitMetadata, bool fromAssembly)
+    public void RecordGitMetadata(GitMetadata gitMetadata)
     {
-        _application?.RecordGitMetadata(gitMetadata);
+        _application.RecordGitMetadata(gitMetadata);
 
-        if (fromAssembly)
-        {
-            _configuration.Record(gitMetadata.RepositoryUrl, gitMetadata.RepositoryUrl, recordValue: true, ConfigurationOrigins.Calculated);
-            _configuration.Record(gitMetadata.CommitSha, gitMetadata.CommitSha, recordValue: true, ConfigurationOrigins.Calculated);
-        }
+        _configuration.Record(gitMetadata.RepositoryUrl, gitMetadata.RepositoryUrl, recordValue: true, ConfigurationOrigins.Calculated);
+        _configuration.Record(gitMetadata.CommitSha, gitMetadata.CommitSha, recordValue: true, ConfigurationOrigins.Calculated);
     }
 
     public void Start()

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryFactory.cs
@@ -59,13 +59,13 @@ namespace Datadog.Trace.Telemetry
         /// </summary>
         public static TelemetryFactory CreateFactory() => new();
 
-        public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider)
-            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings, isAgentAvailable: null), discoveryService, useCiVisibilityTelemetry: false, gitMetadataTagsProvider: gitMetadataTagsProvider);
+        public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService)
+            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings, isAgentAvailable: null), discoveryService, useCiVisibilityTelemetry: false);
 
-        public ITelemetryController CreateCiVisibilityTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService, bool isAgentAvailable, IGitMetadataTagsProvider gitMetadataTagsProvider)
-            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings, isAgentAvailable), discoveryService, useCiVisibilityTelemetry: true, gitMetadataTagsProvider: gitMetadataTagsProvider);
+        public ITelemetryController CreateCiVisibilityTelemetryController(ImmutableTracerSettings tracerSettings, IDiscoveryService discoveryService, bool isAgentAvailable)
+            => CreateTelemetryController(tracerSettings, TelemetrySettings.FromSource(GlobalConfigurationSource.Instance, Config, tracerSettings, isAgentAvailable), discoveryService, useCiVisibilityTelemetry: true);
 
-        public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, TelemetrySettings settings, IDiscoveryService discoveryService, bool useCiVisibilityTelemetry, IGitMetadataTagsProvider gitMetadataTagsProvider)
+        public ITelemetryController CreateTelemetryController(ImmutableTracerSettings tracerSettings, TelemetrySettings settings, IDiscoveryService discoveryService, bool useCiVisibilityTelemetry)
         {
             // Deliberately not a static field, because otherwise creates a circular dependency during startup
             var log = DatadogLogging.GetLoggerFor<TelemetryFactory>();
@@ -110,7 +110,7 @@ namespace Datadog.Trace.Telemetry
                 }
 
                 log.Debug("Creating telemetry controller v2");
-                return CreateController(telemetryTransports, settings, discoveryService, gitMetadataTagsProvider);
+                return CreateController(telemetryTransports, settings, discoveryService);
             }
             catch (Exception ex)
             {
@@ -157,8 +157,7 @@ namespace Datadog.Trace.Telemetry
         private ITelemetryController CreateController(
             TelemetryTransports telemetryTransports,
             TelemetrySettings settings,
-            IDiscoveryService discoveryService,
-            IGitMetadataTagsProvider gitMetadataTagsProvider)
+            IDiscoveryService discoveryService)
         {
             var transportManager = new TelemetryTransportManager(telemetryTransports, discoveryService);
             // The telemetry controller must be a singleton, so we initialize once
@@ -177,8 +176,7 @@ namespace Datadog.Trace.Telemetry
                         Metrics,
                         _logs.IsValueCreated ? _logs.Value : null, // if we haven't created it by now, we don't need it
                         transportManager,
-                        settings.HeartbeatInterval,
-                        gitMetadataTagsProvider);
+                        settings.HeartbeatInterval);
                 }
             }
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -129,7 +129,6 @@ namespace Datadog.Trace
             }
 
             telemetry ??= CreateTelemetryController(settings, discoveryService);
-            telemetry.RecordTracerSettings(settings, defaultServiceName);
 
             var gitMetadataTagsProvider = GetGitMetadataTagsProvider(settings, scopeManager, telemetry);
             logSubmissionManager = DirectLogSubmissionManager.Create(
@@ -142,6 +141,7 @@ namespace Datadog.Trace
                 settings.ServiceVersionInternal,
                 gitMetadataTagsProvider);
 
+            telemetry.RecordTracerSettings(settings, defaultServiceName);
             TelemetryFactory.Metrics.SetWafVersion(Security.Instance.DdlibWafVersion);
             ErrorData? initError = !string.IsNullOrEmpty(Security.Instance.InitializationError)
                                        ? new ErrorData(TelemetryErrorCode.AppsecConfigurationError, Security.Instance.InitializationError)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -139,7 +139,7 @@ namespace Datadog.Trace
                 settings.ServiceVersionInternal,
                 gitMetadataTagsProvider);
 
-            telemetry ??= CreateTelemetryController(settings, discoveryService);
+            telemetry ??= CreateTelemetryController(settings, discoveryService, gitMetadataTagsProvider);
             telemetry.RecordTracerSettings(settings, defaultServiceName);
 
             TelemetryFactory.Metrics.SetWafVersion(Security.Instance.DdlibWafVersion);
@@ -215,9 +215,9 @@ namespace Datadog.Trace
                 tracerFlareManager);
         }
 
-        protected virtual ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService)
+        protected virtual ITelemetryController CreateTelemetryController(ImmutableTracerSettings settings, IDiscoveryService discoveryService, IGitMetadataTagsProvider gitMetadataTagsProvider)
         {
-            return TelemetryFactory.Instance.CreateTelemetryController(settings, discoveryService);
+            return TelemetryFactory.Instance.CreateTelemetryController(settings, discoveryService, gitMetadataTagsProvider);
         }
 
         protected virtual IGitMetadataTagsProvider GetGitMetadataTagsProvider(ImmutableTracerSettings settings, IScopeManager scopeManager)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryHelperTests.cs" company="Datadog">
+// <copyright file="TelemetryHelperTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -34,7 +34,9 @@ public class TelemetryHelperTests
             "dotnet",
             FrameworkDescription.Instance.ProductVersion,
             runtimeName: "dotnet",
-            runtimeVersion: "7.0.1");
+            runtimeVersion: "7.0.1",
+            commitSha: "testCommitSha",
+            repositoryUrl: "testRepositoryUrl");
         _host = new HostTelemetryData("MY_HOST", "Windows", "x64");
     }
 

--- a/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/TelemetryTransportTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryTransportTests.cs" company="Datadog">
+// <copyright file="TelemetryTransportTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -163,7 +163,9 @@ namespace Datadog.Trace.IntegrationTests
                     languageName: "dotnet",
                     languageVersion: "1.2.3",
                     runtimeName: "dotnet",
-                    runtimeVersion: "7.0.3"),
+                    runtimeVersion: "7.0.3",
+                    commitSha: "aaaaaaaaaaaaaaaaaa",
+                    repositoryUrl: "https://github.com/myOrg/myRepo"),
                 host: new HostTelemetryData("SOME_HOST", "Windows", "x64"),
                 payload: null);
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
@@ -143,7 +143,7 @@ namespace Datadog.Trace.Tests.Telemetry
 
             public Task DumpTelemetry(string filePath) => Task.CompletedTask;
 
-            public void RecordGitMetadata(GitMetadata gitMetadata, bool fromAssmbly)
+            public void RecordGitMetadata(GitMetadata gitMetadata)
             {
             }
         }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/CallTargetInvokerTelemetryTests.cs
@@ -142,6 +142,10 @@ namespace Datadog.Trace.Tests.Telemetry
             }
 
             public Task DumpTelemetry(string filePath) => Task.CompletedTask;
+
+            public void RecordGitMetadata(GitMetadata gitMetadata, bool fromAssmbly)
+            {
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
@@ -31,6 +31,8 @@ public class ApplicationTelemetryCollectorTests
                     { ConfigurationKeys.ServiceName, ServiceName },
                     { ConfigurationKeys.Environment, env },
                     { ConfigurationKeys.ServiceVersion, serviceVersion },
+                    { ConfigurationKeys.GitCommitSha, "mySha" },
+                    { ConfigurationKeys.GitRepositoryUrl, "https://github.com/gitOrg/gitRepo" },
                 }),
             configurationTelemetry);
 
@@ -38,7 +40,7 @@ public class ApplicationTelemetryCollectorTests
 
         collector.GetApplicationData().Should().BeNull();
 
-        collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName, new TelemetryControllerTests.TestGitMetadataTagsProvider());
+        collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName);
 
         // calling twice should give same results
         AssertData(collector.GetApplicationData());
@@ -80,7 +82,7 @@ public class ApplicationTelemetryCollectorTests
 
         collector.GetApplicationData().Should().BeNull();
 
-        collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName, new NullGitMetadataProvider());
+        collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName);
 
         // calling twice should give same results
         AssertData(collector.GetApplicationData());
@@ -115,6 +117,8 @@ public class ApplicationTelemetryCollectorTests
                     { ConfigurationKeys.ServiceName, ServiceName },
                     { ConfigurationKeys.Environment, env },
                     { ConfigurationKeys.ServiceVersion, serviceVersion },
+                    { ConfigurationKeys.GitCommitSha, "mySha" },
+                    { ConfigurationKeys.GitRepositoryUrl, "https://github.com/gitOrg/gitRepo" },
                 }),
             configurationTelemetry);
 
@@ -122,7 +126,7 @@ public class ApplicationTelemetryCollectorTests
 
         collector.GetHostData().Should().BeNull();
 
-        collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName, new NullGitMetadataProvider());
+        collector.RecordTracerSettings(new ImmutableTracerSettings(settings), ServiceName);
 
         // calling twice should give same results
         AssertData(collector.GetHostData());

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
@@ -97,8 +97,8 @@ public class ApplicationTelemetryCollectorTests
             data.LanguageVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
             data.RuntimeName.Should().NotBeNullOrEmpty().And.Be(FrameworkDescription.Instance.Name);
             data.RuntimeVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
-            data.CommitSha.Should().Be("mySha");
-            data.RepositoryUrl.Should().Be("https://github.com/gitOrg/gitRepo");
+            data.CommitSha.Should().BeEmpty();
+            data.RepositoryUrl.Should().BeEmpty();
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
@@ -99,8 +99,8 @@ public class ApplicationTelemetryCollectorTests
             data.LanguageVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
             data.RuntimeName.Should().NotBeNullOrEmpty().And.Be(FrameworkDescription.Instance.Name);
             data.RuntimeVersion.Should().Be(FrameworkDescription.Instance.ProductVersion);
-            data.CommitSha.Should().BeEmpty();
-            data.RepositoryUrl.Should().BeEmpty();
+            data.CommitSha.Should().BeNull();
+            data.RepositoryUrl.Should().BeNull();
         }
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -70,7 +70,7 @@ public class TelemetryControllerTests
 
         var sha = "testCommitSha";
         var repo = "testRepositoryUrl";
-        controller.RecordGitMetadata(new GitMetadata(sha, repo), true);
+        controller.RecordGitMetadata(new GitMetadata(sha, repo));
         controller.Start();
 
         var data = await WaitForRequestStarted(transport, _timeout);

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryDataBuilderTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryDataBuilderTests.cs" company="Datadog">
+// <copyright file="TelemetryDataBuilderTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -32,7 +32,9 @@ public class TelemetryDataBuilderTests
             languageName: "dotnet",
             languageVersion: FrameworkDescription.Instance.ProductVersion,
             runtimeName: FrameworkDescription.Instance.Name,
-            runtimeVersion: FrameworkDescription.Instance.ProductVersion);
+            runtimeVersion: FrameworkDescription.Instance.ProductVersion,
+            commitSha: "testCommitSha",
+            repositoryUrl: "testRepositoryUrl");
         _host = new HostTelemetryData("MY_MACHINE", "Windows", "arm64");
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TelemetryFactoryTests.cs" company="Datadog">
+// <copyright file="TelemetryFactoryTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -14,6 +14,7 @@ using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
 using Xunit.Sdk;
+using static Datadog.Trace.Tests.Telemetry.TelemetryControllerTests;
 
 namespace Datadog.Trace.Tests.Telemetry;
 
@@ -22,6 +23,8 @@ namespace Datadog.Trace.Tests.Telemetry;
 [TelemetryRestorer]
 public class TelemetryFactoryTests
 {
+    private readonly IGitMetadataTagsProvider _gitMetadataTagsProvider = new NullGitMetadataProvider();
+
     [Fact]
     public void TelemetryFactory_DisabledIfTelemetryIsDisabled()
     {
@@ -37,7 +40,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
 
         controller.Should().Be(NullTelemetryController.Instance);
     }
@@ -57,7 +60,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
 
         controller.Should().Be(NullTelemetryController.Instance);
     }
@@ -81,7 +84,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
 
         controller.Should().BeOfType<TelemetryController>();
         TelemetryFactory.Config.Should().BeOfType<ConfigurationTelemetry>();
@@ -106,7 +109,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
 
         TelemetryFactory.Metrics.Should().BeOfType<NullMetricsTelemetryCollector>();
     }
@@ -131,7 +134,7 @@ public class TelemetryFactoryTests
             metricsEnabled: true,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
 
         TelemetryFactory.Metrics.Should().Be(metricsTelemetryCollector);
     }
@@ -156,7 +159,7 @@ public class TelemetryFactoryTests
             metricsEnabled: true,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: true);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: true, _gitMetadataTagsProvider);
 
         TelemetryFactory.Metrics
                         .Should()
@@ -186,7 +189,7 @@ public class TelemetryFactoryTests
             debugEnabled: false);
 
         // First controller
-        var controller1 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
+        var controller1 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
         var metrics1 = TelemetryFactory.Metrics;
         var config1 = TelemetryFactory.Config;
 
@@ -205,7 +208,7 @@ public class TelemetryFactoryTests
         var v1Controller1 = controller1.Should().BeOfType<TelemetryController>().Subject;
 
         // Second controller
-        var controller2 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
+        var controller2 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
         var metrics2 = TelemetryFactory.Metrics;
         var config2 = TelemetryFactory.Config;
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
@@ -23,8 +23,6 @@ namespace Datadog.Trace.Tests.Telemetry;
 [TelemetryRestorer]
 public class TelemetryFactoryTests
 {
-    private readonly IGitMetadataTagsProvider _gitMetadataTagsProvider = new NullGitMetadataProvider();
-
     [Fact]
     public void TelemetryFactory_DisabledIfTelemetryIsDisabled()
     {
@@ -40,7 +38,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
 
         controller.Should().Be(NullTelemetryController.Instance);
     }
@@ -60,7 +58,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
 
         controller.Should().Be(NullTelemetryController.Instance);
     }
@@ -84,7 +82,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
 
         controller.Should().BeOfType<TelemetryController>();
         TelemetryFactory.Config.Should().BeOfType<ConfigurationTelemetry>();
@@ -109,7 +107,7 @@ public class TelemetryFactoryTests
             metricsEnabled: false,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
 
         TelemetryFactory.Metrics.Should().BeOfType<NullMetricsTelemetryCollector>();
     }
@@ -134,7 +132,7 @@ public class TelemetryFactoryTests
             metricsEnabled: true,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
 
         TelemetryFactory.Metrics.Should().Be(metricsTelemetryCollector);
     }
@@ -159,7 +157,7 @@ public class TelemetryFactoryTests
             metricsEnabled: true,
             debugEnabled: false);
 
-        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: true, _gitMetadataTagsProvider);
+        var controller = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: true);
 
         TelemetryFactory.Metrics
                         .Should()
@@ -189,7 +187,7 @@ public class TelemetryFactoryTests
             debugEnabled: false);
 
         // First controller
-        var controller1 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
+        var controller1 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
         var metrics1 = TelemetryFactory.Metrics;
         var config1 = TelemetryFactory.Config;
 
@@ -208,7 +206,7 @@ public class TelemetryFactoryTests
         var v1Controller1 = controller1.Should().BeOfType<TelemetryController>().Subject;
 
         // Second controller
-        var controller2 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false, _gitMetadataTagsProvider);
+        var controller2 = factory.CreateTelemetryController(tracerSettings, settings, NullDiscoveryService.Instance, useCiVisibilityTelemetry: false);
         var metrics2 = TelemetryFactory.Metrics;
         var config2 = TelemetryFactory.Config;
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Transports/JsonTelemetryTransportTests.cs
@@ -35,7 +35,9 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                     languageName: "node.js",
                     languageVersion: "14.16.1",
                     runtimeName: "dotnet",
-                    runtimeVersion: "7.0.3"),
+                    runtimeVersion: "7.0.3",
+                    commitSha: "testCommitSha",
+                    repositoryUrl: "testRepositoryUrl"),
                 host: new HostTelemetryData(
                     hostname: "i-09ecf74c319c49be8",
                     os: "GNU/Linux",
@@ -96,7 +98,9 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                     languageName: "node.js",
                     languageVersion: "14.16.1",
                     runtimeName: "dotnet",
-                    runtimeVersion: "7.0.3"),
+                    runtimeVersion: "7.0.3",
+                    commitSha: "testCommitSha",
+                    repositoryUrl: "testRepositoryUrl"),
                 host: new HostTelemetryData(
                     hostname: "i-09ecf74c319c49be8",
                     os: "GNU/Linux",
@@ -165,7 +169,9 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                     languageName: "node.js",
                     languageVersion: "14.16.1",
                     runtimeName: "dotnet",
-                    runtimeVersion: "7.0.3"),
+                    runtimeVersion: "7.0.3",
+                    commitSha: "testCommitSha",
+                    repositoryUrl: "testRepositoryUrl"),
                 host: new HostTelemetryData(
                     hostname: "i-09ecf74c319c49be8",
                     os: "GNU/Linux",
@@ -229,7 +235,9 @@ namespace Datadog.Trace.Tests.Telemetry.Transports
                     languageName: "node.js",
                     languageVersion: "14.16.1",
                     runtimeName: "dotnet",
-                    runtimeVersion: "7.0.3"),
+                    runtimeVersion: "7.0.3",
+                    commitSha: "testCommitSha",
+                    repositoryUrl: "testRepositoryUrl"),
                 host: new HostTelemetryData(
                     hostname: "i-09ecf74c319c49be8",
                     os: "GNU/Linux",

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_app-started.json
@@ -13,7 +13,9 @@
     "service_version": "1.2.3",
     "language_version": "14.16.1",
     "runtime_name": "dotnet",
-    "runtime_version": "7.0.3"
+    "runtime_version": "7.0.3",
+    "commit_sha": "testCommitSha",
+    "repository_url": "testRepositoryUrl"
   },
   "host": {
     "hostname": "i-09ecf74c319c49be8",

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_distributions.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_distributions.json
@@ -12,7 +12,9 @@
     "service_version": "1.2.3",
     "language_version": "14.16.1",
     "runtime_name": "dotnet",
-    "runtime_version": "7.0.3"
+    "runtime_version": "7.0.3",
+    "commit_sha": "testCommitSha",
+    "repository_url": "testRepositoryUrl"
   },
   "host": {
     "hostname": "i-09ecf74c319c49be8",

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_generate-metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_generate-metrics.json
@@ -12,7 +12,9 @@
     "service_version": "1.2.3",
     "language_version": "14.16.1",
     "runtime_name": "dotnet",
-    "runtime_version": "7.0.3"
+    "runtime_version": "7.0.3",
+    "commit_sha": "testCommitSha",
+    "repository_url": "testRepositoryUrl"
   },
   "host": {
     "hostname": "i-09ecf74c319c49be8",

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_message-batch.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/telemetry_message-batch.json
@@ -13,7 +13,9 @@
     "service_version": "1.2.3",
     "language_version": "14.16.1",
     "runtime_name": "dotnet",
-    "runtime_version": "7.0.3"
+    "runtime_version": "7.0.3",
+    "commit_sha": "testCommitSha",
+    "repository_url": "testRepositoryUrl"
   },
   "host": {
     "hostname": "i-09ecf74c319c49be8",


### PR DESCRIPTION
## Summary of changes
Added sha and repo info to telemetry Application data if present

## Reason for change
[https://datadoghq.atlassian.net/browse/APPSEC-52677](https://datadoghq.atlassian.net/browse/APPSEC-52677)
[https://datadoghq.atlassian.net/browse/APMA-65](https://datadoghq.atlassian.net/browse/APMA-65)
It's an OKR

## Implementation details
Added a dependency to `IGitMetadataTagsProvider` to `TelemetryController`.
Added sha and repo fields to telemetry and fill them with the provided `IGitMetadataTagsProvider` instance

## Test coverage
Fixed existing tests to reflect new values and added tests for other situations, like the absence of git ref data

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
