### PR TITLE
Fix RegisterIastAspects signature

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/interop.cpp
+++ b/tracer/src/Datadog.Tracer.Native/interop.cpp
@@ -166,15 +166,15 @@ EXTERN_C VOID STDAPICALLTYPE DisableTracerCLRProfiler()
     trace::profiler->DisableTracerCLRProfiler();
 }
 
-EXTERN_C VOID STDAPICALLTYPE RegisterIastAspects(WCHAR** aspects, int aspectsLength)
+EXTERN_C int STDAPICALLTYPE RegisterIastAspects(WCHAR** aspects, int aspectsLength)
 {
     if (trace::profiler == nullptr)
     {
         trace::Logger::Error("Error in RegisterIastAspects call. Tracer CLR Profiler was not initialized.");
-        return;
+        return 0;
     }
 
-    trace::profiler->RegisterIastAspects(aspects, aspectsLength);
+    return trace::profiler->RegisterIastAspects(aspects, aspectsLength);
 }
 
 


### PR DESCRIPTION
## Summary of changes

Change the signature of the `RegisterIastAspects` method on native side.

## Reason for change

On the managed size, the `RegisterIastAspects` is declared as:

```csharp
int RegisterIastAspects([In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPWStr, SizeParamIndex = 1)] string[] aspects, int aspectsLength);
```

But on the native size, it is declared as:

```cpp
EXTERN_C VOID STDAPICALLTYPE RegisterIastAspects(WCHAR** aspects, int aspectsLength)
```

The mismatch causes the managed side to receive garbage as the return value.

## Implementation details

Changed the native signature to return `int`.