### PR TITLE
[CI] Fix flake in Git Telemetry

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -66,11 +66,10 @@ public class TelemetryControllerTests
             transportManager,
             _flushInterval);
 
-        controller.RecordTracerSettings(new ImmutableTracerSettings(new TracerSettings()), "DefaultServiceName");
-
         var sha = "testCommitSha";
         var repo = "testRepositoryUrl";
         controller.RecordGitMetadata(new GitMetadata(sha, repo));
+        controller.RecordTracerSettings(new ImmutableTracerSettings(new TracerSettings()), "DefaultServiceName");
         controller.Start();
 
         await controller.DisposeAsync();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryControllerTests.cs
@@ -72,8 +72,6 @@ public class TelemetryControllerTests
         controller.RecordTracerSettings(new ImmutableTracerSettings(new TracerSettings()), "DefaultServiceName");
         controller.Start();
 
-        await controller.DisposeAsync();
-
         var data = await WaitForRequestStarted(transport, _timeout);
         data.FirstOrDefault().Application.CommitSha.Should().Be(sha);
         data.FirstOrDefault().Application.RepositoryUrl.Should().Be(repo);
@@ -99,6 +97,8 @@ public class TelemetryControllerTests
            .FirstOrDefault()
            .Should()
            .Be(sha);
+
+        await controller.DisposeAsync();
     }
 
     [Fact]


### PR DESCRIPTION
## Summary of changes

- Ensure we don't lose the Git data if we store it _before_ recording the tracer settings
- Fix test flake

## Reason for change

We want to fix both of those

## Implementation details

Store the latest `GitMetadata` in the `ApplicationTelemetryCollector` to avoid losing the data. This then allows us to invert the method calls to fix the flake

## Test coverage

Same

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
