### PR TITLE
"Manually" install MSI dependencies instead of using choco install

### DIFF
--- a/.azure-pipelines/steps/install-msi.yml
+++ b/.azure-pipelines/steps/install-msi.yml
@@ -1,0 +1,44 @@
+parameters:
+  - name: url
+    type: string
+
+  - name: filename
+    type: string
+
+  - name: msiParams
+    type: string
+    default: ''
+
+  - name: addToPath
+    type: string
+    default: ''
+    
+  - name: retries
+    type: number
+    default: 3
+
+steps:
+  - powershell: |
+      $ErrorActionPreference = 'Stop'
+
+      $url = "${{ parameters.url }}";
+      $file = "$(Agent.TempDirectory)\${{ parameters.filename }}"
+      Write-Host "Downloading from $url to $file";
+      Invoke-WebRequest -Uri $url -OutFile $file
+      
+      $installArgs = "/i $file ${{ parameters.msiParams }} /norestart"
+      Write-Host "Installing using msiexec $installArgs";
+      Start-Process msiexec $installArgs -Wait
+      Write-Host "Installed";
+
+      if("${{ parameters.addToPath }}") {
+        Write-Host "Adding to PATH";
+        Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};${{ parameters.addToPath }}";
+      }
+      
+      Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+      refreshenv
+    displayName: Installing ${{ parameters.filename }}
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT')) # TODO: error on non-windows? 
+    retryCountOnTaskFailure: ${{ parameters.retries }}
+    timeoutInMinutes: 10

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1554,13 +1554,17 @@ stages:
         targetBranch: $(targetBranch)
     - template: steps/install-dotnet-sdks.yml
     - template: steps/restore-working-directory.yml
+        
+    # Not using chocolatey as we're getting 429 Too Many Requests
+    - template: steps/install-msi.yml
+      parameters:
+        url: "https://functionscdn.azureedge.net/public/artifacts/v4/latest/func-cli-x64.msi"
+        filename: "func-cli-x64.msi"
+        addToPath: "C:\\Program Files\\Microsoft\\Azure Functions Core Tools"
 
-    - script: |
-        $(runtimeInstall)
-        func
-      displayName: 'Install Azure Functions core tools'
+    - script: func
+      displayName: 'Display Azure Functions core tools'
       workingDirectory: $(Pipeline.Workspace)
-      retryCountOnTaskFailure: 5
 
     - script: |
         "%ProgramFiles(x86)%\Microsoft SDKs\Azure\Storage Emulator\AzureStorageEmulator.exe" start
@@ -1596,13 +1600,6 @@ stages:
 
     - script: tracer\build.cmd CheckBuildLogsForErrors
       displayName: Check logs for errors
-
-    - script: |
-        $(runtimeUninstall)
-      displayName: 'Uninstall Azure Functions core tools'
-      workingDirectory: $(Pipeline.Workspace)
-      condition: succeededOrFailed()
-      continueOnError: true
 
 - stage: static_analysis_checks_tracer
   dependsOn: [merge_commit_id]

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1654,7 +1654,8 @@ stages:
   condition: >
     and(
       succeeded(), 
-      eq(variables['isBenchmarksOnlyBuild'], 'False')
+      eq(variables['isBenchmarksOnlyBuild'], 'False'),
+      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
     )
   dependsOn: [merge_commit_id, generate_variables]
   variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1657,8 +1657,7 @@ stages:
   condition: >
     and(
       succeeded(), 
-      eq(variables['isBenchmarksOnlyBuild'], 'False'),
-      eq(dependencies.generate_variables.outputs['generate_variables_job.generate_variables_step.IsProfilerChanged'], 'True')
+      eq(variables['isBenchmarksOnlyBuild'], 'False')
     )
   dependsOn: [merge_commit_id, generate_variables]
   variables:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1675,20 +1675,14 @@ stages:
     timeoutInMinutes: 60 #default value
 
     steps:
-    - powershell: |
-        # Required to reload environment apparently
-        Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
-        choco install cppcheck -y --version 2.12
-        $errorCode = $LASTEXITCODE
-        if ($errorCode -ne 0)
-        {
-          # something went wrong. Let's retry
-          exit 1
-        }
-        Write-Host "##vso[task.setvariable variable=PATH;]${env:PATH};C:\Program Files\Cppcheck";
-        refreshenv
-      displayName: Install CppCheck
-      retryCountOnTaskFailure: 3
+    # Based on https://community.chocolatey.org/packages/cppcheck#files
+    # Not using chocolatey as we're getting 429 Too Many Requests
+    - template: steps/install-msi.yml
+      parameters:
+        url: "https://github.com/danmar/cppcheck/releases/download/2.12.0/cppcheck-2.12.0-x64-Setup.msi"
+        filename: "cppcheck.msi"
+        addToPath: "C:\\Program Files\\Cppcheck"
+        msiParams: "ADDLOCAL=CppcheckCore,CLI,GUI,Translations,ConfigFiles,PlatformFiles,PythonAddons,CRT"
 
     - template: steps/clone-repo.yml
       parameters:

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -165,18 +165,11 @@ partial class Build : NukeBuild
             }
             void GenerateIntegrationTestsWindowsAzureFunctionsMatrix()
             {
-                // TODO: test on both x86 and x64?
-                // .NET Core 3.1 tests are disabled in CI because they currently fail for unknown reasons
-                // const string v3Install = @"choco install azure-functions-core-tools-3 --params ""'/x64'""";
-                // const string v3Uninstall = @"choco uninstall azure-functions-core-tools-3";
-                const string v4Install = @"choco install azure-functions-core-tools --params ""'/x64'""";
-                const string v4Uninstall = @"choco uninstall azure-functions-core-tools";
-
                 var combos = new []
                 {
                     // new {framework = TargetFramework.NETCOREAPP3_1, runtimeInstall = v3Install, runtimeUninstall = v3Uninstall },
-                    new {framework = TargetFramework.NET6_0, runtimeInstall = v4Install, runtimeUninstall = v4Uninstall },
-                    new {framework = TargetFramework.NET7_0, runtimeInstall = v4Install, runtimeUninstall = v4Uninstall },
+                    new {framework = TargetFramework.NET6_0 },
+                    new {framework = TargetFramework.NET7_0 },
                 };
 
                 var matrix = new Dictionary<string, object>();


### PR DESCRIPTION
## Summary of changes

- Adds a helper step for installing MSIs
- Update the `func.exe` and `cppcheck` installers to use the helper

## Reason for change

We've been seeing some `429 Too Many Requests` coming from chocolatey. We only install 2 things with it, so installing the MSIs directly is easier than trying to counteract that/handle commercial licensing etc

## Implementation details

Checked what MSI we were installing (fixed for cppcheck and floating for azure functions) and installed them. 

We _could_ directly install cppcheck on the hosted agents, but this was easier for now and will be easier to update if needs be. We can always re-evaluate.

We don't want to pre-install the Azure functions tools, as we want to make sure we're testing with the latest (for now)

## Test coverage

[Ran a test build here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=157719&view=logs&j=b915f7fe-737b-590c-2437-5d9fd23477ed&t=b6a81d99-5699-541f-919b-ca36a45374e0) and all good

## Other details
We're getting a lot of 429s from the mcr docker repo, so that's next in line, but harder to solve...

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
