### PR TITLE
[Profiler] Add `timer_create`-based CPU profiling on Linux

### DIFF
--- a/profiler/build/CpuWallTime.linux.json
+++ b/profiler/build/CpuWallTime.linux.json
@@ -38,6 +38,16 @@
         "DD_INTERNAL_USE_BACKTRACE2": "0",
         "DD_TRACE_ENABLED" : "0"
       }
+    },
+    {
+      "name": "Profiler_cpu_walltime_timer_create",
+      "environmentVariables": {
+        "DD_CLR_ENABLE_NGEN": "true",
+        "DD_PROFILING_ENABLED": "1",
+        "DD_PROFILING_CPU_ENABLED": "1",
+        "DD_INTERNAL_CPU_PROFILER_TYPE": "TimerCreate",
+        "DD_TRACE_ENABLED" : "0"
+      }
     }
   ],
   "processName": "Samples.Computer01",

--- a/profiler/build/crank/Samples.AspNetCoreSimpleController.yml
+++ b/profiler/build/crank/Samples.AspNetCoreSimpleController.yml
@@ -115,3 +115,22 @@ scenarios:
         duration: 240
         serverPort: 5000
         path: /hello
+
+  profiler_cpu_timer_create:
+    application:
+      job: server
+      environmentVariables:
+        COR_ENABLE_PROFILING: 1
+        CORECLR_ENABLE_PROFILING: 1
+        DD_PROFILING_ENABLED: 1
+        DD_PROFILING_WALLTIME_ENABLED: 0
+        DD_PROFILING_CPU_ENABLED: 1
+        DD_INTERNAL_CPU_PROFILER_TYPE: "TimerCreate"
+        COMPlus_EnableDiagnostics: 1
+    load:
+      job: bombardier
+      variables:
+        warmup: 30
+        duration: 240
+        serverPort: 5000
+        path: /hello

--- a/profiler/build/crank/run.sh
+++ b/profiler/build/crank/run.sh
@@ -63,6 +63,7 @@ elif [ "$1" = "linux" ]; then
     rm -f profiler_exceptions_baseline_linux.json
     rm -f profiler_exceptions_linux.json
     rm -f profiler_cpu_linux.json
+    rm -f profiler_cpu_timer_create_linux.json
 
     crank --config Samples.AspNetCoreSimpleController.yml --scenario profiler_baseline --profile linux --json profiler_baseline_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=profiler_baseline --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="profiler_baseline_linux.json"
@@ -76,8 +77,8 @@ elif [ "$1" = "linux" ]; then
     crank --config Samples.AspNetCoreSimpleController.yml --scenario profiler_exceptions --profile linux --json profiler_exceptions_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=profiler_exceptions --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
     dd-trace --crank-import="profiler_exceptions_linux.json"
 
-    crank --config Samples.AspNetCoreSimpleController.yml --scenario profiler_cpu --profile linux --json profiler_cpu_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=profiler_cpu --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
-    dd-trace --crank-import="profiler_cpu_linux.json"
+    crank --config Samples.AspNetCoreSimpleController.yml --scenario profiler_cpu_timer_create --profile linux --json profiler_cpu_timer_create_linux.json $repository $commit  --property name=AspNetCoreSimpleController --property scenario=profiler_cpu --property profile=linux --property arch=x64 --variable commit_hash=$commit_sha
+    dd-trace --crank-import="profiler_cpu_timer_create_linux.json"
 else
     echo "Unknown argument $1"
     exit 1

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj
@@ -119,6 +119,7 @@
     <ClCompile Include="OsSpecificApi.cpp" />
     <ClCompile Include="ProfilerSignalManager.cpp" />
     <ClCompile Include="SystemCallsShield.cpp" />
+    <ClCompile Include="TimerCreateCpuProfiler.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="prepare_loader_for_linking.sh" />
@@ -129,6 +130,7 @@
     <ClInclude Include="LinuxThreadInfo.h" />
     <ClInclude Include="ProfilerSignalManager.h" />
     <ClInclude Include="SystemCallsShield.h" />
+    <ClInclude Include="TimerCreateCpuProfiler.h" />
   </ItemGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/Datadog.Profiler.Native.Linux.vcxproj.filters
@@ -9,6 +9,7 @@
     <ClCompile Include="LinuxThreadInfo.cpp" />
     <ClCompile Include="SystemCallsShield.cpp" />
     <ClCompile Include="CrashReportingLinux.cpp" />
+    <ClCompile Include="TimerCreateCpuProfiler.cpp" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="Scripts">
@@ -26,5 +27,6 @@
     <ClInclude Include="LinuxThreadInfo.h" />
     <ClInclude Include="SystemCallsShield.h" />
     <ClInclude Include="CrashReportingLinux.h" />
