### PR TITLE
Update `CODEOWNERS` for APM SDK IDM ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,12 @@ missing-nullability-files.csv             @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
 /tracer/src/Datadog.Trace/PDBs/MethodSymbolResolver.cs        @DataDog/ci-app-libraries-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.XUnitTests/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.NUnitTests/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.MSTestTests/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.MSTestTests2/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs  @DataDog/ci-app-libraries-dotnet
 
 # ASM
 /tracer/src/Datadog.Trace/AppSec/         @DataDog/asm-dotnet
@@ -33,6 +39,12 @@ AspectsDefinitions.g.cs 				@DataDog/asm-dotnet
 /tracer/test/test-applications/integrations/Samples.InstrumentedTests/ @DataDog/asm-dotnet
 /tracer/src/Datadog.Trace/Tags.AppSec.cs @DataDog/asm-dotnet
 /tracer/test/benchmarks/Benchmarks.Trace/Asm/   @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CryptographyAlgorithm/  @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/HashAlgorithm/  @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/  @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/StackTraceLeak/  @DataDog/asm-dotnet
+/tracer/test/test-applications/integrations/Samples.ProcessStart  @DataDog/asm-dotnet
+
 
 # Profiler
 /profiler/                                @DataDog/profiling-dotnet
@@ -76,74 +88,21 @@ docker-compose.serverless.yml                                      @DataDog/trac
 /tracer/src/Datadog.Trace/DataStreamsMonitoring/                                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 
 ## auto instrumentations
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/                                   @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CosmosDb/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Couchbase/                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/                                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+## co-owned auto instrumentations
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/                                   @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/asm-dotnet
 
 ## tagging
 /tracer/src/Datadog.Trace/Tagging/                                                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 
 ## integration tests for auto-instrumentations
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs                                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringKafkaTests.cs              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLCommon.cs                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs                                   @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RemotingTests.cs                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/                                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+### co-owned integrations tests
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet  @DataDog/asm-dotnet
 
 ## sample applications
 
@@ -154,58 +113,46 @@ docker-compose.serverless.yml                                      @DataDog/trac
 /tracer/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/test/test-applications/integrations/dependency-libs/Samples.WebRequestHelper.NetFramework20     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 
-/tracer/test/test-applications/integrations/LogsInjection.ILogger                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/LogsInjection.ILogger.ExtendedLogger                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/LogsInjection.Log4Net                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/LogsInjection.NLog                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/LogsInjection.Serilog                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Aerospike                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc30                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AspNetCoreRazorPages                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AWS.DynamoDBv2                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AWS.Kinesis                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AWS.SimpleNotificationService                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AWS.SQS                                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.AzureServiceBus                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.CosmosDb                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Couchbase                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Couchbase3                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Dapper                                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.DataStreams.AzureServiceBus                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka                                   @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.DataStreams.RabbitMQ                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Elasticsearch                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Elasticsearch.V7                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.FakeDbCommand                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.GraphQL                                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.GraphQL3                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.GraphQL4                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.GraphQL7                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.GrpcDotNet                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.GrpcLegacy                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.HttpMessageHandler                                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Kafka                                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.MongoDB                                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Msmq                                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.MySql                                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.MySqlConnector                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Npgsql                                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.OracleMDA                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.OracleMDA.Core                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Owin.WebApi2                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.RabbitMQ                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.ServiceStack.Redis                                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.SQLite.Core                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.SqlServer                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.SqlServer.NetFramework20                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.StackExchange.Redis                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Wcf                                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.WebRequest                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/test/test-applications/integrations/Samples.Yarp.DistributedTracing                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/                                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+
+## NON-IDM
+
+/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/                              @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.NetActivitySdk/                                     @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.OpenTelemetrySdk/                                   @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.TraceAnnotations/                                   @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.AfterFeature/      @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.BeforeFeature/     @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.TraceAnnotations.VersionMismatch.NewerNuGet/        @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.TracingWithoutLimits/                               @DataDog/tracing-dotnet
+
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/                                @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/                             @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/                                        @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/                                     @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TestCollections/                                @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/                                     @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/                                @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AgentMalfunctionTests.cs                        @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AppTrimmingTests.cs                             @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs                        @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CustomTestFramework.cs                          @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs                    @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationVerificationSanityCheckTests.cs  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs                   @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NativeProfilerChecks.cs                         @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs                          @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NoMultiLoaderTests.cs                           @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs                        @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PackageVersions.g.cs                            @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PackageVersionsLatestMajors.g.cs                @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PackageVersionsLatestMinors.g.cs                @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PackageVersionsLatestSpecific.g.cs              @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RemotingTests.cs                                @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RuntimeMetricsTests.cs                          @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TelemetryTests.cs                               @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TraceAnnotationsTests.cs                        @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs                             @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs                       @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs                               @DataDog/tracing-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,3 +68,145 @@ docker-compose.serverless.yml                                      @DataDog/trac
 
 # Shared code we could move to the root folder
 /tracer/build/                            @DataDog/apm-dotnet
