### PR TITLE
Remove direct references to Datadog.Trace from Security samples

### DIFF
--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/Samples.Security.AspNetCore2.csproj
@@ -38,7 +38,4 @@
       <DependentUpon>appsettings.json</DependentUpon>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
 </Project>

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/CreateExtraServiceController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/CreateExtraServiceController.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Samples.Security.AspNetCore5.Models;
 using Samples.Security.AspNetCore5.IdentityStores;
-using Datadog.Trace;
 
 namespace Samples.Security.AspNetCore5.Controllers;
 
@@ -14,11 +13,11 @@ public class CreateExtraServiceController: Controller
     [HttpGet]
     public IActionResult Index(string? serviceName)
     {
-        using var scope = Tracer.Instance.StartActive("create-extra-service");
-        scope.Span.ServiceName = serviceName;
+        using var scope = Samples.SampleHelpers.CreateScope("create-extra-service");
+        Samples.SampleHelpers.TrySetServiceName(scope, serviceName);
 
         // fake a http.url tag so it'll appear in the snapshot
-        scope.Span.SetTag("http.url", $"http://localhost:00000/createextraservice/?serviceName={serviceName}");
+        Samples.SampleHelpers.TrySetTag(scope, "http.url", $"http://localhost:00000/createextraservice/?serviceName={serviceName}");
 
         return Content("Created: " + serviceName);
     }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/MetaStructController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/MetaStructController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using Datadog.Trace;
 using MessagePack.Formatters;
 using Microsoft.AspNetCore.Mvc;
 
@@ -18,7 +17,6 @@ public class MetaStructController : ControllerBase
     private static MethodInfo _tagsProperty = _spanType.GetProperty("Tags", BindingFlags.NonPublic | BindingFlags.Instance)?.GetMethod;
     private static readonly Type _tagsListType = Type.GetType("Datadog.Trace.Tagging.TagsList, Datadog.Trace");        
     private static MethodInfo _AddMetaStructMethod = _tagsListType.GetMethod("SetMetaStruct", BindingFlags.Public | BindingFlags.Instance);