+    <ClInclude Include="TimerCreateCpuProfiler.h" />
   </ItemGroup>
 </Project>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/MmapMemoryResource.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/MmapMemoryResource.cpp
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "MmapMemoryResource.h"
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+inline long get_page_size()
+{
+    static long page_size = 0;
+    if (!page_size)
+    {
+        page_size = sysconf(_SC_PAGESIZE);
+    }
+    return page_size;
+}
+
+inline uint64_t align_to_page(uint64_t x)
+{
+    return ((x - 1) | (get_page_size() - 1)) + 1;
+}
+
+void* MmapMemoryResource::do_allocate(size_t _Bytes, size_t _Align)
+{
+    auto const total_length = align_to_page(_Bytes);
+    void* region = mmap(nullptr, total_length, PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (MAP_FAILED == region || region == nullptr)
+    {
+        return nullptr;
+    }
+
+    return region;
+}
+
+void MmapMemoryResource::do_deallocate(void* _Ptr, size_t _Bytes, size_t _Align)
+{
+    auto const total_length = align_to_page(_Bytes);
+    munmap(_Ptr, total_length);
+}
+
+bool MmapMemoryResource::do_is_equal(const memory_resource& _That) const noexcept
+{
+    return this == &_That;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/MmapMemoryResource.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/MmapMemoryResource.h
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "shared/src/native-src/dd_memory_resource.hpp"
+
+class MmapMemoryResource : public shared::pmr::memory_resource
+{
+public:
+    ~MmapMemoryResource() = default;
+
+private:
+    void* do_allocate(size_t _Bytes, size_t _Align) override;
+    void do_deallocate(void* _Ptr, size_t _Bytes, size_t _Align) override;
+    bool do_is_equal(const memory_resource& _That) const noexcept override;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/OsSpecificApi.cpp
@@ -63,7 +63,7 @@ std::unique_ptr<StackFramesCollectorBase> CreateNewStackFramesCollectorInstance(
     IConfiguration const* const pConfiguration,
     CallstackProvider* callstackProvider)
 {
-    return std::make_unique<LinuxStackFramesCollector>(ProfilerSignalManager::Get(), pConfiguration, callstackProvider, LibrariesInfoCache::Get());
+    return std::make_unique<LinuxStackFramesCollector>(ProfilerSignalManager::Get(SIGUSR1), pConfiguration, callstackProvider, LibrariesInfoCache::Get());
 }
 
 // https://linux.die.net/man/5/proc

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -165,12 +165,12 @@ bool ProfilerSignalManager::SetupSignalHandler()
     int32_t result = sigaction(_signalToSend, &sampleAction, &_previousAction);
     if (result != 0)
     {
-        Log::Error("ProfilerSignalManager::SetupSignalHandler: Failed to setup signal handler for ", _signalToSend, " signals. Reason: ",
+        Log::Error("ProfilerSignalManager::SetupSignalHandler: Failed to setup signal handler for ", strsignal(_signalToSend), " signals. Reason: ",
                    strerror(errno), ".");
         return false;
     }
 
-    Log::Info("ProfilerSignalManager::SetupSignalHandler: Successfully setup signal handler for ", _signalToSend, " signal.");
+    Log::Info("ProfilerSignalManager::SetupSignalHandler: Successfully setup signal handler for ", strsignal(_signalToSend), " signal.");
     return true;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -4,9 +4,8 @@
 #include "ProfilerSignalManager.h"
 
 #include <signal.h>
-#include <sys/syscall.h>
 #include <stdexcept>
-
+#include <sys/syscall.h>
 
 #include "Log.h"
 #include "OpSysTools.h"
@@ -204,4 +203,9 @@ void ProfilerSignalManager::CallOrignalHandler(int32_t signal, siginfo_t* info, 
     }
 
     isExecuting = false;
+}
+
+int32_t ProfilerSignalManager::GetSignal() const
+{
+    return _signalToSend;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -179,6 +179,12 @@ bool ProfilerSignalManager::SetupSignalHandler()
 void ProfilerSignalManager::SignalHandler(int signal, siginfo_t* info, void* context)
 {
     auto* signalManager = Get(signal);
+
+    if (signalManager == nullptr) [[unlikely]]
+    {
+        return;
+    }
+
     if (!signalManager->CallCustomHandler(signal, info, context))
     {
         signalManager->CallOrignalHandler(signal, info, context);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp
@@ -37,7 +37,8 @@ ProfilerSignalManager* ProfilerSignalManager::Get(int signal)
 
     if (signal < 1 || signal > 31)
     {
-        throw std::invalid_argument(std::string("Signal argument is invalid ") + "(" + std::to_string(signal) + "). Value must be: 1 <= signal <= 31");
+        Log::Info("Signal argument is invalid (", std::to_string(signal), " aka ", strsignal(signal), "). Value must be: 1 <= signal <= 31");
+        return nullptr;
     }
 
     auto* manager = &signalManagers[signal - 1]; // 0-based array
@@ -88,6 +89,7 @@ bool ProfilerSignalManager::UnRegisterHandler()
         return false;
     }
 
+    _isHandlerInPlace = false;
     return true;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -17,6 +17,7 @@ public:
     static ProfilerSignalManager* Get(int signal);
 
     bool RegisterHandler(HandlerFn_t handler);
+    bool UnRegisterHandler();
     int32_t SendSignal(pid_t threadId);
     bool CheckSignalHandler();
     bool IsHandlerInPlace() const;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -14,7 +14,7 @@ class ProfilerSignalManager
 public:
     using HandlerFn_t = std::add_pointer<bool(int, siginfo_t*, void*)>::type;
 
-    static ProfilerSignalManager* Get();
+    static ProfilerSignalManager* Get(int signal);
 
     bool RegisterHandler(HandlerFn_t handler);
     int32_t SendSignal(pid_t threadId);
@@ -37,8 +37,8 @@ private:
     // prevent copy and move semantics.
     ProfilerSignalManager(ProfilerSignalManager&) noexcept = delete;
     ProfilerSignalManager& operator=(ProfilerSignalManager&) noexcept = delete;
-    ProfilerSignalManager(ProfilerSignalManager&&) noexcept = delete;
-    ProfilerSignalManager& operator=(ProfilerSignalManager&&) noexcept = delete;
+    ProfilerSignalManager(ProfilerSignalManager&& other) noexcept = delete;
+    ProfilerSignalManager& operator=(ProfilerSignalManager&& other) noexcept = delete;
 
     ~ProfilerSignalManager() noexcept;
 
@@ -46,6 +46,7 @@ private:
     bool SetupSignalHandler();
     bool CallCustomHandler(int32_t signal, siginfo_t* info, void* context);
     void CallOrignalHandler(int32_t signal, siginfo_t* info, void* context);
+    void SetSignal(int32_t signal);
 
     static void SignalHandler(int signal, siginfo_t* info, void* context);
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h
@@ -20,6 +20,7 @@ public:
     int32_t SendSignal(pid_t threadId);
     bool CheckSignalHandler();
     bool IsHandlerInPlace() const;
+    int32_t GetSignal() const;
 
 #ifdef DD_TEST
     void Reset()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -41,9 +41,9 @@ TimerCreateCpuProfiler::~TimerCreateCpuProfiler()
 
 void TimerCreateCpuProfiler::RegisterThread(std::shared_ptr<ManagedThreadInfo> threadInfo)
 {
-    std::shared_lock(_registerLock);
+    std::shared_lock lock(_registerLock);
 
-    if (GetState() != SeriveBase::State::Started)
+    if (GetState() != ServiceBase::State::Started)
     {
         return;
     }
@@ -71,7 +71,7 @@ const char* TimerCreateCpuProfiler::GetName()
 
 bool TimerCreateCpuProfiler::StartImpl()
 {
-    // If the signal is higjacked, what to do?
+    // If the signal is highjacked, what to do?
     auto registered = _pSignalManager->RegisterHandler(TimerCreateCpuProfiler::CollectStackSampleSignalHandler);
 
     if (registered)
@@ -79,8 +79,8 @@ bool TimerCreateCpuProfiler::StartImpl()
         std::unique_lock lock(_registerLock);
         Instance = this;
 
-        // Create and start timer for all threads
-        _pManagedThreadsList->ForEach([this](ManagedThreadList* thread) { RegisterImpl(thread); });
+        // Create and start timer for all threads.
+        _pManagedThreadsList->ForEach([this](ManagedThreadInfo* thread) { RegisterThreadImpl(thread); });
     }
 
     return registered;
@@ -99,7 +99,7 @@ bool TimerCreateCpuProfiler::CollectStackSampleSignalHandler(int sig, siginfo_t*
     auto instance = Instance;
     if (instance == nullptr)
     {
-        return;
+        return false;
     }
 
     return instance->Collect(ucontext);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -28,10 +28,10 @@ TimerCreateCpuProfiler::TimerCreateCpuProfiler(
     _pManagedThreadsList{pManagedThreadsList},
     _pProvider{pProvider},
     _callstackProvider{std::move(callstackProvider)},
-    _serviceState{ServiceState::Initialized},
     _samplingInterval{pConfiguration->GetCpuProfilingInterval()}
 {
     Log::Info("Cpu profiling interval: ", _samplingInterval.count(), "ms");
+    Log::Info("timer_create Cpu profiler is enabled");
 }
 
 TimerCreateCpuProfiler::~TimerCreateCpuProfiler()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -71,7 +71,14 @@ const char* TimerCreateCpuProfiler::GetName()
 
 bool TimerCreateCpuProfiler::StartImpl()
 {
-    // If the signal is highjacked, what to do?
+    if (_pSignalManager == nullptr)
+    {
+        Log::Info("Profiler Signal manager was not correctly initialized (see previous messages).",
+                  "timer_create-based CPU profiler is disabled.");
+        return false;
+    }
+
+    // If the signal is hijacked, what to do?
     auto registered = _pSignalManager->RegisterHandler(TimerCreateCpuProfiler::CollectStackSampleSignalHandler);
 
     if (registered)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.cpp
@@ -1,0 +1,219 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "TimerCreateCpuProfiler.h"
+
+#include "CpuTimeProvider.h"
+#include "IManagedThreadList.h"
+#include "Log.h"
+#include "OpSysTools.h"
+#include "ProfilerSignalManager.h"
+
+#include <libunwind.h>
+#include <sys/syscall.h> /* Definition of SYS_* constants */
+#include <sys/types.h>
+#include <ucontext.h>
+#include <unistd.h>
+
+TimerCreateCpuProfiler* TimerCreateCpuProfiler::Instance = nullptr;
+
+TimerCreateCpuProfiler::TimerCreateCpuProfiler(
+    IConfiguration* pConfiguration,
+    ProfilerSignalManager* pSignalManager,
+    IManagedThreadList* pManagedThreadsList,
+    CpuTimeProvider* pProvider,
+    CallstackProvider callstackProvider) noexcept
+    :
+    _pSignalManager{pSignalManager}, // put it as parameter for better testing
+    _pManagedThreadsList{pManagedThreadsList},
+    _pProvider{pProvider},
+    _callstackProvider{std::move(callstackProvider)},
+    _processId{OpSysTools::GetProcId()},
+    _serviceState{ServiceState::Initialized},
+    _samplingInterval{pConfiguration->GetCpuProfilingInterval()}
+{
+    Log::Info("Cpu profiling interval: ", _samplingInterval.count(), "ms");
+
+    Instance = this;
+}
+
+TimerCreateCpuProfiler::~TimerCreateCpuProfiler()
+{
+    Stop();
+}
+
+void TimerCreateCpuProfiler::RegisterThread(std::shared_ptr<ManagedThreadInfo> threadInfo)
+{
+    if (_serviceState != ServiceState::Started)
+    {
+        return;
+    }
+
+    auto tid = threadInfo->GetOsThreadId();
+    Log::Debug("Creating timer for thread ", tid);
+
+    struct sigevent sev;
+    sev.sigev_value.sival_ptr = nullptr;
+    sev.sigev_signo = _pSignalManager->GetSignal();
+    sev.sigev_notify = SIGEV_THREAD_ID;
+    ((int*)&sev.sigev_notify)[1] = tid;
+
+    // Use raw syscalls, since libc wrapper allows only predefined clocks
+    clockid_t clock = ((~tid) << 3) | 6; // CPUCLOCK_SCHED | CPUCLOCK_PERTHREAD_MASK thread_cpu_clock(tid);
+    int timerId;
+    if (syscall(__NR_timer_create, clock, &sev, &timerId) < 0)
+    {
+        Log::Error("Call to timer_create failed for thread ", tid);
+        return;
+    }
+
+    auto oldTimerId = threadInfo->SetTimerId(timerId);
+
+    // In case of SSI:
+    // There is a race when Start() and RegisterThread :
+    // The thread can be added while lookping over the in the managed threads list
+    // and a call being made to RegisterThread
+    // In that case, just keep the first timer id and delete the other
+    if (oldTimerId != -1)
+    {
+        // delete the newly created timer
+        syscall(__NR_timer_delete, timerId);
+        threadInfo->SetTimerId(oldTimerId);
+        return;
+    }
+
+    std::int32_t _interval = std::chrono::duration_cast<std::chrono::nanoseconds>(_samplingInterval).count();
+    struct itimerspec ts;
+    ts.it_interval.tv_sec = (time_t)(_interval / 1000000000);
+    ts.it_interval.tv_nsec = _interval % 1000000000;
+    ts.it_value = ts.it_interval;
+    syscall(__NR_timer_settime, timerId, 0, &ts, nullptr);
+}
+
+void TimerCreateCpuProfiler::UnregisterThread(std::shared_ptr<ManagedThreadInfo> threadInfo)
+{
+    if (_serviceState != ServiceState::Started)
+    {
+        return;
+    }
+
+    auto timerId = threadInfo->SetTimerId(-1);
+
+    Log::Debug("Unregister timer for thread ", threadInfo->GetOsThreadId());
+    syscall(__NR_timer_delete, timerId);
+}
+
+const char* TimerCreateCpuProfiler::GetName()
+{
+    return "timer_create-based Cpu Profiler";
+}
+
+bool TimerCreateCpuProfiler::Start()
+{
+    if (_serviceState.exchange(ServiceState::Started) == ServiceState::Started)
+    {
+        // Log to say that it's already stated
+        return true;
+    }
+
+    // If the signal is higjacked, what to do?
+    auto registered = _pSignalManager->RegisterHandler(TimerCreateCpuProfiler::CollectStackSampleSignalHandler);
+
+    auto it = _pManagedThreadsList->CreateIterator();
+
+    ManagedThreadInfo* first = nullptr;
+
+    auto current = _pManagedThreadsList->LoopNext(it);
+    while (current != nullptr && current.get() != first)
+    {
+        if (first == nullptr)
+        {
+            first = current.get();
+        }
+
+        if (current->GetTimerId() != -1)
+        {
+            continue;
+        }
+
+        RegisterThread(current);
+        current = _pManagedThreadsList->LoopNext(it);
+    }
+
+    return registered;
+}
+
+bool TimerCreateCpuProfiler::Stop()
+{
+    auto old = _serviceState.exchange(ServiceState::Stopped);
+    if (old == ServiceState::Initialized)
+    {
+        // TODO Log must be started first
+        return false;
+    }
+
+    if (old == ServiceState::Stopped)
+    {
+        // Maybe a race. Log to say that it's already stopped
+        return true;
+    }
+
+    // TODO
+    //_signalManager->UnRegisterHandler(SIGPROF);
+
+    // for now it's ok not necessary to go through threads and delete the timer
+    // If Stop is called, the process is going down.
+    return true;
+}
+
+bool TimerCreateCpuProfiler::CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext)
+{
+    return Instance->Collect(info->si_pid, ucontext);
+}
+
+bool TimerCreateCpuProfiler::Collect(pid_t callerProcess, void* ctx)
+{
+    if (_serviceState == ServiceState::Stopped)
+    {
+        return false;
+    }
+
+    auto threadInfo = ManagedThreadInfo::CurrentThreadInfo;
+    if (threadInfo == nullptr)
+    {
+        // Ooops should never happen
+        return false;
+    }
+
+    auto* context = reinterpret_cast<unw_context_t*>(ctx);
+
+    auto callstack = _callstackProvider.Get();
+
+    if (callstack.Capacity() <= 0)
+    {
+        return false;
+    }
+
+    auto buffer = callstack.Data();
+    auto count = unw_backtrace2((void**)buffer.data(), buffer.size(), context, UNW_INIT_SIGNAL_FRAME);
+    callstack.SetCount(count);
+
+    if (count == 0)
+    {
+        // TODO a metric on event without callstack ?
+        return false;
+    }
+
+    RawCpuSample rawCpuSample;
+
+    std::tie(rawCpuSample.LocalRootSpanId, rawCpuSample.SpanId) = threadInfo->GetTracingContext();
+
+    rawCpuSample.Timestamp = OpSysTools::GetTimestampSafe();
+    rawCpuSample.AppDomainId = threadInfo->GetAppDomainId();
+    rawCpuSample.Stack = std::move(callstack);
+    rawCpuSample.ThreadInfo = std::move(threadInfo);
+    rawCpuSample.Duration = _samplingInterval.count();
+    _pProvider->Add(std::move(rawCpuSample));
+
+    return true;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -49,18 +49,10 @@ private:
     bool StartImpl() override;
     bool StopImpl() override;
 
-    enum class ServiceState
-    {
-        Started,
-        Stopped,
-        Initialized
-    };
-
     ProfilerSignalManager* _pSignalManager;
     IManagedThreadList* _pManagedThreadsList;
     CpuTimeProvider* _pProvider;
     CallstackProvider _callstackProvider;
-    std::atomic<ServiceState> _serviceState;
     std::chrono::milliseconds _samplingInterval;
     std::shared_mutex _registerLock;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -47,7 +47,7 @@ private:
     void RegisterThreadImpl(ManagedThreadInfo* thread);
 
     bool StartImpl() override;
-    bool StopImp() override;
+    bool StopImpl() override;
 
     enum class ServiceState
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -44,7 +44,7 @@ private:
     static bool CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext);
     static TimerCreateCpuProfiler* Instance;
 
-    bool Collect(pid_t callerProcess, void* ucontext);
+    bool Collect(void* ucontext);
 
     enum class ServiceState
     {
@@ -57,7 +57,6 @@ private:
     IManagedThreadList* _pManagedThreadsList;
     CpuTimeProvider* _pProvider;
     CallstackProvider _callstackProvider;
-    pid_t _processId;
     std::atomic<ServiceState> _serviceState;
     std::chrono::milliseconds _samplingInterval;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/TimerCreateCpuProfiler.h
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "IService.h"
+#include "ManagedThreadInfo.h"
+#include "CallstackProvider.h"
+
+#include <signal.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <unordered_set>
+
+class IConfiguration;
+class IThreadInfo;
+class IManagedThreadList;
+class ProfilerSignalManager;
+class CpuTimeProvider;
+class CallstackProvider;
+
+class TimerCreateCpuProfiler : public IService
+{
+public:
+    TimerCreateCpuProfiler(
+        IConfiguration* pConfiguration,
+        ProfilerSignalManager* pSignalManager,
+        IManagedThreadList* pManagedThreadsList,
+        CpuTimeProvider* pProvider,
+        CallstackProvider calstackProvider) noexcept;
+
+    ~TimerCreateCpuProfiler();
+
+    void RegisterThread(std::shared_ptr<ManagedThreadInfo> threadInfo);
+    void UnregisterThread(std::shared_ptr<ManagedThreadInfo> threadInfo);
+
+    const char* GetName() override;
+    bool Start() override;
+    bool Stop() override;
+
+private:
+    static bool CollectStackSampleSignalHandler(int sig, siginfo_t* info, void* ucontext);
+    static TimerCreateCpuProfiler* Instance;
+
+    bool Collect(pid_t callerProcess, void* ucontext);
+
+    enum class ServiceState
+    {
+        Started,
+        Stopped,
+        Initialized
+    };
+
+    ProfilerSignalManager* _pSignalManager;
+    IManagedThreadList* _pManagedThreadsList;
+    CpuTimeProvider* _pProvider;
+    CallstackProvider _callstackProvider;
+    pid_t _processId;
+    std::atomic<ServiceState> _serviceState;
+    std::chrono::milliseconds _samplingInterval;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -15,8 +15,6 @@
 #include "shared/src/native-src/string.h"
 #include "shared/src/native-src/util.h"
 
-using namespace std::literals::chrono_literals;
-
 std::string const Configuration::DefaultDevSite = "datad0g.com";
 std::string const Configuration::DefaultProdSite = "datadoghq.com";
 std::string const Configuration::DefaultVersion = "Unspecified-Version";
@@ -78,6 +76,7 @@ Configuration::Configuration()
     // Check CI Visibility mode
     _isCIVisibilityEnabled = GetEnvironmentValue(EnvironmentVariables::CIVisibilityEnabled, false);
     _internalCIVisibilitySpanId = uint64_t{0};
+    _cpuProfilingInterval = ExtractCpuProfilingInterval();
     if (_isCIVisibilityEnabled)
     {
         // We cannot write 0ull instead of std::uint64_t{0} because on Windows, compiling in x64, std::uint64_t == unsigned long long.
@@ -87,6 +86,8 @@ Configuration::Configuration()
 
         // If we detect CI Visibility we allow to reduce the minimum ms in sampling rate down to 1ms.
         _cpuWallTimeSamplingRate = ExtractCpuWallTimeSamplingRate(1);
+        // for timer_create based profiling
+        _cpuProfilingInterval = ExtractCpuProfilingInterval(1ms);
     }
 
     _isEtwEnabled = GetEnvironmentValue(EnvironmentVariables::EtwEnabled, false);
@@ -94,7 +95,6 @@ Configuration::Configuration()
     _isEtwLoggingEnabled = GetEnvironmentValue(EnvironmentVariables::EtwLoggingEnabled, false);
     _enablementStatus = ExtractEnablementStatus();
     _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, CpuProfilerType::ManualCpuTime);
-    _cpuProfilingInterval = ExtractCpuProfilingInterval();
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -459,16 +459,12 @@ std::chrono::seconds Configuration::ExtractUploadInterval()
     return GetDefaultUploadInterval();
 }
 
-std::chrono::milliseconds Configuration::ExtractCpuProfilingInterval()
+std::chrono::milliseconds Configuration::ExtractCpuProfilingInterval(std::chrono::milliseconds minimum)
 {
-    auto r = shared::GetEnvironmentValue(EnvironmentVariables::CpuProfilingInterval);
-    int32_t interval;
-    if (TryParse(r, interval))
-    {
-        return std::max(std::chrono::milliseconds(interval), DefaultCpuProfilingInterval);
-    }
-
-    return DefaultCpuProfilingInterval;
+    // For normal path (no CI-visibility), 9ms is the default and lowest value we can have
+    // for CI-Visibility we allow it to be less
+    auto interval = GetEnvironmentValue(EnvironmentVariables::CpuProfilingInterval, DefaultCpuProfilingInterval);
+    return std::max(interval, minimum);
 }
 
 std::chrono::nanoseconds Configuration::ExtractCpuWallTimeSamplingRate(int minimum)
@@ -629,6 +625,17 @@ static bool convert_to(shared::WSTRING const& s, double& result)
 
     // Based on tests, numbers such as "0.1.2" are converted into 0.1 without error
     return (errno != ERANGE);
+}
+
+static bool convert_to(shared::WSTRING const& s, std::chrono::milliseconds& result)
+{
+    std::uint64_t value;
+    auto parsed = TryParse(s, value);
+    if (parsed)
+    {
+        result = std::chrono::milliseconds(value);
+    }
+    return parsed;
 }
 
 static bool convert_to(shared::WSTRING const& s, DeploymentMode& result)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -26,6 +26,7 @@ int32_t const Configuration::DefaultAgentPort = 8126;
 std::string const Configuration::DefaultEmptyString = "";
 std::chrono::seconds const Configuration::DefaultDevUploadInterval = 20s;
 std::chrono::seconds const Configuration::DefaultProdUploadInterval = 60s;
+std::chrono::milliseconds const Configuration::DefaultCpuProfilingInterval = 10ms;
 
 Configuration::Configuration()
 {
@@ -93,6 +94,7 @@ Configuration::Configuration()
     _isEtwLoggingEnabled = GetEnvironmentValue(EnvironmentVariables::EtwLoggingEnabled, false);
     _enablementStatus = ExtractEnablementStatus();
     _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, CpuProfilerType::ManualCpuTime);
+    _cpuProfilingInterval = ExtractCpuProfilingInterval();
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -457,6 +459,18 @@ std::chrono::seconds Configuration::ExtractUploadInterval()
     return GetDefaultUploadInterval();
 }
 
+std::chrono::milliseconds Configuration::ExtractCpuProfilingInterval()
+{
+    auto r = shared::GetEnvironmentValue(EnvironmentVariables::CpuProfilingInterval);
+    int32_t interval;
+    if (TryParse(r, interval))
+    {
+        return std::max(std::chrono::milliseconds(interval), DefaultCpuProfilingInterval);
+    }
+
+    return DefaultCpuProfilingInterval;
+}
+
 std::chrono::nanoseconds Configuration::ExtractCpuWallTimeSamplingRate(int minimum)
 {
     // default sampling rate is 9 ms; could be changed via env vars but down to a minimum of 5 ms
@@ -565,6 +579,12 @@ DeploymentMode Configuration::GetDeploymentMode() const
 CpuProfilerType Configuration::GetCpuProfilerType() const
 {
     return _cpuProfilerType;
+}
+
+=======
+std::chrono::milliseconds Configuration::GetCpuProfilingInterval() const
+{
+    return _cpuProfilingInterval;
 }
 
 static bool convert_to(shared::WSTRING const& s, bool& result)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -26,7 +26,7 @@ int32_t const Configuration::DefaultAgentPort = 8126;
 std::string const Configuration::DefaultEmptyString = "";
 std::chrono::seconds const Configuration::DefaultDevUploadInterval = 20s;
 std::chrono::seconds const Configuration::DefaultProdUploadInterval = 60s;
-std::chrono::milliseconds const Configuration::DefaultCpuProfilingInterval = 10ms;
+std::chrono::milliseconds const Configuration::DefaultCpuProfilingInterval = 9ms;
 
 Configuration::Configuration()
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -581,7 +581,6 @@ CpuProfilerType Configuration::GetCpuProfilerType() const
     return _cpuProfilerType;
 }
 
-=======
 std::chrono::milliseconds Configuration::GetCpuProfilingInterval() const
 {
     return _cpuProfilingInterval;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -92,6 +92,7 @@ Configuration::Configuration()
     _deploymentMode = GetEnvironmentValue(EnvironmentVariables::SsiDeployed, DeploymentMode::Manual);
     _isEtwLoggingEnabled = GetEnvironmentValue(EnvironmentVariables::EtwLoggingEnabled, false);
     _enablementStatus = ExtractEnablementStatus();
+    _cpuProfilerType = GetEnvironmentValue(EnvironmentVariables::CpuProfilerType, CpuProfilerType::ManualCpuTime);
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -559,6 +560,11 @@ EnablementStatus Configuration::GetEnablementStatus() const
 DeploymentMode Configuration::GetDeploymentMode() const
 {
     return _deploymentMode;
+}
+
+CpuProfilerType Configuration::GetCpuProfilerType() const
+{
+    return _cpuProfilerType;
 }
 
 static bool convert_to(shared::WSTRING const& s, bool& result)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -8,6 +8,7 @@
 
 #include "DeploymentMode.h"
 #include "EnablementStatus.h"
+#include "CpuProfilerType.h"
 #include "IConfiguration.h"
 #include "TagsHelper.h"
 #include "shared/src/native-src/string.h"
@@ -72,6 +73,8 @@ public:
     bool IsEtwLoggingEnabled() const override;
     EnablementStatus GetEnablementStatus() const override;
     DeploymentMode GetDeploymentMode() const override;
+    CpuProfilerType GetCpuProfilerType() const override;
+
 
 private:
     static tags ExtractUserTags();
@@ -159,4 +162,5 @@ private:
     DeploymentMode _deploymentMode;
     bool _isEtwLoggingEnabled;
     EnablementStatus _enablementStatus;
+    CpuProfilerType _cpuProfilerType;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -16,6 +16,8 @@
 #include "shared/src/native-src/dd_filesystem.hpp"
 // namespace fs is an alias defined in "dd_filesystem.hpp"
 
+using namespace std::literals::chrono_literals;
+
 class Configuration final : public IConfiguration
 {
 public:
@@ -82,7 +84,7 @@ private:
     static std::string GetDefaultSite();
     static std::string ExtractSite();
     static std::chrono::seconds ExtractUploadInterval();
-    static std::chrono::milliseconds ExtractCpuProfilingInterval();
+    static std::chrono::milliseconds ExtractCpuProfilingInterval(std::chrono::milliseconds minimum = DefaultCpuProfilingInterval);
     static fs::path GetDefaultLogDirectoryPath();
     static fs::path GetApmBaseDirectory();
     static fs::path ExtractLogDirectory();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -74,6 +74,7 @@ public:
     EnablementStatus GetEnablementStatus() const override;
     DeploymentMode GetDeploymentMode() const override;
     CpuProfilerType GetCpuProfilerType() const override;
+    std::chrono::milliseconds GetCpuProfilingInterval() const override;
 
 
 private:
@@ -81,6 +82,7 @@ private:
     static std::string GetDefaultSite();
     static std::string ExtractSite();
     static std::chrono::seconds ExtractUploadInterval();
+    static std::chrono::milliseconds ExtractCpuProfilingInterval();
     static fs::path GetDefaultLogDirectoryPath();
     static fs::path GetApmBaseDirectory();
     static fs::path ExtractLogDirectory();
@@ -108,6 +110,7 @@ private:
     static int32_t const DefaultAgentPort;
     static std::chrono::seconds const DefaultDevUploadInterval;
     static std::chrono::seconds const DefaultProdUploadInterval;
+    static std::chrono::milliseconds const DefaultCpuProfilingInterval;
 
     bool _isProfilingEnabled;
     bool _isCpuProfilingEnabled;
@@ -163,4 +166,5 @@ private:
     bool _isEtwLoggingEnabled;
     EnablementStatus _enablementStatus;
     CpuProfilerType _cpuProfilerType;
+    std::chrono::milliseconds _cpuProfilingInterval;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1513,6 +1513,11 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
 #endif
 
 #ifdef LINUX
+    auto threadInfo = _pManagedThreadList->GetOrCreate(managedThreadId);
+    // CurrentThreadInfo relies on the assumption that the native thread calling ThreadAssignedToOSThread/ThreadDestroyed
+    // is the same native thread assigned to the managed thread.
+    ManagedThreadInfo::CurrentThreadInfo = threadInfo;
+
     if (_systemCallsShield != nullptr)
     {
         // Register/Unregister rely on the following assumption:
@@ -1521,7 +1526,6 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
         // If at some point, it's not true, we can remove Register/Unregister on the SystemCallsShield class.
         // Then initiliaze the TLS managedThreadInfo (by calling TryGetCurrentThreadInfo) the first time a call is made in SystemCallsShield
         // SystemCallsShield::SetSharedMemory callback.
-        auto threadInfo = _pManagedThreadList->GetOrCreate(managedThreadId);
         _systemCallsShield->Register(threadInfo);
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1495,6 +1495,11 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadDestroyed(ThreadID threadId
     {
         _systemCallsShield->Unregister();
     }
+
+    if (_pCpuProfiler != nullptr)
+    {
+        _pCpuProfiler->UnregisterThread(pThreadInfo);
+    }
 #endif
 
     return S_OK;
@@ -1537,6 +1542,11 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
     // CurrentThreadInfo relies on the assumption that the native thread calling ThreadAssignedToOSThread/ThreadDestroyed
     // is the same native thread assigned to the managed thread.
     ManagedThreadInfo::CurrentThreadInfo = threadInfo;
+
+    if (_pCpuProfiler != nullptr)
+    {
+        _pCpuProfiler->RegisterThread(threadInfo);
+    }
 
     if (_systemCallsShield != nullptr)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -15,11 +15,12 @@
 #include <windows.h>
 #else
 #include "cgroup.h"
-#include <signal.h>
 #include <libunwind.h>
+#include <signal.h>
 #endif
 
 #include "AllocationsProvider.h"
+#include "AllocationsRecorder.h"
 #include "AppDomainStore.h"
 #include "ApplicationStore.h"
 #include "CallstackProvider.h"
@@ -36,11 +37,12 @@
 #include "GCThreadsCpuProvider.h"
 #include "IMetricsSender.h"
 #include "IMetricsSenderFactory.h"
-#include "ProfileExporter.h"
 #include "Log.h"
 #include "ManagedThreadList.h"
+#include "MetadataProvider.h"
 #include "OpSysTools.h"
 #include "OsSpecificApi.h"
+#include "ProfileExporter.h"
 #include "ProfilerEngineStatus.h"
 #include "RuntimeIdStore.h"
 #include "RuntimeInfo.h"
@@ -49,10 +51,10 @@
 #include "StackSamplerLoopManager.h"
 #include "ThreadsCpuManager.h"
 #include "WallTimeProvider.h"
-#include "AllocationsRecorder.h"
-#include "MetadataProvider.h"
 #ifdef LINUX
+#include "ProfilerSignalManager.h"
 #include "SystemCallsShield.h"
+#include "TimerCreateCpuProfiler.h"
 #endif
 
 #include "shared/src/native-src/environment_variables.h"
@@ -60,7 +62,6 @@
 #include "shared/src/native-src/string.h"
 
 #include "dd_profiler_version.h"
-
 
 IClrLifetime* CorProfilerCallback::GetClrLifetime() const
 {
@@ -75,7 +76,6 @@ extern "C" __declspec(dllexport) const char* Profiler_Version = PROFILER_VERSION
 #else
 extern "C" __attribute__((visibility("default"))) const char* Profiler_Version = PROFILER_VERSION;
 #endif
-
 
 // Initialization
 CorProfilerCallback* CorProfilerCallback::_this = nullptr;
@@ -168,7 +168,17 @@ bool CorProfilerCallback::InitializeServices()
 
     if (_pConfiguration->IsCpuProfilingEnabled())
     {
-        _pCpuTimeProvider = RegisterService<CpuTimeProvider>(valueTypeProvider, _pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore, _pConfiguration.get(), MemoryResourceManager::GetDefault());
+        shared::pmr::memory_resource* memoryResource = MemoryResourceManager::GetDefault();
+
+#ifdef LINUX
+        if (_pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
+        {
+            auto const useMmap = true;
+            memoryResource = _memoryResourceManager.GetSynchronizedPool(100, 4096, useMmap);
+        }
+#endif
+        _pCpuTimeProvider = RegisterService<CpuTimeProvider>(
+            valueTypeProvider, _pThreadsCpuManager, _pFrameStore.get(), _pAppDomainStore.get(), pRuntimeIdStore, _pConfiguration.get(), memoryResource);
     }
 
     if (_pConfiguration->IsExceptionProfilingEnabled())
@@ -219,7 +229,7 @@ bool CorProfilerCallback::InitializeServices()
                     _metricsRegistry,
                     CallstackProvider(_memoryResourceManager.GetDefault()),
                     MemoryResourceManager::GetDefault()
-                    );
+                );
 
                 if (!_pConfiguration->IsAllocationProfilingEnabled())
                 {
@@ -248,7 +258,7 @@ bool CorProfilerCallback::InitializeServices()
                 _metricsRegistry,
                 CallstackProvider(_memoryResourceManager.GetDefault()),
                 MemoryResourceManager::GetDefault()
-                );
+            );
         }
 
         if (_pConfiguration->IsContentionProfilingEnabled())
@@ -265,7 +275,7 @@ bool CorProfilerCallback::InitializeServices()
                 _metricsRegistry,
                 CallstackProvider(_memoryResourceManager.GetDefault()),
                 MemoryResourceManager::GetDefault()
-                );
+            );
         }
 
         if (_pConfiguration->IsGarbageCollectionProfilingEnabled())
@@ -278,7 +288,7 @@ bool CorProfilerCallback::InitializeServices()
                 pRuntimeIdStore,
                 _pConfiguration.get(),
                 MemoryResourceManager::GetDefault()
-                );
+            );
             _pGarbageCollectionProvider = RegisterService<GarbageCollectionProvider>(
                 valueTypeProvider,
                 _pFrameStore.get(),
@@ -288,7 +298,7 @@ bool CorProfilerCallback::InitializeServices()
                 _pConfiguration.get(),
                 _metricsRegistry,
                 MemoryResourceManager::GetDefault()
-                );
+            );
         }
         else
         {
@@ -301,7 +311,7 @@ bool CorProfilerCallback::InitializeServices()
             _pAllocationsProvider,
             _pContentionProvider,
             _pStopTheWorldProvider
-            );
+        );
 
         if (_pGarbageCollectionProvider != nullptr)
         {
@@ -440,6 +450,19 @@ bool CorProfilerCallback::InitializeServices()
         _metricsRegistry,
         CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize)));
 
