### PR TITLE
Run integrations tests based on modification in PRs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2342,7 +2342,6 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables.isMainOrReleaseBranch, true),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
       )
@@ -2351,7 +2350,7 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-    RunTestsWithTracerOnly: $[ and(eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False'),
+    RunOnlyTestsWithTracer: $[ and(eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False'),
                                    eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True'))]
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -2396,7 +2395,7 @@ stages:
         archiveFilePatterns: '$(Agent.TempDirectory)/windows-tracer-home.zip'
         destinationFolder: $(monitoringHome)
 
-    - script: tracer\build.cmd BuildProfilerSamples BuildAndRunProfilerIntegrationTests --TargetPlatform $(targetPlatform) --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)
+    - script: tracer\build.cmd BuildProfilerSamples BuildAndRunProfilerIntegrationTests --TargetPlatform $(targetPlatform) --RunOnlyTestsWithTracer $(RunOnlyTestsWithTracer)
       displayName: Run Profiler Integration tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2419,7 +2418,6 @@ stages:
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
-        eq(variables.isMainOrReleaseBranch, true),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
         eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
       )
@@ -2428,7 +2426,7 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-    RunTestsWithTracerOnly: $[ and(eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False'),
+    RunOnlyTestsWithTracer: $[ and(eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False'),
                                    eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True'))]
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -2484,7 +2482,7 @@ stages:
       parameters:
         baseImage: $(baseImage)
         useNativeSdkVersion: $(useNativeSdkVersion)
-        command: "BuildAndRunProfilerCpuLimitTests --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)"
+        command: "BuildAndRunProfilerCpuLimitTests --RunOnlyTestsWithTracer $(RunOnlyTestsWithTracer)"
         extraArgs: "--cpus 2 --env CONTAINER_CPUS=1"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
@@ -2492,7 +2490,7 @@ stages:
       parameters:
         baseImage: $(baseImage)
         useNativeSdkVersion: $(useNativeSdkVersion)
-        command: "BuildAndRunProfilerCpuLimitTests --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)"
+        command: "BuildAndRunProfilerCpuLimitTests --RunOnlyTestsWithTracer $(RunOnlyTestsWithTracer)"
         extraArgs: "--cpus 0.5 --env CONTAINER_CPUS=0.5"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
@@ -2503,7 +2501,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --rm -e baseImage=$(baseImage) ProfilerIntegrationTests --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)
+        dockerComposeCommand: run --rm -e baseImage=$(baseImage) ProfilerIntegrationTests --RunOnlyTestsWithTracer $(RunOnlyTestsWithTracer)
         projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1273,7 +1273,12 @@ stages:
           condition: succeededOrFailed()
 
 - stage: integration_tests_windows
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition: >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+    )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -1410,7 +1415,12 @@ stages:
       displayName: Check logs for errors
 
 - stage: integration_tests_windows_iis
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition:  >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+    )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -1470,7 +1480,12 @@ stages:
       displayName: Check logs for errors
 
 - stage: integration_tests_windows_iis_security
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition:  >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+    )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -1530,6 +1545,11 @@ stages:
       displayName: Check logs for errors
 
 - stage: integration_tests_azure_functions
+  condition: >
+    and(
+      succeeded(),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+    )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -1740,7 +1760,12 @@ stages:
       continueOnError: true
 
 - stage: msi_integration_tests_windows
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition:  >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+    )
   dependsOn: [build_windows_tracer, package_windows, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -1823,7 +1848,12 @@ stages:
       displayName: Check logs for errors
 
 - stage: integration_tests_linux
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition:  >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+    )
   dependsOn: [package_linux, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
@@ -2313,13 +2343,16 @@ stages:
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
         eq(variables.isMainOrReleaseBranch, true),
-        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
+        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
+        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
       )
     )
   dependsOn: [package_windows, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    RunTestsWithTracerOnly: $[ and(eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False'),
+                                   eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True'))]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -2363,7 +2396,7 @@ stages:
         archiveFilePatterns: '$(Agent.TempDirectory)/windows-tracer-home.zip'
         destinationFolder: $(monitoringHome)
 
-    - script: tracer\build.cmd BuildProfilerSamples BuildAndRunProfilerIntegrationTests --TargetPlatform $(targetPlatform)
+    - script: tracer\build.cmd BuildProfilerSamples BuildAndRunProfilerIntegrationTests --TargetPlatform $(targetPlatform) --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)
       displayName: Run Profiler Integration tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2387,13 +2420,16 @@ stages:
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
       or(
         eq(variables.isMainOrReleaseBranch, true),
-        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
+        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True'),
+        eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
       )
     )
   dependsOn: [package_linux, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+    RunTestsWithTracerOnly: $[ and(eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False'),
+                                   eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True'))]
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
@@ -2448,7 +2484,7 @@ stages:
       parameters:
         baseImage: $(baseImage)
         useNativeSdkVersion: $(useNativeSdkVersion)
-        command: "BuildAndRunProfilerCpuLimitTests"
+        command: "BuildAndRunProfilerCpuLimitTests --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)"
         extraArgs: "--cpus 2 --env CONTAINER_CPUS=1"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
@@ -2456,7 +2492,7 @@ stages:
       parameters:
         baseImage: $(baseImage)
         useNativeSdkVersion: $(useNativeSdkVersion)
-        command: "BuildAndRunProfilerCpuLimitTests"
+        command: "BuildAndRunProfilerCpuLimitTests --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)"
         extraArgs: "--cpus 0.5 --env CONTAINER_CPUS=0.5"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
@@ -2467,7 +2503,7 @@ stages:
         dockerComposeFileArgs: |
           baseImage=$(baseImage)
           DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --rm -e baseImage=$(baseImage) ProfilerIntegrationTests
+        dockerComposeCommand: run --rm -e baseImage=$(baseImage) ProfilerIntegrationTests --RunTestsWithTracerOnly $(RunTestsWithTracerOnly)
         projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2634,7 +2670,12 @@ stages:
       continueOnError: false
 
 - stage: integration_tests_arm64
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
+  condition:  >
+    and(
+      succeeded(),
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+    )
   dependsOn: [package_arm64, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1277,7 +1277,7 @@ stages:
     and(
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False')
     )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
@@ -1419,7 +1419,7 @@ stages:
     and(
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False')
     )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
@@ -1484,7 +1484,7 @@ stages:
     and(
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False')
     )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
@@ -1548,7 +1548,7 @@ stages:
   condition: >
     and(
       succeeded(),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False')
     )
   dependsOn: [build_windows_tracer, generate_variables, merge_commit_id]
   variables:
@@ -1764,7 +1764,7 @@ stages:
     and(
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False')
     )
   dependsOn: [build_windows_tracer, package_windows, generate_variables, merge_commit_id]
   variables:
@@ -1852,7 +1852,7 @@ stages:
     and(
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False')
     )
   dependsOn: [package_linux, generate_variables, merge_commit_id]
   variables:
@@ -2672,7 +2672,7 @@ stages:
     and(
       succeeded(),
       eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsTracerChanged'], 'True')
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'False')
     )
   dependsOn: [package_arm64, generate_variables, merge_commit_id]
   variables:

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -22,7 +22,7 @@ using Logger = Serilog.Log;
 partial class Build
 {
     [Parameter("Enrich the default Profiler test filter: Runs only integration tests with the Tracer or All of them (default: false)")]
-    readonly bool RunTestsWithTracerOnly = false;
+    readonly bool RunOnlyTestsWithTracer = false;
 
     const string ClangTidyChecks = "-clang-analyzer-osx*,-clang-analyzer-optin.osx*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-type-vararg,-readability-braces-around-statements";
     const string LinuxApiWrapperLibrary = "Datadog.Linux.ApiWrapper.x64.so";
@@ -230,7 +230,7 @@ partial class Build
     {
         var isDebugRun = await IsDebugRun();
 
-        if (RunTestsWithTracerOnly)
+        if (RunOnlyTestsWithTracer)
         {
             filter = $"{filter}&WithTracer=True";
         }

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -21,6 +21,9 @@ using Logger = Serilog.Log;
 
 partial class Build
 {
+    [Parameter("Enrich the default Profiler test filter: Runs only integration tests with the Tracer or All of them (default: false)")]
+    readonly bool RunTestsWithTracerOnly = false;
+
     const string ClangTidyChecks = "-clang-analyzer-osx*,-clang-analyzer-optin.osx*,-cppcoreguidelines-avoid-magic-numbers,-cppcoreguidelines-pro-type-vararg,-readability-braces-around-statements";
     const string LinuxApiWrapperLibrary = "Datadog.Linux.ApiWrapper.x64.so";
 
@@ -226,6 +229,11 @@ partial class Build
     private async Task BuildAndRunProfilerIntegrationTestsInternal(string filter)
     {
         var isDebugRun = await IsDebugRun();
+
+        if (RunTestsWithTracerOnly)
+        {
+            filter = $"{filter}&WithTracer=True";
+        }
 
         EnsureExistingDirectory(ProfilerTestLogsDirectory);
 


### PR DESCRIPTION
## Summary of changes

Run integrations tests job based on modification(s) in PRs.

## Reason for change

Today when a modification is done in the Profiler, tracer integration tests run. When modification are done in the Tracer, profiler integration tests subset is not run (with CodeHotspot, End point aggregation...).

The goal of this PR is to run profiler integration tests on Profiler PRs (only), run the tracer integration tests + a subset of profiler integration tests (Code Hotspot...). This may speed up the CI for profiler PRs.

## Implementation details

- Detect at runtime if the changes are related to the profiler and/or the tracer
- For profiler integration tests, pass a flag to update the test filter (done in this [PR](https://github.com/DataDog/dd-trace-dotnet/pull/5501)) 

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
