### PR TITLE
[Dynamic Instrumentation] DEBUG-2088 Support nullable types in templates

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -207,7 +207,6 @@ namespace Datadog.Trace.Tests.Debugger
             scope.AddMember(new ScopeMember("NullableNotNullValueLocal", typeof(Guid?), TestObject.NullableNotNullValue, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("NullableNullValueLocal", typeof(Guid?), TestObject.NullableNullValue, ScopeMemberKind.Local));
 
-
             // Add arguments
             scope.AddMember(new ScopeMember("IntArg", TestObject.IntNumber.GetType(), TestObject.IntNumber, ScopeMemberKind.Argument));
             scope.AddMember(new ScopeMember("DoubleArg", TestObject.DoubleNumber.GetType(), TestObject.DoubleNumber, ScopeMemberKind.Argument));

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -47,6 +47,8 @@ namespace Datadog.Trace.Tests.Debugger
                 AnotherChar = 'A',
                 BooleanValue = true,
                 Null = null,
+                NullableNullValue = null,
+                NullableNotNullValue = new Guid("{00000000-0000-0000-0000-000000000000}"),
                 Nested = new TestStruct.NestedObject { NestedString = "Hello from nested object", Nested = new TestStruct.NestedObject { NestedString = "Hello from another nested object" } },
                 ChildNested = new TestStruct.ChildNestedObject(),
                 ParentAsChildNested = new TestStruct.ChildNestedObject()
@@ -87,11 +89,6 @@ namespace Datadog.Trace.Tests.Debugger
         [MemberData(nameof(TemplatesResources))]
         public async Task TestTemplates(string expressionTestFilePath)
         {
-            if (expressionTestFilePath.EndsWith("DictionaryKeyNotExist.json"))
-            {
-                throw new SkipException("Skip because this test has an issue of not raising a KeyNotFoundException");
-            }
-
             await Test(expressionTestFilePath);
         }
 
@@ -207,6 +204,9 @@ namespace Datadog.Trace.Tests.Debugger
             scope.AddMember(new ScopeMember("BooleanValue", TestObject.BooleanValue.GetType(), TestObject.BooleanValue, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("Char", TestObject.Char.GetType(), TestObject.Char, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("AnotherChar", TestObject.AnotherChar.GetType(), TestObject.AnotherChar, ScopeMemberKind.Local));
+			scope.AddMember(new ScopeMember("NullableNotNullValueLocal", typeof(Guid?), TestObject.NullableNotNullValue, ScopeMemberKind.Local));
+            scope.AddMember(new ScopeMember("NullableNullValueLocal", typeof(Guid?), TestObject.NullableNullValue, ScopeMemberKind.Local));
+
 
             // Add arguments
             scope.AddMember(new ScopeMember("IntArg", TestObject.IntNumber.GetType(), TestObject.IntNumber, ScopeMemberKind.Argument));
@@ -343,8 +343,12 @@ namespace Datadog.Trace.Tests.Debugger
             public NestedObject ParentAsChildNested;
 
             public NestedObject Null;
+			
+			public bool BooleanValue;
 
-            public bool BooleanValue;
+            public Guid? NullableNullValue;
+
+            public Guid? NullableNotNullValue;
 
             internal class NestedObject
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -204,7 +204,7 @@ namespace Datadog.Trace.Tests.Debugger
             scope.AddMember(new ScopeMember("BooleanValue", TestObject.BooleanValue.GetType(), TestObject.BooleanValue, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("Char", TestObject.Char.GetType(), TestObject.Char, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("AnotherChar", TestObject.AnotherChar.GetType(), TestObject.AnotherChar, ScopeMemberKind.Local));
-			scope.AddMember(new ScopeMember("NullableNotNullValueLocal", typeof(Guid?), TestObject.NullableNotNullValue, ScopeMemberKind.Local));
+            scope.AddMember(new ScopeMember("NullableNotNullValueLocal", typeof(Guid?), TestObject.NullableNotNullValue, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("NullableNullValueLocal", typeof(Guid?), TestObject.NullableNullValue, ScopeMemberKind.Local));
 
 
@@ -343,8 +343,8 @@ namespace Datadog.Trace.Tests.Debugger
             public NestedObject ParentAsChildNested;
 
             public NestedObject Null;
-			
-			public bool BooleanValue;
+
+            public bool BooleanValue;
 
             public Guid? NullableNullValue;
 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
@@ -31,11 +31,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Null.NestedString;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStruct.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStruct.verified.txt
@@ -1,0 +1,81 @@
+﻿Template:
+Segments: 
+
+{
+    "getmember": [
+        {
+            "ref": "this"
+        },
+        "NullableNullValue"
+    ]
+}
+Expressions: 
+(
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    FieldInfo[] fieldsArray;
+    StringBuilder fieldValues;
+    int index;
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[7].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[8].Value;
+    var IntArg = (int)scopeMemberArray[9].Value;
+    var DoubleArg = (double)scopeMemberArray[10].Value;
+    var StringArg = (string)scopeMemberArray[11].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[12].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[13].Value;
+    var $dd_el_result = (this.NullableNullValue == null)
+        ? "null"
+        : {
+            fieldsArray = this.NullableNullValue.GetType().GetFields(
+                BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            fieldValues = new StringBuilder();
+            index = 0;
+            while (true)
+            {
+                if ((index < fieldsArray.Length) && (index < 5))
+                {
+                    fieldValues.Append(
+                        ProbeExpressionParser<string>.DumpObject(
+                            fieldsArray[index].GetValue(this.NullableNullValue),
+                            fieldsArray[index].FieldType,
+                            fieldsArray[index].Name,
+                            0));
+                    index++;
+
+                    if ((index < fieldsArray.Length) && (index < 5))
+                    {
+                        return fieldValues.Append(", ");
+                    }
+                }
+                else
+                {
+                    if (index < fieldsArray.Length)
+                    {
+                        return fieldValues.Append(", ...");
+                    }
+
+                    break;
+                }
+            }
+
+            return fieldValues.ToString();
+        };
+
+    return $dd_el_result;
+}
+Result: The result of the expression is: null

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStruct.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStruct.verified.txt
@@ -32,18 +32,24 @@ Expressions:
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
     var BooleanValue = (bool)scopeMemberArray[7].Value;
-    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[8].Value;
-    var NullableNullValueLocal = (Guid?)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (this.NullableNullValue == null)
         ? "null"
         : {
-            fieldsArray = this.NullableNullValue.GetType().GetFields(
-                BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            fieldsArray = this.NullableNullValue
+                .GetType()
+                .GetFields(
+                    BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                .OrderBy(fieldInfo => fieldInfo.MetadataToken)
+                .ToArray();
             fieldValues = new StringBuilder();
             index = 0;
             while (true)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStruct.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStruct.verified.txt
@@ -31,13 +31,14 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[7].Value;
-    var NullableNullValueLocal = (Guid?)scopeMemberArray[8].Value;
-    var IntArg = (int)scopeMemberArray[9].Value;
-    var DoubleArg = (double)scopeMemberArray[10].Value;
-    var StringArg = (string)scopeMemberArray[11].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[12].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[13].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[8].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[9].Value;
+    var IntArg = (int)scopeMemberArray[10].Value;
+    var DoubleArg = (double)scopeMemberArray[11].Value;
+    var StringArg = (string)scopeMemberArray[12].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
     var $dd_el_result = (this.NullableNullValue == null)
         ? "null"
         : {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStructNotNull.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStructNotNull.verified.txt
@@ -32,18 +32,24 @@ Expressions:
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
     var BooleanValue = (bool)scopeMemberArray[7].Value;
-    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[8].Value;
-    var NullableNullValueLocal = (Guid?)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (this.NullableNotNullValue == null)
         ? "null"
         : {
-            fieldsArray = this.NullableNotNullValue.GetType().GetFields(
-                BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            fieldsArray = this.NullableNotNullValue
+                .GetType()
+                .GetFields(
+                    BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                .OrderBy(fieldInfo => fieldInfo.MetadataToken)
+                .ToArray();
             fieldValues = new StringBuilder();
             index = 0;
             while (true)
@@ -79,4 +85,4 @@ Expressions:
 
     return $dd_el_result;
 }
-Result: The result of the expression is: _a=0, _b=0, _c=0, _d=0, _e=0, ...
+Result: The result of the expression is: Empty=00000000-0000-0000-0000-000000000000, _a=0, _b=0, _c=0, _d=0, ...

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStructNotNull.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStructNotNull.verified.txt
@@ -1,0 +1,81 @@
+﻿Template:
+Segments: 
+
+{
+    "getmember": [
+        {
+            "ref": "this"
+        },
+        "NullableNotNullValue"
+    ]
+}
+Expressions: 
+(
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    FieldInfo[] fieldsArray;
+    StringBuilder fieldValues;
+    int index;
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[7].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[8].Value;
+    var IntArg = (int)scopeMemberArray[9].Value;
+    var DoubleArg = (double)scopeMemberArray[10].Value;
+    var StringArg = (string)scopeMemberArray[11].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[12].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[13].Value;
+    var $dd_el_result = (this.NullableNotNullValue == null)
+        ? "null"
+        : {
+            fieldsArray = this.NullableNotNullValue.GetType().GetFields(
+                BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+            fieldValues = new StringBuilder();
+            index = 0;
+            while (true)
+            {
+                if ((index < fieldsArray.Length) && (index < 5))
+                {
+                    fieldValues.Append(
+                        ProbeExpressionParser<string>.DumpObject(
+                            fieldsArray[index].GetValue(this.NullableNotNullValue),
+                            fieldsArray[index].FieldType,
+                            fieldsArray[index].Name,
+                            0));
+                    index++;
+
+                    if ((index < fieldsArray.Length) && (index < 5))
+                    {
+                        return fieldValues.Append(", ");
+                    }
+                }
+                else
+                {
+                    if (index < fieldsArray.Length)
+                    {
+                        return fieldValues.Append(", ...");
+                    }
+
+                    break;
+                }
+            }
+
+            return fieldValues.ToString();
+        };
+
+    return $dd_el_result;
+}
+Result: The result of the expression is: _a=0, _b=0, _c=0, _d=0, _e=0, ...

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStructNotNull.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullableStructNotNull.verified.txt
@@ -31,13 +31,14 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[7].Value;
-    var NullableNullValueLocal = (Guid?)scopeMemberArray[8].Value;
-    var IntArg = (int)scopeMemberArray[9].Value;
-    var DoubleArg = (double)scopeMemberArray[10].Value;
-    var StringArg = (string)scopeMemberArray[11].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[12].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[13].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[8].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[9].Value;
+    var IntArg = (int)scopeMemberArray[10].Value;
+    var DoubleArg = (double)scopeMemberArray[11].Value;
+    var StringArg = (string)scopeMemberArray[12].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
     var $dd_el_result = (this.NullableNotNullValue == null)
         ? "null"
         : {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildPrivateMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildPrivateMember.verified.txt
@@ -37,11 +37,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildStaticPublicMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildStaticPublicMember.verified.txt
@@ -37,11 +37,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Collection.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Collection.verified.txt
@@ -14,6 +14,8 @@ Expressions:
 {
     string loopItem;
     IEnumerator<string> enumerator;
+    int index;
+    StringBuilder itemValues;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
     var @duration = (TimeSpan)scopeMember.Value;
@@ -28,53 +30,56 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
-    var $dd_el_result =
-    {
-        enumerator = this.Collection.GetEnumerator();
-        var index = 0;
-        var itemValues = new StringBuilder();
-        itemValues.Append("[");
-        while (true)
-        {
-            if (enumerator.MoveNext())
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
+    var $dd_el_result = (this.Collection == null)
+        ? "null"
+        : {
+            enumerator = this.Collection.GetEnumerator();
+            index = 0;
+            itemValues = new StringBuilder();
+            itemValues.Append("[");
+            while (true)
             {
-                string loopItem;
-
-                if (index < 3)
+                if (enumerator.MoveNext())
                 {
-                    if (index > 0)
-                    {
-                        return itemValues.Append(", ");
-                    }
+                    string loopItem;
 
-                    loopItem = enumerator.Current;
-                    itemValues.Append(ProbeExpressionParser<string>.DumpObject(
-                        loopItem,
-                        typeof(string),
-                        "",
-                        1));
-                    index++;
+                    if (index < 3)
+                    {
+                        if (index > 0)
+                        {
+                            return itemValues.Append(", ");
+                        }
+
+                        loopItem = enumerator.Current;
+                        itemValues.Append(ProbeExpressionParser<string>.DumpObject(
+                            loopItem,
+                            typeof(string),
+                            "",
+                            1));
+                        index++;
+                    }
+                    else
+                    {
+                        itemValues.Append(", ...");
+                        break;
+                    }
                 }
                 else
                 {
-                    itemValues.Append(", ...");
                     break;
                 }
             }
-            else
-            {
-                break;
-            }
-        }
-        itemValues.Append("]");
+            itemValues.Append("]");
 
-        return itemValues.ToString();
-    };
+            return itemValues.ToString();
+        };
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionCount.verified.txt
@@ -30,11 +30,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = CollectionLocal.Count.ToString();
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndex.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndex.verified.txt
@@ -31,11 +31,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (string)CollectionLocal[0];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndexOutOfRange.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndexOutOfRange.verified.txt
@@ -31,11 +31,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (string)CollectionLocal[100];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CompareStringAndInt.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CompareStringAndInt.verified.txt
@@ -42,11 +42,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKey.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKey.verified.txt
@@ -31,11 +31,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (string)DictionaryLocal["hello"];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKeyNotExist.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKeyNotExist.verified.txt
@@ -1,1 +1,42 @@
-﻿
+﻿Template:
+Segments: 
+
+{
+    "index": [
+        {
+            "ref": "DictionaryLocal"
+        },
+        "not exist"
+    ]
+}
+Expressions: 
+(
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[7].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[8].Value;
+    var IntArg = (int)scopeMemberArray[9].Value;
+    var DoubleArg = (double)scopeMemberArray[10].Value;
+    var StringArg = (string)scopeMemberArray[11].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[12].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[13].Value;
+    var $dd_el_result = (string)DictionaryLocal["not exist"];
+
+    return $dd_el_result;
+}
+Result: The result of the expression is: 

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKeyNotExist.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKeyNotExist.verified.txt
@@ -29,13 +29,15 @@ Expressions:
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
     var BooleanValue = (bool)scopeMemberArray[7].Value;
-    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[8].Value;
-    var NullableNullValueLocal = (Guid?)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (string)DictionaryLocal["not exist"];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKeyNotExist.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKeyNotExist.verified.txt
@@ -28,13 +28,14 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[7].Value;
-    var NullableNullValueLocal = (Guid?)scopeMemberArray[8].Value;
-    var IntArg = (int)scopeMemberArray[9].Value;
-    var DoubleArg = (double)scopeMemberArray[10].Value;
-    var StringArg = (string)scopeMemberArray[11].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[12].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[13].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[8].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[9].Value;
+    var IntArg = (int)scopeMemberArray[10].Value;
+    var DoubleArg = (double)scopeMemberArray[11].Value;
+    var StringArg = (string)scopeMemberArray[12].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
     var $dd_el_result = (string)DictionaryLocal["not exist"];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Duration.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Duration.verified.txt
@@ -26,11 +26,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = @duration.ToString();
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualFalse.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualFalse.verified.txt
@@ -30,11 +30,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = !BooleanValue;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = StringLocal == null;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTru.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTru.verified.txt
@@ -31,11 +31,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrue.verified.txt
@@ -30,11 +30,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = BooleanValue;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrueString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrueString.verified.txt
@@ -31,11 +31,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
@@ -26,11 +26,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (@exception == null)
         ? "System.Exception"
         : "System.Exception" + ", " + @exception.Message + ", " + @exception.StackTrace;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
@@ -43,11 +43,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = CollectionLocal
         .Where(@string => @string.Length > 4)
         .ToList().Count > 2;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = IntArg > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCharChar.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCharChar.verified.txt
@@ -41,11 +41,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Char > this.AnotherChar;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
@@ -33,11 +33,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = CollectionLocal.Count > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanDoubleFloatingPoint.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanDoubleFloatingPoint.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.DoubleNumber > 0.1d;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.IntNumber > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanIntDouble.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanIntDouble.verified.txt
@@ -31,11 +31,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = ((double)this.IntNumber) > ((double)this.DoubleNumber);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = IntLocal > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanString.verified.txt
@@ -46,11 +46,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = string.CompareOrdinal(this.String, this.Nested._string) > 0;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanStringChar.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanStringChar.verified.txt
@@ -42,11 +42,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterthanOrEqualString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterthanOrEqualString.verified.txt
@@ -46,11 +46,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = string.CompareOrdinal(this.String, this.Nested._string) >= 0;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
@@ -36,11 +36,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = CollectionLocal.All(@string => @string.Length > 3);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
@@ -34,11 +34,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = CollectionLocal.Any(@string => @string == "hello");
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalCollectionOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalCollectionOperation.verified.txt
@@ -30,11 +30,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalStringOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalStringOperation.verified.txt
@@ -29,11 +29,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsDefined.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsDefined.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = !(this.Nested is UndefinedValue);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfEmptyType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfEmptyType.verified.txt
@@ -34,11 +34,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = false;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
@@ -34,11 +34,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.String is int;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
@@ -34,11 +34,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.String is string;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
@@ -34,11 +34,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = false;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsUndefined.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsUndefined.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Nested is UndefinedValue;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
@@ -49,11 +49,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (this.String.Length > 2) && (CollectionLocal.Count > 2);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
@@ -78,11 +78,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (this.String.Length > 2) && ((CollectionLocal.Count > 2) || CollectionLocal
         .Where(string1 => string1.Length > 4)
         .ToList()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
@@ -49,11 +49,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (this.String.Length > 2) || (CollectionLocal.Count > 2);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LessThanString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LessThanString.verified.txt
@@ -46,11 +46,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = string.CompareOrdinal(this.String, this.Nested._string) < 0;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
@@ -38,11 +38,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Nested.NestedString.Length > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
@@ -52,11 +52,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (this.Nested.NestedString == "dd") || (this.Nested.NestedString != null);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
@@ -37,11 +37,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentStaticProtectedMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentStaticProtectedMember.verified.txt
@@ -36,11 +36,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (DebuggerExpressionLanguageTests.TestStruct.NestedObject.ParentProtectedStaticMember == "Hello from parent protected static member").ToString();
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMember.verified.txt
@@ -34,11 +34,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Nested.NestedString == "Hello from nested object";
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
@@ -39,11 +39,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Nested.Nested.NestedString == "Hello from another nested object";
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ReturnString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ReturnString.verified.txt
@@ -26,11 +26,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = @return;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.StringLength.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.StringLength.verified.txt
@@ -28,11 +28,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = (double)this.String.Length;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.This.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.This.verified.txt
@@ -31,11 +31,13 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.String;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ToStringNotSupported.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ToStringNotSupported.verified.txt
@@ -12,6 +12,9 @@ Expressions:
     exception,
     scopeMemberArray) =>
 {
+    FieldInfo[] fieldsArray;
+    StringBuilder fieldValues;
+    int index;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
     var @duration = (TimeSpan)scopeMember.Value;
@@ -26,51 +29,54 @@ Expressions:
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
-    var $dd_el_result =
-    {
-        var fieldsArray = this.Nested
-            .GetType()
-            .GetFields(
-                BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-            .OrderBy(fieldInfo => fieldInfo.MetadataToken)
-            .ToArray();
-        var fieldValues = new StringBuilder();
-        var index = 0;
-        while (true)
-        {
-            if ((index < fieldsArray.Length) && (index < 5))
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
+    var $dd_el_result = (this.Nested == null)
+        ? "null"
+        : {
+            fieldsArray = this.Nested
+                .GetType()
+                .GetFields(
+                    BindingFlags.DeclaredOnly | BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                .OrderBy(fieldInfo => fieldInfo.MetadataToken)
+                .ToArray();
+            fieldValues = new StringBuilder();
+            index = 0;
+            while (true)
             {
-                fieldValues.Append(
-                    ProbeExpressionParser<string>.DumpObject(
-                        fieldsArray[index].GetValue(this.Nested),
-                        fieldsArray[index].FieldType,
-                        fieldsArray[index].Name,
-                        0));
-                index++;
-
                 if ((index < fieldsArray.Length) && (index < 5))
                 {
-                    return fieldValues.Append(", ");
+                    fieldValues.Append(
+                        ProbeExpressionParser<string>.DumpObject(
+                            fieldsArray[index].GetValue((object)this.Nested),
+                            fieldsArray[index].FieldType,
+                            fieldsArray[index].Name,
+                            0));
+                    index++;
+
+                    if ((index < fieldsArray.Length) && (index < 5))
+                    {
+                        return fieldValues.Append(", ");
+                    }
                 }
-            }
-            else
-            {
-                if (index < fieldsArray.Length)
+                else
                 {
-                    return fieldValues.Append(", ...");
+                    if (index < fieldsArray.Length)
+                    {
+                        return fieldValues.Append(", ...");
+                    }
+
+                    break;
                 }
-
-                break;
             }
-        }
 
-        return fieldValues.ToString();
-    };
+            return fieldValues.ToString();
+        };
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
@@ -32,11 +32,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/AccessNullableStruct.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/AccessNullableStruct.json
@@ -1,0 +1,9 @@
+{
+    "dsl": "{this.NullableNullValue}",
+    "getmember": [
+        {
+            "ref": "this"
+        },
+        "NullableNullValue"
+    ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/AccessNullableStructNotNull.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/AccessNullableStructNotNull.json
@@ -1,0 +1,9 @@
+{
+    "dsl": "{this.NullableNotNullValue}",
+    "getmember": [
+        {
+            "ref": "this"
+        },
+        "NullableNotNullValue"
+    ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/DictionaryKeyNotExist.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Templates/DictionaryKeyNotExist.json
@@ -1,5 +1,5 @@
 {
-    "dsl": "The value of key 'hello' is {index(ref DictionayLocal, not exist)}",
+    "dsl": "The value of key 'not exist' is {index(ref DictionayLocal, not exist)}",
     "index": [
         {
             "ref": "DictionaryLocal"


### PR DESCRIPTION
## Summary of changes
Support the usage of nullable types (i.e. `Guid?`) in the DI Expression Language

## Test coverage
See tests in the PR