+#ifdef LINUX
+    if (_pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
+    {
+        auto const useMmap = true;
+        _pCpuProfiler = RegisterService<TimerCreateCpuProfiler>(
+            _pConfiguration.get(),
+            ProfilerSignalManager::Get(SIGPROF),
+            _pManagedThreadList,
+            _pCpuTimeProvider,
+            CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize, useMmap)));
+    }
+#endif
+
     _pApplicationStore = RegisterService<ApplicationStore>(_pConfiguration.get());
 
     // The different elements of the libddprof pipeline are created and linked together
@@ -452,8 +475,7 @@ bool CorProfilerCallback::InitializeServices()
         _pEnabledProfilers.get(),
         _metricsRegistry,
         _pMetadataProvider.get(),
-        _pAllocationsRecorder.get()
-        );
+        _pAllocationsRecorder.get());
 
     if (_pConfiguration->IsGcThreadsCpuTimeEnabled() &&
         _pCpuTimeProvider != nullptr &&
@@ -917,14 +939,14 @@ void CorProfilerCallback::InspectRuntimeVersion(ICorProfilerInfo5* pCorProfilerI
         buffer << "{ "
                << "clrInstanceId:" << clrInstanceId
                << ", runtimeType:" <<
-                    ((runtimeType == COR_PRF_DESKTOP_CLR) ? "DESKTOP_CLR" :
-                    (runtimeType == COR_PRF_CORE_CLR) ? "CORE_CLR" :
-                    (std::string("unknown(") + std::to_string(runtimeType) + std::string(")")))
-                << ", majorVersion: " << major
-                << ", minorVersion: " << minor
-                << ", buildNumber: " << buildNumber
-                << ", qfeVersion: " << qfeVersion
-                << " }";
+                     ((runtimeType == COR_PRF_DESKTOP_CLR) ? "DESKTOP_CLR" :
+                     (runtimeType == COR_PRF_CORE_CLR) ? "CORE_CLR" :
+                     (std::string("unknown(") + std::to_string(runtimeType) + std::string(")")))
+               << ", majorVersion: " << major
+               << ", minorVersion: " << minor
+               << ", buildNumber: " << buildNumber
+               << ", qfeVersion: " << qfeVersion
+               << " }";
 
         CorProfilerCallback::_runtimeDescription = buffer.str();
         Log::Info("Initializing the Profiler: Reported runtime version :", CorProfilerCallback::_runtimeDescription);
@@ -1056,8 +1078,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
         _pConfiguration->IsHeapProfilingEnabled() ||
         _pConfiguration->IsAllocationProfilingEnabled() ||
         _pConfiguration->IsContentionProfilingEnabled() ||
-        _pConfiguration->IsGarbageCollectionProfilingEnabled()
-        ;
+        _pConfiguration->IsGarbageCollectionProfilingEnabled();
 
     if ((major >= 5) && AreEventBasedProfilersEnabled)
     {
@@ -1175,13 +1196,12 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
 
         COR_PRF_EVENTPIPE_PROVIDER_CONFIG providers[] =
             {
-                {
-                    WStr("Microsoft-Windows-DotNETRuntime"),
-                    activatedKeywords,
-                    verbosity,
-                    nullptr
-                }
-            };
+                {WStr("Microsoft-Windows-DotNETRuntime"),
+                 activatedKeywords,
+                 verbosity,
+                 nullptr
+            }
+        };
 
         hr = _pCorProfilerInfoEvents->EventPipeStartSession(
             sizeof(providers) / sizeof(providers[0]),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -451,7 +451,7 @@ bool CorProfilerCallback::InitializeServices()
         CallstackProvider(_memoryResourceManager.GetSynchronizedPool(100, Callstack::MaxSize)));
 
 #ifdef LINUX
-    if (_pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
+    if (_pConfiguration->IsCpuProfilingEnabled() && _pConfiguration->GetCpuProfilerType() == CpuProfilerType::TimerCreate)
     {
         auto const useMmap = true;
         _pCpuProfiler = RegisterService<TimerCreateCpuProfiler>(
@@ -1196,12 +1196,13 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::Initialize(IUnknown* corProfilerI
 
         COR_PRF_EVENTPIPE_PROVIDER_CONFIG providers[] =
             {
-                {WStr("Microsoft-Windows-DotNETRuntime"),
-                 activatedKeywords,
-                 verbosity,
-                 nullptr
-            }
-        };
+                {
+                    WStr("Microsoft-Windows-DotNETRuntime"),
+                    activatedKeywords,
+                    verbosity,
+                    nullptr
+                }
+            };
 
         hr = _pCorProfilerInfoEvents->EventPipeStartSession(
             sizeof(providers) / sizeof(providers[0]),

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -50,6 +50,7 @@ class IManagedThreadList;
 class IStackSamplerLoopManager;
 class IConfiguration;
 class IExporter;
+class TimerCreateCpuProfiler;
 
 
 #ifdef LINUX
@@ -240,6 +241,7 @@ private :
     ThreadLifetimeProvider* _pThreadLifetimeProvider = nullptr;
 #ifdef LINUX
     SystemCallsShield* _systemCallsShield = nullptr;
+    TimerCreateCpuProfiler* _pCpuProfiler = nullptr;
 #endif
 
     std::vector<std::unique_ptr<IService>> _services;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuProfilerType.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CpuProfilerType.h
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+#include "shared/src/native-src/string.h"
+
+enum class CpuProfilerType
+{
+    ManualCpuTime,
+#ifdef LINUX
+    TimerCreate
+#endif
+};
+
+inline bool convert_to(shared::WSTRING const& s, CpuProfilerType& profilerType)
+{
+    if (shared::string_iequal(s, WStr("ManualCpuTime")))
+    {
+        profilerType = CpuProfilerType::ManualCpuTime;
+        return true;
+    }
+#ifdef LINUX
+    else if (shared::string_iequal(s, WStr("TimerCreate")))
+    {
+        profilerType = CpuProfilerType::TimerCreate;
+        return true;
+    }
+#endif
+    return false;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -64,6 +64,7 @@ public:
     inline static const shared::WSTRING SsiDeployed                 = WStr("DD_INJECTION_ENABLED");
     inline static const shared::WSTRING EtwLoggingEnabled           = WStr("DD_INTERNAL_ETW_LOGGING_ENABLED");
     inline static const shared::WSTRING CpuProfilerType             = WStr("DD_INTERNAL_CPU_PROFILER_TYPE");
+    inline static const shared::WSTRING CpuProfilingInterval        = WStr("DD_INTERNAL_CPU_PROFILING_INTERVAL");
 
     inline static const shared::WSTRING CIVisibilityEnabled         = WStr("DD_CIVISIBILITY_ENABLED");
     inline static const shared::WSTRING InternalCIVisibilitySpanId  = WStr("DD_INTERNAL_CIVISIBILITY_SPANID");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -63,6 +63,7 @@ public:
     inline static const shared::WSTRING EtwEnabled                  = WStr("DD_INTERNAL_PROFILING_ETW_ENABLED");
     inline static const shared::WSTRING SsiDeployed                 = WStr("DD_INJECTION_ENABLED");
     inline static const shared::WSTRING EtwLoggingEnabled           = WStr("DD_INTERNAL_ETW_LOGGING_ENABLED");
+    inline static const shared::WSTRING CpuProfilerType             = WStr("DD_INTERNAL_CPU_PROFILER_TYPE");
 
     inline static const shared::WSTRING CIVisibilityEnabled         = WStr("DD_CIVISIBILITY_ENABLED");
     inline static const shared::WSTRING InternalCIVisibilitySpanId  = WStr("DD_INTERNAL_CIVISIBILITY_SPANID");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -11,6 +11,7 @@
 #include "DeploymentMode.h"
 #include "EnablementStatus.h"
 #include "TagsHelper.h"
+#include "CpuProfilerType.h"
 
 #include "shared/src/native-src/dd_filesystem.hpp"
 // namespace fs is an alias defined in "dd_filesystem.hpp"
@@ -70,4 +71,5 @@ public:
     virtual bool IsEtwLoggingEnabled() const = 0;
     virtual EnablementStatus GetEnablementStatus() const = 0;
     virtual DeploymentMode GetDeploymentMode() const = 0;
+    virtual CpuProfilerType GetCpuProfilerType() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -72,4 +72,5 @@ public:
     virtual EnablementStatus GetEnablementStatus() const = 0;
     virtual DeploymentMode GetDeploymentMode() const = 0;
     virtual CpuProfilerType GetCpuProfilerType() const = 0;
+    virtual std::chrono::milliseconds GetCpuProfilingInterval() const = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
@@ -8,6 +8,7 @@
 #include "ServiceBase.h"
 #include "ManagedThreadInfo.h"
 
+#include <functional>
 #include <memory>
 
 class IManagedThreadList : public ServiceBase
@@ -25,4 +26,5 @@ public:
     virtual HRESULT TryGetCurrentThreadInfo(std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) = 0;
     virtual std::shared_ptr<ManagedThreadInfo> GetOrCreate(ThreadID clrThreadId) = 0;
     virtual bool TryGetThreadInfo(uint32_t osThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) = 0;
+    virtual void ForEach(std::function<void (ManagedThreadInfo*)> callback) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
@@ -5,6 +5,7 @@
 #include "shared/src/native-src/string.h"
 
 std::atomic<std::uint32_t> ManagedThreadInfo::s_nextProfilerThreadInfoId{1};
+thread_local std::shared_ptr<ManagedThreadInfo> ManagedThreadInfo::CurrentThreadInfo{nullptr};
 
 std::uint32_t ManagedThreadInfo::GenerateProfilerThreadInfoId()
 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -40,6 +40,10 @@ public:
     explicit ManagedThreadInfo(ThreadID clrThreadId, ICorProfilerInfo4* pCorProfilerInfo);
     ~ManagedThreadInfo() = default;
 
+    // This field is set in the CorProfilerCallback. It's based on the assumption that the thread's calling ThreadAssignedToOSThread
+    // is the same native thread assigned to the managed thread.
+    static thread_local std::shared_ptr<ManagedThreadInfo> CurrentThreadInfo;
+
     inline std::uint32_t GetProfilerThreadInfoId() const;
 
     inline ThreadID GetClrThreadId() const;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -93,6 +93,8 @@ public:
 #ifdef LINUX
     inline void SetSharedMemory(volatile int* memoryArea);
     inline void MarkAsInterrupted();
+    inline int32_t SetTimerId(int32_t timerId);
+    inline int32_t GetTimerId() const;
 #endif
     inline bool CanBeInterrupted() const;
 
@@ -146,6 +148,9 @@ private:
     ICorProfilerInfo4* _info;
     std::shared_mutex _threadIdMutex;
     std::shared_mutex _threadNameMutex;
+#ifdef LINUX
+    std::int32_t _timerId;
+#endif
 };
 
 std::string ManagedThreadInfo::GetProfileThreadId()
@@ -457,6 +462,16 @@ inline void ManagedThreadInfo::MarkAsInterrupted()
 inline void ManagedThreadInfo::SetSharedMemory(volatile int* memoryArea)
 {
     _sharedMemoryArea = memoryArea;
+}
+
+inline std::int32_t ManagedThreadInfo::SetTimerId(std::int32_t timerId)
+{
+    return std::exchange(_timerId, timerId);
+}
+
+inline std::int32_t ManagedThreadInfo::GetTimerId() const
+{
+    return _timerId;
 }
 #endif
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -85,7 +85,6 @@ public:
     inline TraceContextTrackingInfo* GetTraceContextPointer();
     inline std::uint64_t GetLocalRootSpanId() const;
     inline std::uint64_t GetSpanId() const;
-    inline bool CanReadTraceContext() const;
     inline bool HasTraceContext() const;
 
     inline std::string GetProfileThreadId() override;
@@ -99,9 +98,12 @@ public:
 
     inline AppDomainID GetAppDomainId();
 
+    inline std::pair<std::uint64_t, std::uint64_t> GetTracingContext() const;
+
 private:
     inline std::string BuildProfileThreadId();
     inline std::string BuildProfileThreadName();
+    inline bool CanReadTraceContext() const;
 
 private:
     static constexpr std::uint32_t MaxProfilerThreadInfoId = 0xFFFFFF; // = 16,777,215
@@ -467,4 +469,18 @@ inline AppDomainID ManagedThreadInfo::GetAppDomainId()
     AppDomainID appDomainId{0};
     HRESULT hr = _info->GetThreadAppDomain(_clrThreadId, &appDomainId);
     return appDomainId;
+}
+
+inline std::pair<std::uint64_t, std::uint64_t> ManagedThreadInfo::GetTracingContext() const
+{
+    std::uint64_t localRootSpanId = 0;
+    std::uint64_t spanId = 0;
+
+    if (CanReadTraceContext())
+    {
+        localRootSpanId = GetLocalRootSpanId();
+        spanId = GetSpanId();
+    }
+
+    return {localRootSpanId, spanId};
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -365,3 +365,13 @@ bool ManagedThreadList::RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThre
 
     return false;
 }
+
+void ManagedThreadList::ForEach(std::function<void (ManagedThreadInfo*)> callback)
+{
+    std::lock_guard<std::recursive_mutex> lock(_mutex);
+
+    for (auto& thread : _threads)
+    {
+        callback(thread.get());
+    }
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
@@ -40,6 +40,7 @@ public:
     HRESULT TryGetCurrentThreadInfo(std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
     std::shared_ptr<ManagedThreadInfo> GetOrCreate(ThreadID clrThreadId) override;
     bool TryGetThreadInfo(uint32_t osThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
+    void ForEach(std::function<void (ManagedThreadInfo*)> callback) override;
 
 private:
     const char* _serviceName = "ManagedThreadList";

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MemoryResourceManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MemoryResourceManager.cpp
@@ -3,6 +3,10 @@
 
 #include "MemoryResourceManager.h"
 
+#ifdef LINUX
+#include "MmapMemoryResource.h"
+#endif
+
 MemoryResourceManager::MemoryResourceManager(MemoryResourceManager&& other) noexcept
 {
     *this = std::move(other);
@@ -24,15 +28,42 @@ shared::pmr::memory_resource* MemoryResourceManager::GetDefault()
     return shared::pmr::get_default_resource();
 }
 
-shared::pmr::memory_resource* MemoryResourceManager::GetSynchronizedPool(std::size_t maxBlocksPerChunk, std::size_t maxBlockSize)
+shared::pmr::memory_resource* MemoryResourceManager::GetSynchronizedPool(
+    std::size_t maxBlocksPerChunk,
+    std::size_t maxBlockSize,
+    bool useMmapAsUpstream)
+{
+    auto* upstream =
+#ifdef _WINDOWS
+        GetDefault();
+#else
+        useMmapAsUpstream ? GetMmapResource() : GetDefault();
+#endif
+
+    return GetSynchronizedPool(upstream, maxBlocksPerChunk, maxBlockSize);
+}
+
+shared::pmr::memory_resource* MemoryResourceManager::GetSynchronizedPool(
+    shared::pmr::memory_resource* upstream,
+    std::size_t maxBlocksPerChunk,
+    std::size_t maxBlockSize)
 {
 #if defined(__cpp_lib_experimental_memory_resources) && (__cpp_lib_experimental_memory_resources <= 201402L)
 #pragma GCC warning "synchronized_pool_resource does not exist. Use the default (new/delete) memory resource for now."
     return GetDefault();
 #else
     _resources.push_back(std::make_unique<shared::pmr::synchronized_pool_resource>(
-        shared::pmr::pool_options{.max_blocks_per_chunk = maxBlocksPerChunk, .largest_required_pool_block = maxBlockSize}));
+        shared::pmr::pool_options{.max_blocks_per_chunk = maxBlocksPerChunk, .largest_required_pool_block = maxBlockSize},
+        upstream));
 
     return _resources.back().get();
 #endif
 }
+
+#ifdef LINUX
+shared::pmr::memory_resource* MemoryResourceManager::GetMmapResource()
+{
+    static auto resource = std::make_unique<MmapMemoryResource>();
+    return resource.get();
+}
+#endif

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MemoryResourceManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/MemoryResourceManager.h
@@ -22,8 +22,17 @@ public:
     MemoryResourceManager& operator=(MemoryResourceManager&& other) noexcept;
 
     static shared::pmr::memory_resource* GetDefault();
-    shared::pmr::memory_resource* GetSynchronizedPool(std::size_t maxBlocksPerChunk, std::size_t maxBlockSize);
+    shared::pmr::memory_resource* GetSynchronizedPool(std::size_t maxBlocksPerChunk, std::size_t maxBlockSize, bool useMmapAsUpstream = false);
 
 private:
+    shared::pmr::memory_resource* GetSynchronizedPool(
+        shared::pmr::memory_resource* upstream,
+        std::size_t maxBlocksPerChunk,
+        std::size_t maxBlockSize);
+
+#ifdef LINUX
+    shared::pmr::memory_resource* GetMmapResource();
+#endif
+
     std::vector<std::unique_ptr<shared::pmr::memory_resource>> _resources;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -106,6 +106,9 @@ public:
         return nbElement == 3;
     }
 
+    ///
+    /// This function get the current timestamp in a signal-safe manner
+    ///
     static inline std::uint64_t GetTimestampSafe()
     {
         struct timespec ts;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -105,6 +105,15 @@ public:
         }
         return nbElement == 3;
     }
+
+    static inline std::uint64_t GetTimestampSafe()
+    {
+        struct timespec ts;
+        // TODO error handling ?
+        clock_gettime(CLOCK_MONOTONIC, &ts);
+        return (std::uint64_t)ts.tv_sec * 1000000000 + ts.tv_nsec;
+    }
+
 #endif
 
     static bool IsSafeToStartProfiler(double coresThreshold, double& cpuLimit);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
@@ -78,3 +78,8 @@ bool ServiceBase::Stop()
 
     return result;
 }
+
+ServiceBase::State ServiceBase::GetState() const
+{
+    return _currentState;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
@@ -19,7 +19,6 @@ protected:
     virtual bool StartImpl() = 0;
     virtual bool StopImpl() = 0;
 
-private:
     enum class State
     {
         Init,
@@ -28,6 +27,10 @@ private:
         Stopping,
         Stopped
     };
+
+    State GetState() const;
+
+private:
 
     friend std::string to_string(ServiceBase::State);
     std::atomic<State> _currentState;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp
@@ -123,18 +123,16 @@ bool StackFramesCollectorBase::TryApplyTraceContextDataFromCurrentCollectionThre
 
     // If TraceContext Tracking is not enabled, then we will simply get zero IDs.
     ManagedThreadInfo* pCurrentCollectionThreadInfo = _pCurrentCollectionThreadInfo;
-    if (nullptr != pCurrentCollectionThreadInfo && pCurrentCollectionThreadInfo->CanReadTraceContext())
+    if (pCurrentCollectionThreadInfo == nullptr)
     {
-        std::uint64_t localRootSpanId = pCurrentCollectionThreadInfo->GetLocalRootSpanId();
-        std::uint64_t spanId = pCurrentCollectionThreadInfo->GetSpanId();
-
-        _pStackSnapshotResult->SetLocalRootSpanId(localRootSpanId);
-        _pStackSnapshotResult->SetSpanId(spanId);
-
-        return true;
+        return false;
     }
 
-    return false;
+    auto [localRootSpanId, spanId] = pCurrentCollectionThreadInfo->GetTracingContext();
+    _pStackSnapshotResult->SetLocalRootSpanId(localRootSpanId);
+    _pStackSnapshotResult->SetSpanId(spanId);
+
+    return true;
 }
 
 StackSnapshotResultBuffer* StackFramesCollectorBase::GetStackSnapshotResult()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -64,10 +64,8 @@ StackSamplerLoop::StackSamplerLoop(
     _cpuThreadsThreshold{pConfiguration->CpuThreadsThreshold()},
     _codeHotspotsThreadsThreshold{pConfiguration->CodeHotspotsThreadsThreshold()},
     _isWalltimeEnabled{pConfiguration->IsWallTimeProfilingEnabled()},
-    _isCpuEnabled{pConfiguration->IsCpuProfilingEnabled()},
-    _areInternalMetricsEnabled{pConfiguration->IsInternalMetricsEnabled()}
     _isCpuEnabled{pConfiguration->IsCpuProfilingEnabled() && pConfiguration->GetCpuProfilerType() == CpuProfilerType::ManualCpuTime},
-    _areInternalMetricsEnabled{pConfiguration->IsInternalMetricsEnabled()},
+    _areInternalMetricsEnabled{pConfiguration->IsInternalMetricsEnabled()}
 {
     _nbCores = OsSpecificApi::GetProcessorCount();
     Log::Info("Processor cores = ", _nbCores);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -66,6 +66,8 @@ StackSamplerLoop::StackSamplerLoop(
     _isWalltimeEnabled{pConfiguration->IsWallTimeProfilingEnabled()},
     _isCpuEnabled{pConfiguration->IsCpuProfilingEnabled()},
     _areInternalMetricsEnabled{pConfiguration->IsInternalMetricsEnabled()}
+    _isCpuEnabled{pConfiguration->IsCpuProfilingEnabled() && pConfiguration->GetCpuProfilerType() == CpuProfilerType::ManualCpuTime},
+    _areInternalMetricsEnabled{pConfiguration->IsInternalMetricsEnabled()},
 {
     _nbCores = OsSpecificApi::GetProcessorCount();
     Log::Info("Processor cores = ", _nbCores);
@@ -75,6 +77,8 @@ StackSamplerLoop::StackSamplerLoop(
     Log::Info("Wall time sampled threads = ", _walltimeThreadsThreshold);
     Log::Info("Max CodeHotspots sampled threads = ", _codeHotspotsThreadsThreshold);
     Log::Info("Max CPU sampled threads = ", _cpuThreadsThreshold);
+    Log::Info("Cpu profiler is ", (_isCpuEnabled) ? "enabled" : "disabled");
+    Log::Info("Wall-time profiler is ", (_isWalltimeEnabled) ? "enabled" : "disabled");
 
     _pCorProfilerInfo->AddRef();
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -75,7 +75,7 @@ StackSamplerLoop::StackSamplerLoop(
     Log::Info("Wall time sampled threads = ", _walltimeThreadsThreshold);
     Log::Info("Max CodeHotspots sampled threads = ", _codeHotspotsThreadsThreshold);
     Log::Info("Max CPU sampled threads = ", _cpuThreadsThreshold);
-    Log::Info("Cpu profiler is ", (_isCpuEnabled) ? "enabled" : "disabled");
+    Log::Info("Manual Cpu profiler is ", (_isCpuEnabled) ? "enabled" : "disabled");
     Log::Info("Wall-time profiler is ", (_isWalltimeEnabled) ? "enabled" : "disabled");
 
     _pCorProfilerInfo->AddRef();

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentVariables.cs
@@ -27,5 +27,7 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
         public const string ThreadLifetimeEnabled = "DD_INTERNAL_THREAD_LIFETIME_ENABLED";
         public const string SsiDeployed = "DD_INJECTION_ENABLED";
         public const string EtwEnabled = "DD_INTERNAL_PROFILING_ETW_ENABLED";
+        public const string CpuProfilerType = "DD_INTERNAL_CPU_PROFILER_TYPE";
+        public const string CpuProfilingInterval = "DD_INTERNAL_CPU_PROFILING_INTERVAL";
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/SignalHandlerTest.cs
@@ -48,7 +48,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
                 .Single(f => Path.GetFileName(f).StartsWith("DD-DotNet-Profiler-Native-"));
 
             var nbSignalHandlerInstallation = File.ReadLines(logFile)
-                .Count(l => l.Contains("Successfully setup signal handler for SIGUSR1 signal."));
+                .Count(l => l.Contains("Successfully setup signal handler for"));
 
             nbSignalHandlerInstallation.Should().Be(1);
         }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
@@ -1,0 +1,74 @@
+// <copyright file="TimerCreateCpuProfilerTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using Datadog.Profiler.IntegrationTests.Helpers;
+using FluentAssertions;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.LinuxOnly
+{
+    [Trait("Category", "LinuxOnly")]
+    public class TimerCreateCpuProfilerTest
+    {
+        private const string CmdLine = "--timeout 10"; // default scenario is PI computation to run for 10 seconds
+
+        private readonly ITestOutputHelper _output;
+
+        public TimerCreateCpuProfilerTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void CheckCpuSamples(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
+            var samplingInterval = "21"; // ms
+            // disable default profilers except CPU
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilingInterval, samplingInterval);
+            runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
+            runner.Environment.SetVariable(EnvironmentVariables.GarbageCollectionProfilerEnabled, "0");
+            runner.Environment.SetVariable(EnvironmentVariables.ExceptionProfilerEnabled, "0");
+            runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "0");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(_output);
+
+            runner.Run(agent);
+
+            // only cpu  profiler enabled so should see 1 value per sample and
+            foreach (var (_, _, values) in SamplesHelper.GetSamples(runner.Environment.PprofDir))
+            {
+                values.Length.Should().Be(1);
+                values.Should().OnlyContain(x => x == long.Parse(samplingInterval) * 1_000_000);
+            }
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void CheckCpuSamplesForDefaultSampingInterval(string appName, string framework, string appAssembly)
+        {
+            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
+            var samplingInterval = "10"; // ms (default)
+            // disable default profilers except CPU
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
+            runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
+            runner.Environment.SetVariable(EnvironmentVariables.GarbageCollectionProfilerEnabled, "0");
+            runner.Environment.SetVariable(EnvironmentVariables.ExceptionProfilerEnabled, "0");
+            runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "0");
+
+            using var agent = MockDatadogAgent.CreateHttpAgent(_output);
+
+            runner.Run(agent);
+
+            // only cpu  profiler enabled so should see 1 value per sample and
+            foreach (var (_, _, values) in SamplesHelper.GetSamples(runner.Environment.PprofDir))
+            {
+                values.Length.Should().Be(1);
+                values.Should().OnlyContain(x => x == long.Parse(samplingInterval) * 1_000_000);
+            }
+        }
+    }
+}

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/TimerCreateCpuProfilerTest.cs
@@ -28,12 +28,10 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
             var samplingInterval = "21"; // ms
             // disable default profilers except CPU
+            EnvironmentHelper.DisableDefaultProfilers(runner);
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
             runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
             runner.Environment.SetVariable(EnvironmentVariables.CpuProfilingInterval, samplingInterval);
-            runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
-            runner.Environment.SetVariable(EnvironmentVariables.GarbageCollectionProfilerEnabled, "0");
-            runner.Environment.SetVariable(EnvironmentVariables.ExceptionProfilerEnabled, "0");
-            runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "0");
 
             using var agent = MockDatadogAgent.CreateHttpAgent(_output);
 
@@ -53,11 +51,8 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, commandLine: CmdLine);
             var samplingInterval = "10"; // ms (default)
             // disable default profilers except CPU
-            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerType, "TimerCreate");
-            runner.Environment.SetVariable(EnvironmentVariables.WallTimeProfilerEnabled, "0");
-            runner.Environment.SetVariable(EnvironmentVariables.GarbageCollectionProfilerEnabled, "0");
-            runner.Environment.SetVariable(EnvironmentVariables.ExceptionProfilerEnabled, "0");
-            runner.Environment.SetVariable(EnvironmentVariables.ContentionProfilerEnabled, "0");
+            EnvironmentHelper.DisableDefaultProfilers(runner);
+            runner.Environment.SetVariable(EnvironmentVariables.CpuProfilerEnabled, "1");
 
             using var agent = MockDatadogAgent.CreateHttpAgent(_output);
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -1004,7 +1004,7 @@ TEST(ConfigurationTest, CheckDefaultCpuProfilingInterval)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilingInterval, WStr(""));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilingInterval(), 10ms);
+    ASSERT_THAT(configuration.GetCpuProfilingInterval(), 9ms);
 }
 
 TEST(ConfigurationTest, CheckCpuProfilingIntervalSetInEnvVar)
