### PR TITLE
Fix dotnet_tool build

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3417,6 +3417,8 @@ stages:
 
     - script: tracer\build.cmd CreateBundleHome BuildBundleNuget BuildRunnerTool PackRunnerToolNuget BuildStandaloneTool BuildBenchmarkNuget
       displayName: Build Bundle, Benchmark NuGet and tools
+      env:
+        MSBUILDDISABLENODEREUSE: "1"
 
     - publish: $(artifacts)/nuget/bundle
       displayName: Uploading Bundle package

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -427,7 +427,8 @@ partial class Build : NukeBuild
                 .SetNoWarnDotNetCore3()
                 .SetDDEnvironmentVariables("dd-trace-dotnet-runner-tool")
                 .SetProperty("PackageOutputPath", ArtifactsDirectory / "nuget" / "dd-trace")
-                .SetProperty("BuildStandalone", "false"));
+                .SetProperty("BuildStandalone", "false")
+                .SetProcessEnvironmentVariable("MSBUILDDISABLENODEREUSE", "1"));
         });
 
     Target PackRunnerToolNuget => _ => _
@@ -445,7 +446,8 @@ partial class Build : NukeBuild
                 .SetProperty("BuildStandalone", "false")
                 .SetProperty("DebugSymbols", "False")
                 .SetProperty("DebugType", "None")
-                .SetProperty("GenerateDocumentationFile", "False"));
+                .SetProperty("GenerateDocumentationFile", "False")
+                .SetProcessEnvironmentVariable("MSBUILDDISABLENODEREUSE", "1"));
         });
 
     Target BuildStandaloneTool => _ => _
@@ -480,6 +482,7 @@ partial class Build : NukeBuild
                 .SetProperty("DebugSymbols", "False")
                 .SetProperty("DebugType", "None")
                 .SetProperty("GenerateDocumentationFile", "False")
+                .SetProcessEnvironmentVariable("MSBUILDDISABLENODEREUSE", "1")
                 .CombineWith(runtimes, (c, runtime) => c
                                 .SetProperty("PublishDir", runtime.output)
                                 .SetRuntime(runtime.rid)));


### PR DESCRIPTION
## Summary of changes

Update the `dotnet_tool` build stage to disable MSBuild Node Reuse

## Reason for change

In v3, we have added Fody to two projects, _Datadog.Trace_ and _Datadog.Trace.Coverage.Collector_. Unfortunately, this seems to trigger a bug in Fody when we build the dotnet runner tool which references both of these attributes.

## Implementation details

The issue appears to be some sort of race condition. Disabling MSBuild node reuse solves the issue. 

Initially I tried just using the `dotnet build` switch `/nodereuse:false` but that didn't solve the issue for `dotnet pack` so switched to setting the env var. However, setting the env var _solely_ in the Nuke build step _also_ didn't seem to solve the issue, so set it _globally_ in that build stage and it worked. I couldn't work out why, but my best I can guess is that a sub MSBuild is created and it doesn't inherit the parent environment 🤷‍♂️ The important thing is it works

## Test coverage

[Ran a full build based on v3](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=156364&view=results) and it worked 🎉 

## Other details
This is only _required_ for v3, but doesn't hurt to merge it here, so would rather keep that branch smaller

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
