### PR TITLE
[Dynamic Instrumentation] Fix PinnedLocalTest

### DIFF
--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PinnedLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.PinnedLocal.verified.txt
@@ -20,12 +20,6 @@
                 "type": "PinnedLocal",
                 "value": "PinnedLocal"
               }
-            },
-            "locals": {
-              "p": {
-                "type": "Char",
-                "value": "h"
-              }
             }
           }
         },

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/PinnedLocal.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/PinnedLocal.cs
@@ -12,7 +12,7 @@ namespace Samples.Probes.TestRuns.SmokeTests
         }
 
         [MethodImpl(MethodImplOptions.NoInlining)]
-        [LogMethodProbeTestData]
+        [LogMethodProbeTestData(skipOnFrameworks: new[] { "net462", "netcoreapp2.1"})]
         public unsafe void MethodWithPinnedLocal()
         {
             fixed (char* p = "hello")


### PR DESCRIPTION
## Summary of changes
Update the approval file to match all frameworks in all runtimes, excluding net461 and netcore2.1

## Reason for change
Test fails in CI

## Test coverage
PinnedLocalTest