@@ -1018,5 +1018,5 @@ TEST(ConfigurationTest, CheckCpuProfilingIntervalIsNotBelowDefault)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilingInterval, WStr("1"));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetCpuProfilingInterval(), 10ms);
+    ASSERT_THAT(configuration.GetCpuProfilingInterval(), 9ms);
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -973,6 +973,12 @@ TEST(ConfigurationTest, CheckDefaultCpuProfilerType)
     ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
 }
 
+TEST(ConfigurationTest, CheckDefaultCpuProfilerTypeWhenEnvVarNotSet)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+}
+
 TEST(ConfigurationTest, CheckUnknownCpuProfilerType)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("UnknownCpuProfilerType"));

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -999,3 +999,24 @@ TEST(ConfigurationTest, CheckTimerCreateCpuProfilerType)
 #endif
     ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
 }
+
+TEST(ConfigurationTest, CheckDefaultCpuProfilingInterval)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilingInterval, WStr(""));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetCpuProfilingInterval(), 10ms);
+}
+
+TEST(ConfigurationTest, CheckCpuProfilingIntervalSetInEnvVar)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilingInterval, WStr("42"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetCpuProfilingInterval(), 42ms);
+}
+
+TEST(ConfigurationTest, CheckCpuProfilingIntervalIsNotBelowDefault)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilingInterval, WStr("1"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetCpuProfilingInterval(), 10ms);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -965,3 +965,37 @@ TEST(ConfigurationTest, CheckEtwLoggingIsEnabledIfEnvVarSetToTrue)
 #endif
     ASSERT_THAT(configuration.IsEtwLoggingEnabled(), expectedValue);
 }
