### PR TITLE
Update `RegexBuilder` to accept a `Timeout` so we can reduce flake

### DIFF
--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -33,15 +33,16 @@ namespace Datadog.Trace.Sampling
             string serviceNamePattern,
             string operationNamePattern,
             string resourceNamePattern,
-            ICollection<KeyValuePair<string, string>> tagPatterns)
+            ICollection<KeyValuePair<string, string>> tagPatterns,
+            TimeSpan timeout)
         {
             _samplingRate = rate;
             RuleName = ruleName;
 
-            _serviceNameRegex = RegexBuilder.Build(serviceNamePattern, patternFormat);
-            _operationNameRegex = RegexBuilder.Build(operationNamePattern, patternFormat);
-            _resourceNameRegex = RegexBuilder.Build(resourceNamePattern, patternFormat);
-            _tagRegexes = RegexBuilder.Build(tagPatterns, patternFormat);
+            _serviceNameRegex = RegexBuilder.Build(serviceNamePattern, patternFormat, timeout);
+            _operationNameRegex = RegexBuilder.Build(operationNamePattern, patternFormat, timeout);
+            _resourceNameRegex = RegexBuilder.Build(resourceNamePattern, patternFormat, timeout);
+            _tagRegexes = RegexBuilder.Build(tagPatterns, patternFormat, timeout);
 
             if (_serviceNameRegex is null &&
                 _operationNameRegex is null &&
@@ -63,7 +64,7 @@ namespace Datadog.Trace.Sampling
         /// </summary>
         public int Priority { get; protected set; } = 1;
 
-        public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(string configuration, string patternFormat)
+        public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(string configuration, string patternFormat, TimeSpan timeout)
         {
             try
             {
@@ -85,7 +86,8 @@ namespace Datadog.Trace.Sampling
                                 r.Service,
                                 r.OperationName,
                                 r.Resource,
-                                r.Tags));
+                                r.Tags,
+                                timeout));
                     }
 
                     return samplingRules;

