### PR TITLE
[v3] Require `ICorProfilerInfo9` for instrumentation

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -1020,7 +1020,7 @@ namespace datadog::shared::nativeloader
         }
         else if (S_OK == corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo9), (void**) &tstVerProfilerInfo))
         {
-            Log::Info("ICorProfilerInfo9 available. Profiling API compatibility: .NET Core 2.2 or later.");
+            Log::Info("ICorProfilerInfo9 available. Profiling API compatibility: .NET Core 2.1 or later.");
             tstVerProfilerInfo->Release();
         }
         else if (S_OK == corProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo8), (void**) &tstVerProfilerInfo))

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.NetCore.cs
@@ -26,6 +26,15 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
 
             var version = Environment.Version;
 
+            // safety net - we should bail out in native instrumentation _before_ we get to this point anyway,
+            // but just in case, check we're not in an unsupported framework
+
+            if (version is { Major: 1 } or { Major: 2, Minor: 0 })
+            {
+                StartupLogger.Log($" .NET Core {version.Major}.{version.Minor} is not supported by the Datadog .NET Tracer. .NET Core 2.1 or newer is required");
+                return null;
+            }
+
             // Old versions of .net core have a major version of 4
             if ((version.Major == 3 && version.Minor >= 1) || version.Major >= 5)
             {

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -209,23 +209,23 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
         info10 = nullptr;
     }
 
-    // get ICorProfilerInfo for >= .NET Core 2.0
-    ICorProfilerInfo8* info8 = nullptr;
-    hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo8), (void**) &info8);
+    // get ICorProfilerInfo for >= .NET Core 2.1
+    ICorProfilerInfo9* info9 = nullptr;
+    hr = cor_profiler_info_unknown->QueryInterface(__uuidof(ICorProfilerInfo9), (void**) &info9);
     if (SUCCEEDED(hr))
     {
-        Logger::Debug("Interface ICorProfilerInfo8 found.");
+        Logger::Debug("Interface ICorProfilerInfo9 found.");
     }
     else
     {
-        info8 = nullptr;
+        info9 = nullptr;
     }
 
     runtime_information_ = GetRuntimeInformation(this->info_);
-    if (info8 == nullptr && runtime_information_.is_core())
+    if (info9 == nullptr && runtime_information_.is_core())
     {
         Logger::Warn(
-            "DATADOG TRACER DIAGNOSTICS - Profiler disabled: .NET Core 2.0 or greater runtime is required for .NET Core automatic instrumentation.");
+            "DATADOG TRACER DIAGNOSTICS - Profiler disabled: .NET Core 2.1 or greater runtime is required for .NET Core automatic instrumentation.");
         return E_FAIL;
     }
 


### PR DESCRIPTION
## Summary of changes

Bail out of instrumentation if we don't detect `ICorProfilerInfo9`

## Reason for change

In #5260 we dropped support for `netstandard2.0` (and by extension, .NET Core 2.0). However, in that PR we didn't ensure we actually bail out of instrumentation when we're running on .NET Core 2.1.

## Implementation details

Check for `ICorProfilerInfo9` (.NET Core 2.1) instead of `ICorProfilerInfo8` (.NET Core 2.0/.NET 4.7.2)

## Test coverage

Did a manual test building a .NET Core 2.0 app. Confirmed that the native loader attaches and the native tracer attach, but bail out. 

<details><summary>Details</summary>

Native loader logs:
```
[2024-04-24 10:55:45.486 | info | PId: 132568 | TId: 128484] No "DD_TRACE_DEBUG" environment variable has been found. Enable debug log = 0 (default).
[2024-04-24 10:55:45.486 | info | PId: 132568 | TId: 128484] DynamicDispatcherImpl::LoadConfiguration: Reading configuration file from: "C:\\repos\\dd-trace-dotnet-3\\shared\\bin\\monitoring-home\\win-x64\\loader.conf"
[2024-04-24 10:55:45.487 | warning | PId: 132568 | TId: 128484] DynamicDispatcherImpl::LoadConfiguration: [PROFILER] Dynamic library for 'C:\repos\dd-trace-dotnet-3\shared\bin\monitoring-home\win-x64\Datadog.Profiler.Native.dll' cannot be loaded, file doesn't exist.
[2024-04-24 10:55:45.490 | info | PId: 132568 | TId: 128484] ICorProfilerInfo8 available. Profiling API compatibility: .NET Fx 4.7.2 or later.
[2024-04-24 10:55:45.490 | info | PId: 132568 | TId: 128484] Initializing the Profiler: Reported runtime version : { clrInstanceId: 9, runtimeType:CORE_CLR, majorVersion: 4, minorVersion: 0, buildNumber: 22220, qfeVersion: 0 }.
[2024-04-24 10:55:45.490 | info | PId: 132568 | TId: 128484] Instrumentation Verification log is disabled.
[2024-04-24 10:55:45.491 | warning | PId: 132568 | TId: 128484] CorProfiler::Initialize: Error Initializing the Tracer Profiler, unloading the dynamic library.
```

Native tracer logs
```
04/24/24 10:55:45.490 AM [132568|128484] [info] Datadog CLR Profiler 3.0.0 on Windows (amd64)
04/24/24 10:55:45.490 AM [132568|128484] [info] ProcessName: dotnet.exe
04/24/24 10:55:45.490 AM [132568|128484] [info] Process CommandLine: "C:\tools\dotnet-runtime-2.0.9-win-x64\dotnet.exe" .\outdatedversions.dll
04/24/24 10:55:45.490 AM [132568|128484] [info] Environment variables:
04/24/24 10:55:45.490 AM [132568|128484] [info]   DD_DOTNET_TRACER_HOME=C:\repos\dd-trace-dotnet-3\shared\bin\monitoring-home
04/24/24 10:55:45.490 AM [132568|128484] [info]   DD_ENV=andrew
04/24/24 10:55:45.491 AM [132568|128484] [warning] DATADOG TRACER DIAGNOSTICS - Profiler disabled: .NET Core 2.1 or greater runtime is required for .NET Core automatic instrumentation.
```

</details> 

## Other details
Interestingly, in this situation, even though we bail out, we _are_ still attached 🤔 You can tell because we can't delete the native tracer or native loader log files (and you can see we're still loaded in process explorer)

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/d2e046b7-a9e3-4d50-ac2b-432f2a75dcf3)


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