+
+TEST(ConfigurationTest, CheckDefaultCpuProfilerType)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr(""));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+}
+
+TEST(ConfigurationTest, CheckUnknownCpuProfilerType)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("UnknownCpuProfilerType"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+}
+
+TEST(ConfigurationTest, CheckManualCpuProfilerType)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("ManualCpuTime"));
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetCpuProfilerType(), CpuProfilerType::ManualCpuTime);
+}
+
+TEST(ConfigurationTest, CheckTimerCreateCpuProfilerType)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::CpuProfilerType, WStr("TimerCreate"));
+    auto configuration = Configuration{};
+    auto expected =
+#ifdef LINUX
+        CpuProfilerType::TimerCreate;
+#else
+        CpuProfilerType::ManualCpuTime;
+#endif
+    ASSERT_THAT(configuration.GetCpuProfilerType(), expected);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/CpuProfilerTypeTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CpuProfilerTypeTest.cpp
@@ -36,7 +36,7 @@ TEST(CpuProfilerTypeTest, CheckManualCpuTimeCaseInsensitive)
 
 #ifdef LINUX
 
-TEST(CpuProfilerTypeTest, CheckTimeCreate)
+TEST(CpuProfilerTypeTest, CheckTimerCreate)
 {
     CpuProfilerType result;
     ASSERT_TRUE(convert_to(WStr("TimerCreate"), result));

--- a/profiler/test/Datadog.Profiler.Native.Tests/CpuProfilerTypeTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CpuProfilerTypeTest.cpp
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "CpuProfilerType.h"
+
+TEST(CpuProfilerTypeTest, CheckEmptyStringConversion)
+{
+    CpuProfilerType result;
+    ASSERT_FALSE(convert_to(WStr(""), result));
+}
+
+TEST(CpuProfilerTypeTest, CheckUnrecognizedType)
+{
+    CpuProfilerType result;
+    ASSERT_FALSE(convert_to(WStr("UnknownType"), result));
+}
+
+TEST(CpuProfilerTypeTest, CheckManualCpuTime)
+{
+    CpuProfilerType result;
+    ASSERT_TRUE(convert_to(WStr("ManualCpuTime"), result));
+
+    ASSERT_EQ(CpuProfilerType::ManualCpuTime, result);
+}
+
+TEST(CpuProfilerTypeTest, CheckManualCpuTimeCaseInsensitive)
+{
+    CpuProfilerType result;
+    ASSERT_TRUE(convert_to(WStr("maNualCPUTimE"), result));
+
+    ASSERT_EQ(CpuProfilerType::ManualCpuTime, result);
+}
+
+#ifdef LINUX
+
+TEST(CpuProfilerTypeTest, CheckTimeCreate)
+{
+    CpuProfilerType result;
+    ASSERT_TRUE(convert_to(WStr("TimerCreate"), result));
+
+    ASSERT_EQ(CpuProfilerType::TimerCreate, result);
+}
+
+TEST(CpuProfilerTypeTest, CheckTimerCreateInsensitive)
+{
+    CpuProfilerType result;
+    ASSERT_TRUE(convert_to(WStr("TimERCreAte"), result));
+
+    ASSERT_EQ(CpuProfilerType::TimerCreate, result);
+}
+#endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -57,6 +57,7 @@
     <ClCompile Include="ApplicationStoreTest.cpp" />
     <ClCompile Include="CallstackTest.cpp" />
     <ClCompile Include="ConfigurationTest.cpp" />
+    <ClCompile Include="CpuProfilerTypeTest.cpp" />
     <ClCompile Include="EnabledProfilersTest.cpp" />
     <ClCompile Include="EnvironmentHelper.cpp" />
     <ClCompile Include="ErrorCodeTest.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -166,6 +166,9 @@
     <ClCompile Include="ServiceBaseTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="CpuProfilerTypeTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">

--- a/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/LinuxStackFramesCollectorTest.cpp
@@ -172,7 +172,7 @@ public:
         StopTest();
         _workerThread.reset();
 
-        ProfilerSignalManager::Get()->Reset();
+        GetSignalManager()->Reset();
 
         SignalHandlerForTest::_instance.reset();
         sigaction(SIGUSR1, &_oldAction, nullptr);
@@ -245,7 +245,7 @@ public:
 
     static ProfilerSignalManager* GetSignalManager()
     {
-        return ProfilerSignalManager::Get();
+        return ProfilerSignalManager::Get(SIGUSR1);
     }
 
     static LinuxStackFramesCollector CreateStackFramesCollector(ProfilerSignalManager* signalManager, IConfiguration* configuration, CallstackProvider* p)
@@ -369,7 +369,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckCollectionAbortIfInPthreadCreateCa
 {
     SimulateInsideWrappedFunctions();
 
-    auto* signalManager = ProfilerSignalManager::Get();
+    auto* signalManager = GetSignalManager();
 
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));
@@ -391,7 +391,7 @@ TEST_F(LinuxStackFramesCollectorFixture, CheckCollectionAbortIfInPthreadCreateCa
 
 TEST_F(LinuxStackFramesCollectorFixture, MustNotCollectIfUnknownThreadId)
 {
-    auto* signalManager = ProfilerSignalManager::Get();
+    auto* signalManager = GetSignalManager();
 
     auto [configuration, mockConfiguration] = CreateConfiguration();
     EXPECT_CALL(mockConfiguration, UseBacktrace2()).WillOnce(Return(true));

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -12,6 +12,7 @@
 #include "IRuntimeIdStore.h"
 #include "ISamplesCollector.h"
 #include "ISamplesProvider.h"
+#include "CpuProfilerType.h"
 #include "Sample.h"
 #include "SamplesEnumerator.h"
 #include "TagsHelper.h"
@@ -73,6 +74,7 @@ public:
     MOCK_METHOD(EnablementStatus, GetEnablementStatus, (), (const override));
     MOCK_METHOD(DeploymentMode, GetDeploymentMode, (), (const override));
     MOCK_METHOD(bool, IsEtwLoggingEnabled, (), (const override));
+    MOCK_METHOD(CpuProfilerType, GetCpuProfilerType, (), (const override));
 };
 
 class MockExporter : public IExporter

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -75,6 +75,7 @@ public:
     MOCK_METHOD(DeploymentMode, GetDeploymentMode, (), (const override));
     MOCK_METHOD(bool, IsEtwLoggingEnabled, (), (const override));
     MOCK_METHOD(CpuProfilerType, GetCpuProfilerType, (), (const override));
+    MOCK_METHOD(std::chrono::milliseconds, GetCpuProfilingInterval, (), (const override));
 };
 
 class MockExporter : public IExporter

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerSignalManagerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerSignalManagerTest.cpp
@@ -5,6 +5,7 @@
 
 #include "gtest/gtest.h"
 
