### PR TITLE
[Dynamic Instrumentation] DEBUG-2323 Add support for `typeof` expression in EL

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -174,7 +174,7 @@ internal partial class ProbeExpressionParser<T>
             Expression.Call(
                 ParseTree(reader, parameters, itParameter),
                 ProbeExpressionParserHelper.GetMethodByReflection(typeof(object), "GetType", Type.EmptyTypes)),
-            "FullName");
+            nameof(Type.FullName));
     }
 
     private Expression IsUndefined(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.General.cs
@@ -168,6 +168,15 @@ internal partial class ProbeExpressionParser<T>
         return Expression.TypeIs(value, type);
     }
 
+    private Expression GetTypeName(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
+    {
+        return Expression.Property(
+            Expression.Call(
+                ParseTree(reader, parameters, itParameter),
+                ProbeExpressionParserHelper.GetMethodByReflection(typeof(object), "GetType", Type.EmptyTypes)),
+            "FullName");
+    }
+
     private Expression IsUndefined(JsonTextReader reader, List<ParameterExpression> parameters, ParameterExpression itParameter)
     {
         var value = ParseTree(reader, parameters, itParameter);

--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -275,6 +275,11 @@ internal partial class ProbeExpressionParser<T>
                                         return IsInstanceOf(reader, parameters, itParameter);
                                     }
 
+                                case "typeof":
+                                    {
+                                        return GetTypeName(reader, parameters, itParameter);
+                                    }
+
                                 case "isUndefined":
                                     {
                                         return IsUndefined(reader, parameters, itParameter);

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AgileObjects.ReadableExpressions;
 using Datadog.Trace.Debugger.Configurations.Models;
@@ -242,7 +243,7 @@ namespace Datadog.Trace.Tests.Debugger
             {
                 builder.AppendLine("Condition:");
                 builder.AppendLine($"Json:{evaluator.Condition.Value.Json}");
-                builder.AppendLine($"Expression: {evaluator.CompiledCondition.Value.ParsedExpression.ToReadableString()}");
+                builder.AppendLine($"Expression: {SanitizeExpression(evaluator.CompiledCondition.Value.ParsedExpression.ToReadableString())}");
                 builder.AppendLine($"Result: {evaluationResult.Condition}");
             }
 
@@ -269,6 +270,12 @@ namespace Datadog.Trace.Tests.Debugger
             }
 
             return builder.ToString();
+        }
+
+        private string SanitizeExpression(string expression)
+        {
+            string pattern = @",(?=\d*d\b)";
+            return Regex.Replace(expression, pattern, ".");
         }
 
         private string SanitizeEvaluationResult(string template)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanDoubleFloatingPoint.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanDoubleFloatingPoint.verified.txt
@@ -36,7 +36,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[14].Value;
     var CollectionArg = (List<string>)scopeMemberArray[15].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
-    var $dd_el_result = this.DoubleNumber > 0.1d;
+    var $dd_el_result = this.DoubleNumber > 0,1d;
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanDoubleFloatingPoint.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanDoubleFloatingPoint.verified.txt
@@ -36,7 +36,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[14].Value;
     var CollectionArg = (List<string>)scopeMemberArray[15].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
-    var $dd_el_result = this.DoubleNumber > 0,1d;
+    var $dd_el_result = this.DoubleNumber > 0.1d;
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofCustomType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofCustomType.verified.txt
@@ -1,0 +1,44 @@
+﻿Template:
+Segments: 
+
+{
+  "typeof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "Nested"
+      ]
+    }
+  ]
+}
+Expressions: 
+(
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = this.Nested.GetType().FullName;
+
+    return $dd_el_result;
+}
+Result: The result of the expression is: Datadog.Trace.Tests.Debugger.DebuggerExpressionLanguageTests+TestStruct+NestedObject

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofCustomType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofCustomType.verified.txt
@@ -32,11 +32,16 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Nested.GetType().FullName;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofString.verified.txt
@@ -1,0 +1,44 @@
+﻿Template:
+Segments: 
+
+{
+  "typeof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    }
+  ]
+}
+Expressions: 
+(
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var IntArg = (int)scopeMemberArray[7].Value;
+    var DoubleArg = (double)scopeMemberArray[8].Value;
+    var StringArg = (string)scopeMemberArray[9].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var $dd_el_result = this.String.GetType().FullName;
+
+    return $dd_el_result;
+}
+Result: The result of the expression is: System.String

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.TypeofString.verified.txt
@@ -32,11 +32,16 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.String.GetType().FullName;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/TypeofCustomType.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/TypeofCustomType.json
@@ -1,0 +1,13 @@
+{
+  "dsl": "{typeof(this.Nested)}",
+  "typeof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "Nested"
+      ]
+    }
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/TypeofString.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/TypeofString.json
@@ -1,0 +1,13 @@
+{
+  "dsl": "{typeof(this.String)}",
+  "typeof": [
+    {
+      "getmember": [
+        {
+          "ref": "this"
+        },
+        "String"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of changes
Add the support to use `typeof(val)`. This will return the full name of the variable type.

## Test coverage
See tests in this PR

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
