### PR TITLE
[All Natives] Fix C5105 Warning for Windows Native Projects

### DIFF
--- a/profiler/Directory.Build.props
+++ b/profiler/Directory.Build.props
@@ -191,6 +191,12 @@
       <SHARED-LIB-INCLUDES>$(SHARED-LIB-PATH)fmt\include;$(SHARED-LIB-PATH)spdlog\include</SHARED-LIB-INCLUDES>
     </PropertyGroup>
 
+    <ItemDefinitionGroup Condition=" '$(MSBuildProjectExtension)' == '.vcxproj' ">
+      <ClCompile>
+        <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS=1</PreprocessorDefinitions>
+      </ClCompile>
+    </ItemDefinitionGroup>
+
 
     <PropertyGroup>
         <RdrctOutptMsgPrefix>Set Output Dirs</RdrctOutptMsgPrefix>

--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -50,5 +50,14 @@
       </PropertyGroup>
     </Otherwise>
   </Choose>
+
+  <!-- Fix C5105 Warning (warning C5105: macro expansion producing 'defined' has undefined behavior) due to a bug in the Windows SDK 10.0.19041.0
+       This can be removed when we upgrade the Windows SDK
+  -->
+  <ItemDefinitionGroup Condition=" '$(MSBuildProjectExtension)' == '.vcxproj' ">
+    <ClCompile>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions);MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS=1</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   
 </Project>


### PR DESCRIPTION
## Summary of changes

Fix the `warning C5105: macro expansion producing 'defined' has undefined behavior` due to a bug in Windows SDK 10.0.19041.0.

## Reason for change

In `WinBase.h`, you can see this kind of code for the Windows SDK 10.0.19.041.0 (the current version of Windows SDK we use)
```
if !defined(MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS)
#define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS (_WIN32_WINNT >= 0x0502 || !defined(_WINBASE_))
#endif

#if MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS
```
But having, `defined` in the result of macro is known as having undefined behavior (see https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5105?view=msvc-170)

In the Windows SDK 10.0.22621.0, the code has changed into
```
#if !defined(MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS)
#define MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS 1
#endif
```

We could upgrade to a newer version of the Windows SDK but we do not know if the new version still allow targeting  Windows Server 2012 (difficulties to find a good and reliable documentation about that).

So the fix will be:
We can safely set `MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS ` to `1`, because when building our project `_WIN32_WINNT ` is `0x0A00` (which is greater than `0x0502`), which means that `MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS ` will be equal to `1`.

## Implementation details

Use `Directory.Build.props` to set the `MICROSOFT_WINDOWS_WINBASE_H_DEFINE_INTERLOCKED_CPLUSPLUS_OVERLOADS ` macro to `1`

## Test coverage
- None
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
