### PR TITLE
[CI Visibility] - Ensure continuous profiler flush on CI Visibility close method

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -272,6 +272,20 @@ namespace Datadog.Trace.Ci
             {
                 Log.Information("CI Visibility is exiting.");
                 LifetimeManager.Instance.RunShutdownTasks();
+
+                // If the continuous profiler is attached we ensure to flush the remaining profiles before closing.
+                try
+                {
+                    if (ContinuousProfiler.Profiler.Instance.Status.IsProfilerReady)
+                    {
+                        ContinuousProfiler.NativeInterop.FlushProfile();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error flushing the profiler.");
+                }
+
                 Interlocked.Exchange(ref _firstInitialization, 1);
             }
         }


### PR DESCRIPTION
## Summary of changes

This PR ensures the flush of the continuous profiler when CI Visibility closes and flushes everything before the `testhost` process gets killed.

## Reason for change

Currently if we run the continuous profiler with ci visibility over a test suite, the profiling data gets lost because the `testhost` process gets killed before the continuous profiler flush.

## Implementation details

We check if the continuous profiler is enabled and call the flush method when CI Visibility is closing.
