### PR TITLE
[CI Visibility] Add linux `whereis` command as a fallback to locate the target binary.

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -295,7 +295,7 @@ namespace Datadog.Trace.Tools.Runner
                             cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&
                             outputLines[0] is { Length: > 0 } temporalOutput)
                         {
-                            foreach (var path in ParseWhereisOutput(temporalOutput))
+                            foreach (var path in ProcessHelpers.ParseWhereisOutput(temporalOutput))
                             {
                                 if (File.Exists(path))
                                 {
@@ -328,25 +328,6 @@ namespace Datadog.Trace.Tools.Runner
             }
 
             return 1;
-        }
-
-        public static IEnumerable<string> ParseWhereisOutput(string output)
-        {
-            if (string.IsNullOrEmpty(output))
-            {
-                return null;
-            }
-
-            // Split the string by spaces to separate parts
-            var parts = output.Split(' ');
-
-            // Check if the first part ends with a colon (e.g., "dotnet:")
-            if (parts.Length > 1 && parts[0].EndsWith(":"))
-            {
-                return parts.Skip(1);
-            }
-
-            return null; // Return null if no valid path is found
         }
 
         public static string[] SplitArgs(string command, bool keepQuote = false)

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -285,13 +285,38 @@ namespace Datadog.Trace.Tools.Runner
                 // The file could not be found, let's try to find it using the where command and retry
                 if (!File.Exists(startInfo.FileName))
                 {
-                    var cmdResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command("where", startInfo.FileName));
-                    if (cmdResponse?.ExitCode == 0 &&
-                        cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&
-                        outputLines[0] is { Length: > 0 } processPath)
+                    if (FrameworkDescription.Instance.OSDescription == OSPlatformName.Linux)
                     {
-                        startInfo.FileName = processPath;
-                        return RunProcess(startInfo, cancellationToken);
+                        // In linux we need to use `whereis`
+                        // output example:
+                        // dotnet: /usr/bin/dotnet /usr/lib/dotnet /etc/dotnet
+                        var cmdResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command("whereis", $"-b {startInfo.FileName}"));
+                        if (cmdResponse?.ExitCode == 0 &&
+                            cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&
+                            outputLines[0] is { Length: > 0 } temporalOutput)
+                        {
+                            foreach (var path in ParseWhereisOutput(temporalOutput))
+                            {
+                                if (File.Exists(path))
+                                {
+                                    startInfo.FileName = path;
+                                    return RunProcess(startInfo, cancellationToken);
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // Both windows and macos can use `where` instead
+                        var cmdResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command("where", startInfo.FileName));
+                        if (cmdResponse?.ExitCode == 0 &&
+                            cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&
+                            outputLines[0] is { Length: > 0 } processPath &&
+                            File.Exists(processPath))
+                        {
+                            startInfo.FileName = processPath;
+                            return RunProcess(startInfo, cancellationToken);
+                        }
                     }
                 }
 
@@ -303,6 +328,25 @@ namespace Datadog.Trace.Tools.Runner
             }
 
             return 1;
+        }
+
+        public static IEnumerable<string> ParseWhereisOutput(string output)
+        {
+            if (string.IsNullOrEmpty(output))
+            {
+                return null;
+            }
+
+            // Split the string by spaces to separate parts
+            var parts = output.Split(' ');
+
+            // Check if the first part ends with a colon (e.g., "dotnet:")
+            if (parts.Length > 1 && parts[0].EndsWith(":"))
+            {
+                return parts.Skip(1);
+            }
+
+            return null; // Return null if no valid path is found
         }
 
         public static string[] SplitArgs(string command, bool keepQuote = false)
@@ -628,6 +672,7 @@ namespace Datadog.Trace.Tools.Runner
 
             // We try to ensure Datadog.Trace.dll is installed in the gac for compatibility with .NET Framework fusion class loader
             // Let's find gacutil, because CI Visibility runs with the SDK / CI environments it's probable that's available.
