### PR TITLE
[ASM][IAST] Add vulnerability marks to Range + Add the mark to Escaped XSS

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastModule.Escape.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.Escape.cs
@@ -45,7 +45,7 @@ internal static partial class IastModule
             }
 
             // Add the mark (exclusion) to the tainted ranges
-            tainted.Ranges = Ranges.CopyWithMark(tainted.Ranges, Mark.Xss);
+            tainted.Ranges = Ranges.CopyWithMark(tainted.Ranges, SecureMarks.Xss);
         }
         catch (Exception ex)
         {

--- a/tracer/src/Datadog.Trace/Iast/IastModule.Escape.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.Escape.cs
@@ -44,11 +44,8 @@ internal static partial class IastModule
                 return res;
             }
 
-            if (object.ReferenceEquals(res, text))
-            {
-                // If returned reference is the same, we create a new one
-                res = text!.CreateNewReference();
-            }
+            // Add the mark (exclusion) to the tainted ranges
+            tainted.Ranges = Ranges.CopyWithMark(tainted.Ranges, Mark.Xss);
         }
         catch (Exception ex)
         {

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -461,7 +461,7 @@ internal static partial class IastModule
             }
 
             OnExecutedSinkTelemetry(IastInstrumentedSinks.Xss);
-            return GetScope(text!, IntegrationId.Xss, VulnerabilityTypeName.Xss, OperationNameXss, Always, exclusionMark: Mark.Xss);
+            return GetScope(text!, IntegrationId.Xss, VulnerabilityTypeName.Xss, OperationNameXss, Always, exclusionSecureMarks: SecureMarks.Xss);
         }
         catch (Exception ex)
         {
@@ -555,7 +555,7 @@ internal static partial class IastModule
         return isRequest && traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed() == true;
     }
 
-    private static IastModuleResponse GetScope(string evidenceValue, IntegrationId integrationId, string vulnerabilityType, string operationName, Func<TaintedObject, bool>? taintValidator = null, bool addLocation = true, int? hash = null, StackTrace? externalStack = null, Mark exclusionMark = Mark.None)
+    private static IastModuleResponse GetScope(string evidenceValue, IntegrationId integrationId, string vulnerabilityType, string operationName, Func<TaintedObject, bool>? taintValidator = null, bool addLocation = true, int? hash = null, StackTrace? externalStack = null, SecureMarks exclusionSecureMarks = SecureMarks.None)
     {
         var tracer = Tracer.Instance;
         if (!iastSettings.Enabled || !tracer.Settings.IsIntegrationEnabled(integrationId))
@@ -593,7 +593,7 @@ internal static partial class IastModule
         }
 
         // Check for marked (excluded) ranges
-        if (Ranges.RangesMarked(tainted?.Ranges, exclusionMark))
+        if (Ranges.RangesMarked(tainted?.Ranges, exclusionSecureMarks))
         {
             return IastModuleResponse.Empty;
         }

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -593,8 +593,7 @@ internal static partial class IastModule
         }
 
         // Check for marked (excluded) ranges
-        var ranges = Ranges.NotMarkedRanges(tainted?.Ranges, exclusionMark);
-        if (ranges is null || ranges.Length == 0)
+        if (Ranges.RangesMarked(tainted?.Ranges, exclusionMark))
         {
             return IastModuleResponse.Empty;
         }
@@ -606,8 +605,8 @@ internal static partial class IastModule
         }
 
         var vulnerability = (hash is null) ?
