### PR TITLE
Fix DSM SQS tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSqsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/DataStreamsMonitoringAwsSqsTests.cs
@@ -70,7 +70,7 @@ public class DataStreamsMonitoringAwsSqsTests : TestHelper
          *  - 1 produce pathway point (tagged with 'direction:out')
          *  - 1 consume pathway points (either with a parent for the "normal" case, or without when headers are full)
          */
-        using (RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
+        using (await RunSampleAndWaitForExit(agent, packageVersion: packageVersion))
         {
 #if NETFRAMEWORK
             // there is no snapshot for NetFramework so this test would fail if run

--- a/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs
+++ b/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs
@@ -87,6 +87,10 @@ namespace Samples.AWS.SQS
 
         public static async Task RunSpecificScenario(AmazonSQSClient sqsClient, Scenario s)
         {
+            // Ensure there's a parent span for all the requests, so that when we compare
+            // the injected context to the active, we _have_ an active trace
+            using var scope = SampleHelpers.CreateScope("async-methods");
+
             // setup
             await CreateSqsQueuesAsync(sqsClient);
             await GetQueuesUrlAsync(sqsClient);


### PR DESCRIPTION
## Summary of changes

- Await the task returned by `RunSampleAndWaitForExit` in the DSM SQS tests.
- Fix the broken tests

## Reason for change

Because the task was not awaited, we didn't detect when the sample app crashed.

## Implementation details

Awaiting the task means we now detect the crash as we hoped. The tests were crashing because the call to `AssertDistributedTracingHeaders` was failing, because there was no active trace ID when the spans were created:

```
System.Exception: The span context was not injected into the message properly. parent-id: 14561832672690147129, trace-id: 8078349720994907415, active trace-id: 0
   at Samples.AWS.SQS.Common.AssertDistributedTracingHeaders(List`1 messages) in /project/tracer/test/test-applications/integrations/Samples.AWS.SQS/Common.cs:line 30
   at Samples.AWS.SQS.AsyncHelpers.SendBatchMessagesWithInjectedHeadersAsync(AmazonSQSClient sqsClient) in /project/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs:line 241
   at Samples.AWS.SQS.AsyncHelpers.RunSpecificScenario(AmazonSQSClient sqsClient, Scenario s) in /project/tracer/test/test-applications/integrations/Samples.AWS.SQS/AsyncHelpers.cs:line 102
   at Samples.AWS.SQS.Program.Main(String[] args) in /project/tracer/test/test-applications/integrations/Samples.AWS.SQS/Program.cs:line 39
   at Samples.AWS.SQS.Program.<Main>(String[] args)  { MachineName: ".", Process: "[8083 dotnet]", AppDomain: "[1 Samples.AWS.SQS]", AssemblyLoadContext: "\"\" Datadog.Trace.ClrProfiler.Managed.Loader.ManagedProfilerAssemblyLoadContext #1", TracerVersion: "2.51.0.0" }
```

The fix was simply to create a "wrapper" span so there's an active trace, which is then injected, and which can then be compared to.

## Test coverage

The tests previously weren't failing because the assertion was run _after_ all the spans had been generated, and all the DSM points sent to the backend. We also globally hooked the uncaught exception and flushed all the data to the agent _before_ the application closed and crashed. 

So the first commits ensures we correctly detect the crashes, and the second commit fixes the tests.

## Other details

It _feels_ like there should be an analyzer for this sort of pattern 🤔 👀  
