### PR TITLE
[CI Visibility] - Fix force Evp proxy environment variable

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CiUtils.cs
@@ -151,9 +151,10 @@ internal static class CiUtils
                 // EVP proxy is enabled.
                 // By setting the environment variables we avoid the usage of the DiscoveryService in each child process
                 // to ask for EVP proxy support.
-                profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy] = "1";
-                EnvironmentHelpers.SetEnvironmentVariable(Configuration.ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, "1");
-                Log.Debug("RunCiCommand: EVP proxy was detected.");
+                var evpProxyMode = CIVisibility.EventPlatformProxySupportFromEndpointUrl(agentConfiguration?.EventPlatformProxyEndpoint).ToString();
+                profilerEnvironmentVariables[Configuration.ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy] = evpProxyMode;
+                EnvironmentHelpers.SetEnvironmentVariable(Configuration.ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, evpProxyMode);
+                Log.Debug("RunCiCommand: EVP proxy was detected: {Mode}", evpProxyMode);
             }
 
             // If we have an api key, and the code coverage or the tests skippable environment variables

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Ci.Configuration
             GitUploadEnabled = config.WithKeys(ConfigurationKeys.CIVisibility.GitUploadEnabled).AsBool();
 
             // Force evp proxy
-            ForceAgentsEvpProxy = config.WithKeys(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy).AsBool(false);
+            ForceAgentsEvpProxy = config.WithKeys(ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy).AsString();
 
             // Check if Datadog.Trace should be installed in the GAC
             InstallDatadogTraceInGac = config.WithKeys(ConfigurationKeys.CIVisibility.InstallDatadogTraceInGac).AsBool(true);
@@ -152,7 +152,7 @@ namespace Datadog.Trace.Ci.Configuration
         /// <summary>
         /// Gets a value indicating whether EVP Proxy must be used.
         /// </summary>
-        public bool ForceAgentsEvpProxy { get; }
+        public string? ForceAgentsEvpProxy { get; }
 
         /// <summary>
         /// Gets a value indicating whether we ensure Datadog.Trace GAC installation.

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CIVisibilitySettingsTests.cs
@@ -177,8 +177,8 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [MemberData(nameof(BooleanTestCases), false)]
-        public void ForceAgentsEvpProxy(string value, bool expected)
+        [MemberData(nameof(StringTestCases))]
+        public void ForceAgentsEvpProxy(string value, string expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CIVisibility.ForceAgentsEvpProxy, value));
             var settings = new CIVisibilitySettings(source, NullConfigurationTelemetry.Instance);


### PR DESCRIPTION
## Summary of changes

This PR fixes the `DD_CIVISIBILITY_FORCE_AGENT_EVP_PROXY` environment variable used to propagate the EVP proxy support result from `IDiscoveryService`.

## Reason for change

Previously the var was a boolean, because we either supported EVP or not, but now, we have two versions of EVP support:
- `V2` : The previous and old one.
- `V4`: A new version that supports gzip headers

Currently the `dd-trace` process was detecting `V4` but setting the env-var to `1` the child process was reading the var and using `V2`, so there's no data loss but we were never using the V4 for sending the test spans.

Converting the environment variable from a `boolean` to a `string?`, now we can pass the version to the `testhost` child process without requiring to repeat the request to the `IDiscoveryService`.

## Implementation details

Move from `boolean` to `string?` The value now is the `.ToString()` of the EVP proxy enum.

## Test coverage

Change the configuration test to use string instead.

## Other details
The issue was detected thanks to the `test-environment`. It didn't appear on our CI Visibility tests because the failure was on the `dd-trace` -> `testhost` environment propagation.

<img width="1524" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/4beda72c-4530-454f-be91-52e7724c0507">