+            // Because gacutil is only available in Windows we use `where` command to find it.
             var cmdResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command("where", "gacutil"));
             if (cmdResponse?.ExitCode == 0 &&
                 cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&
@@ -696,6 +741,7 @@ namespace Datadog.Trace.Tools.Runner
              */
 
             Log.Debug("EnsureNETFrameworkVSTestConsoleDevPathSupport: Looking for vstest.console");
+            // Because vstest.console is only available in windows we use `where` command to find it.
             var cmdResponse = ProcessHelpers.RunCommand(new ProcessHelpers.Command("where", "vstest.console"));
             if (cmdResponse?.ExitCode == 0 &&
                 cmdResponse.Output.Split(["\n", "\r\n"], StringSplitOptions.RemoveEmptyEntries) is { Length: > 0 } outputLines &&

--- a/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
+++ b/tracer/src/Datadog.Trace/Ci/IntelligentTestRunnerClient.cs
@@ -1169,7 +1169,8 @@ internal class IntelligentTestRunnerClient
                                 _workingDirectory,
                                 outputEncoding: Encoding.Default,
                                 errorEncoding: Encoding.Default,
-                                inputEncoding: Encoding.Default),
+                                inputEncoding: Encoding.Default,
+                                useWhereIsIfFileNotFound: true),
                             input).ConfigureAwait(false);
         TelemetryFactory.Metrics.RecordDistributionCIVisibilityGitCommandMs(ciVisibilityCommand, sw.Elapsed.TotalMilliseconds);
         if (gitOutput is null)

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/UtilsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/UtilsTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using Datadog.Trace.Util;
 using FluentAssertions;
 using Xunit;
 
@@ -18,16 +19,16 @@ public class UtilsTests
         yield return ["dotnet: /usr/bin/dotnet /usr/lib/dotnet /etc/dotnet", new[] { "/usr/bin/dotnet", "/usr/lib/dotnet", "/etc/dotnet" }];
         yield return ["git: /usr/bin/git", new[] { "/usr/bin/git" }];
         yield return ["cmake: /usr/bin/cmake /usr/lib/cmake /usr/share/cmake", new[] { "/usr/bin/cmake", "/usr/lib/cmake", "/usr/share/cmake" }];
-        yield return ["docker:", null];
-        yield return [string.Empty, null];
-        yield return [null, null];
+        yield return ["docker:", Array.Empty<string>()];
+        yield return [string.Empty, Array.Empty<string>()];
+        yield return [null, Array.Empty<string>()];
     }
 
     [Theory]
     [MemberData(nameof(ParseWhereIsOutputData))]
     public void ParseWhereisOutputTests(string line, string[] expectedPaths)
     {
-        var actualPath = Utils.ParseWhereisOutput(line);
+        var actualPath = ProcessHelpers.ParseWhereisOutput(line);
         actualPath.Should().BeEquivalentTo(expectedPaths);
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/UtilsTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/UtilsTests.cs
@@ -1,0 +1,33 @@
+// <copyright file="UtilsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tools.Runner.Tests;
+
+public class UtilsTests
+{
+    public static IEnumerable<object?[]> ParseWhereIsOutputData()
+    {
+        yield return ["dotnet: /usr/bin/dotnet /usr/lib/dotnet /etc/dotnet", new[] { "/usr/bin/dotnet", "/usr/lib/dotnet", "/etc/dotnet" }];
+        yield return ["git: /usr/bin/git", new[] { "/usr/bin/git" }];
+        yield return ["cmake: /usr/bin/cmake /usr/lib/cmake /usr/share/cmake", new[] { "/usr/bin/cmake", "/usr/lib/cmake", "/usr/share/cmake" }];
+        yield return ["docker:", null];
+        yield return [string.Empty, null];
+        yield return [null, null];
+    }
+
+    [Theory]
+    [MemberData(nameof(ParseWhereIsOutputData))]
+    public void ParseWhereisOutputTests(string line, string[] expectedPaths)
+    {
+        var actualPath = Utils.ParseWhereisOutput(line);
+        actualPath.Should().BeEquivalentTo(expectedPaths);
+    }
+}


### PR DESCRIPTION
## Summary of changes

This PR adds the linux `whereis` command (windows and macOS uses the existing `where` command) as a fallback to locate the target process binary on common paths before throwing a exception due to file not found.

Also adds the option to use this fallback on normal `ProcessHelper.RunCommand...` this is opt-in.

## Reason for change

There's an existing code using `where` but this one is only compatible on Windows and MacOS, this PR adds the support of `whereis` used. by Linux

## Test coverage

A test to check the parser for the new command output.

