### PR TITLE
[Profiler] Fix crash in Sampler at shutdown

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AdaptiveSampler.h
@@ -1,7 +1,9 @@
 #pragma once
+
 #include <atomic>
 #include <chrono>
 #include <random>
+#include <mutex>
 
 #include "Timer.h"
 
@@ -44,6 +46,8 @@ public:
     // For tests
     State GetInternalState();
 
+    void Stop();
+
 private:
     double _emaAlpha;
     int32_t _samplesPerWindow;
@@ -63,6 +67,7 @@ private:
     Counts _countsSlots[2];
 
     Timer _timer;
+    std::mutex _callbackMutex;
     std::function<void()> _rollWindowCallback;
 
     std::mutex _rngMutex;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GroupSampler.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GroupSampler.h
@@ -33,6 +33,11 @@ public:
     {
     }
 
+    ~GroupSampler<TGroup>()
+    {
+        _sampler.Stop();
+    }
+
 public:
     struct GroupInfo
     {

--- a/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/AdaptiveSamplerTest.cpp
@@ -103,3 +103,18 @@ TEST(AdaptiveSamplerTest, TestRollWindow)
     ASSERT_DOUBLE_EQ(3.0, state.TotalAverage);
     ASSERT_DOUBLE_EQ(2.0/3.0, state.Probability);
 }
+
+TEST(AdaptiveSamplerTest, TestStop)
+{
+    bool callbackCalled = false;
+    AdaptiveSampler sampler(std::chrono::milliseconds::zero(), 2, 1, 1, [&callbackCalled]() { callbackCalled = true; });
+
+    sampler.RollWindow();
+
+    ASSERT_TRUE(callbackCalled);
+
+    callbackCalled = false;
+    sampler.Stop();
+
+    ASSERT_FALSE(callbackCalled);
+}


### PR DESCRIPTION
## Summary of changes

Address a race when shutting down the profiler and the `GroupSampler`.

## Reason for change

The `Exception provider` uses a `GroupSampler` to sample exception events. `GroupSampler` inherits from `GenericSampler` which has a `AdaptiveSampler` field. This field has a timer which calls back to a member function of `GroupSampler` every XX time.  This call is handled by another thread (on Linux a specific thread, on Windows, it's a thread from the threadpool).

When the profiler is shutting down, the `Exception provider` destructor is called which calls the destructor of all of its fields.
So, if the destructor of `GroupSampler` is called, and the timer thread kicks in, there is a race on the `_knownGroups` field.
Since there is no lock when the destructor is called, we have a problem.

With inheritance in C++, base class destructor is called after child class destructor. Which means that all fields of a child class have their destructor called before the base class destructor. And that's an undefined behavior.
In our case, the timer thread could call the callback which in the end would access the `_knownGroups` field.

## Implementation details

- Add a `Stop()` method on `AdaptiveSampler` and call it from the destructor of `GroupSampler`.
- Access to the callback field under a lock 

## Test coverage

- Add a unit test
- 
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
