### PR TITLE
[Dynamic Instrumentation] Add 'connectionString' to the list of redacted values

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/Redaction.cs
@@ -96,6 +96,7 @@ namespace Datadog.Trace.Debugger.Snapshots
             "clientid",
             "clientsecret",
             "config",
+            "connectionstring",
             "connectsid",
             "cookie",
             "credentials",


### PR DESCRIPTION
## Summary of changes
Add `connectionString` to the list of redacted values

## Reason for change
The value of `connectionString` can be leaked. This PR fixes that. 
