### PR TITLE
[Dynamic Instrumentation] DEBUG-2374 Support using Boolean literals in the expression language

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionParser.cs
@@ -365,6 +365,11 @@ internal partial class ProbeExpressionParser<T>
                         {
                             return Expression.Constant(null);
                         }
+
+                    case JsonToken.Boolean:
+                        {
+                            return Expression.Constant(Convert.ChangeType(readerValue, TypeCode.Boolean));
+                        }
                 }
             }
             catch (Exception e)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -43,6 +43,7 @@ namespace Datadog.Trace.Tests.Debugger
                 IntNumber = 42,
                 DoubleNumber = 3.14159,
                 String = "Hello world!",
+                BooleanValue = true,
                 Null = null,
                 Nested = new TestStruct.NestedObject { NestedString = "Hello from nested object", Nested = new TestStruct.NestedObject { NestedString = "Hello from another nested object" } },
                 ChildNested = new TestStruct.ChildNestedObject(),
@@ -201,6 +202,7 @@ namespace Datadog.Trace.Tests.Debugger
             scope.AddMember(new ScopeMember("DictionaryLocal", TestObject.Dictionary.GetType(), TestObject.Dictionary, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("NestedObjectLocal", TestObject.Nested.GetType(), TestObject.Nested, ScopeMemberKind.Local));
             scope.AddMember(new ScopeMember("NullLocal", TestObject.Nested.GetType(), TestObject.Null, ScopeMemberKind.Local));
+            scope.AddMember(new ScopeMember("BooleanValue", TestObject.BooleanValue.GetType(), TestObject.BooleanValue, ScopeMemberKind.Local));
 
             // Add arguments
             scope.AddMember(new ScopeMember("IntArg", TestObject.IntNumber.GetType(), TestObject.IntNumber, ScopeMemberKind.Argument));
@@ -333,6 +335,8 @@ namespace Datadog.Trace.Tests.Debugger
             public NestedObject ParentAsChildNested;
 
             public NestedObject Null;
+
+            public bool BooleanValue;
 
             internal class NestedObject
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.AccessNullObject.verified.txt
@@ -28,11 +28,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.Null.NestedString;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildPrivateMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildPrivateMember.verified.txt
@@ -34,11 +34,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildStaticPublicMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ChildStaticPublicMember.verified.txt
@@ -34,11 +34,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Collection.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Collection.verified.txt
@@ -25,11 +25,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result =
     {
         enumerator = this.Collection.GetEnumerator();

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionCount.verified.txt
@@ -27,11 +27,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = CollectionLocal.Count.ToString();
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndex.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndex.verified.txt
@@ -28,11 +28,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (string)CollectionLocal[0];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndexOutOfRange.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.CollectionIndexOutOfRange.verified.txt
@@ -28,11 +28,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (string)CollectionLocal[100];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKey.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.DictionaryKey.verified.txt
@@ -28,11 +28,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (string)DictionaryLocal["hello"];
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Duration.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Duration.verified.txt
@@ -23,11 +23,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = @duration.ToString();
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualFalse.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualFalse.verified.txt
@@ -1,18 +1,14 @@
 ﻿Condition:
 Json:
 {
-    "eq": [
-        {
-            "getmember": [
-                {
-                    "ref": "Nested"
-                },
-                "NestedString"
-            ]
-        },
-        "Hello from nested object"
-    ]
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    false
+  ]
 }
+
 Expression: (
     scopeMember,
     scopeMember,
@@ -37,8 +33,8 @@ Expression: (
     var StringArg = (string)scopeMemberArray[10].Value;
     var CollectionArg = (List<string>)scopeMemberArray[11].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
-    var $dd_el_result = this.Nested.NestedString == "Hello from nested object";
+    var $dd_el_result = !BooleanValue;
 
     return $dd_el_result;
 }
-Result: True
+Result: False

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualToNull.verified.txt
@@ -26,11 +26,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = StringLocal == null;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTru.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTru.verified.txt
@@ -1,18 +1,14 @@
 ﻿Condition:
 Json:
 {
-    "eq": [
-        {
-            "getmember": [
-                {
-                    "ref": "Nested"
-                },
-                "NestedString"
-            ]
-        },
-        "Hello from nested object"
-    ]
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    tru
+  ]
 }
+
 Expression: (
     scopeMember,
     scopeMember,
@@ -20,6 +16,7 @@ Expression: (
     exception,
     scopeMemberArray) =>
 {
+    bool $dd_el_result;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
     var @duration = (TimeSpan)scopeMember.Value;
@@ -37,8 +34,9 @@ Expression: (
     var StringArg = (string)scopeMemberArray[10].Value;
     var CollectionArg = (List<string>)scopeMemberArray[11].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
-    var $dd_el_result = this.Nested.NestedString == "Hello from nested object";
 
-    return $dd_el_result;
+    return true;
 }
 Result: True
+Errors:
+EvaluationError { Expression = BooleanValue == N/A, Message = Error parsing boolean value. Path 'eq[0]', line 7, position 7. }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrue.verified.txt
@@ -1,18 +1,14 @@
 ﻿Condition:
 Json:
 {
-    "eq": [
-        {
-            "getmember": [
-                {
-                    "ref": "Nested"
-                },
-                "NestedString"
-            ]
-        },
-        "Hello from nested object"
-    ]
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    true
+  ]
 }
+
 Expression: (
     scopeMember,
     scopeMember,
@@ -37,7 +33,7 @@ Expression: (
     var StringArg = (string)scopeMemberArray[10].Value;
     var CollectionArg = (List<string>)scopeMemberArray[11].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
-    var $dd_el_result = this.Nested.NestedString == "Hello from nested object";
+    var $dd_el_result = BooleanValue;
 
     return $dd_el_result;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrueString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.EqualTrueString.verified.txt
@@ -1,18 +1,14 @@
 ﻿Condition:
 Json:
 {
-    "eq": [
-        {
-            "getmember": [
-                {
-                    "ref": "Nested"
-                },
-                "NestedString"
-            ]
-        },
-        "Hello from nested object"
-    ]
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    "true"
+  ]
 }
+
 Expression: (
     scopeMember,
     scopeMember,
@@ -20,6 +16,7 @@ Expression: (
     exception,
     scopeMemberArray) =>
 {
+    bool $dd_el_result;
     var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
     var @return = (string)scopeMember.Value;
     var @duration = (TimeSpan)scopeMember.Value;
@@ -37,8 +34,9 @@ Expression: (
     var StringArg = (string)scopeMemberArray[10].Value;
     var CollectionArg = (List<string>)scopeMemberArray[11].Value;
     var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
-    var $dd_el_result = this.Nested.NestedString == "Hello from nested object";
 
-    return $dd_el_result;
+    return true;
 }
 Result: True
+Errors:
+EvaluationError { Expression = BooleanValue == "true", Message = The binary operator Equal is not defined for the types 'System.Boolean' and 'System.String'. }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Exception.verified.txt
@@ -23,11 +23,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (@exception == null)
         ? "System.Exception"
         : "System.Exception" + ", " + @exception.Message + ", " + @exception.StackTrace;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.Filter.verified.txt
@@ -40,11 +40,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = CollectionLocal
         .Where(@string => @string.Length > 4)
         .ToList().Count > 2;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanArgument.verified.txt
@@ -26,11 +26,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = IntArg > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanCount.verified.txt
@@ -30,11 +30,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = CollectionLocal.Count > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanField.verified.txt
@@ -26,11 +26,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.IntNumber > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.GreaterThanLocal.verified.txt
@@ -26,11 +26,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = IntLocal > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAll.verified.txt
@@ -33,11 +33,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = CollectionLocal.All(@string => @string.Length > 3);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.HasAny.verified.txt
@@ -31,11 +31,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = CollectionLocal.Any(@string => @string == "hello");
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalBinaryOperation.verified.txt
@@ -26,11 +26,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalCollectionOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalCollectionOperation.verified.txt
@@ -27,11 +27,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalStringOperation.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IllegalStringOperation.verified.txt
@@ -26,11 +26,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsDefined.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsDefined.verified.txt
@@ -26,11 +26,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = !(this.Nested is UndefinedValue);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfEmptyType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfEmptyType.verified.txt
@@ -31,11 +31,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = false;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfFalse.verified.txt
@@ -31,11 +31,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.String is int;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfTrue.verified.txt
@@ -31,11 +31,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.String is string;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsInstanceOfUnknownType.verified.txt
@@ -31,11 +31,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = false;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsUndefined.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsUndefined.verified.txt
@@ -26,11 +26,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.Nested is UndefinedValue;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCount.verified.txt
@@ -46,11 +46,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (this.String.Length > 2) && (CollectionLocal.Count > 2);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenAndCountOrHasAny.verified.txt
@@ -75,11 +75,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (this.String.Length > 2) && ((CollectionLocal.Count > 2) || CollectionLocal
         .Where(string1 => string1.Length > 4)
         .ToList()

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.LenOrCount.verified.txt
@@ -46,11 +46,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (this.String.Length > 2) || (CollectionLocal.Count > 2);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NestedFieldAccess.verified.txt
@@ -35,11 +35,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.Nested.NestedString.Length > 2;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.NotEqual.verified.txt
@@ -49,11 +49,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (this.Nested.NestedString == "dd") || (this.Nested.NestedString != null);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentPrivateMember.verified.txt
@@ -34,11 +34,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
 
     return "UndefinedValue";
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentStaticProtectedMember.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ParentStaticProtectedMember.verified.txt
@@ -33,11 +33,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = (DebuggerExpressionLanguageTests.TestStruct.NestedObject.ParentProtectedStaticMember == "Hello from parent protected static member").ToString();
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.RefGetMemberTwoLevels.verified.txt
@@ -36,11 +36,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.Nested.Nested.NestedString == "Hello from another nested object";
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ReturnString.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ReturnString.verified.txt
@@ -23,11 +23,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = @return;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.StringLength.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.StringLength.verified.txt
@@ -25,11 +25,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = ((IConvertible)this.String.Length).ToDouble(NumberFormatInfo);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.This.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.This.verified.txt
@@ -28,11 +28,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result = this.String;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ToStringNotSupported.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.ToStringNotSupported.verified.txt
@@ -23,11 +23,12 @@ Expressions:
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
     var $dd_el_result =
     {
         var fieldsArray = this.Nested.GetType().GetFields(

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.UndefinedField.verified.txt
@@ -1,4 +1,4 @@
-Condition:
+﻿Condition:
 Json:
 {
   "gt": [
@@ -29,11 +29,12 @@ Expression: (
     var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
-    var IntArg = (int)scopeMemberArray[7].Value;
-    var DoubleArg = (double)scopeMemberArray[8].Value;
-    var StringArg = (string)scopeMemberArray[9].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[10].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[11].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualFalse.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualFalse.json
@@ -1,0 +1,9 @@
+{
+  "dsl": "ref BooleanValue == false",
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    false
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualTru.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualTru.json
@@ -1,0 +1,9 @@
+{
+  "dsl": "ref BooleanValue == tru",
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    tru
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualTrue.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualTrue.json
@@ -1,0 +1,9 @@
+{
+  "dsl": "ref BooleanValue == true",
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    true
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualTrueString.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/EqualTrueString.json
@@ -1,0 +1,9 @@
+{
+  "dsl": "ref BooleanValue == true",
+  "eq": [
+    {
+      "ref": "BooleanValue"
+    },
+    "true"
+  ]
+}


### PR DESCRIPTION
## Summary of changes
Let the customer use expression like this: `myVariable == true`

## Test coverage
See tests in this PR
