### PR TITLE
[CI Visibility] - Close and flush incomplete TSLV objects before exiting

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -541,9 +541,11 @@ namespace Datadog.Trace.Ci
             // Let's close any opened test, suite, modules and sessions before shutting down to avoid losing any data.
             // But marking them as failed.
 
+            var exception = LifetimeManager.Instance.CurrentException;
+
             foreach (var test in Test.ActiveTests)
             {
-                if (LifetimeManager.Instance.CurrentException is { } exception)
+                if (exception is not null)
                 {
                     test.SetErrorInfo(exception);
                 }
@@ -553,7 +555,7 @@ namespace Datadog.Trace.Ci
 
             foreach (var testSuite in TestSuite.ActiveTestSuites)
             {
-                if (LifetimeManager.Instance.CurrentException is { } exception)
+                if (exception is not null)
                 {
                     testSuite.SetErrorInfo(exception);
                 }
@@ -563,7 +565,7 @@ namespace Datadog.Trace.Ci
 
             foreach (var testModule in TestModule.ActiveTestModules)
             {
-                if (LifetimeManager.Instance.CurrentException is { } exception)
+                if (exception is not null)
                 {
                     testModule.SetErrorInfo(exception);
                 }
@@ -573,7 +575,7 @@ namespace Datadog.Trace.Ci
 
             foreach (var testSession in TestSession.ActiveTestSessions)
             {
-                if (LifetimeManager.Instance.CurrentException is { } exception)
+                if (exception is not null)
                 {
                     testSession.SetErrorInfo(exception);
                 }

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -538,7 +538,7 @@ namespace Datadog.Trace.Ci
 
         private static async Task ShutdownAsync()
         {
-            // Let's close any opened test, suite, modules and sessions before shutting down to avoid loosing any data.
+            // Let's close any opened test, suite, modules and sessions before shutting down to avoid losing any data.
             // But marking them as failed.
 
             foreach (var test in Test.ActiveTests)

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -38,7 +38,20 @@ namespace Datadog.Trace.Ci
 
         public static bool Enabled => _enabledLazy.Value;
 
-        public static bool IsRunning => Interlocked.CompareExchange(ref _firstInitialization, 0, 0) == 0;
+        public static bool IsRunning
+        {
+            get
+            {
+                // We try first the fast path, if the value is 0 we are running, so we can avoid the Interlocked operation.
+                if (_firstInitialization == 0)
+                {
+                    return true;
+                }
+
+                // If the value is not 0, maybe the value hasn't been updated yet, so we use the Interlocked operation to ensure the value is correct.
+                return Interlocked.CompareExchange(ref _firstInitialization, 0, 0) == 0;
+            }
+        }
 
         public static CIVisibilitySettings Settings
         {

--- a/tracer/src/Datadog.Trace/Ci/TestSuite.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSuite.cs
@@ -5,6 +5,8 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Datadog.Trace.Ci.Tagging;
 using Datadog.Trace.Ci.Tags;
@@ -21,6 +23,8 @@ namespace Datadog.Trace.Ci;
 public sealed class TestSuite
 {
     private static readonly AsyncLocal<TestSuite?> CurrentSuite = new();
+    private static readonly HashSet<TestSuite> OpenedTestSuites = new();
+
     private readonly Span _span;
     private int _finished;
 
@@ -45,6 +49,11 @@ public sealed class TestSuite
 
         _span = span;
         Current = this;
+        lock (OpenedTestSuites)
+        {
+            OpenedTestSuites.Add(this);
+        }
+
         CIVisibility.Log.Debug("###### New Test Suite Created: {Name} ({Module})", Name, Module.Name);
 
         if (startDate is null)
@@ -79,6 +88,20 @@ public sealed class TestSuite
     {
         get => CurrentSuite.Value;
         set => CurrentSuite.Value = value;
+    }
+
+    /// <summary>
+    /// Gets the active test suites
+    /// </summary>
+    internal static IReadOnlyCollection<TestSuite> ActiveTestSuites
+    {
+        get
+        {
+            lock (OpenedTestSuites)
+            {
+                return OpenedTestSuites.Count == 0 ? [] : OpenedTestSuites.ToArray();
+            }
+        }
     }
 
     internal TestSuiteSpanTags Tags => (TestSuiteSpanTags)_span.Tags;
@@ -178,6 +201,11 @@ public sealed class TestSuite
         TelemetryFactory.Metrics.RecordCountCIVisibilityEventFinished(TelemetryHelper.GetTelemetryTestingFrameworkEnum(Tags.Framework), MetricTags.CIVisibilityTestingEventTypeWithCodeOwnerAndSupportedCiAndBenchmarkAndEarlyFlakeDetectionAndRum.Suite);
 
         Current = null;
+        lock (OpenedTestSuites)
+        {
+            OpenedTestSuites.Remove(this);
+        }
+
         Module.RemoveSuite(Name);
         CIVisibility.Log.Debug("###### Test Suite Closed: {Name} ({Module}) | {Status}", Name, Module.Name, Tags.Status);
     }

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -60,6 +60,8 @@ namespace Datadog.Trace
 
         public TimeSpan TaskTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
+        public Exception CurrentException { get; private set; }
+
         public void AddShutdownTask(Action action)
         {
             _shutdownHooks.Enqueue(action);
@@ -79,6 +81,7 @@ namespace Datadog.Trace
         private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
         {
             Log.Warning("Application threw an unhandled exception: {Exception}", e.ExceptionObject);
+            CurrentException = e.ExceptionObject as Exception;
             RunShutdownTasks();
             AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
         }

--- a/tracer/src/Datadog.Trace/SpanExtensions.cs
+++ b/tracer/src/Datadog.Trace/SpanExtensions.cs
@@ -119,5 +119,8 @@ namespace Datadog.Trace
             // so it can be converted automatically by the backend (only if a measurement facet is created for this tag)
             return span.SetTag(key, value?.ToString());
         }
+
+        internal static bool IsCiVisibilitySpan(this ISpan span)
+            => span.Type is SpanTypes.TestSession or SpanTypes.TestModule or SpanTypes.TestSuite or SpanTypes.Test or SpanTypes.Browser;
     }
 }

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -204,7 +204,7 @@ namespace Datadog.Trace
                     _spans = default;
                     TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();
                 }
-                else if (CIVisibility.IsRunning && span.Type is SpanTypes.TestSession or SpanTypes.TestModule or SpanTypes.TestSuite or SpanTypes.Test or SpanTypes.Browser)
+                else if (CIVisibility.IsRunning && span.IsCiVisibilitySpan())
                 {
                     // TestSession, TestModule, TestSuite, Test and Browser spans are part of CI Visibility
                     // all of them are known to be Root spans, so we can flush them as soon as they are closed

--- a/tracer/src/Datadog.Trace/TraceContext.cs
+++ b/tracer/src/Datadog.Trace/TraceContext.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Datadog.Trace.AppSec;
+using Datadog.Trace.Ci;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.ContinuousProfiler;
@@ -199,6 +200,16 @@ namespace Datadog.Trace
 
                 if (_openSpans == 0)
                 {
+                    spansToWrite = _spans.GetArray();
+                    _spans = default;
+                    TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();
+                }
+                else if (CIVisibility.IsRunning && span.Type is SpanTypes.TestSession or SpanTypes.TestModule or SpanTypes.TestSuite or SpanTypes.Test or SpanTypes.Browser)
+                {
+                    // TestSession, TestModule, TestSuite, Test and Browser spans are part of CI Visibility
+                    // all of them are known to be Root spans, so we can flush them as soon as they are closed
+                    // even if their children have not been closed yet.
+                    // An unclosed/unfinished child span should never block the report of a test.
                     spansToWrite = _spans.GetArray();
                     _spans = default;
                     TelemetryFactory.Metrics.RecordCountTraceSegmentsClosed();


### PR DESCRIPTION
## Summary of changes

This PR ensures that all Test Suite Level Visibility objects are closed and flushed before exiting.

## Reason for change

Currently if an UnhandledException occurs the process run the LifetimeManager.RunShutdown method flushing everything and closing, but we were missing all opened tests, suites, modules and session. This PR changes that, now if something happens and we are about to crash we ensure closing all spans and flushing them, to avoid data loss.

Also another case that is fixed by this PR is related to unfinished children spans of a tests blocking the test report from CI Visibility. We need to avoid scenarios where we close a test a is never reported to the backend.

## Implementation details

Adds HashSets for all TSLV objects to keep all active spans, and in the shutdown process we read those hashsets to force the close.

Change of the TraceContext class to check if the span we are closing is part of a CI Visibility known span type to flush it.

## Test coverage

It's hard to reproduce this kind of crashes. I have seen some related to accessing unloaded AppDomains in .NET Framework.