### PR TITLE
Remove some write flags from GetModuleMetaData calls

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -1124,7 +1124,7 @@ HRESULT ResolveTypeInternal(ICorProfilerInfo4* info,
         if (moduleId == 0) continue;
 
         ComPtr<IUnknown> metadata_interfaces;
-        auto hr = info->GetModuleMetaData(moduleId, ofRead | ofWrite, IID_IMetaDataImport2,
+        auto hr = info->GetModuleMetaData(moduleId, ofRead, IID_IMetaDataImport2,
                                                             metadata_interfaces.GetAddressOf());
         if (FAILED(hr))
         {

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -417,7 +417,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::AssemblyLoadFinished(AssemblyID assembly_
         }
 
         ComPtr<IUnknown> metadata_interfaces;
-        auto hr = this->info_->GetModuleMetaData(assembly_info.manifest_module_id, ofRead | ofWrite,
+        auto hr = this->info_->GetModuleMetaData(assembly_info.manifest_module_id, ofRead,
                                                  IID_IMetaDataImport2, metadata_interfaces.GetAddressOf());
 
         if (FAILED(hr))
@@ -760,7 +760,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
         corlib_app_domain_id = app_domain_id;
 
         ComPtr<IUnknown> metadata_interfaces;
-        auto hr = this->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,
+        auto hr = this->info_->GetModuleMetaData(module_id, ofRead, IID_IMetaDataImport2,
                                                  metadata_interfaces.GetAddressOf());
 
         // Get the IMetaDataAssemblyImport interface to get metadata from the
@@ -986,7 +986,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
             bool foundType = false;
 
             ComPtr<IUnknown> metadata_interfaces;
-            auto hr = this->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,
+            auto hr = this->info_->GetModuleMetaData(module_id, ofRead, IID_IMetaDataImport2,
                                                      metadata_interfaces.GetAddressOf());
 
             if (FAILED(hr))


### PR DESCRIPTION
## Summary of changes

This PR removes some unused write flags from the `GetModuleMetaData` flags.

## Reason for change

We are getting some warnings from this call on some modules (presumably mscorlib) and we think is due the fact we are trying to open it with the write flag. We hope to reduce the number of warnings with this change.

Also the write flag introduces some overhead for metadata modification that we are not doing in these cases.

## Implementation details

Remove the flags when we don't emit any modification to the module.

## Test coverage
There shouldn't be any change of behavior for existing tests.
