### PR TITLE
[v3] Fix `SpanContextInjectorExtractorTests` to account for `tracestate`

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/SpanContextInjectorExtractorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextInjectorExtractorTests.cs
@@ -36,6 +36,7 @@ public class SpanContextInjectorExtractorTests
             ["x-datadog-trace-id"] = traceId.ToString(),
             ["x-datadog-parent-id"] = spanId.ToString(),
             ["traceparent"] = $"00-{traceId:x32}-{spanId:x16}-01",
+            ["tracestate"] = $"dd=p:{spanId:x16}",
         });
     }
 
@@ -51,7 +52,7 @@ public class SpanContextInjectorExtractorTests
         headers.Length--;
         headers.Append("}");
 
-        headers.ToString().Should().Be("{{x-datadog-trace-id,123456789101112},{x-datadog-parent-id,109876543210},{traceparent,00-000000000000000000007048860f3a38-000000199526feea-01}}");
+        headers.ToString().Should().Be("{{x-datadog-trace-id,123456789101112},{x-datadog-parent-id,109876543210},{traceparent,00-000000000000000000007048860f3a38-000000199526feea-01},{tracestate,dd=p:000000199526feea}}");
     }
 
     [Fact]
@@ -85,6 +86,7 @@ public class SpanContextInjectorExtractorTests
             "x-datadog-trace-id",
             "x-datadog-parent-id",
             "traceparent",
+            "tracestate",
             // DSM specific header
             "dd-pathway-ctx-base64",
         ]);
@@ -113,6 +115,7 @@ public class SpanContextInjectorExtractorTests
             "x-datadog-trace-id",
             "x-datadog-parent-id",
             "traceparent",
+            "tracestate",
         ]);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/SpanContextInjectorExtractorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanContextInjectorExtractorTests.cs
@@ -31,13 +31,12 @@ public class SpanContextInjectorExtractorTests
 
         injector.Inject(headers, (h, k, v) => h[k] = v, context);
 
-        headers.Count.Should().Be(expected: 3);
-        headers.Keys.Should().Contain("x-datadog-trace-id");
-        headers.Keys.Should().Contain("x-datadog-parent-id");
-        headers.Keys.Should().Contain("traceparent");
-        headers["x-datadog-trace-id"].Should().Be(traceId.ToString());
-        headers["x-datadog-parent-id"].Should().Be(spanId.ToString());
-        headers["traceparent"].Should().Be($"00-{traceId:x32}-{spanId:x16}-01");
+        headers.Should().BeEquivalentTo(new Dictionary<string, string>
+        {
+            ["x-datadog-trace-id"] = traceId.ToString(),
+            ["x-datadog-parent-id"] = spanId.ToString(),
+            ["traceparent"] = $"00-{traceId:x32}-{spanId:x16}-01",
+        });
     }
 
     [Fact]
@@ -80,13 +79,16 @@ public class SpanContextInjectorExtractorTests
 
         injector.InjectIncludingDsm(headers, (h, k, v) => h[k] = v, context, "Pneumatic Tube", "cashier1");
 
-        headers.Count.Should().Be(expected: 4);
-        // regular trace propagation headers
-        headers.Keys.Should().Contain("x-datadog-trace-id");
-        headers.Keys.Should().Contain("x-datadog-parent-id");
-        headers.Keys.Should().Contain("traceparent");
-        // DSM specific header
-        headers.Keys.Should().Contain("dd-pathway-ctx-base64");
+        headers.Keys.Should().BeEquivalentTo(
+        [
+            // regular trace propagation headers
+            "x-datadog-trace-id",
+            "x-datadog-parent-id",
+            "traceparent",
+            // DSM specific header
+            "dd-pathway-ctx-base64",
+        ]);
+
         // should not throw (i.e. should be valid base64)
         Convert.FromBase64String(headers["dd-pathway-ctx-base64"]).Should().NotBeEmpty();
 
@@ -105,11 +107,13 @@ public class SpanContextInjectorExtractorTests
 
         injector.InjectIncludingDsm(headers, (h, k, v) => h[k] = v, context, "Pneumatic Tube", "cashier1");
 
-        headers.Count.Should().Be(expected: 3);
-        // regular trace propagation headers only
-        headers.Keys.Should().Contain("x-datadog-trace-id");
-        headers.Keys.Should().Contain("x-datadog-parent-id");
-        headers.Keys.Should().Contain("traceparent");
+        headers.Keys.Should().BeEquivalentTo(
+        [
+            // regular trace propagation headers
+            "x-datadog-trace-id",
+            "x-datadog-parent-id",
+            "traceparent",
+        ]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of changes

Fixes `SpanContextInjectorExtractorTests` which are broken on v3

## Reason for change

https://github.com/DataDog/dd-trace-dotnet/pull/5176 added support for encoding the last seen Datadog span ID in the `tracestate`. However, this conflicted with expectations of unit tests introduced in the `v3-main` branch

## Implementation details

- First commit refactors the unit tests to better expose the issue (by way of "better" `FluentAssertion` methods)
- Second commit fixes the issue by accounting for `tracestate`

## Test coverage

Same

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