-    private static MethodInfo _internalActiveScopeProperty = _tracerType.GetProperty("InternalActiveScope", BindingFlags.NonPublic | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _rootProperty = _scopeType.GetProperty("Root", BindingFlags.NonPublic | BindingFlags.Instance)?.GetMethod;
     private static MethodInfo _setTagMethod = _spanType.GetMethod("SetTag", BindingFlags.Instance | BindingFlags.NonPublic);
    
@@ -88,8 +86,7 @@ public class MetaStructController : ControllerBase
     [HttpGet("MetaStructTest")]
     public IActionResult MetaStructTest()
     {
-        var tracerInstance = Tracer.Instance;
-        var internalActiveScope = _internalActiveScopeProperty.Invoke(tracerInstance, null);
+        var internalActiveScope = Samples.SampleHelpers.GetActiveScope();
         var root = _rootProperty.Invoke(internalActiveScope, null);
         var rootSpan = _spanProperty.Invoke(root, null);
         var tags = _tagsProperty.Invoke(rootSpan, null);
@@ -108,8 +105,7 @@ public class MetaStructController : ControllerBase
     [HttpGet("VulnWithoutMetaStructTest")]
     public IActionResult VulnWithoutMetaStructTest()
     {
-        var tracerInstance = Tracer.Instance;
-        var internalActiveScope = _internalActiveScopeProperty.Invoke(tracerInstance, null);
+        var internalActiveScope = Samples.SampleHelpers.GetActiveScope();
         var root = _rootProperty.Invoke(internalActiveScope, null);
         var rootSpan = _spanProperty.Invoke(root, null);
         var tags = _tagsProperty.Invoke(rootSpan, null);

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/UserController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/UserController.cs
@@ -4,7 +4,6 @@ using Samples.Security.AspNetCore5.Models;
 using System;
 using System.Diagnostics;
 using System.Linq;
-using Datadog.Trace;
 
 namespace Samples.Security.AspNetCore5.Controllers
 {
@@ -19,11 +18,7 @@ namespace Samples.Security.AspNetCore5.Controllers
 
         public IActionResult Index(string userId = null)
         {
-            var userDetails = new UserDetails
-            {
-                Id = userId ?? "user3"
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            Samples.SampleHelpers.SetUser(userId ?? "user3");
 
             return View();
         }

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Samples.Security.AspNetCore5.csproj
@@ -62,10 +62,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
     <Content Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/UserController.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Controllers/UserController.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using System.Web.Mvc;
-using Datadog.Trace;
 using Samples.AspNetMvc5.Models;
 
 namespace Samples.AspNetMvc5.Controllers
@@ -10,13 +9,7 @@ namespace Samples.AspNetMvc5.Controllers
         [ValidateInput(false)]
         public ActionResult Index()
         {
-            var userId = "user3";
-
-            var userDetails = new UserDetails()
-            {
-                Id = userId,
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            Samples.SampleHelpers.SetUser("user3");
 
             return View();
         }

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.AspNetMvc5/Samples.Security.AspNetMvc5.csproj
@@ -217,12 +217,6 @@
     <Content Include="Views\User\Index.cshtml" />
     <Content Include="Views\Iast\ReflectedXss.cshtml" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Target Name="CopyFiles" AfterTargets="Build">
     <Copy SourceFiles="@(SecurityLibraryFiles)" DestinationFolder="$(TargetDir)\%(RecursiveDir)" SkipUnchangedFiles="true" />
   </Target>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Controllers/UserController.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Controllers/UserController.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Web.Http;
 using System.Web.Mvc;
-using Datadog.Trace;
 
 namespace Samples.Security.WebApi.Controllers
 {
@@ -19,12 +18,7 @@ namespace Samples.Security.WebApi.Controllers
         public string Get(string id)
         {
             var userId = id ?? "user3";
-
-            var userDetails = new UserDetails()
-            {
-                Id = userId,
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            Samples.SampleHelpers.SetUser(userId);
 
             return userId;
         }

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
@@ -193,12 +193,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebApi/Samples.Security.WebApi.csproj
@@ -209,6 +209,8 @@
         <WebProjectProperties>
           <UseIIS>True</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
+          
+          
           <DevelopmentServerPort>53812</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
           <IISUrl>http://localhost:51517</IISUrl>
@@ -227,6 +229,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
+  <Import Project="..\..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
@@ -187,12 +187,6 @@
       <DependentUpon>Web.config</DependentUpon>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj">
-      <Project>{5dfdf781-f24c-45b1-82ef-9125875a80a4}</Project>
-      <Name>Datadog.Trace</Name>
-    </ProjectReference>
-  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/Samples.Security.WebForms.csproj
@@ -220,6 +220,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
+  <Import Project="..\..\..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/User.aspx.cs
+++ b/tracer/test/test-applications/security/aspnet/Samples.Security.WebForms/User.aspx.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-using Datadog.Trace;
 
 namespace Samples.Security.WebForms
 {
@@ -12,13 +11,7 @@ namespace Samples.Security.WebForms
     {
         protected void Page_Load(object sender, EventArgs e)
         {
-            var userId = "user3";
-
-            var userDetails = new UserDetails()
-            {
-                Id = userId,
-            };
-            Tracer.Instance.ActiveScope?.Span.SetUser(userDetails);
+            Samples.SampleHelpers.SetUser("user3");
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

- Add some helpers for calling security methods to SampleHelpers
- Remove direct references to Datadog.Trace from the samples 

## Reason for change

Referencing Datadog.Trace _directly_ has (historically) caused us various issues with code coverage (because of interactions with auto-instrumentation). By removing the direct reference, we can also simplify some build aspects (coming later)

## Implementation details

- Add helper for calling `Tracer.Instance.ActiveScope.Span.SetUser(string)`
- Add helper for calling `scope.Span.ServiceName = "service"`
- Use these helpers in the security samples

## Test coverage

Covered by existing tests

## Other details

We have some other non-Security samples that reference Datadog.Trace, I'll address those in a separate PR.

Also of "interest". The `SetUser()` method _can_ thrown an Exception (and that's expected). In .NET Framework, it gets wrapped in a `TargetInvocationException` which interferes with the blocking, so we have to manually unwrap. In .NET Core we can opt-out of the wrapping directly

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
