### PR TITLE
Fix some flaky tests in IAST and sampling

### DIFF
--- a/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/OriginTagSendTraces.cs
@@ -22,7 +22,7 @@ namespace Datadog.Trace.IntegrationTests
         {
             var settings = new TracerSettings();
             _testApi = new MockApi();
-            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+            var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, automaticFlush: false);
             _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
         }
 
@@ -36,6 +36,7 @@ namespace Datadog.Trace.IntegrationTests
                 }
             }
 
+            _tracer.FlushAsync();
             var traceChunks = _testApi.Wait();
 
             traceChunks.SelectMany(s => s)
@@ -57,6 +58,7 @@ namespace Datadog.Trace.IntegrationTests
                 }
             }
 
+            _tracer.FlushAsync();
             var traceChunks = _testApi.Wait();
 
             traceChunks.SelectMany(s => s)

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/AASTagsTests.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/AASTagsTests.cs
@@ -31,7 +31,7 @@ public class AASTagsTests
     {
         var source = GetMockVariables();
         var settings = new TracerSettings(source);
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, automaticFlush: false);
         var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
         using (tracer.StartActiveInternal("root"))
@@ -48,7 +48,7 @@ public class AASTagsTests
     public async Task NoAasTagsIfNotInAASContext()
     {
         var settings = new TracerSettings(null);
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, automaticFlush: false);
         var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
         using (tracer.StartActiveInternal("root"))
@@ -72,7 +72,7 @@ public class AASTagsTests
 
         var source = GetMockVariables();
         var settings = new TracerSettings(source);
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, automaticFlush: false);
         var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
 
         ISpan span1;

--- a/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
+++ b/tracer/test/Datadog.Trace.IntegrationTests/Tagging/SamplingPriorityTests_MultipleChunksWithUpstreamService.cs
@@ -20,14 +20,15 @@ public class SamplingPriorityTests_MultipleChunksWithUpstreamService
 
     private readonly MockApi _testApi;
     private readonly Tracer _tracer;
+    private AgentWriter _agentWriter;
 
     public SamplingPriorityTests_MultipleChunksWithUpstreamService()
     {
         _testApi = new MockApi();
 
         var settings = new TracerSettings();
-        var agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null);
-        _tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null);
+        _agentWriter = new AgentWriter(_testApi, statsAggregator: null, statsd: null, automaticFlush: false);
+        _tracer = new Tracer(settings, _agentWriter, sampler: null, scopeManager: null, statsd: null);
     }
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/EvidenceRedactorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/EvidenceRedactorTests.cs
@@ -19,7 +19,7 @@ namespace Datadog.Trace.Tests.Util.Http
     [Collection(nameof(EvidenceRedactorTests))]
     public class EvidenceRedactorTests
     {
-        private const double Timeout = 500;
+        private const double Timeout = 10_000;
 
         [Theory]
         [InlineData(null)]

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMessagePackFormatterTests.cs
@@ -250,7 +250,7 @@ public class SpanMessagePackFormatterTests
     {
         var mockApi = new MockApi();
         var settings = TracerSettings.Create(new() { { ConfigurationKeys.FeatureFlags.TraceId128BitGenerationEnabled, false } });
-        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: null);
+        var agentWriter = new AgentWriter(mockApi, statsAggregator: null, statsd: null, automaticFlush: false);
         var tracer = new Tracer(settings, agentWriter, sampler: null, scopeManager: null, statsd: null, NullTelemetryController.Instance, NullDiscoveryService.Instance);
 
         using (var scope = tracer.StartActiveInternal("root"))


### PR DESCRIPTION
## Summary of changes

- Fix a flaky IAST unit test related to regex timeouts
- Try fix flaky sampling tests

## Reason for change

The macos CI runs very slow, and I think the IAST regexes timed out, so bumped up the timeout to avoid the flake.

For the sampling tests, I've seen these fail in other places (i.e. non-macos), and so I _suspect_ this is due to them _not_ setting `automaticFlush: false` on the `AgentWriter`. That would mean they were previously running the serialization on a background thread, although I'm not 100% sure why this is an issue given the flush should wait for that I believe. Nevertheless, most of the other (non-flaky) `AgentWriter` tests set `automaticFlush: false`, so it seems like a good option to me. (I subsequently updated _all_ other usages to set this to be safe)

## Implementation details

- Bump the timeout
- Set `automaticFlush: false`

## Test coverage

Same coverage, no with less flake hopefully

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
