### PR TITLE
Bump Sep to 0.5.2

### DIFF
--- a/tracer/build/_build/_build.csproj
+++ b/tracer/build/_build/_build.csproj
@@ -39,7 +39,7 @@
     <!-- Explicitly override the version of octokit used by Nuke -->
     <PackageReference Include="Octokit" Version="10.0.0" />
     <PackageReference Include="Perfolizer" Version="0.2.1" />
-    <PackageReference Include="Sep" Version="0.3.0" />
+    <PackageReference Include="Sep" Version="0.5.2" />
     <PackageReference Include="ByteSize" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of changes

Bumps the Sep dependency to latest

## Reason for change

Keep up to date

## Implementation details

N/A

## Test coverage

N/A

## Other details

Original:
- https://github.com/DataDog/dd-trace-dotnet/pull/5514

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