+#include "OpSysTools.h"
 #include "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.h"
 
 #include <future>
@@ -88,13 +89,14 @@ TEST_F(ProfilerSignalManagerFixture, CheckTwoDifferentSignalInstallation)
     EXPECT_TRUE(sigusr1SignalManager->RegisterHandler(CustomHandler));
     EXPECT_TRUE(sigprofSignalManager->RegisterHandler(SigProfCustomHandler));
 
+    auto tid = OpSysTools::GetThreadId();
     SigProfHandlerCalled = false;
-    sigusr1SignalManager->SendSignal(gettid());
+    sigusr1SignalManager->SendSignal(tid);
 
     ASSERT_FALSE(SigProfHandlerCalled);
 
     SigProfHandlerCalled = false;
-    sigprofSignalManager->SendSignal(gettid());
+    sigprofSignalManager->SendSignal(tid);
 
     ASSERT_TRUE(SigProfHandlerCalled);
 }
@@ -103,7 +105,7 @@ TEST_F(ProfilerSignalManagerFixture, CheckTwoDifferentSignalInstallation)
 TEST_F(ProfilerSignalManagerFixture, CheckThrowIfSignalAbove31)
 {
     ASSERT_NO_THROW(ProfilerSignalManager::Get(SIGUSR1));
-    ASSERT_NO_THROW(ProfilerSignalManager::Get(SIGUSR1));
+    ASSERT_NO_THROW(ProfilerSignalManager::Get(SIGPROF));
 
     ASSERT_THROW(ProfilerSignalManager::Get(-1), std::invalid_argument);
     ASSERT_THROW(ProfilerSignalManager::Get(0), std::invalid_argument);

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerSignalManagerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerSignalManagerTest.cpp
@@ -81,7 +81,7 @@ bool SigProfCustomHandler(int signal, siginfo_t* info, void* context)
     return true;
 }
 
