### PR TITLE
Ignore expected CI Visibility error

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2390,6 +2390,7 @@ partial class Build
                // This one is annoying but we _think_ due to a dodgy named pipes implementation, so ignoring for now
                new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\trace-.*The operation has timed out.*", RegexOptions.Compiled),
                new(@".*An error occurred while sending data to the agent at \\\\\.\\pipe\\metrics-.*The operation has timed out.*", RegexOptions.Compiled),
+               new(@".*Error detecting and reconfiguring git repository for shallow clone. System.IO.FileLoadException.*", RegexOptions.Compiled),
            };
 
            CheckLogsForErrors(knownPatterns, allFilesMustExist: false, minLogLevel: LogLevel.Error);


### PR DESCRIPTION
## Summary of changes

Ignores an error log we expect to see occasionally

## Reason for change

[Spotted this error in a build](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=156545&view=logs&j=a9ce85a3-e3a5-587c-4d0d-dd57319e842f&t=1aaed37f-15ea-5687-3b62-65023f5d8564):

```
[Error] Error detecting and reconfiguring git repository for shallow clone. System.IO.FileLoadException: Could not load file or assembly 'Datadog.Trace, Version=3.0.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb'. Error 2147500035 (0x80004003 (E_POINTER))
File name: 'Datadog.Trace, Version=3.0.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb'
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.VisualStudio.TestPlatform.PlatformAbstractions.PlatformAssemblyResolver.AssemblyResolverEvent(Object sender, Object eventArgs)
     at System.Runtime.Loader.AssemblyLoadContext.GetFirstResolvedAssemblyFromResolvingEvent(AssemblyName assemblyName)
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingEvent(AssemblyName assemblyName)
   at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingResolvingEvent(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
   at System.Diagnostics.Process.Start()
   at System.Diagnostics.Process.Start(ProcessStartInfo startInfo)
   at Datadog.Trace.Util.ProcessHelpers.StartWithDoNotTrace(ProcessStartInfo startInfo, Boolean doNotTrace) in /project/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs:line 216
   at Datadog.Trace.Util.ProcessHelpers.RunCommandAsync(Command command, String input) in /project/tracer/src/Datadog.Trace/Util/ProcessHelpers.cs:line 138
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.RunGitCommandAsync(String arguments, CIVisibilityCommands ciVisibilityCommand, String input) in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 1024
   at Datadog.Trace.Ci.IntelligentTestRunnerClient.UploadRepositoryChangesAsync() in /project/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs:line 211
```

But we expect to see that occasionally, so don't error if it happens


## Implementation details

The exception is caused by https://github.com/DataDog/dd-trace-dotnet/pull/5088 which is ultimately a bug in vstest and we have a race condition.

Ignoring the error because we will hit occasionally

## Test coverage

N/A

## Other details

@tonyredondo to confirm we _do_ want to ignore this

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