--- a/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
@@ -14,7 +14,12 @@ namespace Datadog.Trace.Sampling;
 
 internal static class RegexBuilder
 {
-    public static Regex? Build(string? pattern, string format)
+    /// <summary>
+    /// The default timeout used in production for most regexes.
+    /// </summary>
+    internal static readonly TimeSpan DefaultTimeout = TimeSpan.FromMilliseconds(200);
+
+    public static Regex? Build(string? pattern, string format, TimeSpan timeout)
     {
         if (pattern is null)
         {
@@ -23,7 +28,6 @@ internal static class RegexBuilder
         }
 
         const RegexOptions options = RegexOptions.Compiled | RegexOptions.IgnoreCase;
-        var timeout = TimeSpan.FromMilliseconds(200);
 
         switch (format)
         {
@@ -60,7 +64,7 @@ internal static class RegexBuilder
         }
     }
 
-    public static List<KeyValuePair<string, Regex?>> Build(ICollection<KeyValuePair<string, string?>> patterns, string format)
+    public static List<KeyValuePair<string, Regex?>> Build(ICollection<KeyValuePair<string, string?>> patterns, string format, TimeSpan timeout)
     {
         if (patterns is { Count: > 0 })
         {
@@ -68,7 +72,7 @@ internal static class RegexBuilder
 
             foreach (var pattern in patterns)
             {
-                var regex = Build(pattern.Value, format);
+                var regex = Build(pattern.Value, format, timeout);
 
                 if (regex != null)
                 {

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -258,7 +258,7 @@ namespace Datadog.Trace
 
             if (patternFormatIsValid && !string.IsNullOrWhiteSpace(samplingRules))
             {
-                foreach (var rule in CustomSamplingRule.BuildFromConfigurationString(samplingRules, samplingRulesFormat))
+                foreach (var rule in CustomSamplingRule.BuildFromConfigurationString(samplingRules, samplingRulesFormat, RegexBuilder.DefaultTimeout))
                 {
                     sampler.RegisterRule(rule);
                 }
@@ -288,7 +288,7 @@ namespace Datadog.Trace
                 return new SpanSampler(Enumerable.Empty<ISpanSamplingRule>());
             }
 
-            return new SpanSampler(SpanSamplingRule.BuildFromConfigurationString(settings.SpanSamplingRules));
+            return new SpanSampler(SpanSamplingRule.BuildFromConfigurationString(settings.SpanSamplingRules, RegexBuilder.DefaultTimeout));
         }
 
         protected virtual IAgentWriter GetAgentWriter(ImmutableTracerSettings settings, IDogStatsd statsd, Action<Dictionary<string, float>> updateSampleRates, IDiscoveryService discoveryService)

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleGlobTests.cs
@@ -14,6 +14,8 @@ namespace Datadog.Trace.Tests.Sampling
     [Collection(nameof(Datadog.Trace.Tests.Sampling))]
     public class CustomSamplingRuleGlobTests
     {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
         [Fact]
         public void Constructs_ZeroRateOnly_From_Config_String()
         {
@@ -54,7 +56,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_ResourceName()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/*" }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
@@ -68,7 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_Tags()
         {
             const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE?", "http.status_code": "200", "balance": "*" } }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
 
             var matchingSpan1 = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan1.SetTag("http.method", "GET");
@@ -109,7 +111,7 @@ namespace Datadog.Trace.Tests.Sampling
                                   ]
                                   """;
 
-            var rules = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).ToArray();
+            var rules = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).ToArray();
             rules.Should().HaveCount(4);
 
             var cartRule = rules[0];
@@ -153,7 +155,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void RuleShouldBeCaseInsensitive()
         {
             var config = "[{\"sample_rate\":0.5, \"service\":\"SHOPPING-cart-service\", \"name\":\"CHECKOUT\"}]";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifySingleRule(rule, TestSpans.CartCheckoutSpan, true);
         }
 
@@ -164,13 +166,13 @@ namespace Datadog.Trace.Tests.Sampling
         [InlineData("""[{"sample_rate":0.3, "name":"["}]""", 1)] // invalid regex, but valid glob
         public void Malformed_Rules_Do_Not_Register_Or_Crash(string ruleConfig, int count)
         {
-            var rules = CustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Glob).ToArray();
+            var rules = CustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Glob, Timeout).ToArray();
             rules.Should().HaveCount(count);
         }
 
         private static void VerifyRate(string config, float expectedRate)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifyRate(rule, expectedRate);
         }
 
@@ -181,7 +183,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static void VerifySingleRule(string config, Span span, bool isMatch)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Glob, Timeout).Single();
             VerifySingleRule(rule, span, isMatch);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
@@ -14,6 +14,8 @@ namespace Datadog.Trace.Tests.Sampling
     [Collection(nameof(Datadog.Trace.Tests.Sampling))]
     public class CustomSamplingRuleRegexTests
     {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
         [Fact]
         public void Constructs_ZeroRateOnly_From_Config_String()
         {
@@ -54,7 +56,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_ResourceName()
         {
             const string config = """[{ "sample_rate":0.3, resource: "/api/v1/.*" }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v1/user/123" };
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
@@ -68,7 +70,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void Constructs_With_Tags()
         {
             const string config = """[{ "sample_rate":0.3, tags: { "http.method": "GE.", "http.status_code": "200" } }]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
 
             var matchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now);
             matchingSpan.SetTag("http.method", "GET");
@@ -98,7 +100,7 @@ namespace Datadog.Trace.Tests.Sampling
                          ]
                          """;
 
-            var rules = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex).ToArray();
+            var rules = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).ToArray();
             rules.Should().HaveCount(4);
 
             var cartRule = rules[0];
@@ -142,7 +144,7 @@ namespace Datadog.Trace.Tests.Sampling
         public void RuleShouldBeCaseInsensitive()
         {
             var config = """[{"sample_rate":0.5, "service":"SHOPPING-cart-service", "name":"CHECKOUT"}]""";
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifySingleRule(rule, TestSpans.CartCheckoutSpan, true);
         }
 
@@ -156,13 +158,13 @@ namespace Datadog.Trace.Tests.Sampling
 
         public void Malformed_Rules_Do_Not_Register_Or_Crash(string ruleConfig)
         {
-            var rules = CustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Regex).ToArray();
+            var rules = CustomSamplingRule.BuildFromConfigurationString(ruleConfig, SamplingRulesFormat.Regex, Timeout).ToArray();
             Assert.Empty(rules);
         }
 
         private static void VerifyRate(string config, float expectedRate)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifyRate(rule, expectedRate);
         }
 
@@ -173,7 +175,7 @@ namespace Datadog.Trace.Tests.Sampling
 
         private static void VerifySingleRule(string config, Span span, bool isMatch)
         {
-            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex).Single();
+            var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
             VerifySingleRule(rule, span, isMatch);
         }
 

--- a/tracer/test/Datadog.Trace.Tests/Sampling/RegexBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/RegexBuilderTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.Sampling;
 using FluentAssertions;
 using Xunit;
@@ -11,6 +12,8 @@ namespace Datadog.Trace.Tests.Sampling;
 
 public class RegexBuilderTests
 {
+    private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
     [Theory]
     // regex
     [InlineData(null, "regex", null)]
@@ -32,7 +35,7 @@ public class RegexBuilderTests
     [InlineData("te?st", "glob", "^te.st$")]
     public void Build(string pattern, string format, string expected)
     {
-        var regex = RegexBuilder.Build(pattern, format);
+        var regex = RegexBuilder.Build(pattern, format, Timeout);
 
         if (expected == null)
         {

--- a/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/SpanSamplerTests.cs
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Tests.Sampling
     [Collection(nameof(Sampling))]
     public class SpanSamplerTests
     {
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
+
         [Fact]
         public void Constructor_ShouldThrow_WhenNullRulesGiven()
         {
@@ -31,6 +33,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operationName",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 1.0f,
                 maxPerSecond: 500.0f);
 
@@ -39,6 +42,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operationName2",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 1.0f,
                 maxPerSecond: 500.0f);
 
@@ -61,6 +65,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operationName",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 0.0f);
 
             var rules = new List<SpanSamplingRule> { rule };
@@ -86,6 +91,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operation-name",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 1.0f,
                 maxPerSecond: 500.0f);
 
@@ -94,6 +100,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operation-name",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 1.0f,
                 maxPerSecond: 600.0f); // note different max per second here
 
@@ -120,6 +127,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "nomatch",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 1.0f,
                 maxPerSecond: 500.0f);
 
@@ -128,6 +136,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operation-name",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 1.0f,
                 maxPerSecond: 600.0f); // note different max per second here
 
@@ -150,6 +159,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "*",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 0.0f); // sample_rate is set to drop all
 
             var rule2 = new SpanSamplingRule(
@@ -157,6 +167,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "*",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 1.0f);
 
             var rules = new List<SpanSamplingRule> { rule1, rule2 };
@@ -191,6 +202,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "o?erat?o?",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 maxPerSecond: 1000.0f);
 
             var sampler = new SpanSampler(new List<SpanSamplingRule> { rule });
@@ -211,6 +223,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "o?erat?o?",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 maxPerSecond: 1000.0f);
 
             var sampler = new SpanSampler(new List<SpanSamplingRule> { rule });
@@ -234,6 +247,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operation-name",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 0.99f);
 
             var rules = new List<SpanSamplingRule> { rule1 };
@@ -259,6 +273,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operation-name",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 0.99f,
                 maxPerSecond: 500.0f);
 
@@ -281,13 +296,15 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "*",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 0.0f); // this rule comes before allow all, so it has priority
 
             var allowAllRule = new SpanSamplingRule(
                 serviceNameGlob: "*",
                 operationNameGlob: "*",
                 resourceNameGlob: null,
-                tagGlobs: null);
+                tagGlobs: null,
+                timeout: Timeout);
 
             var rules = new List<SpanSamplingRule> { allowNoneRule, allowAllRule };
             var sampler = new SpanSampler(rules);
@@ -302,7 +319,8 @@ namespace Datadog.Trace.Tests.Sampling
                 serviceNameGlob: "*",
                 operationNameGlob: "*",
                 resourceNameGlob: null,
-                tagGlobs: null);
+                tagGlobs: null,
+                timeout: Timeout);
 
             var rules = new List<SpanSamplingRule> { allowAllRule };
             var sampler = new SpanSampler(rules);
@@ -318,6 +336,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "*",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 0.0f);
 
             var rules = new List<SpanSamplingRule> { allowNoneRule };
@@ -334,6 +353,7 @@ namespace Datadog.Trace.Tests.Sampling
                 operationNameGlob: "operation?name",
                 resourceNameGlob: null,
                 tagGlobs: null,
+                timeout: Timeout,
                 samplingRate: 0.5f);
 
             var rules = new List<SpanSamplingRule> { allowHalfRule };

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
@@ -22,6 +23,7 @@ namespace Datadog.Trace.Tests.Sampling
         private const string OperationName = "test";
         private const string ResourceName = "test-resource-name";
 
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(10);
         private static readonly Dictionary<string, float> MockAgentRates = new() { { $"service:{ServiceName},env:{Env}", FallbackRate } };
 
         [Fact]
@@ -49,7 +51,8 @@ namespace Datadog.Trace.Tests.Sampling
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
                     resourceNamePattern: ".*",
-                    tagPatterns: null));
+                    tagPatterns: null,
+                    timeout: Timeout));
 
             await RunSamplerTest(
                 sampler,
@@ -72,7 +75,8 @@ namespace Datadog.Trace.Tests.Sampling
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
                     resourceNamePattern: ".*",
-                    tagPatterns: null));
+                    tagPatterns: null,
+                    timeout: Timeout));
 
             await RunSamplerTest(
                 sampler,
@@ -95,7 +99,8 @@ namespace Datadog.Trace.Tests.Sampling
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
                     resourceNamePattern: ".*",
-                    tagPatterns: null));
+                    tagPatterns: null,
+                    timeout: Timeout));
 
             await RunSamplerTest(
                 sampler,
@@ -118,7 +123,8 @@ namespace Datadog.Trace.Tests.Sampling
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
                     resourceNamePattern: ".*",
-                    tagPatterns: null));
+                    tagPatterns: null,
+                    timeout: Timeout));
 
             await RunSamplerTest(
                 sampler,


### PR DESCRIPTION
## Summary of changes

Parameterize the timeout used in `RegexBuilder` used in `CustomSamplingRule` and `SpanSamplingRule`

## Reason for change

Currently the timeout is hard-coded to 200ms. That's typically fine, but when running in CI on macOS (which is notoriously slow), this has caused some flake. By parameterizing it, we can increase the timeout significantly in tests.

## Implementation details

A lot of R# refactoring to move the timeout up and out so we can set it in tests! I intentionally didn't use default values here, as would be too easy to miss

## Test coverage

Test coverage is the same, we should hopefully just avoid flake now

## Other details

We have other, similar, timeout-based flake, but decided to handle that in a separate PR given this one touched a lot of files

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
