### PR TITLE
[ASM] Remove the need to pass httpcontext to SecurityCoordinators

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ControllerContextExtensions.Framework.cs
@@ -78,7 +78,7 @@ namespace Datadog.Trace.AppSec
 
             if (security.Enabled)
             {
-                var securityTransport = new Coordinator.SecurityCoordinator(security, context, scope.Span!);
+                var securityTransport = new Coordinator.SecurityCoordinator(security, scope.Span!);
                 if (!securityTransport.IsBlocked)
                 {
                     var inputData = new Dictionary<string, object>();

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -7,13 +7,16 @@
 using System.Collections.Generic;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.Headers;
+#if !NETFRAMEWORK
+using Microsoft.AspNetCore.Http;
+#else
+using System.Web;
+#endif
 
 namespace Datadog.Trace.AppSec.Coordinator;
 
 internal abstract class HttpTransportBase
 {
-    internal const string AsmApiSecurity = "asm.apisecurity";
-
     internal abstract bool IsBlocked { get; }
 
     internal abstract int StatusCode { get; }
@@ -21,6 +24,8 @@ internal abstract class HttpTransportBase
     internal abstract IDictionary<string, object>? RouteData { get; }
 
     internal abstract bool ReportedExternalWafsRequestHeaders { get; set; }
+
+    public abstract HttpContext Context { get; }
 
     internal abstract IContext? GetAdditiveContext();
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -29,8 +29,6 @@ internal readonly partial struct SecurityCoordinator
     private static readonly Lazy<Action<IResult, HttpStatusCode, string, string>?> _throwHttpResponseException = new(CreateThrowHttpResponseExceptionDynMeth);
     private static readonly bool? UsingIntegratedPipeline;
 
-    private readonly HttpContext _context;
-
     static SecurityCoordinator()
     {
         if (UsingIntegratedPipeline == null)
@@ -47,17 +45,14 @@ internal readonly partial struct SecurityCoordinator
         }
     }
 
-    internal SecurityCoordinator(Security security, HttpContext context, Span span)
+    internal SecurityCoordinator(Security security, Span span)
     {
-        _context = context;
         _security = security;
         _localRootSpan = TryGetRoot(span);
-        _httpTransport = new HttpTransport(context);
+        _httpTransport = new HttpTransport(HttpContext.Current);
     }
 
     private bool CanAccessHeaders => UsingIntegratedPipeline is true or null;
-
-    public static HttpContext Context => HttpContext.Current;
 
     private static Action<IResult, HttpStatusCode, string, string>? CreateThrowHttpResponseExceptionDynMeth()
     {
@@ -239,19 +234,19 @@ internal readonly partial struct SecurityCoordinator
 
     internal Dictionary<string, object> GetBodyFromRequest()
     {
-        var formData = new Dictionary<string, object>(_context.Request.Form.Keys.Count);
-        foreach (string key in _context.Request.Form.Keys)
+        var formData = new Dictionary<string, object>(_httpTransport.Context.Request.Form.Keys.Count);
+        foreach (string key in _httpTransport.Context.Request.Form.Keys)
         {
             // key could be null, but it's not a valid key in a dictionary
             // Using [] instead of Add to avoid potential duplicate key
             // but it does mean there's a (tiny) chance of overwriting the key
-            formData[key ?? string.Empty] = _context.Request.Form[key];
+            formData[key ?? string.Empty] = _httpTransport.Context.Request.Form[key];
         }
 
         return formData;
     }
 
-    internal object? GetPathParams() => ObjectExtractor.Extract(_context.Request.RequestContext.RouteData.Values);
+    internal object? GetPathParams() => ObjectExtractor.Extract(_httpTransport.Context.Request.RequestContext.RouteData.Values);
 
     /// <summary>
     /// Framework can do it all at once, but framework only unfortunately
@@ -312,8 +307,8 @@ internal readonly partial struct SecurityCoordinator
 
     private void ChooseBlockingMethodAndBlock(IResult result, Action<int?, bool> reporting, Dictionary<string, object?>? blockInfo, Dictionary<string, object?>? redirectInfo)
     {
-        var blockingAction = _security.GetBlockingAction([_context.Request.Headers["Accept"]], blockInfo, redirectInfo);
-        var isWebApiRequest = _context.CurrentHandler?.GetType().FullName == WebApiControllerHandlerTypeFullname;
+        var blockingAction = _security.GetBlockingAction([_httpTransport.Context.Request.Headers["Accept"]], blockInfo, redirectInfo);
+        var isWebApiRequest = _httpTransport.Context.CurrentHandler?.GetType().FullName == WebApiControllerHandlerTypeFullname;
         if (isWebApiRequest)
         {
             if (!blockingAction.IsRedirect && _throwHttpResponseException.Value is { } throwException)
@@ -338,7 +333,7 @@ internal readonly partial struct SecurityCoordinator
 
     private void WriteAndEndResponse(BlockingAction blockingAction)
     {
-        var httpResponse = _context.Response;
+        var httpResponse = _httpTransport.Context.Response;
         httpResponse.Clear();
         httpResponse.Cookies.Clear();
 
@@ -366,12 +361,12 @@ internal readonly partial struct SecurityCoordinator
 
         httpResponse.Flush();
         httpResponse.Close();
-        _context.ApplicationInstance.CompleteRequest();
+        _httpTransport.Context.ApplicationInstance.CompleteRequest();
     }
 
     public Dictionary<string, object> GetBasicRequestArgsForWaf()
     {
-        var request = _context.Request;
+        var request = _httpTransport.Context.Request;
         var headersDic = new Dictionary<string, string[]>(request.Headers.Keys.Count);
         var headerKeys = request.Headers.Keys;
         foreach (string originalKey in headerKeys)
@@ -461,7 +456,7 @@ internal readonly partial struct SecurityCoordinator
 
     public Dictionary<string, string[]> GetResponseHeadersForWaf()
     {
-        var response = _context.Response;
+        var response = _httpTransport.Context.Response;
         var headersDic = new Dictionary<string, string[]>(response.Headers.Keys.Count);
         var headerKeys = response.Headers.Keys;
         foreach (string originalKey in headerKeys)
@@ -492,29 +487,32 @@ internal readonly partial struct SecurityCoordinator
 
         private static bool _canReadHttpResponseHeaders = true;
 
-        private readonly HttpContext _context;
+        public HttpTransport(HttpContext context)
+        {
+            Context = context;
+        }
 
-        public HttpTransport(HttpContext context) => _context = context;
+        internal override bool IsBlocked => Context.Items[BlockingAction.BlockDefaultActionName] is true;
 
-        internal override bool IsBlocked => _context.Items[BlockingAction.BlockDefaultActionName] is true;
+        internal override int StatusCode => Context.Response.StatusCode;
 
-        internal override int StatusCode => _context.Response.StatusCode;
+        public override HttpContext Context { get; }
 
-        internal override IDictionary<string, object>? RouteData => _context.Request.RequestContext.RouteData?.Values;
+        internal override IDictionary<string, object>? RouteData => Context.Request.RequestContext.RouteData?.Values;
 
         internal override bool ReportedExternalWafsRequestHeaders
         {
-            get => _context.Items["ReportedExternalWafsRequestHeaders"] is true;
-            set => _context.Items["ReportedExternalWafsRequestHeaders"] = value;
+            get => Context.Items["ReportedExternalWafsRequestHeaders"] is true;
+            set => Context.Items["ReportedExternalWafsRequestHeaders"] = value;
         }
 
-        internal override void MarkBlocked() => _context.Items[BlockingAction.BlockDefaultActionName] = true;
+        internal override void MarkBlocked() => Context.Items[BlockingAction.BlockDefaultActionName] = true;
 
-        internal override IContext? GetAdditiveContext() => _context.Items[WafKey] as IContext;
+        internal override IContext? GetAdditiveContext() => Context.Items[WafKey] as IContext;
 
-        internal override void SetAdditiveContext(IContext additiveContext) => _context.Items[WafKey] = additiveContext;
+        internal override void SetAdditiveContext(IContext additiveContext) => Context.Items[WafKey] = additiveContext;
 
-        internal override IHeadersCollection GetRequestHeaders() => new NameValueHeadersCollection(_context.Request.Headers);
+        internal override IHeadersCollection GetRequestHeaders() => new NameValueHeadersCollection(Context.Request.Headers);
 
         internal override IHeadersCollection GetResponseHeaders()
         {
@@ -522,8 +520,7 @@ internal readonly partial struct SecurityCoordinator
             {
                 try
                 {
-                    var headers = _context.Response.Headers;
-                    return new NameValueHeadersCollection(_context.Response.Headers);
+                    return new NameValueHeadersCollection(Context.Response.Headers);
                 }
                 catch (PlatformNotSupportedException ex)
                 {

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -45,11 +45,11 @@ internal readonly partial struct SecurityCoordinator
         }
     }
 
-    internal SecurityCoordinator(Security security, Span span)
+    internal SecurityCoordinator(Security security, Span span, HttpTransport? transport = null)
     {
         _security = security;
         _localRootSpan = TryGetRoot(span);
-        _httpTransport = new HttpTransport(HttpContext.Current);
+        _httpTransport = transport ?? new HttpTransport(HttpContext.Current);
     }
 
     private bool CanAccessHeaders => UsingIntegratedPipeline is true or null;

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinatorHelpers.Core.cs
@@ -7,7 +7,6 @@
 #if !NETFRAMEWORK
 using System;
 using System.Collections.Generic;
-using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK;
 using Datadog.Trace.Logging;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Abstractions;
@@ -26,7 +25,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, context, span, transport);
+                var securityCoordinator = new SecurityCoordinator(security, span, transport);
                 var result = securityCoordinator.Scan();
                 securityCoordinator.BlockAndReport(result);
             }
@@ -42,7 +41,7 @@ internal static class SecurityCoordinatorHelpers
                 var transport = new SecurityCoordinator.HttpTransport(httpContext);
                 if (!transport.IsBlocked)
                 {
-                    var securityCoordinator = new SecurityCoordinator(security, httpContext, span, transport);
+                    var securityCoordinator = new SecurityCoordinator(security, span, transport);
                     var args = new Dictionary<string, object>
                     {
                         {
@@ -74,7 +73,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, context, span, transport);
+                var securityCoordinator = new SecurityCoordinator(security, span, transport);
                 var args = new Dictionary<string, object> { { AddressesConstants.RequestPathParams, pathParams } };
                 var result = securityCoordinator.RunWaf(args);
                 securityCoordinator.BlockAndReport(result);
@@ -89,7 +88,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, context, span, transport);
+                var securityCoordinator = new SecurityCoordinator(security, span, transport);
                 var args = new Dictionary<string, object> { { AddressesConstants.UserId, userId } };
                 var result = securityCoordinator.RunWaf(args);
                 securityCoordinator.BlockAndReport(result);
@@ -104,7 +103,7 @@ internal static class SecurityCoordinatorHelpers
             var transport = new SecurityCoordinator.HttpTransport(context);
             if (!transport.IsBlocked)
             {
-                var securityCoordinator = new SecurityCoordinator(security, context, span, transport);
+                var securityCoordinator = new SecurityCoordinator(security, span, transport);
                 var pathParams = new Dictionary<string, object>(actionPathParams.Count);
                 for (var i = 0; i < actionPathParams.Count; i++)
                 {
@@ -132,7 +131,7 @@ internal static class SecurityCoordinatorHelpers
         var transport = new SecurityCoordinator.HttpTransport(context);
         if (!transport.IsBlocked)
         {
-            var securityCoordinator = new SecurityCoordinator(security, context, span, transport);
+            var securityCoordinator = new SecurityCoordinator(security, span, transport);
             var keysAndValues = ObjectExtractor.Extract(body);
 
             if (keysAndValues is not null)

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -81,7 +81,7 @@ internal static class RaspModule
 
     private static void RunWafRasp(Dictionary<string, object> arguments, Span rootSpan, string address)
     {
-        var securityCoordinator = new SecurityCoordinator(Security.Instance, SecurityCoordinator.Context, rootSpan);
+        var securityCoordinator = new SecurityCoordinator(Security.Instance, rootSpan);
         var result = securityCoordinator.RunWaf(arguments, runWithEphemeral: true);
 
         if (result is not null)

--- a/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
+++ b/tracer/src/Datadog.Trace/AspNet/TracingHttpModule.cs
@@ -183,7 +183,7 @@ namespace Datadog.Trace.AspNet
                 if (security.Enabled)
                 {
                     SecurityCoordinator.ReportWafInitInfoOnce(security, scope.Span);
-                    var securityCoordinator = new SecurityCoordinator(security, httpContext, scope.Span);
+                    var securityCoordinator = new SecurityCoordinator(security, scope.Span);
 
                     // request args
                     var args = securityCoordinator.GetBasicRequestArgsForWaf();
@@ -244,7 +244,7 @@ namespace Datadog.Trace.AspNet
                         var security = Security.Instance;
                         if (security.Enabled)
                         {
-                            var securityCoordinator = new SecurityCoordinator(security, app.Context, rootSpan);
+                            var securityCoordinator = new SecurityCoordinator(security, rootSpan);
                             var args = securityCoordinator.GetBasicRequestArgsForWaf();
                             args.Add(AddressesConstants.RequestPathParams, securityCoordinator.GetPathParams());
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ControllerActionInvoker_InvokeAction_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ControllerActionInvoker_InvokeAction_Integration.cs
@@ -93,11 +93,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     var responseObject = actionResult.Data;
                     if (responseObject is not null)
                     {
-                        var context = HttpContext.Current;
-                        var scope = SharedItems.TryPeekScope(context, AspNetMvcIntegration.HttpContextKey);
+                        var scope = SharedItems.TryPeekScope(HttpContext.Current, AspNetMvcIntegration.HttpContextKey);
                         if (scope is not null)
                         {
-                            var securityTransport = new SecurityCoordinator(security, context, scope.Span);
+                            var securityTransport = new SecurityCoordinator(security, scope.Span);
                             if (!securityTransport.IsBlocked)
                             {
                                 var extractedObject = ObjectExtractor.Extract(responseObject);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ReflectedHttpActionDescriptor_ExecuteAsync_Integration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNet/ReflectedHttpActionDescriptor_ExecuteAsync_Integration.cs
@@ -84,11 +84,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNet
                     var responseObject = actionResult.Content;
                     if (responseObject is not null)
                     {
-                        var context = HttpContext.Current;
-                        var scope = SharedItems.TryPeekScope(context, AspNetWebApi2Integration.HttpContextKey);
+                        var scope = SharedItems.TryPeekScope(HttpContext.Current, AspNetWebApi2Integration.HttpContextKey);
                         if (scope is not null)
                         {
-                            var securityTransport = new SecurityCoordinator(security, context, scope.Span);
+                            var securityTransport = new SecurityCoordinator(security, scope.Span);
                             if (!securityTransport.IsBlocked)
                             {
                                 var extractedObj = ObjectExtractor.Extract(responseObject);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/BlockingMiddleware.cs
@@ -80,7 +80,7 @@ internal class BlockingMiddleware
         {
             if (Tracer.Instance?.ActiveScope?.Span is Span span)
             {
-                var securityCoordinator = new SecurityCoordinator(security, context, span);
+                var securityCoordinator = new SecurityCoordinator(security, span, new SecurityCoordinator.HttpTransport(context));
                 if (_endPipeline && !context.Response.HasStarted)
                 {
                     context.Response.StatusCode = 404;
@@ -123,7 +123,7 @@ internal class BlockingMiddleware
                 {
                     if (Tracer.Instance?.ActiveScope?.Span is Span span)
                     {
-                        var securityCoordinator = new SecurityCoordinator(security, context, span);
+                        var securityCoordinator = new SecurityCoordinator(security, span, new SecurityCoordinator.HttpTransport(context));
                         if (!blockException.Reported)
                         {
                             securityCoordinator.TryReport(blockException.Result, endedResponse);

--- a/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
+++ b/tracer/src/Datadog.Trace/PlatformHelpers/AspNetCoreHttpRequestHandler.cs
@@ -169,7 +169,7 @@ namespace Datadog.Trace.PlatformHelpers
                 span.SetHeaderTags(new HeadersCollectionAdapter(httpContext.Response.Headers), tracer.Settings.HeaderTagsInternal, defaultTagPrefix: SpanContextPropagator.HttpResponseHeadersTagPrefix);
                 if (security.Enabled)
                 {
-                    var transport = new SecurityCoordinator(security, httpContext, span);
+                    var transport = new SecurityCoordinator(security, span, new SecurityCoordinator.HttpTransport(httpContext));
                     transport.AddResponseHeadersToSpanAndCleanup();
                 }
                 else

--- a/tracer/src/Datadog.Trace/SpanExtensions.Framework.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.Framework.cs
@@ -26,7 +26,7 @@ namespace Datadog.Trace
 
             if (security.Enabled)
             {
-                var securityCoordinator = new SecurityCoordinator(Security.Instance, HttpContext.Current, span);
+                var securityCoordinator = new SecurityCoordinator(Security.Instance, span);
 
                 var wafArgs = new Dictionary<string, object>
                 {

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -78,8 +78,8 @@ namespace Benchmarks.Trace.Asm
             context?.Dispose();
             _httpContext.Features.Set<IContext>(null);
 #else
-            var securityTransport = new SecurityCoordinator(_security, _httpContext, span);
-            var result = securityTransport.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestBody, ObjectExtractor.Extract(body) } });
+            var securityTransport = new SecurityCoordinator(_security, span, new SecurityCoordinator.HttpTransport(_httpContext));
+            securityTransport.RunWaf(new Dictionary<string, object> { { AddressesConstants.RequestBody, ObjectExtractor.Extract(body) } });
             var context = _httpContext.Items["waf"] as IContext;
             context?.Dispose();
             _httpContext.Items["waf"] = null;


### PR DESCRIPTION
## Summary of changes

Small refactoring, no need to pass an httpcontext, we can get it from async local / httpcontext.current (netfx) and if we already have it from the callee pov, we can pass an HttpTransport directly for Core

## Reason for change

Simplify

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
