### PR TITLE
[Tracing] sampling code cleanup

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -24,8 +24,6 @@ src/Datadog.Trace/OSPlatformName.cs
 src/Datadog.Trace/ProcessArchitecture.cs
 src/Datadog.Trace/PropagationErrorTagValues.cs
 src/Datadog.Trace/ReadOnlySpanContext.cs
-src/Datadog.Trace/SamplingPriority.cs
-src/Datadog.Trace/SamplingPriorityValues.cs
 src/Datadog.Trace/Scope.cs
 src/Datadog.Trace/Scope.IScope.cs
 src/Datadog.Trace/Span.cs
@@ -85,7 +83,6 @@ src/Datadog.Trace/Ci/IEvent.cs
 src/Datadog.Trace/ClrProfiler/AutomaticTracer.cs
 src/Datadog.Trace/ClrProfiler/CallTargetKind.cs
 src/Datadog.Trace/ClrProfiler/ClrNames.cs
-src/Datadog.Trace/ClrProfiler/CommonTracer.cs
 src/Datadog.Trace/ClrProfiler/DistributedTracer.cs
 src/Datadog.Trace/ClrProfiler/IAutomaticTracer.cs
 src/Datadog.Trace/ClrProfiler/ICommonTracer.cs
@@ -198,20 +195,14 @@ src/Datadog.Trace/RuntimeMetrics/PerformanceCounterWrapper.cs
 src/Datadog.Trace/RuntimeMetrics/RuntimeEventListener.cs
 src/Datadog.Trace/RuntimeMetrics/RuntimeMetricsWriter.cs
 src/Datadog.Trace/RuntimeMetrics/Timing.cs
-src/Datadog.Trace/Sampling/CustomSamplingRule.cs
-src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
-src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
 src/Datadog.Trace/Sampling/IRateLimiter.cs
-src/Datadog.Trace/Sampling/ISamplingRule.cs
 src/Datadog.Trace/Sampling/ISpanSamplingRule.cs
-src/Datadog.Trace/Sampling/ITraceSampler.cs
 src/Datadog.Trace/Sampling/OverheadController.cs
 src/Datadog.Trace/Sampling/RateLimiter.cs
 src/Datadog.Trace/Sampling/SamplingMechanism.cs
 src/Datadog.Trace/Sampling/SpanRateLimiter.cs
 src/Datadog.Trace/Sampling/SpanSamplingRule.cs
 src/Datadog.Trace/Sampling/TracerRateLimiter.cs
