### PR TITLE
[CIVisibility] Add SourceLink support to CIEnvironmentValues

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
@@ -4,6 +4,9 @@
 // </copyright>
 #nullable enable
 
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Pdb;
+
 namespace Datadog.Trace.Ci.CiEnvironment;
 
 internal sealed class UnsupportedCIEnvironmentValues<TValueProvider>(TValueProvider valueProvider) : CIEnvironmentValues<TValueProvider>(valueProvider)
@@ -17,5 +20,19 @@ internal sealed class UnsupportedCIEnvironmentValues<TValueProvider>(TValueProvi
         Repository = gitInfo.Repository;
         SourceRoot = gitInfo.SourceRoot;
         WorkspacePath = gitInfo.SourceRoot;
+
+        if (string.IsNullOrEmpty(Commit) || string.IsNullOrEmpty(Repository))
+        {
+            if (EntryAssemblyLocator.GetEntryAssembly() is { } assembly)
+            {
+                Log.Information("CIEnvironmentValues: Commit or Repository is empty, trying to load from SourceLink");
+                if (SourceLinkInformationExtractor.TryGetSourceLinkInfo(assembly, out var commitSha, out var repositoryUrl))
+                {
+                    Log.Information("Found SourceLink information for assembly {Name}: commit {CommitSha} from {RepositoryUrl}", assembly.GetName().Name, commitSha, repositoryUrl);
+                    Commit = commitSha;
+                    Repository = repositoryUrl;
+                }
+            }
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
+++ b/tracer/src/Datadog.Trace/Ci/CiEnvironment/UnsupportedCIEnvironmentValues.cs
@@ -24,22 +24,15 @@ internal sealed class UnsupportedCIEnvironmentValues<TValueProvider>(TValueProvi
 
         if (string.IsNullOrEmpty(Commit) || string.IsNullOrEmpty(Repository))
         {
-            try
+            if (EntryAssemblyLocator.GetEntryAssembly() is { } assembly)
             {
-                if (EntryAssemblyLocator.GetEntryAssembly() is { } assembly)
+                Log.Information("CIEnvironmentValues: Commit or Repository is empty, trying to load from SourceLink");
+                if (SourceLinkInformationExtractor.TryGetSourceLinkInfo(assembly, out var commitSha, out var repositoryUrl))
                 {
-                    Log.Information("CIEnvironmentValues: Commit or Repository is empty, trying to load from SourceLink");
-                    if (SourceLinkInformationExtractor.TryGetSourceLinkInfo(assembly, out var commitSha, out var repositoryUrl))
-                    {
-                        Log.Information("Found SourceLink information for assembly {Name}: commit {CommitSha} from {RepositoryUrl}", assembly.GetName().Name, commitSha, repositoryUrl);
-                        Commit ??= commitSha;
-                        Repository ??= repositoryUrl;
-                    }
+                    Log.Information("Found SourceLink information for assembly {Name}: commit {CommitSha} from {RepositoryUrl}", assembly.GetName().Name, commitSha, repositoryUrl);
+                    Commit ??= commitSha;
+                    Repository ??= repositoryUrl;
                 }
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "CIEnvironmentValues: Error while trying to load SourceLink information");
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Configuration/EntryAssemblyLocator.cs
+++ b/tracer/src/Datadog.Trace/Configuration/EntryAssemblyLocator.cs
@@ -71,7 +71,7 @@ internal static class EntryAssemblyLocator
     }
 
 #if NETFRAMEWORK
-    private static bool IsMicrosoftAssembly(Assembly assembly) => assembly.FullName!.StartsWith("Microsoft.") || assembly.FullName.StartsWith("System.");
+    private static bool IsMicrosoftAssembly(Assembly assembly) => assembly.FullName?.StartsWith("Microsoft.") == true || assembly.FullName?.StartsWith("System.") == true;
 
     /// <summary>
     /// ! This method should be called from within a try-catch block !

--- a/tracer/src/Datadog.Trace/PDBs/SourceLink/GitHubSourceLinkUrlParser.cs
+++ b/tracer/src/Datadog.Trace/PDBs/SourceLink/GitHubSourceLinkUrlParser.cs
@@ -23,17 +23,27 @@ internal class GitHubSourceLinkUrlParser : SourceLinkUrlParser
     /// </summary>
     internal override bool TryParseSourceLinkUrl(Uri uri, [NotNullWhen(true)] out string? commitSha, [NotNullWhen(true)] out string? repositoryUrl)
     {
-        var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+        commitSha = null;
+        repositoryUrl = null;
 
-        if (uri.Host != "raw.githubusercontent.com" || segments.Length != 4 || !IsValidCommitSha(segments[2]))
+        try
         {
-            commitSha = null;
-            repositoryUrl = null;
-            return false;
+            var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (uri.Host != "raw.githubusercontent.com" || segments.Length != 4 || !IsValidCommitSha(segments[2]))
+            {
+                return false;
+            }
+
+            repositoryUrl = $"https://github.com/{segments[0]}/{segments[1]}";
+            commitSha = segments[2];
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error while trying to parse GitHub SourceLink URL");
         }
 
-        repositoryUrl = $"https://github.com/{segments[0]}/{segments[1]}";
-        commitSha = segments[2];
-        return true;
+        return false;
     }
 }

--- a/tracer/src/Datadog.Trace/PDBs/SourceLink/GitLabSourceLinkUrlParser.cs
+++ b/tracer/src/Datadog.Trace/PDBs/SourceLink/GitLabSourceLinkUrlParser.cs
@@ -21,16 +21,26 @@ internal class GitLabSourceLinkUrlParser : SourceLinkUrlParser
     /// </summary>
     internal override bool TryParseSourceLinkUrl(Uri uri, [NotNullWhen(true)] out string? commitSha, [NotNullWhen(true)] out string? repositoryUrl)
     {
-        var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
-        if (segments.Length != 5 || segments[2] != "raw" || segments[4] != "*" || !IsValidCommitSha(segments[3]))
+        commitSha = null;
+        repositoryUrl = null;
+
+        try
         {
-            commitSha = null;
-            repositoryUrl = null;
-            return false;
+            var segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length != 5 || segments[2] != "raw" || segments[4] != "*" || !IsValidCommitSha(segments[3]))
+            {
+                return false;
+            }
+
+            repositoryUrl = $"{uri.Scheme}://{uri.Authority}/{segments[0]}/{segments[1]}";
+            commitSha = segments[3];
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Error while trying to parse GitLab SourceLink URL");
         }
 
-        repositoryUrl = $"{uri.Scheme}://{uri.Authority}/{segments[0]}/{segments[1]}";
-        commitSha = segments[3];
-        return true;
+        return false;
     }
 }

--- a/tracer/src/Datadog.Trace/PDBs/SourceLink/SourceLinkUrlParser.cs
+++ b/tracer/src/Datadog.Trace/PDBs/SourceLink/SourceLinkUrlParser.cs
@@ -7,11 +7,14 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Datadog.Trace.Logging;
 
 namespace Datadog.Trace.Pdb.SourceLink
 {
     internal abstract class SourceLinkUrlParser
     {
+        protected static IDatadogLogger Log { get; } = DatadogLogging.GetLoggerFor(typeof(SourceLinkUrlParser));
+
         protected static bool IsValidCommitSha([NotNullWhen(true)] string? commitSha) => commitSha is { Length: 40 } && commitSha.All(char.IsLetterOrDigit);
 
         /// <summary>


### PR DESCRIPTION
## Summary of changes

This PR adds SourceLink data as a fallback in `CIEnvironmentValues`

## Reason for change

Avoid not having commit or repo information.