-TEST_F(ProfilerSignalManagerFixture, CheckTwoDifferentSignalInstallation)
+TEST_F(ProfilerSignalManagerFixture, CheckTwoDifferentSignalsInstallation)
 {
     auto* sigusr1SignalManager = ProfilerSignalManager::Get(SIGUSR1);
     auto* sigprofSignalManager = ProfilerSignalManager::Get(SIGPROF);
@@ -101,7 +101,6 @@ TEST_F(ProfilerSignalManagerFixture, CheckTwoDifferentSignalInstallation)
     ASSERT_TRUE(SigProfHandlerCalled);
 }
 
-
 TEST_F(ProfilerSignalManagerFixture, CheckThrowIfSignalAbove31)
 {
     ASSERT_NO_THROW(ProfilerSignalManager::Get(SIGUSR1));
@@ -112,6 +111,17 @@ TEST_F(ProfilerSignalManagerFixture, CheckThrowIfSignalAbove31)
     ASSERT_THROW(ProfilerSignalManager::Get(32), std::invalid_argument);
     ASSERT_THROW(ProfilerSignalManager::Get(33), std::invalid_argument);
     ASSERT_THROW(ProfilerSignalManager::Get(100), std::invalid_argument);
+}
+
+TEST_F(ProfilerSignalManagerFixture, CheckSignalDeRegistration)
+{
+    ProfilerSignalManager* manager = nullptr;
+    ASSERT_NO_THROW(manager = ProfilerSignalManager::Get(SIGPROF));
+
+    ASSERT_TRUE(manager->UnRegisterHandler());
+
+    // Make sure we do not un register more than once
+    ASSERT_FALSE(manager->UnRegisterHandler());
 }
 
 #endif

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerSignalManagerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerSignalManagerTest.cpp
@@ -103,20 +103,20 @@ TEST_F(ProfilerSignalManagerFixture, CheckTwoDifferentSignalsInstallation)
 
 TEST_F(ProfilerSignalManagerFixture, CheckThrowIfSignalAbove31)
 {
-    ASSERT_NO_THROW(ProfilerSignalManager::Get(SIGUSR1));
-    ASSERT_NO_THROW(ProfilerSignalManager::Get(SIGPROF));
+    ASSERT_NE(ProfilerSignalManager::Get(SIGUSR1), nullptr);
+    ASSERT_NE(ProfilerSignalManager::Get(SIGPROF), nullptr);
 
-    ASSERT_THROW(ProfilerSignalManager::Get(-1), std::invalid_argument);
-    ASSERT_THROW(ProfilerSignalManager::Get(0), std::invalid_argument);
-    ASSERT_THROW(ProfilerSignalManager::Get(32), std::invalid_argument);
-    ASSERT_THROW(ProfilerSignalManager::Get(33), std::invalid_argument);
-    ASSERT_THROW(ProfilerSignalManager::Get(100), std::invalid_argument);
+    ASSERT_EQ(ProfilerSignalManager::Get(-1), nullptr);
+    ASSERT_EQ(ProfilerSignalManager::Get(0), nullptr);
+    ASSERT_EQ(ProfilerSignalManager::Get(32), nullptr);
+    ASSERT_EQ(ProfilerSignalManager::Get(33), nullptr);
+    ASSERT_EQ(ProfilerSignalManager::Get(100), nullptr);
 }
 
 TEST_F(ProfilerSignalManagerFixture, CheckSignalDeRegistration)
 {
     ProfilerSignalManager* manager = nullptr;
-    ASSERT_NO_THROW(manager = ProfilerSignalManager::Get(SIGPROF));
+    ASSERT_NE(manager = ProfilerSignalManager::Get(SIGPROF), nullptr);
 
     ASSERT_TRUE(manager->UnRegisterHandler());
 

--- a/shared/src/native-src/string.cpp
+++ b/shared/src/native-src/string.cpp
@@ -145,4 +145,18 @@ namespace shared {
         return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
     }
 
+    bool icompare_pred(WCHAR a, WCHAR b)
+    {
+        return std::tolower(a) == std::tolower(b);
+    }
+
+    bool string_iequal(WSTRING const& s1, WSTRING const& s2)
+    {
+        if (s1.length() == s2.length())
+        {
+            return std::equal(s2.begin(), s2.end(), s1.begin(), icompare_pred);
+        }
+
+        return false;
+    }
 }  // namespace trace

