### PR TITLE
Fix git metadata collection

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -1,4 +1,4 @@
-// <copyright file="TelemetryController.cs" company="Datadog">
+﻿// <copyright file="TelemetryController.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -20,6 +20,7 @@ using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.Telemetry.Transports;
 using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
+using ConfigurationKeys = Datadog.Trace.Configuration.ConfigurationKeys;
 
 namespace Datadog.Trace.Telemetry;
 
@@ -98,8 +99,8 @@ internal class TelemetryController : ITelemetryController
     {
         _application.RecordGitMetadata(gitMetadata);
 
-        _configuration.Record(gitMetadata.RepositoryUrl, gitMetadata.RepositoryUrl, recordValue: true, ConfigurationOrigins.Calculated);
-        _configuration.Record(gitMetadata.CommitSha, gitMetadata.CommitSha, recordValue: true, ConfigurationOrigins.Calculated);
+        _configuration.Record(ConfigurationKeys.GitRepositoryUrl, gitMetadata.RepositoryUrl, recordValue: true, ConfigurationOrigins.Calculated);
+        _configuration.Record(ConfigurationKeys.GitCommitSha, gitMetadata.CommitSha, recordValue: true, ConfigurationOrigins.Calculated);
     }
 
     public void Start()

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="TelemetryControllerTests.cs" company="Datadog">
+﻿// <copyright file="TelemetryControllerTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -76,6 +76,15 @@ public class TelemetryControllerTests
         var data = await WaitForRequestStarted(transport, _timeout);
         data.FirstOrDefault().Application.CommitSha.Should().Be(sha);
         data.FirstOrDefault().Application.RepositoryUrl.Should().Be(repo);
+
+        var config = data
+                    .Select(x => x.TryGetPayload<AppStartedPayload>(TelemetryRequestTypes.AppStarted))
+                    .FirstOrDefault(x => x != null);
+        config?.Configuration
+              .Should()
+              .NotBeNull()
+              .And.Contain(x => x.Name == "DD_GIT_REPOSITORY_URL" && x.Value.ToString() == repo)
+              .And.Contain(x => x.Name == "DD_GIT_COMMIT_SHA" && x.Value.ToString() == sha);
 
         await controller.DisposeAsync();
     }


### PR DESCRIPTION
## Summary of changes

Fixes using incorrect keys in telemetry

## Reason for change

It was recording the value as the key

## Implementation details

Use the correct values

## Test coverage

Added a unit test that fails before and passes afterwards

## Other details

Introduced in #5459 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