-            new Vulnerability(vulnerabilityType, location, new Evidence(evidenceValue, ranges), integrationId) :
-            new Vulnerability(vulnerabilityType, (int)hash, location, new Evidence(evidenceValue, ranges), integrationId);
+            new Vulnerability(vulnerabilityType, location, new Evidence(evidenceValue, tainted?.Ranges), integrationId) :
+            new Vulnerability(vulnerabilityType, (int)hash, location, new Evidence(evidenceValue, tainted?.Ranges), integrationId);
 
         if (!iastSettings.DeduplicationEnabled || HashBasedDeduplication.Instance.Add(vulnerability))
         {

--- a/tracer/src/Datadog.Trace/Iast/Mark.cs
+++ b/tracer/src/Datadog.Trace/Iast/Mark.cs
@@ -8,7 +8,7 @@ using System;
 namespace Datadog.Trace.Iast;
 
 [Flags]
-internal enum Mark
+internal enum Mark : byte
 {
     None = 0,
     Xss = 1,

--- a/tracer/src/Datadog.Trace/Iast/Mark.cs
+++ b/tracer/src/Datadog.Trace/Iast/Mark.cs
@@ -1,0 +1,15 @@
+// <copyright file="Mark.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.Iast;
+
+[Flags]
+internal enum Mark
+{
+    None = 0,
+    Xss = 1,
+}

--- a/tracer/src/Datadog.Trace/Iast/Mark.cs
+++ b/tracer/src/Datadog.Trace/Iast/Mark.cs
@@ -5,6 +5,8 @@
 
 using System;
 
+#nullable enable
+
 namespace Datadog.Trace.Iast;
 
 [Flags]

--- a/tracer/src/Datadog.Trace/Iast/Range.cs
+++ b/tracer/src/Datadog.Trace/Iast/Range.cs
@@ -13,11 +13,14 @@ namespace Datadog.Trace.Iast;
 
 internal readonly struct Range : IComparable<Range>
 {
-    public Range(int start, int length, Source? source = null)
+    private static readonly Mark NotMarked = Mark.None;
+
+    public Range(int start, int length, Source? source = null, Mark mark = Mark.None)
     {
         this.Start = start;
         this.Length = length;
         this.Source = source;
+        this.Mark = mark;
     }
 
     public int Start { get; }
@@ -25,6 +28,8 @@ internal readonly struct Range : IComparable<Range>
     public int Length { get; }
 
     public Source? Source { get; }
+
+    public Mark Mark { get; }
 
     public bool IsEmpty()
     {
@@ -43,12 +48,17 @@ internal readonly struct Range : IComparable<Range>
             return this;
         }
 
-        return new Range(Start + offset, Length, Source);
+        return new Range(Start + offset, Length, Source, Mark);
     }
 
     public int CompareTo([AllowNull] Range other)
     {
         return this.Start.CompareTo(other.Start);
+    }
+
+    public bool IsMarked(Mark mark)
+    {
+        return (Mark & mark) != NotMarked;
     }
 
     internal bool IsBefore(Range? range)
@@ -102,14 +112,14 @@ internal readonly struct Range : IComparable<Range>
             List<Range> res = new List<Range>(3);
             if (range.Start > Start)
             {
-                res.Add(new Range(Start, range.Start - Start, Source));
+                res.Add(new Range(Start, range.Start - Start, Source, Mark));
             }
 
             int end = Start + Length;
             int rangeEnd = range.Start + range.Length;
             if (rangeEnd < end)
             {
-                res.Add(new Range(rangeEnd, (end - rangeEnd), Source));
+                res.Add(new Range(rangeEnd, (end - rangeEnd), Source, Mark));
             }
 
             return res;

--- a/tracer/src/Datadog.Trace/Iast/Range.cs
+++ b/tracer/src/Datadog.Trace/Iast/Range.cs
@@ -13,14 +13,14 @@ namespace Datadog.Trace.Iast;
 
 internal readonly struct Range : IComparable<Range>
 {
-    private static readonly Mark NotMarked = Mark.None;
+    private static readonly SecureMarks NotMarked = SecureMarks.None;
 
-    public Range(int start, int length, Source? source = null, Mark mark = Mark.None)
+    public Range(int start, int length, Source? source = null, SecureMarks secureMarks = SecureMarks.None)
     {
         this.Start = start;
         this.Length = length;
         this.Source = source;
-        this.Mark = mark;
+        this.SecureMarks = secureMarks;
     }
 
     public int Start { get; }
@@ -29,7 +29,7 @@ internal readonly struct Range : IComparable<Range>
 
     public Source? Source { get; }
 
-    public Mark Mark { get; }
+    public SecureMarks SecureMarks { get; }
 
     public bool IsEmpty()
     {
@@ -48,7 +48,7 @@ internal readonly struct Range : IComparable<Range>
             return this;
         }
 
-        return new Range(Start + offset, Length, Source, Mark);
+        return new Range(Start + offset, Length, Source, SecureMarks);
     }
 
     public int CompareTo([AllowNull] Range other)
@@ -56,9 +56,9 @@ internal readonly struct Range : IComparable<Range>
         return this.Start.CompareTo(other.Start);
     }
 
-    public bool IsMarked(Mark mark)
+    public bool IsMarked(SecureMarks marks)
     {
-        return (Mark & mark) != NotMarked;
+        return (SecureMarks & marks) != NotMarked;
     }
 
     internal bool IsBefore(Range? range)
@@ -112,14 +112,14 @@ internal readonly struct Range : IComparable<Range>
             List<Range> res = new List<Range>(3);
             if (range.Start > Start)
             {
-                res.Add(new Range(Start, range.Start - Start, Source, Mark));
+                res.Add(new Range(Start, range.Start - Start, Source, SecureMarks));
             }
 
             int end = Start + Length;
             int rangeEnd = range.Start + range.Length;
             if (rangeEnd < end)
             {
-                res.Add(new Range(rangeEnd, (end - rangeEnd), Source, Mark));
+                res.Add(new Range(rangeEnd, (end - rangeEnd), Source, SecureMarks));
             }
 
             return res;

--- a/tracer/src/Datadog.Trace/Iast/Ranges.cs
+++ b/tracer/src/Datadog.Trace/Iast/Ranges.cs
@@ -136,7 +136,7 @@ internal static class Ranges
 
                 if (newLength > 0)
                 {
-                    newRanges[newRangeIndex] = new Range(newStart, newLength, range.Source, range.Mark);
+                    newRanges[newRangeIndex] = new Range(newStart, newLength, range.Source, range.SecureMarks);
                 }
             }
         }