--- a/shared/src/native-src/string.h
+++ b/shared/src/native-src/string.h
@@ -75,4 +75,6 @@ std::basic_string<TChar> ReplaceString(std::basic_string<TChar> subject, const s
     return subject;
 }
 
+bool string_iequal(WSTRING const& s1, WSTRING const& s2);
+
 } // namespace shared


### PR DESCRIPTION
## Summary of changes

Add `timer_create`-based CPU profiling on linux.

## Reason for change

On Linux, at each profiling tick, the sampling thread goes over the thread `proc` information (reading files) to 1) check if it's currently running on a CPU 2) retrieve the CPU time.

This is a significant overhead ( in addition to the stackwalking) and has a greater impact (relatively) in case of job application (applications that wait most of the time, and time to time, process requests/jobs)

With this (and the other improvements we've done in the past), this decrease the profiler overhead by at least 2x (2.46, the profiler had a 2.5s CPU overhead over a minute, with the various improvements, its goes to 1s CPU over a minute).

## Implementation details

- Revisit the `ProfilerSignalManager` to be able to get a manager by signal
- Add mmap-based memory resource
- Allow to change CPU profiler type ( manual or timer_create)
- Allow to change the CPU sampling interval

## Test coverage
- Add unit tests for new classes and new configuration
- Add integration tests for the new CPU profiler
- Add benchmark tests
- Add throughput test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