-src/Datadog.Trace/Sampling/TraceSampler.cs
 src/Datadog.Trace/ServiceFabric/ServiceRemotingConstants.cs
 src/Datadog.Trace/Tagging/AerospikeTags.cs
 src/Datadog.Trace/Tagging/AspNetCoreEndpointTags.cs

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Runtime.CompilerServices;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Processors;
@@ -228,8 +227,10 @@ namespace Datadog.Trace.Agent.MessagePack
         private int WriteSpanLink(ref byte[] bytes, int offset, in SpanModel spanModel)
         {
             int originalOffset = offset;
+
             offset += MessagePackBinary.WriteStringBytes(ref bytes, offset, _spanLinkBytes);
             offset += MessagePackBinary.WriteArrayHeader(ref bytes, offset, spanModel.Span.SpanLinks.Count);
+
             foreach (var spanLink in spanModel.Span.SpanLinks)
             {
                 var context = spanLink.Context;
@@ -240,7 +241,9 @@ namespace Datadog.Trace.Agent.MessagePack
                     > 0 => 1u + (1u << 31), // keep
                     <= 0 => 1u << 31,       // drop
                 };
+
                 var len = 3;
+
                 // check to serialize tracestate
                 if (context.IsRemote)
                 {

--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -235,6 +235,7 @@ namespace Datadog.Trace.Agent.MessagePack
             {
                 var context = spanLink.Context;
                 var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
+
                 var traceFlags = samplingPriority switch
                 {
                     null => 0u,             // not set

--- a/tracer/src/Datadog.Trace/Ci/Test.cs
+++ b/tracer/src/Datadog.Trace/Ci/Test.cs
@@ -51,7 +51,7 @@ public sealed class Test
 
         scope.Span.Type = SpanTypes.Test;
         scope.Span.ResourceName = $"{suite.Name}.{name}";
-        scope.Span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep, SamplingMechanism.Manual);
+        scope.Span.Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoKeep, SamplingMechanism.Manual);
         scope.Span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
         TelemetryFactory.Metrics.RecordCountSpanCreated(MetricTags.IntegrationName.CiAppManual);
 

--- a/tracer/src/Datadog.Trace/Ci/TestModule.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestModule.cs
@@ -172,7 +172,7 @@ public sealed class TestModule
 
         span.Type = SpanTypes.TestModule;
         span.ResourceName = name;
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
         span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.ModuleId = span.SpanId;

--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -61,7 +61,7 @@ public sealed class TestSession
 
         span.Type = SpanTypes.TestSession;
         span.ResourceName = $"{span.OperationName}.{command}";
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
         span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.SessionId = span.SpanId;

--- a/tracer/src/Datadog.Trace/Ci/TestSuite.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSuite.cs
@@ -38,7 +38,7 @@ public sealed class TestSuite
 
         span.Type = SpanTypes.TestSuite;
         span.ResourceName = name;
-        span.Context.TraceContext.SetSamplingPriority((int)SamplingPriority.AutoKeep);
+        span.Context.TraceContext.SetSamplingPriority(SamplingPriorityValues.AutoKeep);
         span.Context.TraceContext.Origin = TestTags.CIAppTestOriginName;
 
         tags.SuiteId = span.SpanId;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcLegacy/Client/GrpcLegacyClientCommon.cs
@@ -81,9 +81,9 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
                 span.SetHeaderTags(requestMetadataWrapper, tracer.Settings.GrpcTagsInternal, GrpcCommon.RequestMetadataTagPrefix);
                 scope = tracer.ActivateSpan(span);
 
-                if (setSamplingPriority && existingSpanContext?.SamplingPriority is not null)
+                if (setSamplingPriority && existingSpanContext?.SamplingPriority is { } samplingPriority)
                 {
-                    span.Context.TraceContext?.SetSamplingPriority(existingSpanContext.SamplingPriority.Value);
+                    span.Context.TraceContext?.SetSamplingPriority(samplingPriority);
                 }
 
                 GrpcCommon.RecordFinalStatus(span, receivedStatus.StatusCode, receivedStatus.Detail, receivedStatus.DebugException);
@@ -242,10 +242,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcLegacy.Client
             var operationName = tracer.CurrentTraceSettings.Schema.Client.GetOperationNameForProtocol("grpc");
             var serviceName = tracer.CurrentTraceSettings.Schema.Client.GetServiceName(component: "grpc-client");
             var tags = tracer.CurrentTraceSettings.Schema.Client.CreateGrpcClientTags();
-            var span = tracer.StartSpan(operationName, tags, serviceName: serviceName, addToTraceContext: false);
             tags.SetAnalyticsSampleRate(IntegrationId.Grpc, tracer.Settings, enabledWithGlobalSetting: false);
             tracer.CurrentTraceSettings.Schema.RemapPeerService(tags);
 
+            var span = tracer.StartSpan(operationName, tags, serviceName: serviceName, addToTraceContext: false);
             span.Type = SpanTypes.Grpc;
             span.ResourceName = methodFullName;
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/CommonTracer.cs
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using Datadog.Trace.Sampling;
+#nullable enable
 
 namespace Datadog.Trace.ClrProfiler
 {

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AzureAppService.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AzureAppService.cs
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Configuration
             internal const string OperatingSystemKey = "WEBSITE_OS";
 
             /// <summary>
-            /// Used to force the loader to start the tracer agent (in case automatic instrumentation is disabled)
+            /// Used to force the loader to start the trace agent (in case automatic instrumentation is disabled)
             /// </summary>
             public const string AasEnableCustomTracing = "DD_AAS_ENABLE_CUSTOM_TRACING";
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/DynamicConfigConfigurationSource.cs
@@ -15,7 +15,7 @@ namespace Datadog.Trace.Configuration.ConfigurationSources
 {
     internal class DynamicConfigConfigurationSource : JsonConfigurationSource
     {
-        private static readonly IReadOnlyDictionary<string, string> Mapping = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> Mapping = new()
         {
             { ConfigurationKeys.TraceEnabled, "tracing_enabled" },
             // { ConfigurationKeys.DebugEnabled, "tracing_debug" },
@@ -48,17 +48,17 @@ namespace Datadog.Trace.Configuration.ConfigurationSources
             return jobject;
         }
 
-        private static IDictionary<string, string> ReadHeaderTags(JToken token)
+        private static Dictionary<string, string> ReadHeaderTags(JToken token)
         {
             return ((JArray)token).ToDictionary(t => t["header"]!.Value<string>()!, t => t["tag_name"]!.Value<string>()!);
         }
 
-        private static IDictionary<string, string> ReadServiceMapping(JToken token)
+        private static Dictionary<string, string> ReadServiceMapping(JToken token)
         {
             return ((JArray)token).ToDictionary(t => t["from_key"]!.Value<string>()!, t => t["to_name"]!.Value<string>()!);
         }
 
-        private static IDictionary<string, string> ReadGlobalTags(JToken token)
+        private static Dictionary<string, string> ReadGlobalTags(JToken token)
         {
             var result = new Dictionary<string, string>();
 

--- a/tracer/src/Datadog.Trace/Configuration/PerTraceSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/PerTraceSettings.cs
@@ -52,16 +52,5 @@ namespace Datadog.Trace.Configuration
 
             return finalServiceName;
         }
-
-        internal bool TryGetServiceName(string key, out string? serviceName)
-        {
-            if (ServiceNames.TryGetValue(key, out serviceName))
-            {
-                return true;
-            }
-
-            serviceName = null;
-            return false;
-        }
     }
 }

--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -74,7 +74,9 @@ namespace Datadog.Trace.Propagators
         internal static void CreateHeaders(SpanContext context, out string traceId, out string spanId, out string sampled)
         {
             // BUG: we should fall back to SamplingPriorityValues.AutoKeep
-            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
+            var samplingPriority = context.TraceContext?.SamplingPriority ??
+                                   context.SamplingPriority; // should never happen in production, but some tests rely on this
+
             sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "1" : "0";
             traceId = context.RawTraceId;
             spanId = context.RawSpanId;

--- a/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3MultipleHeaderContextPropagator.cs
@@ -73,9 +73,9 @@ namespace Datadog.Trace.Propagators
 
         internal static void CreateHeaders(SpanContext context, out string traceId, out string spanId, out string sampled)
         {
+            // BUG: we should fall back to SamplingPriorityValues.AutoKeep
             var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
-            sampled = samplingPriority > 0 ? "1" : "0";
-
+            sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "1" : "0";
             traceId = context.RawTraceId;
             spanId = context.RawSpanId;
         }

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -140,7 +140,9 @@ namespace Datadog.Trace.Propagators
         internal static string CreateHeader(SpanContext context)
         {
             // BUG: we should fall back to SamplingPriorityValues.AutoKeep
-            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
+            var samplingPriority = context.TraceContext?.SamplingPriority ??
+                                   context.SamplingPriority; // should never happen in production, but some tests rely on this
+
             var sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "1" : "0";
 
 #if NET6_0_OR_GREATER

--- a/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/B3SingleHeaderContextPropagator.cs
@@ -139,8 +139,9 @@ namespace Datadog.Trace.Propagators
 
         internal static string CreateHeader(SpanContext context)
         {
+            // BUG: we should fall back to SamplingPriorityValues.AutoKeep
             var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
-            var sampled = samplingPriority > 0 ? "1" : "0";
+            var sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "1" : "0";
 
 #if NET6_0_OR_GREATER
             return string.Create(null, stackalloc char[128], $"{context.RawTraceId}-{context.RawSpanId}-{sampled}");

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -40,15 +40,7 @@ namespace Datadog.Trace.Propagators
 
             if (samplingPriority != null)
             {
-                var samplingPriorityString = samplingPriority.Value switch
-                                             {
-                                                 -1 => "-1",
-                                                 0 => "0",
-                                                 1 => "1",
-                                                 2 => "2",
-                                                 _ => samplingPriority.Value.ToString(invariantCulture)
-                                             };
-
+                var samplingPriorityString = SamplingPriorityValues.ToString(samplingPriority);
                 carrierSetter.Set(carrier, HttpHeaderNames.SamplingPriority, samplingPriorityString);
             }
 

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -36,7 +36,8 @@ namespace Datadog.Trace.Propagators
                 carrierSetter.Set(carrier, HttpHeaderNames.Origin, context.Origin);
             }
 
-            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority;
+            var samplingPriority = context.TraceContext?.SamplingPriority ??
+                                   context.SamplingPriority; // should never happen in production, but some tests rely on this
 
             if (samplingPriority != null)
             {

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -11,7 +11,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Headers;
-using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Propagators
 {

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -132,7 +132,10 @@ namespace Datadog.Trace.Propagators
 
         internal static string CreateTraceParentHeader(SpanContext context)
         {
-            var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority ?? SamplingPriorityValues.AutoKeep;
+            var samplingPriority = context.TraceContext?.SamplingPriority ??
+                                   context.SamplingPriority ?? // should never happen in production, but some tests rely on this
+                                   SamplingPriorityValues.AutoKeep; // fallback
+
             var sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "01" : "00";
 
 #if NET6_0_OR_GREATER

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -154,7 +154,7 @@ namespace Datadog.Trace.Propagators
                 sb.Append("dd=");
 
                 // sampling priority ("s:<value>")
-                if (context.SamplingPriority is { } samplingPriority)
+                if (context.TraceContext?.SamplingPriority is { } samplingPriority)
                 {
                     sb.Append("s:").Append(SamplingPriorityValues.ToString(samplingPriority)).Append(TraceStateDatadogPairsSeparator);
                 }

--- a/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/W3CTraceContextPropagator.cs
@@ -8,7 +8,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Datadog.Trace.SourceGenerators;
@@ -119,6 +118,7 @@ namespace Datadog.Trace.Propagators
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleInjected(MetricTags.ContextHeaderStyle.TraceContext);
+
             var traceparent = CreateTraceParentHeader(context);
             carrierSetter.Set(carrier, TraceParentHeaderName, traceparent);
 
@@ -133,7 +133,8 @@ namespace Datadog.Trace.Propagators
         internal static string CreateTraceParentHeader(SpanContext context)
         {
             var samplingPriority = context.TraceContext?.SamplingPriority ?? context.SamplingPriority ?? SamplingPriorityValues.AutoKeep;
-            var sampled = samplingPriority > 0 ? "01" : "00";
+            var sampled = SamplingPriorityValues.IsKeep(samplingPriority) ? "01" : "00";
+
 #if NET6_0_OR_GREATER
             return string.Create(null, stackalloc char[128], $"00-{context.RawTraceId}-{context.RawSpanId}-{sampled}");
 #else
@@ -150,11 +151,9 @@ namespace Datadog.Trace.Propagators
                 sb.Append("dd=");
 
                 // sampling priority ("s:<value>")
-                var samplingPriority = SamplingPriorityToString(context.TraceContext?.SamplingPriority);
-
-                if (samplingPriority != null)
+                if (context.SamplingPriority is { } samplingPriority)
                 {
-                    sb.Append("s:").Append(samplingPriority).Append(TraceStateDatadogPairsSeparator);
+                    sb.Append("s:").Append(SamplingPriorityValues.ToString(samplingPriority)).Append(TraceStateDatadogPairsSeparator);
                 }
 
                 // origin ("o:<value>")
@@ -561,20 +560,6 @@ namespace Datadog.Trace.Propagators
                 sb.Append(otherValuesLeft).Append(TraceStateHeaderValuesSeparator).Append(otherValuesRight);
                 additionalValues = StringBuilderCache.GetStringAndRelease(sb);
             }
-        }
-
-        [return: NotNullIfNotNull("samplingPriority")]
-        private static string? SamplingPriorityToString(int? samplingPriority)
-        {
-            return samplingPriority switch
-                   {
-                       2 => "2",
-                       1 => "1",
-                       0 => "0",
-                       -1 => "-1",
-                       null => null,
-                       not null => samplingPriority.Value.ToString(CultureInfo.InvariantCulture)
-                   };
         }
 
 #if NETCOREAPP

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmCapabilitiesIndices.cs
@@ -49,6 +49,26 @@ namespace Datadog.Trace.RemoteConfigurationManagement
 
         public static readonly BigInteger ApmTracingTracingEnabled = Create(19);
 
+        public static readonly BigInteger ApmTracingDataStreamsEnabled = Create(20);
+
+        public static readonly BigInteger AsmRaspSqli = Create(21);
+
+        public static readonly BigInteger AsmRaspLfi = Create(22);
+
+        public static readonly BigInteger AsmRaspSsrf = Create(23);
+
+        public static readonly BigInteger AsmRaspShi = Create(24);
+
+        public static readonly BigInteger AsmRaspXxe = Create(25);
+
+        public static readonly BigInteger AsmRaspRce = Create(26);
+
+        public static readonly BigInteger AsmRaspNosqli = Create(27);
+
+        public static readonly BigInteger AsmRaspXss = Create(28);
+
+        public static readonly BigInteger ApmTracingSampleRules = Create(29);
+
         private static BigInteger Create(int index) => new(1UL << index);
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -136,10 +136,7 @@ namespace Datadog.Trace.Sampling
             return "LocalSamplingRule";
         }
 
-        // The [Serializable] attribute is not here because we use the BinaryFormatter.
-        // It is here to silence certain compiler warnings about the
-        // class not being instantiated or property setters not used.
-        [Serializable]
+        // ReSharper disable once ClassNeverInstantiated.Local
         private class CustomRuleConfig
         {
             [JsonRequired]

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
@@ -19,25 +21,23 @@ namespace Datadog.Trace.Sampling
         private readonly bool _alwaysMatch;
 
         // TODO consider moving toward these https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/SimpleRegex.cs
-        private readonly Regex _serviceNameRegex;
-        private readonly Regex _operationNameRegex;
-        private readonly Regex _resourceNameRegex;
-        private readonly List<KeyValuePair<string, Regex>> _tagRegexes;
+        private readonly Regex? _serviceNameRegex;
+        private readonly Regex? _operationNameRegex;
+        private readonly Regex? _resourceNameRegex;
+        private readonly List<KeyValuePair<string, Regex?>>? _tagRegexes;
 
         private bool _regexTimedOut;
 
         public CustomSamplingRule(
             float rate,
-            string ruleName,
             string patternFormat,
-            string serviceNamePattern,
-            string operationNamePattern,
-            string resourceNamePattern,
-            ICollection<KeyValuePair<string, string>> tagPatterns,
+            string? serviceNamePattern,
+            string? operationNamePattern,
+            string? resourceNamePattern,
+            ICollection<KeyValuePair<string, string?>>? tagPatterns,
             TimeSpan timeout)
         {
             _samplingRate = rate;
-            RuleName = ruleName;
 
             _serviceNameRegex = RegexBuilder.Build(serviceNamePattern, patternFormat, timeout);
             _operationNameRegex = RegexBuilder.Build(operationNamePattern, patternFormat, timeout);
@@ -54,15 +54,13 @@ namespace Datadog.Trace.Sampling
             }
         }
 
-        public string RuleName { get; }
-
         public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.TraceSamplingRule;
 
         /// <summary>
-        /// Gets or sets the priority of the rule.
+        /// Gets the priority of the rule.
         /// Configuration rules will default to 1 as a priority and rely on order of specification.
         /// </summary>
-        public int Priority { get; protected set; } = 1;
+        public int Priority => 1;
 
         public static IEnumerable<CustomSamplingRule> BuildFromConfigurationString(string configuration, string patternFormat, TimeSpan timeout)
         {
@@ -71,23 +69,19 @@ namespace Datadog.Trace.Sampling
                 if (!string.IsNullOrWhiteSpace(configuration) &&
                     JsonConvert.DeserializeObject<List<CustomRuleConfig>>(configuration) is { Count: > 0 } rules)
                 {
-                    var index = 0;
                     var samplingRules = new List<CustomSamplingRule>(rules.Count);
 
                     foreach (var r in rules)
                     {
-                        index++; // Used to create a readable rule name if one is not specified
-
                         samplingRules.Add(
                             new CustomSamplingRule(
-                                r.SampleRate,
-                                r.RuleName ?? $"config-rule-{index}",
-                                patternFormat,
-                                r.Service,
-                                r.OperationName,
-                                r.Resource,
-                                r.Tags,
-                                timeout));
+                                rate: r.SampleRate,
+                                patternFormat: patternFormat,
+                                serviceNamePattern: r.Service,
+                                operationNamePattern: r.OperationName,
+                                resourceNamePattern: r.Resource,
+                                tagPatterns: r.Tags,
+                                timeout: timeout));
                     }
 
                     return samplingRules;
@@ -135,27 +129,33 @@ namespace Datadog.Trace.Sampling
             return _samplingRate;
         }
 
+        public override string ToString()
+        {
+            // later this will return different values depending on the rule's provenance
+            return "LocalSamplingRule";
+        }
+
+        // The [Serializable] attribute is not here because we use the BinaryFormatter.
+        // It is here to silence certain compiler warnings about the
+        // class not being instantiated or property setters not used.
         [Serializable]
         private class CustomRuleConfig
         {
-            [JsonProperty(PropertyName = "rule_name")]
-            public string RuleName { get; set; }
-
             [JsonRequired]
             [JsonProperty(PropertyName = "sample_rate")]
             public float SampleRate { get; set; }
 
             [JsonProperty(PropertyName = "name")]
-            public string OperationName { get; set; }
+            public string? OperationName { get; set; }
 
             [JsonProperty(PropertyName = "service")]
-            public string Service { get; set; }
+            public string? Service { get; set; }
 
             [JsonProperty(PropertyName = "resource")]
-            public string Resource { get; set; }
+            public string? Resource { get; set; }
 
             [JsonProperty(PropertyName = "tags")]
-            public Dictionary<string, string> Tags { get; set; }
+            public Dictionary<string, string?>? Tags { get; set; }
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/CustomSamplingRule.cs
@@ -131,7 +131,8 @@ namespace Datadog.Trace.Sampling
 
         public override string ToString()
         {
-            // later this will return different values depending on the rule's provenance
+            // later this will return different values depending on the rule's provenance:
+            // local, customer (remote), or dynamic (remote)
             return "LocalSamplingRule";
         }
 

--- a/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/DefaultSamplingRule.cs
@@ -1,4 +1,4 @@
-// <copyright file="DefaultSamplingRule.cs" company="Datadog">
+// <copyright file="AgentSamplingRule.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -13,10 +13,10 @@ namespace Datadog.Trace.Sampling
 {
     // These "default" sampling rule contains the mapping of service/env names to sampling rates.
     // These rates are received in http responses from the trace agent after we send a trace payload.
-    internal class DefaultSamplingRule : ISamplingRule
+    internal class AgentSamplingRule : ISamplingRule
     {
         private const string DefaultKey = "service:,env:";
-        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<DefaultSamplingRule>();
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<AgentSamplingRule>();
 
         private Dictionary<SampleRateKey, float> _sampleRates = new();
         private float? _defaultSamplingRate;
@@ -60,7 +60,7 @@ namespace Datadog.Trace.Sampling
 
             if (_sampleRates.TryGetValue(key, out var sampleRate))
             {
-                SetSamplingAgentDecision(span, sampleRate);
+                SetSamplingRateTag(span, sampleRate);
                 return sampleRate;
             }
 
@@ -70,10 +70,10 @@ namespace Datadog.Trace.Sampling
             }
 
             defaultRate = _defaultSamplingRate ?? 1;
-            SetSamplingAgentDecision(span, defaultRate);
+            SetSamplingRateTag(span, defaultRate);
             return defaultRate;
 
-            static void SetSamplingAgentDecision(Span span, float sampleRate)
+            static void SetSamplingRateTag(Span span, float sampleRate)
             {
                 if (span.Tags is CommonTags commonTags)
                 {

--- a/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/GlobalSamplingRule.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Sampling
@@ -18,8 +20,6 @@ namespace Datadog.Trace.Sampling
             _globalRate = rate;
         }
 
-        public string RuleName => "global-rate-rule";
-
         /// <summary>
         /// Gets the priority which is one beneath custom rules.
         /// </summary>
@@ -27,16 +27,19 @@ namespace Datadog.Trace.Sampling
 
         public int SamplingMechanism => Datadog.Trace.Sampling.SamplingMechanism.TraceSamplingRule;
 
-        public bool IsMatch(Span span)
-        {
-            return true;
-        }
+        public bool IsMatch(Span span) => true;
 
         public float GetSamplingRate(Span span)
         {
             Log.Debug("Using the global sampling rate: {Rate}", _globalRate);
+
             span.SetMetric(Metrics.SamplingRuleDecision, _globalRate);
             return _globalRate;
+        }
+
+        public override string ToString()
+        {
+            return "GlobalSamplingRate";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/ISamplingRule.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ISamplingRule.cs
@@ -3,16 +3,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace.Sampling
 {
     internal interface ISamplingRule
     {
-        /// <summary>
-        /// Gets the rule name.
-        /// Used for debugging purposes mostly.
-        /// </summary>
-        string RuleName { get; }
-
         /// <summary>
         /// Gets the rule priority.
         /// Higher number means higher priority.

--- a/tracer/src/Datadog.Trace/Sampling/ITraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/ITraceSampler.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System.Collections.Generic;
 
 namespace Datadog.Trace.Sampling

--- a/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
+++ b/tracer/src/Datadog.Trace/Sampling/RegexBuilder.cs
@@ -64,7 +64,7 @@ internal static class RegexBuilder
         }
     }
 
-    public static List<KeyValuePair<string, Regex?>> Build(ICollection<KeyValuePair<string, string?>> patterns, string format, TimeSpan timeout)
+    public static List<KeyValuePair<string, Regex?>> Build(ICollection<KeyValuePair<string, string?>>? patterns, string format, TimeSpan timeout)
     {
         if (patterns is { Count: > 0 })
         {

--- a/tracer/src/Datadog.Trace/Sampling/SamplingDecision.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingDecision.cs
@@ -14,7 +14,7 @@ internal readonly struct SamplingDecision
     /// or no sampling rules match. For example, this value is used if the tracer has not yet
     /// received any sampling rates from agent and there are no configured sampling rates.
     /// </summary>
-    public static SamplingDecision Default = new(SamplingPriorityValues.AutoKeep, SamplingMechanism.Default);
+    public static SamplingDecision Default = new(SamplingPriorityValues.Default, SamplingMechanism.Default);
 
     public readonly int Priority;
 

--- a/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
@@ -86,12 +86,17 @@ internal static class SamplingMechanism
     public const int OtlpIngestProbabilisticSampling = 9;
 
     /// <summary>
+    /// Traces coming from spark/databricks workload tracing
+    /// </summary>
+    public const int DataJobsMonitoring = 10;
+
+    /// <summary>
     /// A sampling decision was made using a trace sampling rule that was configured remotely by the user
     /// and sent via remote configuration (RCM).
     /// The available sampling priorities are <see cref="SamplingPriorityValues.UserReject"/> (-1)
     /// and <see cref="SamplingPriorityValues.UserKeep"/> (2).
     /// </summary>
-    public const int RemoteUserSamplingRule = 10;
+    public const int RemoteUserSamplingRule = 11;
 
     /// <summary>
     /// A sampling decision was made using a trace sampling rule that was computed remotely by Datadog
@@ -99,19 +104,15 @@ internal static class SamplingMechanism
     /// The available sampling priorities are <see cref="SamplingPriorityValues.UserReject"/> (-1)
     /// and <see cref="SamplingPriorityValues.UserKeep"/> (2).
     /// </summary>
-    public const int RemoteAdaptiveSamplingRule = 11;
+    public const int RemoteAdaptiveSamplingRule = 12;
 
     public static string GetTagValue(int mechanism)
     {
-        // set the sampling mechanism trace tag
-        // * only set tag if priority is AUTO_KEEP (1) or USER_KEEP (2)
-        // * do not overwrite an existing value
-        // * don't set tag if sampling mechanism is unknown (null)
-        // * the "-" prefix is a left-over separator from a previous iteration of this feature (not a typo or a negative sign)
-
+        // the "-" prefix is a left-over separator from a previous iteration of this feature
+        // (not a negative sign)
+#pragma warning disable CS0618 // Type or member is obsolete
         return mechanism switch
         {
-#pragma warning disable CS0618 // Type or member is obsolete
             Default => "-0",
             AgentRate => "-1",
             RemoteRateAuto => "-2",
@@ -122,10 +123,13 @@ internal static class SamplingMechanism
             RemoteRateDatadog => "-7",
             SpanSamplingRule => "-8",
             OtlpIngestProbabilisticSampling => "-9",
-            RemoteUserSamplingRule => "-10",
-            RemoteAdaptiveSamplingRule => "-11",
+            DataJobsMonitoring => "-10",
+            RemoteUserSamplingRule => "-11",
+            RemoteAdaptiveSamplingRule => "-12",
+
+            // forwards-compatibility for future values
             _ => $"-{mechanism.ToString(CultureInfo.InvariantCulture)}"
-#pragma warning restore CS0618 // Type or member is obsolete
         };
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Globalization;
 
 namespace Datadog.Trace.Sampling;
@@ -32,6 +33,7 @@ internal static class SamplingMechanism
     /// and <see cref="SamplingPriorityValues.AutoKeep"/> (1).
     /// (Reserved for future use.)
     /// </summary>
+    [Obsolete("This value is reserved for future use.")]
     public const int RemoteRateAuto = 2;
 
     /// <summary>
@@ -61,12 +63,14 @@ internal static class SamplingMechanism
     /// and <see cref="SamplingPriorityValues.UserKeep"/> (2).
     /// (Reserved for future use.)
     /// </summary>
+    [Obsolete("This value is reserved for future use.")]
     public const int RemoteRateUser = 6;
 
     /// <summary>
     /// A sampling decision was made using a sampling rule configured remotely by Datadog.
     /// (Reserved for future use.)
     /// </summary>
+    [Obsolete("This value is reserved for future use.")]
     public const int RemoteRateDatadog = 7;
 
     /// <summary>
@@ -74,6 +78,28 @@ internal static class SamplingMechanism
     /// The only available sampling priority is <see cref="SamplingPriorityValues.UserKeep"/> (2).
     /// </summary>
     public const int SpanSamplingRule = 8;
+
+    /// <summary>
+    /// A sampling decision was made using the OTLP-compatible probabilistic sampling in the Agent.
+    /// </summary>
+    [Obsolete("This value is used in the trace agent, not in tracing libraries.", error: false)]
+    public const int OtlpIngestProbabilisticSampling = 9;
+
+    /// <summary>
+    /// A sampling decision was made using a trace sampling rule that was configured remotely by the user
+    /// and sent via remote configuration (RCM).
+    /// The available sampling priorities are <see cref="SamplingPriorityValues.UserReject"/> (-1)
+    /// and <see cref="SamplingPriorityValues.UserKeep"/> (2).
+    /// </summary>
+    public const int RemoteUserSamplingRule = 10;
+
+    /// <summary>
+    /// A sampling decision was made using a trace sampling rule that was computed remotely by Datadog
+    /// and sent via remote configuration (RCM).
+    /// The available sampling priorities are <see cref="SamplingPriorityValues.UserReject"/> (-1)
+    /// and <see cref="SamplingPriorityValues.UserKeep"/> (2).
+    /// </summary>
+    public const int RemoteAdaptiveSamplingRule = 11;
 
     public static string GetTagValue(int mechanism)
     {
@@ -85,6 +111,7 @@ internal static class SamplingMechanism
 
         return mechanism switch
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             Default => "-0",
             AgentRate => "-1",
             RemoteRateAuto => "-2",
@@ -94,7 +121,11 @@ internal static class SamplingMechanism
             RemoteRateUser => "-6",
             RemoteRateDatadog => "-7",
             SpanSamplingRule => "-8",
+            OtlpIngestProbabilisticSampling => "-9",
+            RemoteUserSamplingRule => "-10",
+            RemoteAdaptiveSamplingRule => "-11",
             _ => $"-{mechanism.ToString(CultureInfo.InvariantCulture)}"
+#pragma warning restore CS0618 // Type or member is obsolete
         };
     }
 }

--- a/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
+++ b/tracer/src/Datadog.Trace/Sampling/SamplingMechanism.cs
@@ -82,7 +82,7 @@ internal static class SamplingMechanism
     /// <summary>
     /// A sampling decision was made using the OTLP-compatible probabilistic sampling in the Agent.
     /// </summary>
-    [Obsolete("This value is used in the trace agent, not in tracing libraries.", error: false)]
+    [Obsolete("This value is used in the trace agent, not in tracing libraries.")]
     public const int OtlpIngestProbabilisticSampling = 9;
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System.Collections.Generic;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
@@ -42,8 +44,8 @@ namespace Datadog.Trace.Sampling
                         if (Log.IsEnabled(LogEventLevel.Debug))
                         {
                             Log.Debug(
-                                "Matched on rule {RuleName}. Applying rate of {Rate} to trace id {TraceId}",
-                                rule.RuleName,
+                                "Matched on rule {Rule}. Applying rate of {Rate} to trace id {TraceId}",
+                                rule,
                                 sampleRate,
                                 span.Context.RawTraceId);
                         }

--- a/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
+++ b/tracer/src/Datadog.Trace/Sampling/TraceSampler.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Sampling
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<TraceSampler>();
 
         private readonly IRateLimiter _limiter;
-        private readonly DefaultSamplingRule _defaultRule = new();
+        private readonly AgentSamplingRule _defaultRule = new();
         private readonly List<ISamplingRule> _rules = new();
 
         public TraceSampler(IRateLimiter limiter)

--- a/tracer/src/Datadog.Trace/SamplingPriority.cs
+++ b/tracer/src/Datadog.Trace/SamplingPriority.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 namespace Datadog.Trace
 {
     /// <summary>

--- a/tracer/src/Datadog.Trace/SamplingPriorityValues.cs
+++ b/tracer/src/Datadog.Trace/SamplingPriorityValues.cs
@@ -3,10 +3,22 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+
 namespace Datadog.Trace
 {
     internal static class SamplingPriorityValues
     {
+        /// <summary>
+        /// The default sampling priority used when there is no sampler available
+        /// or no sampling rules match. For example, this value is used if the tracer has not yet
+        /// received any sampling rates from agent and there are no configured sampling rates.
+        /// </summary>
+        public const int Default = AutoKeep;
+
         /// <summary>
         /// Trace should be dropped (not sampled).
         /// Sampling decision made explicitly by user through
@@ -32,5 +44,23 @@ namespace Datadog.Trace
         /// code or configuration (e.g. the rules sampler).
         /// </summary>
         public const int UserKeep = 2;
+
+        [return: NotNullIfNotNull("samplingPriority")]
+        internal static string? ToString(int? samplingPriority)
+        {
+            return samplingPriority switch
+            {
+                2 => "2",
+                1 => "1",
+                0 => "0",
+                -1 => "-1",
+                null => null,
+                { } value => value.ToString(CultureInfo.InvariantCulture)
+            };
+        }
+
+        internal static bool IsKeep(int? samplingPriority) => samplingPriority > 0;
+
+        internal static bool IsDrop(int? samplingPriority) => samplingPriority <= 0;
     }
 }

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -4,20 +4,16 @@
 // </copyright>
 
 using System;
-using System.Collections;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 using Datadog.Trace.Debugger.ExceptionAutoInstrumentation;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Telemetry;
-using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Events;
 
@@ -176,11 +172,14 @@ namespace Datadog.Trace
             sb.AppendLine($"OperationName: {OperationName}");
             sb.AppendLine($"Resource: {ResourceName}");
             sb.AppendLine($"Type: {Type}");
-            sb.AppendLine($"Start: {StartTime.ToString("O")}");
+            sb.AppendLine($"Start: {StartTime:O}");
             sb.AppendLine($"Duration: {Duration}");
-            sb.AppendLine($"End: {StartTime.Add(Duration).ToString("O")}");
+            sb.AppendLine($"End: {StartTime.Add(Duration):O}");
             sb.AppendLine($"Error: {Error}");
-            sb.AppendLine($"TraceSamplingPriority: {(Context.TraceContext.SamplingPriority?.ToString(CultureInfo.InvariantCulture) ?? "not set")}");
+
+            var samplingPriority = Context.TraceContext?.SamplingPriority;
+            sb.AppendLine($"TraceSamplingPriority: {SamplingPriorityValues.ToString(samplingPriority) ?? "not set"}");
+
             sb.AppendLine($"Meta: {Tags}");
 
             return StringBuilderCache.GetStringAndRelease(sb);
@@ -421,7 +420,7 @@ namespace Datadog.Trace
                     // for AggregateException, use the first inner exception until we can support multiple errors.
                     // there will be only one error in most cases, and even if there are more and we lose
                     // the other ones, it's still better than the generic "one or more errors occurred" message.
-                    if (exception is AggregateException aggregateException && aggregateException.InnerExceptions.Count > 0)
+                    if (exception is AggregateException { InnerExceptions.Count: > 0 } aggregateException)
                     {
                         exception = aggregateException.InnerExceptions[0];
                     }
@@ -452,21 +451,15 @@ namespace Datadog.Trace
         {
             // since we don't expose a public API for getting trace-level attributes yet,
             // allow retrieval through any span in the trace
-            switch (key)
+            return key switch
             {
-                case Trace.Tags.SamplingPriority:
-                    return Context.TraceContext?.SamplingPriority?.ToString();
-                case Trace.Tags.Env:
-                    return Context.TraceContext?.Environment;
-                case Trace.Tags.Version:
-                    return Context.TraceContext?.ServiceVersion;
-                case Trace.Tags.Origin:
-                    return Context.TraceContext?.Origin;
-                case Trace.Tags.TraceId:
-                    return Context.RawTraceId;
-                default:
-                    return Tags.GetTag(key);
-            }
+                Trace.Tags.SamplingPriority => SamplingPriorityValues.ToString(Context.TraceContext?.SamplingPriority),
+                Trace.Tags.Env => Context.TraceContext?.Environment,
+                Trace.Tags.Version => Context.TraceContext?.ServiceVersion,
+                Trace.Tags.Origin => Context.TraceContext?.Origin,
+                Trace.Tags.TraceId => Context.RawTraceId,
+                _ => Tags.GetTag(key)
+            };
         }
 
         internal void Finish(TimeSpan duration)

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -33,6 +33,7 @@ namespace Datadog.Trace
 
         private ArrayBuilder<Span> _spans;
         private int _openSpans;
+        private int? _samplingPriority;
 
         // _rootSpan was chosen in #4125 to be the lock that protects
         // * _spans
@@ -43,7 +44,6 @@ namespace Datadog.Trace
         // The reason _rootSpan was chosen is to avoid
         // allocating a separate object for the lock.
         private Span? _rootSpan;
-        private int? _samplingPriority;
 
         public TraceContext(IDatadogTracer tracer, TraceTagCollection? tags = null)
         {

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -106,7 +106,10 @@ namespace Datadog.Trace
         /// </summary>
         internal IastRequestContext? IastRequestContext => _iastRequestContext;
 
-        internal static TraceContext? GetTraceContext(in ArraySegment<Span> spans) => spans.Count > 0 ? spans.Array![spans.Offset].Context.TraceContext : null;
+        internal static TraceContext? GetTraceContext(in ArraySegment<Span> spans) =>
+            spans.Count > 0 ?
+                spans.Array![spans.Offset].Context.TraceContext :
+                null;
 
         internal void AddWafSecurityEvents(IReadOnlyCollection<object> events)
         {

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.ClrProfiler;
@@ -34,27 +33,26 @@ namespace Datadog.Trace
 
         private ArrayBuilder<Span> _spans;
         private int _openSpans;
-        private int? _samplingPriority;
-        // _rootSpan was chosen at some point to be used as the key for a lock that protects
+
+        // _rootSpan was chosen in #4125 to be the lock that protects
         // * _spans
         // * _openSpans
         // although it's a nullable field, the _rootSpan must always be set before operations on
-        // _spans & _samplingPriority take place, so it's okay to use it as a lock key
+        // _spans take place, so it's okay to use it as a lock key
         // even though we need to override the nullable warnings in some places.
-        // The reason _rootSpan was chosen is unknown, we're assuming it's to avoid
-        // allocation a separate field for the lock
+        // The reason _rootSpan was chosen is to avoid
+        // allocating a separate object for the lock.
         private Span? _rootSpan;
+        private int? _samplingPriority;
 
         public TraceContext(IDatadogTracer tracer, TraceTagCollection? tags = null)
         {
             CurrentTraceSettings = tracer.PerTraceSettings;
 
-            var settings = tracer.Settings;
-
             // TODO: Environment, ServiceVersion, GitCommitSha, and GitRepositoryUrl are stored on the TraceContext
             // even though they likely won't change for the lifetime of the process. We should consider moving them
             // elsewhere to reduce the memory usage.
-            if (settings is not null)
+            if (tracer.Settings is { } settings)
             {
                 // these could be set from DD_ENV/DD_VERSION or from DD_TAGS
                 Environment = settings.EnvironmentInternal;
@@ -69,7 +67,6 @@ namespace Datadog.Trace
         public Span? RootSpan
         {
             get => _rootSpan;
-            private set => _rootSpan = value;
         }
 
         public TraceClock Clock => _clock;
@@ -81,7 +78,6 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets the collection of trace-level tags.
         /// </summary>
-        [NotNull]
         public TraceTagCollection Tags { get; }
 
         /// <summary>
@@ -109,6 +105,8 @@ namespace Datadog.Trace
         /// Gets the IAST context.
         /// </summary>
         internal IastRequestContext? IastRequestContext => _iastRequestContext;
+
+        internal static TraceContext? GetTraceContext(in ArraySegment<Span> spans) => spans.Count > 0 ? spans.Array![spans.Offset].Context.TraceContext : null;
 
         internal void AddWafSecurityEvents(IReadOnlyCollection<object> events)
         {
@@ -155,7 +153,7 @@ namespace Datadog.Trace
             ArraySegment<Span> spansToWrite = default;
 
             // Propagate the resource name to the profiler for root web spans
-            if (span.IsRootSpan && span.Type == SpanTypes.Web)
+            if (span is { IsRootSpan: true, Type: SpanTypes.Web })
             {
                 Profiler.Instance.ContextTracker.SetEndpoint(span.RootSpanId, span.ResourceName);
 
@@ -173,10 +171,7 @@ namespace Datadog.Trace
                     }
                 }
 
-                if (_appSecRequestContext != null)
-                {
-                    _appSecRequestContext.CloseWebSpan(Tags);
-                }
+                _appSecRequestContext?.CloseWebSpan(Tags);
             }
 
             if (!string.Equals(span.ServiceName, Tracer.DefaultServiceName, StringComparison.OrdinalIgnoreCase))
@@ -256,6 +251,7 @@ namespace Datadog.Trace
 
             if (priority > 0 && mechanism != null)
             {
+                // add the tag once, but never overwrite an existing tag
                 Tags.TryAddTag(tagName, SamplingMechanism.GetTagValue(mechanism.Value));
             }
             else if (priority <= 0)
@@ -277,11 +273,13 @@ namespace Datadog.Trace
                 return;
             }
 
-            if (spans.Array![spans.Offset].Context.TraceContext?.SamplingPriority <= 0)
+            var samplingPriority = SamplingPriority;
+
+            if (SamplingPriorityValues.IsDrop(samplingPriority))
             {
                 for (int i = 0; i < spans.Count; i++)
                 {
-                    CurrentTraceSettings.SpanSampler.MakeSamplingDecision(spans.Array[i + spans.Offset]);
+                    CurrentTraceSettings.SpanSampler.MakeSamplingDecision(spans.Array![i + spans.Offset]);
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -276,9 +276,7 @@ namespace Datadog.Trace
                 return;
             }
 
-            var samplingPriority = SamplingPriority;
-
-            if (SamplingPriorityValues.IsDrop(samplingPriority))
+            if (SamplingPriorityValues.IsDrop(SamplingPriority))
             {
                 for (int i = 0; i < spans.Count; i++)
                 {

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -27,7 +27,6 @@ using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.RuntimeMetrics;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Telemetry;
-using Datadog.Trace.Util;
 using Datadog.Trace.Util.Http;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.StatsdClient;
@@ -162,7 +161,7 @@ namespace Datadog.Trace
 
         public RuntimeMetricsWriter RuntimeMetrics { get; }
 
-        public PerTraceSettings PerTraceSettings { get; set; }
+        public PerTraceSettings PerTraceSettings { get; }
 
         /// <summary>
         /// Replaces the global <see cref="TracerManager"/> settings. This affects all <see cref="Tracer"/> instances

--- a/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/SamplingHelpers.cs
@@ -35,7 +35,10 @@ namespace Datadog.Trace.Util
         internal static bool SampleByRate(ulong id, double rate) =>
             ((id * KnuthFactor) % Modulo) <= (rate * Modulo);
 
-        internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace) =>
-            trace.Array![trace.Offset].Context.TraceContext?.SamplingPriority > 0;
+        internal static bool IsKeptBySamplingPriority(ArraySegment<Span> trace)
+        {
+            var traceContext = TraceContext.GetTraceContext(trace);
+            return SamplingPriorityValues.IsKeep(traceContext?.SamplingPriority);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs
@@ -87,10 +87,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             using (var agent = EnvironmentHelper.GetMockAgent())
             using (ProcessResult processResult = await RunSampleAndWaitForExit(agent, arguments: $"Port={httpPort}"))
             {
-                var allSpans = agent.WaitForSpans(expectedAllSpansCount).OrderBy(s => s.Start);
+                var allSpans = agent.WaitForSpans(expectedAllSpansCount).OrderBy(s => s.Start).ToList();
                 allSpans.Should().OnlyHaveUniqueItems(s => new { s.SpanId, s.TraceId });
 
-                var spans = allSpans.Where(s => s.Type == SpanTypes.Http);
+                var spans = allSpans.Where(s => s.Type == SpanTypes.Http).ToList();
                 spans.Should().HaveCount(expectedSpanCount);
                 ValidateIntegrationSpans(spans, metadataSchemaVersion, expectedServiceName: clientSpanServiceName, isExternalSpan);
 

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -49,7 +49,7 @@ namespace Datadog.Trace.Tests.Agent
             var spanContext = new SpanContext(null, traceContext, "service");
             var span = new Span(spanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
             traceContext.AddSpan(span);
-            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            traceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
             span.Finish(); // triggers the span sampler to run
             var traceChunk = new ArraySegment<Span>(new[] { span });
 
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Tests.Agent
             var spanContext = new SpanContext(null, traceContext, "service");
             var span = new Span(spanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
             traceContext.AddSpan(span);
-            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            traceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
             span.Finish();
             var traceChunk = new ArraySegment<Span>(new[] { span });
             var expectedData1 = Vendors.MessagePack.MessagePackSerializer.Serialize(new TraceChunkModel(traceChunk, SamplingPriorityValues.UserKeep), SpanFormatterResolver.Instance);
@@ -105,7 +105,7 @@ namespace Datadog.Trace.Tests.Agent
             var tracer = new Tracer(settings, agent, sampler: null, scopeManager: null, statsd: null);
 
             var traceContext = new TraceContext(tracer);
-            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            traceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
             var rootSpanContext = new SpanContext(null, traceContext, "service");
             var rootSpan = new Span(rootSpanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
             var keptChildSpan = new Span(new SpanContext(rootSpanContext, traceContext, "service"), DateTimeOffset.UtcNow) { OperationName = "operation" };
@@ -141,7 +141,7 @@ namespace Datadog.Trace.Tests.Agent
             var tracer = new Tracer(settings, agent, sampler: null, scopeManager: null, statsd: null);
 
             var traceContext = new TraceContext(tracer);
-            traceContext.SetSamplingPriority(new SamplingDecision(SamplingPriorityValues.UserReject, SamplingMechanism.Manual));
+            traceContext.SetSamplingPriority(SamplingPriorityValues.UserReject, SamplingMechanism.Manual);
             var rootSpanContext = new SpanContext(null, traceContext, "service");
             var rootSpan = new Span(rootSpanContext, DateTimeOffset.UtcNow) { OperationName = "operation" };
             var droppedChildSpan = new Span(new SpanContext(rootSpanContext, traceContext, "service"), DateTimeOffset.UtcNow) { OperationName = "drop_me" };

--- a/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DistributedTracer/CommonTracerTests.cs
@@ -26,7 +26,9 @@ namespace Datadog.Trace.Tests.DistributedTracer
 
             commonTracer.SetSamplingPriority(expectedSamplingPriority);
 
-            scope.Span.Context.TraceContext.SamplingPriority.Should().Be(expectedSamplingPriority, "SetSamplingPriority should have successfully set the active trace sampling priority");
+            scope.Span.Context.TraceContext.SamplingPriority
+                 .Should()
+                 .Be(expectedSamplingPriority, "SetSamplingPriority should have successfully set the active trace sampling priority");
         }
 
         private class CommonTracerImpl : CommonTracer

--- a/tracer/test/Datadog.Trace.Tests/HttpOverStreams/DatadogHttpClientTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/HttpOverStreams/DatadogHttpClientTests.cs
@@ -10,12 +10,11 @@ using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.HttpOverStreams;
 using Datadog.Trace.HttpOverStreams.HttpContent;
-using Datadog.Trace.Tests.HttpOverStreams;
 using Datadog.Trace.Util;
 using FluentAssertions;
 using Xunit;
 
-namespace Datadog.Trace.Tests
+namespace Datadog.Trace.Tests.HttpOverStreams
 {
     public class DatadogHttpClientTests
     {

--- a/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/LambdaRequestBuilderTests.cs
@@ -20,9 +20,10 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithError()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: null, samplingPriority: null);
+
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
-            var request = requestBuilder.GetEndInvocationRequest(scope, true);
+            var request = requestBuilder.GetEndInvocationRequest(scope, isError: true);
             request.Headers.Get("x-datadog-invocation-error").Should().Be("true");
             request.Headers.Get("x-datadog-tracing-enabled").Should().Be("false");
             request.Headers.Get("x-datadog-sampling-priority").Should().Be("1");
@@ -34,9 +35,10 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithoutError()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: null, samplingPriority: null);
+
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
-            var request = requestBuilder.GetEndInvocationRequest(scope, false);
+            var request = requestBuilder.GetEndInvocationRequest(scope, isError: false);
             request.Headers.Get("x-datadog-invocation-error").Should().BeNull();
             request.Headers.Get("x-datadog-tracing-enabled").Should().Be("false");
             request.Headers.Get("x-datadog-sampling-priority").Should().Be("1");
@@ -48,9 +50,10 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithScope()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, "1234", "-1");
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: "1234", samplingPriority: "-1");
+
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
-            var request = requestBuilder.GetEndInvocationRequest(scope, false);
+            var request = requestBuilder.GetEndInvocationRequest(scope, isError: false);
             request.Headers.Get("x-datadog-invocation-error").Should().BeNull();
             request.Headers.Get("x-datadog-tracing-enabled").Should().Be("false");
             request.Headers.Get("x-datadog-sampling-priority").Should().Be("-1");
@@ -62,7 +65,7 @@ namespace Datadog.Trace.Tests
         public void TestGetEndInvocationRequestWithoutScope()
         {
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
-            var request = requestBuilder.GetEndInvocationRequest(null, false);
+            var request = requestBuilder.GetEndInvocationRequest(scope: null, isError: false);
             request.Headers.Get("x-datadog-invocation-error").Should().BeNull();
             request.Headers.Get("x-datadog-tracing-enabled").Should().Be("false");
             request.Headers.Get("x-datadog-sampling-priority").Should().BeNull();
@@ -74,10 +77,11 @@ namespace Datadog.Trace.Tests
         public async Task TestGetEndInvocationRequestWithErrorTags()
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
-            var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
+            var scope = LambdaCommon.CreatePlaceholderScope(tracer, traceId: null, samplingPriority: null);
             scope.Span.SetTag("error.msg", "Exception");
             scope.Span.SetTag("error.type", "Exception");
             scope.Span.SetTag("error.stack", "everything is " + System.Environment.NewLine + "fine");
+
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);
             request.Headers.Get("x-datadog-invocation-error").Should().NotBeNull();
@@ -95,6 +99,7 @@ namespace Datadog.Trace.Tests
         {
             await using var tracer = TracerHelper.CreateWithFakeAgent();
             var scope = LambdaCommon.CreatePlaceholderScope(tracer, null, null);
+
             ILambdaExtensionRequest requestBuilder = new LambdaRequestBuilder();
             var request = requestBuilder.GetEndInvocationRequest(scope, true);
             request.Headers.Get("x-datadog-invocation-error").Should().NotBeNull();

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3MultipleHeadersPropagatorTests.cs
@@ -89,6 +89,7 @@ namespace Datadog.Trace.Tests.Propagators
 
             newHeaders.Verify(h => h.Set("x-b3-traceid", "0123456789abcdef1122334455667788"), Times.Once());
             newHeaders.Verify(h => h.Set("x-b3-spanid", "000000003ade68b1"), Times.Once());
+            // BUG: we should default to KEEP if there's no sampler, but this never happens in real life, will fix later
             newHeaders.Verify(h => h.Set("x-b3-sampled", "0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 

--- a/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/B3SingleHeaderPropagatorTests.cs
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System.Reflection;
 using Datadog.Trace.Headers;
 using Datadog.Trace.Propagators;
 using FluentAssertions;
@@ -19,8 +18,8 @@ namespace Datadog.Trace.Tests.Propagators
         static B3SingleHeaderPropagatorTests()
         {
             B3Propagator = SpanContextPropagatorFactory.GetSpanContextPropagator(
-                new[] { ContextPropagationHeaderStyle.B3SingleHeader },
-                new[] { ContextPropagationHeaderStyle.B3SingleHeader },
+                [ContextPropagationHeaderStyle.B3SingleHeader],
+                [ContextPropagationHeaderStyle.B3SingleHeader],
                 false);
         }
 
@@ -29,8 +28,7 @@ namespace Datadog.Trace.Tests.Propagators
         {
             var traceId = new TraceId(0x0123456789abcdef, 0x1122334455667788);
             const ulong spanId = 987654321;
-            const int samplingPriority = SamplingPriorityValues.UserKeep;
-            var context = new SpanContext(traceId, spanId, samplingPriority, serviceName: null, origin: null);
+            var context = new SpanContext(traceId, spanId, SamplingPriorityValues.UserKeep, serviceName: null, origin: null);
             var headers = new Mock<IHeadersCollection>();
 
             B3Propagator.Inject(context, headers.Object);
@@ -38,13 +36,15 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-1"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            // Extract sampling from trace context
+            // Extract default (no sampler) sampling from trace context
             var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object);
+            // BUG: we should default to KEEP if there's no sampler, but this never happens in real life, will fix later
             newHeaders.Verify(h => h.Set("b3", "0123456789abcdef1122334455667788-000000003ade68b1-0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
+            // override sampling decision
             newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
             newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object);
@@ -68,13 +68,15 @@ namespace Datadog.Trace.Tests.Propagators
             headers.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-1"), Times.Once());
             headers.VerifyNoOtherCalls();
 
-            // Extract sampling from trace context
+            // Extract default (no sampler) sampling from trace context
             var newContext = new SpanContext(parent: null, new TraceContext(Mock.Of<IDatadogTracer>()), serviceName: null, traceId, spanId);
             var newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));
+            // BUG: we should default to KEEP if there's no sampler, but this never happens in real life, will fix later
             newHeaders.Verify(h => h.Set("b3", "000000000000000000000000075bcd15-000000003ade68b1-0"), Times.Once());
             newHeaders.VerifyNoOtherCalls();
 
+            // override sampling decision
             newContext.TraceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
             newHeaders = new Mock<IHeadersCollection>();
             B3Propagator.Inject(newContext, newHeaders.Object, (carrier, name, value) => carrier.Set(name, value));

--- a/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Propagators/W3CTraceContextPropagatorTests.cs
@@ -127,7 +127,7 @@ namespace Datadog.Trace.Tests.Propagators
         public void CreateTraceStateHeader_With128Bit_TraceId()
         {
             var traceContext = new TraceContext(Mock.Of<IDatadogTracer>());
-            traceContext.SetSamplingPriority(2);
+            traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep);
 
             var traceId = new TraceId(0x1234567890abcdef, 0x1122334455667788);
             var spanContext = new SpanContext(parent: SpanContext.None, traceContext, serviceName: null, traceId: traceId, spanId: 2);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/AgentSamplingRuleTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/AgentSamplingRuleTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="DefaultSamplingRuleTests.cs" company="Datadog">
+// <copyright file="AgentSamplingRuleTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Datadog.Trace.Tests.Sampling
 {
-    public class DefaultSamplingRuleTests
+    public class AgentSamplingRuleTests
     {
         [Theory]
         // Value returned by the agent per default
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Tests.Sampling
             scope.Span.Context.TraceContext.Environment = expectedEnv;
 
             // create sampling rule
-            var rule = new DefaultSamplingRule();
+            var rule = new AgentSamplingRule();
             rule.SetDefaultSampleRates(new Dictionary<string, float> { { key, .5f } });
 
             // assert that the sampling rate applied to the span is correct
@@ -45,13 +45,13 @@ namespace Datadog.Trace.Tests.Sampling
         }
 
         [Fact]
-        public async Task DefaultSamplingRuleIsApplied()
+        public async Task SamplingRulesAreApplied()
         {
             const string configuredService = "NiceService";
             const string configuredEnv = "BeautifulEnv";
             const string unconfiguredService = "RogueService";
 
-            var rule = new DefaultSamplingRule();
+            var rule = new AgentSamplingRule();
 
             var settings = new TracerSettings();
             await using var tracer = TracerHelper.CreateWithFakeAgent(settings);

--- a/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/CustomSamplingRuleRegexTests.cs
@@ -62,8 +62,8 @@ namespace Datadog.Trace.Tests.Sampling
             var nonMatchingSpan = new Span(new SpanContext(1, 1, serviceName: "foo"), DateTimeOffset.Now) { ResourceName = "/api/v2/user/123" };
 
             VerifyRate(rule, 0.3f);
-            VerifySingleRule(rule, matchingSpan, isMatch: true);
-            VerifySingleRule(rule, nonMatchingSpan, isMatch: false);
+            VerifySingleRule(rule, matchingSpan, expected: true);
+            VerifySingleRule(rule, nonMatchingSpan, expected: false);
         }
 
         [Fact]
@@ -83,9 +83,9 @@ namespace Datadog.Trace.Tests.Sampling
             nonMatchingSpan2.SetTag("http.method", "POST");
 
             VerifyRate(rule, 0.3f);
-            VerifySingleRule(rule, matchingSpan, isMatch: true);
-            VerifySingleRule(rule, nonMatchingSpan1, isMatch: false);
-            VerifySingleRule(rule, nonMatchingSpan2, isMatch: false);
+            VerifySingleRule(rule, matchingSpan, expected: true);
+            VerifySingleRule(rule, nonMatchingSpan1, expected: false);
+            VerifySingleRule(rule, nonMatchingSpan2, expected: false);
         }
 
         [Fact]
@@ -173,15 +173,15 @@ namespace Datadog.Trace.Tests.Sampling
             rule.GetSamplingRate(TestSpans.CartCheckoutSpan).Should().Be(expectedRate);
         }
 
-        private static void VerifySingleRule(string config, Span span, bool isMatch)
+        private static void VerifySingleRule(string config, Span span, bool expected)
         {
             var rule = CustomSamplingRule.BuildFromConfigurationString(config, SamplingRulesFormat.Regex, Timeout).Single();
-            VerifySingleRule(rule, span, isMatch);
+            VerifySingleRule(rule, span, expected);
         }
 
-        private static void VerifySingleRule(ISamplingRule rule, Span span, bool isMatch)
+        private static void VerifySingleRule(ISamplingRule rule, Span span, bool expected)
         {
-            Assert.Equal(rule.IsMatch(span), isMatch);
+            rule.IsMatch(span).Should().Be(expected);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Sampling/TraceSamplerTests.cs
@@ -46,7 +46,6 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 1,
-                    ruleName: "Allow_all",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -70,7 +69,6 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 1,
-                    ruleName: "Allow_all",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -94,7 +92,6 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 0,
-                    ruleName: "Allow_nothing",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",
@@ -118,7 +115,6 @@ namespace Datadog.Trace.Tests.Sampling
             sampler.RegisterRule(
                 new CustomSamplingRule(
                     rate: 0.5f,
-                    ruleName: "Allow_half",
                     patternFormat: SamplingRulesFormat.Regex,
                     serviceNamePattern: ".*",
                     operationNamePattern: ".*",

--- a/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/TraceContextTests.cs
@@ -4,10 +4,6 @@
 // </copyright>
 
 using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using Datadog.Trace.Configuration;
-using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.TestHelpers;
 using Datadog.Trace.Util;
 using FluentAssertions;
@@ -18,7 +14,7 @@ namespace Datadog.Trace.Tests
 {
     public class TraceContextTests
     {
-        private readonly Mock<IDatadogTracer> _tracerMock = new Mock<IDatadogTracer>();
+        private readonly Mock<IDatadogTracer> _tracerMock = new();
 
         [Fact]
         public void UtcNow_GivesLegitTime()
@@ -168,11 +164,12 @@ namespace Datadog.Trace.Tests
             // but a full flush should be triggered rather than a partial, because every span in the trace has been closed
             traceContext.CloseSpan(rootSpan);
 
-            spans.Value.Should().NotBeNullOrEmpty("a full flush should have been triggered");
+            spans.Should().NotBeNull("a full flush should have been triggered");
+            spans!.Value.Should().NotBeNullOrEmpty("a full flush should have been triggered");
 
             rootSpan.GetMetric(Metrics.SamplingPriority).Should().BeNull("because sampling priority is not added until serialization");
 
-            spans.Value.Should().OnlyContain(s => s.GetMetric(Metrics.SamplingPriority) == null, "because sampling priority is not added until serialization");
+            spans!.Value.Should().OnlyContain(s => s.GetMetric(Metrics.SamplingPriority) == null, "because sampling priority is not added until serialization");
         }
 
         [Fact]
@@ -214,8 +211,9 @@ namespace Datadog.Trace.Tests
                 traceContext.CloseSpan(span);
             }
 
-            spans.Value.Should().NotBeNullOrEmpty("partial flush should have been triggered");
-            spans.Value.Should().OnlyContain(s => s.GetMetric(Metrics.SamplingPriority) == null, "because sampling priority is not added until serialization");
+            spans.Should().NotBeNull("partial flush should have been triggered");
+            spans!.Value.Should().NotBeNullOrEmpty("partial flush should have been triggered");
+            spans!.Value.Should().OnlyContain(s => s.GetMetric(Metrics.SamplingPriority) == null, "because sampling priority is not added until serialization");
         }
     }
 }

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
@@ -40,8 +40,12 @@ namespace Samples.WebRequest
 
                 // send http requests using WebClient
                 Console.WriteLine();
-                Console.WriteLine("Sending request with WebClient.");
+                Console.WriteLine("Sending requests with WebClient.");
                 await RequestHelpers.SendWebClientRequests(_tracingDisabled, url, RequestContent);
+
+                // send http requests using WebClient
+                Console.WriteLine();
+                Console.WriteLine("Sending requests with WebRequest.");
                 await RequestHelpers.SendWebRequestRequests(_tracingDisabled, url, RequestContent);
 
                 Console.WriteLine();
@@ -54,6 +58,20 @@ namespace Samples.WebRequest
         private static void HandleHttpRequests(HttpListenerContext context)
         {
             Console.WriteLine("[HttpListener] received request");
+
+            // read request content and headers.
+            // output the headers to the console first _before_ asserting their presence.
+            using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+            {
+                string requestContent = reader.ReadToEnd();
+                Console.WriteLine($"[HttpListener] request content: {requestContent}");
+
+                foreach (string headerName in context.Request.Headers)
+                {
+                    string headerValue = context.Request.Headers[headerName];
+                    Console.WriteLine($"[HttpListener] request header: {headerName}={headerValue}");
+                }
+            }
 
             // Check Datadog headers
             if (!_ignoreAsync || context.Request.Url.Query.IndexOf("Async", StringComparison.OrdinalIgnoreCase) == -1)
@@ -78,19 +96,6 @@ namespace Samples.WebRequest
                             Environment.Exit(-1);
                         }
                     }
-                }
-            }
-
-            // read request content and headers
-            using (var reader = new StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
-            {
-                string requestContent = reader.ReadToEnd();
-                Console.WriteLine($"[HttpListener] request content: {requestContent}");
-
-                foreach (string headerName in context.Request.Headers)
-                {
-                    string headerValue = context.Request.Headers[headerName];
-                    Console.WriteLine($"[HttpListener] request header: {headerName}={headerValue}");
                 }
             }
 

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/Program.cs
@@ -43,7 +43,7 @@ namespace Samples.WebRequest
                 Console.WriteLine("Sending requests with WebClient.");
                 await RequestHelpers.SendWebClientRequests(_tracingDisabled, url, RequestContent);
 
-                // send http requests using WebClient
+                // send http requests using WebRequest
                 Console.WriteLine();
                 Console.WriteLine("Sending requests with WebRequest.");
                 await RequestHelpers.SendWebRequestRequests(_tracingDisabled, url, RequestContent);

--- a/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.WebRequest/RequestHelpers.cs
@@ -657,10 +657,8 @@ namespace Samples.WebRequest
         private static NameValueCollection GenerateCurrentDistributedTracingHeaders()
         {
             var current = Activity.Current;
-            var decimalTraceId = Convert.ToUInt64(current.TraceId.ToHexString().Substring(16, 16), 16);
-            var decimalSpanId = Convert.ToUInt64(current.SpanId.ToHexString(), 16);
 
-            return new NameValueCollection()
+            return new NameValueCollection
             {
                 { "traceparent", current.Id },
                 { "tracestate", current.TraceStateString },


### PR DESCRIPTION
## Summary of changes

As I was working on two PRs related to sampling rules, I made a lot of small clean ups like reformatting code, adding code comments, or using newer C# syntax. I pulled all those changes into this PR...

## Reason for change

...to make it easier to review the "cleanup" changes separately from the other PRs, and to reduce noise in those other PRs.

## Implementation details

Reformatting, adding comments, using newer C# syntax, etc.
Refactored some code to reduce duplication, and to stop using `int.ToString()` on sampling priorities.
Added nullability annotations to several files.
Renamed or moved a few files.
Added new constants to sampling mechanisms and RCM capabilities.

## Test coverage

No changes.

## Other details

PRs:
1. (this one) #5477
2. #5306
3. #5453

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