@@ -186,36 +186,36 @@ internal static class Ranges
                 newEnd = endAfterRemoveArea ? ranges[i].Start + ranges[i].Length - (endIndex - beginIndex) : beginIndex;
             }
 
-            var newRange = new Range(newStart, newEnd - newStart, ranges[i].Source, ranges[i].Mark);
+            var newRange = new Range(newStart, newEnd - newStart, ranges[i].Source, ranges[i].SecureMarks);
             newRanges.Add(newRange);
         }
 
         return newRanges.ToArray();
     }
 
-    internal static Range[] CopyWithMark(Range[] ranges, Mark mark)
+    internal static Range[] CopyWithMark(Range[] ranges, SecureMarks secureMarks)
     {
         var newRanges = new List<Range>();
 
         foreach (var range in ranges)
         {
-            var newRange = new Range(range.Start, range.Length, range.Source, mark);
+            var newRange = new Range(range.Start, range.Length, range.Source, secureMarks);
             newRanges.Add(newRange);
         }
 
         return newRanges.ToArray();
     }
 
-    internal static bool RangesMarked(IEnumerable<Range>? ranges, Mark mark)
+    internal static bool RangesMarked(IEnumerable<Range>? ranges, SecureMarks secureMarks)
     {
-        if (ranges is null || mark == Mark.None)
+        if (ranges is null || secureMarks == SecureMarks.None)
         {
             return false;
         }
 
         foreach (var range in ranges)
         {
-            if (range.IsMarked(mark))
+            if (range.IsMarked(secureMarks))
             {
                 return true;
             }

--- a/tracer/src/Datadog.Trace/Iast/Ranges.cs
+++ b/tracer/src/Datadog.Trace/Iast/Ranges.cs
@@ -206,49 +206,21 @@ internal static class Ranges
         return newRanges.ToArray();
     }
 
-    internal static Range[]? NotMarkedRanges(Range[]? ranges, Mark mark)
+    internal static bool RangesMarked(IEnumerable<Range>? ranges, Mark mark)
     {
-        // Skip if no mark is provided
-        if (ranges == null || mark == Mark.None) { return ranges; }
-
-        var markedRangesCount = RangesMarkedCount(ranges, mark);
-        if (markedRangesCount == 0)
+        if (ranges is null || mark == Mark.None)
         {
-            return ranges;
+            return false;
         }
-
-        // All ranges are marked
-        if (markedRangesCount == ranges.Length)
-        {
-            return null;
-        }
-
-        var newRanges = new Range[ranges.Length - markedRangesCount];
-        var newRangesIndex = 0;
-
-        foreach (var range in ranges)
-        {
-            if (!range.IsMarked(mark))
-            {
-                newRanges[newRangesIndex++] = range;
-            }
-        }
-
-        return newRanges;
-    }
-
-    private static int RangesMarkedCount(IEnumerable<Range> ranges, Mark mark)
-    {
-        var count = 0;
 
         foreach (var range in ranges)
         {
             if (range.IsMarked(mark))
             {
-                count++;
+                return true;
             }
         }
 
-        return count;
+        return false;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Ranges.cs
+++ b/tracer/src/Datadog.Trace/Iast/Ranges.cs
@@ -136,7 +136,7 @@ internal static class Ranges
 
                 if (newLength > 0)
                 {
-                    newRanges[newRangeIndex] = new Range(newStart, newLength, range.Source);
+                    newRanges[newRangeIndex] = new Range(newStart, newLength, range.Source, range.Mark);
                 }
             }
         }
