### PR TITLE
[Dynamic Instrumentation] Check specific path for diagnostics upload

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.Debugger.Upload
 {
     internal class DiagnosticsUploadApi : DebuggerUploadApiBase
     {
+        private const string LegacyEndpoint = "debugger/v1/input";
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DiagnosticsUploadApi>();
 
         private readonly IApiRequestFactory _apiRequestFactory;
@@ -60,20 +61,22 @@ namespace Datadog.Trace.Debugger.Upload
 
         private Task<IApiResponse> PostAsync(string uri, ArraySegment<byte> data)
         {
-            if (uri.Contains("diagnostics"))
+            var isLegacy = uri.Contains(LegacyEndpoint);
+            if (isLegacy)
             {
-                var multipart = _apiRequestFactory.Create(new Uri(uri));
-
-                return
-                    multipart
-                         .PostAsync(new MultipartFormItem[]
-                          {
-                              new("event", MimeTypes.Json, "event.json", data)
-                          });
+                return _apiRequestFactory
+                      .Create(new Uri(uri))
+                      .PostAsync(data, MimeTypes.Json);
             }
 
-            var request = _apiRequestFactory.Create(new Uri(uri));
-            return request.PostAsync(data, MimeTypes.Json);
+            var multipart = _apiRequestFactory.Create(new Uri(uri));
+
+            return
+                    multipart
+                   .PostAsync(new MultipartFormItem[]
+                    {
+                        new("event", MimeTypes.Json, "event.json", data)
+                    });
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Upload/DiagnosticsUploadApi.cs
@@ -61,22 +61,15 @@ namespace Datadog.Trace.Debugger.Upload
 
         private Task<IApiResponse> PostAsync(string uri, ArraySegment<byte> data)
         {
+            var request = _apiRequestFactory.Create(new Uri(uri));
             var isLegacy = uri.Contains(LegacyEndpoint);
-            if (isLegacy)
-            {
-                return _apiRequestFactory
-                      .Create(new Uri(uri))
-                      .PostAsync(data, MimeTypes.Json);
-            }
 
-            var multipart = _apiRequestFactory.Create(new Uri(uri));
-
-            return
-                    multipart
-                   .PostAsync(new MultipartFormItem[]
-                    {
-                        new("event", MimeTypes.Json, "event.json", data)
-                    });
+            return isLegacy ?
+                request.PostAsync(data, MimeTypes.Json) :
+                request.PostAsync(new MultipartFormItem[]
+                {
+                    new("event", MimeTypes.Json, "event.json", data)
+                });
         }
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiRequest.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiRequest.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestApiRequest.cs" company="Datadog">
+// <copyright file="TestApiRequest.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Agent.Transports;
@@ -32,6 +33,8 @@ internal class TestApiRequest : IApiRequest
 
     public Uri Endpoint { get; }
 
+    public string ContentType { get; private set; }
+
     public Dictionary<string, string> ExtraHeaders { get; } = new();
 
     public List<TestApiResponse> Responses { get; } = new();
@@ -56,6 +59,7 @@ internal class TestApiRequest : IApiRequest
     {
         var response = new TestApiResponse(_statusCode, _responseContent, _responseContentType);
         Responses.Add(response);
+        ContentType = contentType;
 
         return Task.FromResult((IApiResponse)response);
     }
@@ -69,8 +73,19 @@ internal class TestApiRequest : IApiRequest
         }
     }
 
-    public Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None)
+    public async Task<IApiResponse> PostAsync(MultipartFormItem[] items, MultipartCompression multipartCompression = MultipartCompression.None)
     {
-        throw new NotImplementedException();
+        var boundary = "----not implemented" + Guid.NewGuid().ToString("N");
+        var contentType = ContentTypeHelper.GetContentType("multipart/form-data", boundary);
+
+        return await PostAsync(
+                   async stream =>
+                   {
+                       using var writer = new StreamWriter(stream, Encoding.UTF8);
+                       await writer.WriteAsync("not implemented \r\n");
+                   },
+                   contentType,
+                   "utf-8",
+                   boundary);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DiagnosticsUploadApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DiagnosticsUploadApiTests.cs
@@ -1,0 +1,53 @@
+// <copyright file="DiagnosticsUploadApiTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Debugger.Upload;
+using Datadog.Trace.TestHelpers.TransportHelpers;
+using Datadog.Trace.Tests.Agent;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Debugger;
+
+public class DiagnosticsUploadApiTests
+{
+    private readonly TestRequestFactory _testRequestFactory;
+    private readonly DiscoveryServiceMock _discoveryServiceMock;
+    private readonly NullGitMetadataProvider _nullGitMetadataProvider;
+    private readonly ArraySegment<byte> _data;
+
+    public DiagnosticsUploadApiTests()
+    {
+        _testRequestFactory = new TestRequestFactory();
+        _discoveryServiceMock = new DiscoveryServiceMock();
+        _nullGitMetadataProvider = new NullGitMetadataProvider();
+        _data = new ArraySegment<byte>(Encoding.UTF8.GetBytes("str"));
+    }
+
+    [Fact]
+    public async Task DiagnosticsLegacy_RequestSentAsJson()
+    {
+        var api = DiagnosticsUploadApi.Create(_testRequestFactory, _discoveryServiceMock, _nullGitMetadataProvider);
+        _discoveryServiceMock.TriggerChange(diagnosticsEndpoint: "debugger/v1/input");
+
+        await api.SendBatchAsync(_data);
+        _testRequestFactory.RequestsSent.First().ContentType.Should().StartWith("application/json");
+    }
+
+    [Fact]
+    public async Task DiagnosticsUpToDat_RequestSentAsMultipart()
+    {
+        var api = DiagnosticsUploadApi.Create(_testRequestFactory, _discoveryServiceMock, _nullGitMetadataProvider);
+        _discoveryServiceMock.TriggerChange(diagnosticsEndpoint: "debugger/v1/diagnostics");
+
+        await api.SendBatchAsync(_data);
+        _testRequestFactory.RequestsSent.First().ContentType.Should().StartWith("multipart/form-data");
+    }
+}


### PR DESCRIPTION
## Summary of changes
Send by default for the updated endpoint, instead of legacy.
Better path checking for legacy

## Reason for change
Comment resolve for https://github.com/DataDog/dd-trace-dotnet/pull/5456#discussion_r1568606142