+
+# IDM (note @DataDog/tracing-dotnet may be removed at a later date)
+
+## DBM and DSM
+/tracer/src/Datadog.Trace/DatabaseMonitoring/                                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/DataStreamsMonitoring/                                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+## auto instrumentations
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/                                   @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Azure/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CosmosDb/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Couchbase/                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/GraphQL/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Http/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/IbmMq/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Kafka/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Logging/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/MongoDb/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Msmq/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/OpenTelemetry/                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+## tagging
+/tracer/src/Datadog.Trace/Tagging/                                                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+## integration tests for auto-instrumentations
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AdoNet/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNetCore/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/IIS/                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Transports/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AerospikeTests.cs                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs                                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Couchbase3Tests.cs                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CouchbaseTests.cs                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringKafkaTests.cs              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DataStreamsMonitoringRabbitMQTests.cs           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch5Tests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch6Tests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Elasticsearch7Tests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLCommon.cs                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GraphQLTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/GrpcTests.cs                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HotChocolateTests.cs                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/HttpMessageHandlerTests.cs                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ILoggerTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/KafkaTests.cs                                   @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Log4NetTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/LogsInjectionTestBase.cs                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MongoDbTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/MsmqTests.cs                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NLogTests.cs                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/PeerServiceMappingTests.cs                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RabbitMQTests.cs                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/RemotingTests.cs                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SerilogTests.cs                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceMappingTests.cs                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ServiceStackRedisTests.cs                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/StackExchangeRedisTests.cs                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WcfTests.cs                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequest20Tests.cs                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/WebRequestTests.cs                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/YarpDistributedTracingTests.cs                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+## sample applications
+
+/tracer/test/test-applications/integrations/dependency-libs/LogsInjectionHelper/                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.NetFramework20       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/dependency-libs/Samples.DatabaseHelper.netstandard          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/dependency-libs/Samples.SqlServer.Vb                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/dependency-libs/Samples.WebRequestHelper.NetFramework20     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+
+/tracer/test/test-applications/integrations/LogsInjection.ILogger                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/LogsInjection.ILogger.ExtendedLogger                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/LogsInjection.Log4Net                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/LogsInjection.NLog                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/LogsInjection.Serilog                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Aerospike                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AspNetCoreMinimalApis                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc21                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc30                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AspNetCoreMvc31                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AspNetCoreRazorPages                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AWS.DynamoDBv2                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AWS.Kinesis                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AWS.SimpleNotificationService                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AWS.SQS                                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.AzureServiceBus                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.CosmosDb                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Couchbase                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Couchbase3                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Dapper                                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.DataStreams.AzureServiceBus                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.DataStreams.Kafka                                   @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.DataStreams.RabbitMQ                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Elasticsearch                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Elasticsearch.V5                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Elasticsearch.V7                                    @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.FakeDbCommand                                       @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.GraphQL                                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.GraphQL3                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.GraphQL4                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.GraphQL7                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.GrpcDotNet                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.GrpcLegacy                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.HttpMessageHandler                                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Kafka                                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Microsoft.Data.SqlClient                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Microsoft.Data.Sqlite                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.MongoDB                                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Msmq                                                @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.MySql                                               @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.MySqlConnector                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Npgsql                                              @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.OracleMDA                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.OracleMDA.Core                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Owin.WebApi2                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.RabbitMQ                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.ServiceStack.Redis                                  @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.SQLite.Core                                         @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.SqlServer                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.SqlServer.NetFramework20                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.StackExchange.Redis                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Wcf                                                 @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.WebRequest                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.WebRequest.NetFramework20                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
+/tracer/test/test-applications/integrations/Samples.Yarp.DistributedTracing                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,7 +97,6 @@ docker-compose.serverless.yml                                      @DataDog/trac
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/RabbitMQ/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Redis/                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Remoting/                                     @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/                                      @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/TraceAnnotations/                             @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/                                          @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 


### PR DESCRIPTION
## Summary of changes

Adds the `@DataDog/apm-idm-dotnet` team as a code owner for APM SDK IDM-related directories and files within `dd-trace-dotnet`.
Keeps the `tracing-dotnet` team as owner as well as this is intended to not be a hard shift in ownership at the moment.

Please go through and if you see anything that doesn't appear to be something that the APM SDK IDM teams should own flag it. (example I am stating that all of `Tagging/` is owned by the APM SDK IDM team).

If there are files/directories that I have missed here and should be owned by the APM SDK IDM team let me know (or we can always add the APM SDK IDM team as a code owner at a later date).

## Reason for change

The APM SDK IDM teams has an initiative to go through the various libraries and update `CODEOWNERS` files to ensure that the correct APM SDK IDM GitHub team is declared as an owner of that file.

Note that for the time being the APM SDK IDM teams have opted to go for language based GitHub teams. The members of `apm-idm-dotnet` should be familiar with .NET (hence the name).

## Implementation details

- Made a script that just enumerated folders/files in directories that largely had APM SDK IDM ownership that created each line changed here.
- I then went through and attempted to remove ones that I didn't think were owned by the APM SDK IDM teams (example are some serverless and ASM ones).

Again - the intention here isn't for the `apm-idm-dotnet` team to take exclusive ownership of these files (yet) and is intended to help narrow pull request notifications for the APM SDK IDM teams, specifically for .NET, but that may change in the future as well.

## Test coverage

GitHub is telling me that this `CODEOWNERS` file is valid.

## Other details
<!-- Fixes #{issue} -->

Resolves: https://datadoghq.atlassian.net/browse/AIDM-63

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