@@ -186,10 +186,69 @@ internal static class Ranges
                 newEnd = endAfterRemoveArea ? ranges[i].Start + ranges[i].Length - (endIndex - beginIndex) : beginIndex;
             }
 
-            var newRange = new Range(newStart, newEnd - newStart, ranges[i].Source);
+            var newRange = new Range(newStart, newEnd - newStart, ranges[i].Source, ranges[i].Mark);
             newRanges.Add(newRange);
         }
 
         return newRanges.ToArray();
+    }
+
+    internal static Range[] CopyWithMark(Range[] ranges, Mark mark)
+    {
+        var newRanges = new List<Range>();
+
+        foreach (var range in ranges)
+        {
+            var newRange = new Range(range.Start, range.Length, range.Source, mark);
+            newRanges.Add(newRange);
+        }
+
+        return newRanges.ToArray();
+    }
+
+    internal static Range[]? NotMarkedRanges(Range[]? ranges, Mark mark)
+    {
+        // Skip if no mark is provided
+        if (ranges == null || mark == Mark.None) { return ranges; }
+
+        var markedRangesCount = RangesMarkedCount(ranges, mark);
+        if (markedRangesCount == 0)
+        {
+            return ranges;
+        }
+
+        // All ranges are marked
+        if (markedRangesCount == ranges.Length)
+        {
+            return null;
+        }
+
+        var newRanges = new Range[ranges.Length - markedRangesCount];
+        var newRangesIndex = 0;
+
+        foreach (var range in ranges)
+        {
+            if (!range.IsMarked(mark))
+            {
+                newRanges[newRangesIndex++] = range;
+            }
+        }
+
+        return newRanges;
+    }
+
+    private static int RangesMarkedCount(IEnumerable<Range> ranges, Mark mark)
+    {
+        var count = 0;
+
+        foreach (var range in ranges)
+        {
+            if (range.IsMarked(mark))
+            {
+                count++;
+            }
+        }
+
+        return count;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/SecureMarks.cs
+++ b/tracer/src/Datadog.Trace/Iast/SecureMarks.cs
@@ -1,4 +1,4 @@
-// <copyright file="Mark.cs" company="Datadog">
+// <copyright file="SecureMarks.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -10,7 +10,7 @@ using System;
 namespace Datadog.Trace.Iast;
 
 [Flags]
-internal enum Mark : byte
+internal enum SecureMarks : byte
 {
     None = 0,
     Xss = 1,

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
@@ -14,7 +14,7 @@ public class VulnerabilityMarksTests
     public void DefaultMarkIsNone()
     {
         var range = new Range(0, 0);
-        Assert.Equal(Mark.None, range.Mark);
+        Assert.Equal(SecureMarks.None, range.SecureMarks);
     }
 
     [Fact]
@@ -24,13 +24,13 @@ public class VulnerabilityMarksTests
         [
             new Range(0, 0),
             new Range(1, 2),
-            new Range(3, 4, null, Mark.None)
+            new Range(3, 4, null, SecureMarks.None)
         ];
 
-        var newRanges = Ranges.CopyWithMark(ranges, Mark.Xss);
+        var newRanges = Ranges.CopyWithMark(ranges, SecureMarks.Xss);
         foreach (var range in newRanges)
         {
-            Assert.Equal(Mark.Xss, range.Mark);
+            Assert.Equal(SecureMarks.Xss, range.SecureMarks);
         }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
@@ -1,0 +1,36 @@
+// <copyright file="VulnerabilityMarksTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.Iast;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests.IAST.Tainted;
+
+public class VulnerabilityMarksTests
+{
+    [Fact]
+    public void DefaultMarkIsNone()
+    {
+        var range = new Range(0, 0);
+        Assert.Equal(Mark.None, range.Mark);
+    }
+
+    [Fact]
+    public void SetMarkOnArrayOfRanges()
+    {
+        Range[] ranges =
+        [
+            new Range(0, 0),
+            new Range(1, 2),
+            new Range(3, 4, null, Mark.Ssrf)
+        ];
+
+        var newRanges = Ranges.CopyWithMark(ranges, Mark.Xss);
+        foreach (var range in newRanges)
+        {
+            Assert.Equal(Mark.Xss, range.Mark);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
@@ -24,7 +24,7 @@ public class VulnerabilityMarksTests
         [
             new Range(0, 0),
             new Range(1, 2),
-            new Range(3, 4, null, Mark.Ssrf)
+            new Range(3, 4, null, Mark.None)
         ];
 
         var newRanges = Ranges.CopyWithMark(ranges, Mark.Xss);

--- a/tracer/test/snapshots/Iast.ReflectedXssEscaped.AspNetCore5.IastDisabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectedXssEscaped.AspNetCore5.IastDisabled.verified.txt
@@ -15,7 +15,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/reflectedxssescaped,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/ReflectedXssEscaped?param=RawValue,
+      http.url: http://localhost:00000/Iast/ReflectedXssEscaped?param=...,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,

--- a/tracer/test/snapshots/Iast.ReflectedXssEscaped.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.ReflectedXssEscaped.AspNetCore5.IastEnabled.verified.txt
@@ -15,7 +15,7 @@
       http.request.headers.host: localhost:00000,
       http.route: iast/reflectedxssescaped,
       http.status_code: 200,
-      http.url: http://localhost:00000/Iast/ReflectedXssEscaped?param=RawValue,
+      http.url: http://localhost:00000/Iast/ReflectedXssEscaped?param=...,
       http.useragent: Mistake Not...,
       language: dotnet,
       runtime-id: Guid_1,

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -34,7 +34,7 @@ public class InstrumentationTestsBase : IDisposable
     private static readonly Type _spanContextType = Type.GetType("Datadog.Trace.SpanContext, Datadog.Trace");
     private static readonly Type _traceContextType = Type.GetType("Datadog.Trace.TraceContext, Datadog.Trace");
     private static readonly Type _sourceType = Type.GetType("Datadog.Trace.Iast.Source, Datadog.Trace");
-    private static readonly Type _markType = Type.GetType("Datadog.Trace.Iast.Mark, Datadog.Trace");
+    private static readonly Type _markType = Type.GetType("Datadog.Trace.Iast.SecureMarks, Datadog.Trace");
     private static readonly Type _vulnerabilityType = Type.GetType("Datadog.Trace.Iast.Vulnerability, Datadog.Trace");
     private static readonly Type _rangeType = Type.GetType("Datadog.Trace.Iast.Range, Datadog.Trace");
     private static readonly Type _vulnerabilityBatchType = Type.GetType("Datadog.Trace.Iast.VulnerabilityBatch, Datadog.Trace");

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/InstrumentationTestsBase.cs
@@ -34,6 +34,7 @@ public class InstrumentationTestsBase : IDisposable
     private static readonly Type _spanContextType = Type.GetType("Datadog.Trace.SpanContext, Datadog.Trace");
     private static readonly Type _traceContextType = Type.GetType("Datadog.Trace.TraceContext, Datadog.Trace");
     private static readonly Type _sourceType = Type.GetType("Datadog.Trace.Iast.Source, Datadog.Trace");
+    private static readonly Type _markType = Type.GetType("Datadog.Trace.Iast.Mark, Datadog.Trace");
     private static readonly Type _vulnerabilityType = Type.GetType("Datadog.Trace.Iast.Vulnerability, Datadog.Trace");
     private static readonly Type _rangeType = Type.GetType("Datadog.Trace.Iast.Range, Datadog.Trace");
     private static readonly Type _vulnerabilityBatchType = Type.GetType("Datadog.Trace.Iast.VulnerabilityBatch, Datadog.Trace");
@@ -104,7 +105,7 @@ public class InstrumentationTestsBase : IDisposable
     protected object AddTainted(object tainted, byte sourceType)
     {
         var source = Activator.CreateInstance(_sourceType, new object[] { (byte)sourceType, (string)null, tainted.ToString() });
-        var defaultRange = Activator.CreateInstance(_rangeType, new object[] { 0, tainted.ToString().Length, source });
+        var defaultRange = Activator.CreateInstance(_rangeType, new object[] { 0, tainted.ToString().Length, source, Activator.CreateInstance(_markType) });
         var rangeArray = Array.CreateInstance(_rangeType, 1);
         rangeArray.SetValue(defaultRange, 0);
         _taintMethod.Invoke(_taintedObjects, new object[] { tainted, rangeArray });


### PR DESCRIPTION
## Summary of changes

- Add vulnerability marks to the Range
- Provide a mark for vulnerabilityType
- Provide a new method that set all ranges to a mark

- Add the XSS mark on the Escaped XSS Vulnerability ranges.

## Reason for change

Add an exclusion mark system to avoid reporting vulnerabilities if all its ranges are marked as excluded for that type of vulnerability.

## Test coverage

- Unit Test method to check if the default Mark is None
- Unit Test to check if the new Ranges method is correctly copying Range with the defined mark

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
