### PR TITLE
[Dynamic Instrumentation] DEBUG-2320 Support pointer and pinned local

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -380,6 +380,18 @@ std::tuple<unsigned, int> TypeSignature::GetElementTypeAndFlags() const
 
     PCCOR_SIGNATURE pbCur = &pbBase[offset];
 
+    if (*pbCur == ELEMENT_TYPE_PTR)
+    {
+        pbCur++;
+        typeFlags |= TypeFlagByRef;
+    }
+
+    if (*pbCur == ELEMENT_TYPE_PINNED)
+    {
+        pbCur++;
+        typeFlags |= TypeFlagPinnedType;
+    }
+
     if (*pbCur == ELEMENT_TYPE_VOID)
     {
         typeFlags |= TypeFlagVoid;
@@ -433,6 +445,11 @@ mdToken TypeSignature::GetTypeTok(const ComPtr<IMetaDataEmit2>& pEmit, mdAssembl
     mdToken token = mdTokenNil;
     PCCOR_SIGNATURE pbCur = &pbBase[offset];
     const PCCOR_SIGNATURE pStart = pbCur;
+
+    if (*pbCur == ELEMENT_TYPE_PTR || *pbCur == ELEMENT_TYPE_PINNED)
+    {
+        pbCur++;
+    }
 
     if (*pbCur == ELEMENT_TYPE_BYREF)
     {

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.h
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.h
@@ -448,7 +448,8 @@ enum MethodArgumentTypeFlag
 {
     TypeFlagByRef = 0x01,
     TypeFlagVoid = 0x02,
-    TypeFlagBoxedType = 0x04
+    TypeFlagBoxedType = 0x04,
+    TypeFlagPinnedType = 0x08
 };
 
 // Represents a segment inside a larger signature (Method Signature / Local Var Signature) of

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -116,6 +116,13 @@ HRESULT DebuggerMethodRewriter::WriteCallsToLogArgOrLocal(
             continue;
         }
 
+        if (argTypeFlags & ELEMENT_TYPE_PINNED)
+        {
+            Logger::Warn("DebuggerRewriter: Skipped ", isArgs ? "argument" : "local", " index = ", argOrLocalIndex,
+                         " because it's a pinned local.");
+            continue;
+        }
+
         if (isArgs)
         {
             hr = LoadArgument(isStatic, rewriterWrapper, argOrLocalIndex, argOrLocal);

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -116,7 +116,7 @@ HRESULT DebuggerMethodRewriter::WriteCallsToLogArgOrLocal(
             continue;
         }
 
-        if (argTypeFlags & ELEMENT_TYPE_PINNED)
+        if (argTypeFlags & TypeFlagPinnedType)
         {
             Logger::Warn("DebuggerRewriter: Skipped ", isArgs ? "argument" : "local", " index = ", argOrLocalIndex,
                          " because it's a pinned local.");

--- a/tracer/src/Datadog.Tracer.Native/debugger_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_tokens.cpp
@@ -110,11 +110,17 @@ HRESULT DebuggerTokens::WriteLogArgOrLocal(void* rewriterWrapperPtr, const TypeS
     {
         PCCOR_SIGNATURE argSigBuff;
         auto signatureSize = argOrLocal.GetSignature(argSigBuff);
-        if (argSigBuff[0] == ELEMENT_TYPE_BYREF)
+        if (argSigBuff[0] == ELEMENT_TYPE_BYREF || argSigBuff[0] == ELEMENT_TYPE_PTR)
         {
             argumentSignatureBuffer = argSigBuff + 1;
             argumentSignatureSize = signatureSize - 1;
             signatureLength += signatureSize - 1;
+        }
+        else if (argSigBuff[0] == ELEMENT_TYPE_PINNED)
+        {
+            argumentSignatureBuffer = argSigBuff + 2;
+            argumentSignatureSize = signatureSize - 2;
+            signatureLength += signatureSize - 2;
         }
         else
         {
@@ -1426,17 +1432,11 @@ HRESULT DebuggerTokens::WriteRentArray(void* rewriterWrapperPtr, const TypeSigna
     {
         PCCOR_SIGNATURE argSigBuff;
         auto signatureSize = type.GetSignature(argSigBuff);
-        if (argSigBuff[0] == ELEMENT_TYPE_BYREF || argSigBuff[0] == ELEMENT_TYPE_PTR)
+        if (argSigBuff[0] == ELEMENT_TYPE_BYREF)
         {
             argumentSignatureBuffer = argSigBuff + 1;
             argumentSignatureSize = signatureSize - 1;
             signatureLength += signatureSize - 1;
-        }
-        else if (argSigBuff[0] == ELEMENT_TYPE_PINNED)
-        {
-            argumentSignatureBuffer = argSigBuff + 2;
-            argumentSignatureSize = signatureSize - 2;
-            signatureLength += signatureSize - 2;
         }
         else
         {

--- a/tracer/src/Datadog.Tracer.Native/debugger_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_tokens.cpp
@@ -142,7 +142,7 @@ HRESULT DebuggerTokens::WriteLogArgOrLocal(void* rewriterWrapperPtr, const TypeS
                                                           &logArgMethodSpec);
     if (FAILED(hr))
     {
-        Logger::Warn("Error creating log exception method spec.");
+        Logger::Warn("Error creating LogArg or LogLocal method spec.");
         return hr;
     }
 
@@ -1426,11 +1426,17 @@ HRESULT DebuggerTokens::WriteRentArray(void* rewriterWrapperPtr, const TypeSigna
     {
         PCCOR_SIGNATURE argSigBuff;
         auto signatureSize = type.GetSignature(argSigBuff);
-        if (argSigBuff[0] == ELEMENT_TYPE_BYREF)
+        if (argSigBuff[0] == ELEMENT_TYPE_BYREF || argSigBuff[0] == ELEMENT_TYPE_PTR)
         {
             argumentSignatureBuffer = argSigBuff + 1;
             argumentSignatureSize = signatureSize - 1;
             signatureLength += signatureSize - 1;
+        }
+        else if (argSigBuff[0] == ELEMENT_TYPE_PINNED)
+        {
+            argumentSignatureBuffer = argSigBuff + 2;
+            argumentSignatureSize = signatureSize - 2;
+            signatureLength += signatureSize - 2;
         }
         else
         {
@@ -1458,7 +1464,7 @@ HRESULT DebuggerTokens::WriteRentArray(void* rewriterWrapperPtr, const TypeSigna
                                                           &logArgMethodSpec);
     if (FAILED(hr))
     {
-        Logger::Warn("Error creating log exception method spec.");
+        Logger::Warn("Error creating RentArray method spec.");
         return hr;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/method_rewriter.cpp
@@ -301,9 +301,9 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
                 reWriterWrapper.BeginLoadValueIntoArray(i);
                 reWriterWrapper.LoadArgument(i + (isStatic ? 0 : 1));
                 const auto [elementType, argTypeFlags] = methodArguments[i].GetElementTypeAndFlags();
-                if (argTypeFlags & TypeFlagByRef)
+                if (argTypeFlags & TypeFlagByRef || argTypeFlags & TypeFlagPinnedType)
                 {
-                    Logger::Warn("*** CallTarget_RewriterCallback(): Methods with ref parameters "
+                    Logger::Warn("*** CallTarget_RewriterCallback(): Methods with ref parameters or pinned locals"
                         "cannot be instrumented. ");
                     return S_FALSE;
                 }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PinnedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PinnedLocal.verified.txt
@@ -1,0 +1,57 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "this": {
+                "type": "PinnedLocal",
+                "value": "PinnedLocal"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "this": {
+                "type": "PinnedLocal",
+                "value": "PinnedLocal"
+              }
+            },
+            "locals": {
+              "p": {
+                "type": "Char",
+                "value": "h"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "MethodWithPinnedLocal",
+            "type": "Samples.Probes.TestRuns.SmokeTests.PinnedLocal"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "MethodWithPinnedLocal",
+      "name": "Samples.Probes.TestRuns.SmokeTests.PinnedLocal",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.PinnedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.PinnedLocal.verified.txt
@@ -1,0 +1,16 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/Samples.Probes.TestRuns.csproj
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/Samples.Probes.TestRuns.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Samples.Probes.External\Samples.Probes.External.csproj" />
   </ItemGroup>

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/PinnedLocal.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/PinnedLocal.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    internal class PinnedLocal : IRun
+    {
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Run()
+        {
+            MethodWithPinnedLocal();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        [LogMethodProbeTestData]
+        public unsafe void MethodWithPinnedLocal()
+        {
+            fixed (char* p = "hello")
+            {
+                Console.WriteLine(*p);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
Support this:

```
fixed (char* p = "hello")
{
    Console.WriteLine(*p);
}
```

## Test coverage
`PinnedLocal.cs`
