### PR TITLE
test: Lint produced deb and rpm packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -67,7 +67,7 @@ publish:
           try {
               # The grants option at the end is used to allow public access on the files we upload as the acls only aren't enough.
               aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-              If ($LASTEXITCODE -eq 0) { 
+              If ($LASTEXITCODE -eq 0) {
                 return
               }
 
@@ -166,6 +166,7 @@ package:
       allow_failure: false
   script:
     - ../.gitlab/build-deb-rpm.sh
+    - find . -iregex '.*\.\(deb\|rpm\)' -printf '%f\0' | xargs -0 dd-pkg lint
   variables:
     ARCH: amd64
 
@@ -179,6 +180,7 @@ package-arm:
       allow_failure: false
   script:
     - ../.gitlab/build-deb-rpm.sh
+    - find . -iregex '.*\.\(deb\|rpm\)' -printf '%f\0' | xargs -0 dd-pkg lint
   variables:
     ARCH: arm64
 


### PR DESCRIPTION
## Summary of changes

The latest stable version of the packaging template now includes a tool `dd-pkg`. This PR uses this tool to lint the produced DEB and RPM packages.

## Reason for change

This lint has been run at the time of package promotion, this change moves this step to the left and lets teams identify issues _before_ they're trying to release to production.

## Implementation details

## Test coverage

## Other details

[BARX-245](https://datadoghq.atlassian.net/browse/BARX-245)
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->


[BARX-245]: https://datadoghq.atlassian.net/browse/BARX-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Originally opened here:
- https://github.com/DataDog/dd-trace-dotnet/pull/5481