### PR TITLE
[Dynamic Instrumentation] DEBUG-2337 Add 'this' parameter to method arguments symbols

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -676,26 +676,30 @@ namespace Datadog.Trace.Debugger.Symbols
             var parameters = method.GetParameters();
             if (parameters.Count == 0)
             {
-                return null;
+                if (method.IsStaticMethod())
+                {
+                    return null;
+                }
+
+                return [new Symbol { Name = "this", SymbolType = SymbolType.Arg, Line = UnknownFieldAndArgLine, Type = method.GetDeclaringType().FullName(MetadataReader) }];
             }
 
-            /* hidden this */
-            var hasThis = MetadataReader.GetParameter(parameters.First()).SequenceNumber == -2;
-            var count = hasThis ? parameters.Count - 1 : parameters.Count;
-            if (count == 0)
-            {
-                return null;
-            }
-
-            var argsSymbol = new Symbol[count];
+            var argsSymbol = CreateArgSymbolArray(method, parameters);
             int index = 0;
-
+            var methodSig = method.DecodeSignature(new TypeProvider(false), 0);
+            var paramTypesMatchArgSymbols = methodSig.ParameterTypes.Length == argsSymbol.Length || methodSig.ParameterTypes.Length == argsSymbol.Length - 1;
             foreach (var parameterHandle in parameters)
             {
                 var parameterDef = MetadataReader.GetParameter(parameterHandle);
-                if (parameterDef.SequenceNumber == -2)
+                if (index == 0)
                 {
-                    continue;
+                    argsSymbol[index] = new Symbol { Name = "this", SymbolType = SymbolType.Arg, Line = UnknownFieldAndArgLine, Type = method.GetDeclaringType().FullName(MetadataReader) };
+                    index++;
+
+                    if (parameterDef.IsHiddenThis())
+                    {
+                        continue;
+                    }
                 }
 
                 argsSymbol[index] = new Symbol
@@ -703,26 +707,21 @@ namespace Datadog.Trace.Debugger.Symbols
                     Name = MetadataReader.GetString(parameterDef.Name),
                     SymbolType = SymbolType.Arg,
                     Line = UnknownFieldAndArgLine,
-                    Type = "Unknown"
+                    Type = paramTypesMatchArgSymbols ? methodSig.ParameterTypes[parameterDef.IsHiddenThis() ? index : index - 1] : "Unknown"
                 };
                 index++;
             }
 
-            var methodSig = method.DecodeSignature(new TypeProvider(false), 0);
-            var paramTypesMatchArgSymbols =
-                (!hasThis && methodSig.ParameterTypes.Length == argsSymbol.Length) ||
-                (hasThis && methodSig.ParameterTypes.Length == argsSymbol.Length + 1);
-            if (!paramTypesMatchArgSymbols)
-            {
-                return argsSymbol;
-            }
-
-            for (int i = hasThis ? 1 : 0; i < argsSymbol.Length; i++)
-            {
-                argsSymbol[i].Type = methodSig.ParameterTypes[i];
-            }
-
             return argsSymbol;
+        }
+
+        private Symbol[] CreateArgSymbolArray(MethodDefinition method, ParameterHandleCollection parameters)
+        {
+            // ReSharper disable once NotDisposedResource
+            return method.IsStaticMethod() ?
+                       new Symbol[parameters.Count] :
+                       MetadataReader.GetParameter(parameters.GetEnumerator().Current).IsHiddenThis() ?
+                           new Symbol[parameters.Count] : new Symbol[parameters.Count + 1];
         }
 
         private string[]? GetClassBaseClassNames(TypeDefinition type)

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsExtensions.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolsExtensions.cs
@@ -2,6 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+
 #nullable enable
 
 using System.Reflection;
@@ -43,24 +44,24 @@ internal static class SymbolsExtensions
         switch (handle)
         {
             case { Kind: HandleKind.TypeDefinition }:
-                {
-                    return ((TypeDefinitionHandle)handle).FullName(metadataReader);
-                }
+            {
+                return ((TypeDefinitionHandle)handle).FullName(metadataReader);
+            }
 
             case { Kind: HandleKind.TypeReference }:
-                {
-                    return ((TypeReferenceHandle)handle).FullName(metadataReader, false);
-                }
+            {
+                return ((TypeReferenceHandle)handle).FullName(metadataReader, false);
+            }
 
             case { Kind: HandleKind.TypeSpecification }:
-                {
-                    return ((TypeSpecificationHandle)handle).FullName(metadataReader);
-                }
+            {
+                return ((TypeSpecificationHandle)handle).FullName(metadataReader);
+            }
 
             default:
-                {
-                    return "Unknown";
-                }
+            {
+                return "Unknown";
+            }
         }
     }
 
@@ -68,5 +69,15 @@ internal static class SymbolsExtensions
     {
         var typeAttributes = typeDefinition.Attributes;
         return (typeAttributes & TypeAttributes.Interface) == TypeAttributes.Interface;
+    }
+
+    internal static bool IsHiddenThis(this Parameter parameter)
+    {
+        return parameter.SequenceNumber == -2;
+    }
+
+    internal static bool IsStaticMethod(this MethodDefinition method)
+    {
+        return (method.Attributes & System.Reflection.MethodAttributes.Static) > 0;
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.AsyncMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.AsyncMethod.verified.txt
@@ -40,6 +40,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.AsyncMethod",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -55,6 +63,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.AsyncMethod+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",
@@ -88,7 +104,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.AsyncMethod",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.ComprehensiveLinqWithClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.ComprehensiveLinqWithClosure.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.ComprehensiveLinqWithClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -53,6 +61,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.ComprehensiveLinqWithClosure+<>c__DisplayClass0_0",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "i",
                       "type": "System.Int32",
@@ -91,7 +105,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.ComprehensiveLinqWithClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.ComprehensiveLinqWithoutClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.ComprehensiveLinqWithoutClosure.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.ComprehensiveLinqWithoutClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -53,6 +61,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.ComprehensiveLinqWithoutClosure+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "i",
                       "type": "System.Int32",
@@ -97,7 +111,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.ComprehensiveLinqWithoutClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.EmptyType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.EmptyType.verified.txt
@@ -32,7 +32,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.EmptyType",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedAndNotHoistedLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedAndNotHoistedLocals.verified.txt
@@ -55,6 +55,12 @@
               },
               "symbols": [
                 {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
+                {
                   "name": "service",
                   "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals+IService",
                   "symbol_type": "arg",
@@ -80,6 +86,12 @@
                 "end_column": 999
               },
               "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
                 {
                   "name": "name",
                   "type": "System.String",
@@ -117,6 +129,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals+<AssignRoom>d__3",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",
@@ -168,6 +188,12 @@
               },
               "symbols": [
                 {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
+                {
                   "name": "name",
                   "type": "System.String",
                   "symbol_type": "arg",
@@ -196,6 +222,12 @@
                 "end_column": 999
               },
               "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
                 {
                   "name": "name",
                   "type": "System.String",
@@ -239,6 +271,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals+Service",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "person",
                       "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+Person",
                       "symbol_type": "arg",
@@ -262,7 +300,15 @@
                       "sanitized"
                     ],
                     "return_type": "System.Void"
-                  }
+                  },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedAndNotHoistedLocals+Service",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ]
                 }
               ]
             }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedLocalsAndArgsInStateMachine.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.HoistedLocalsAndArgsInStateMachine.verified.txt
@@ -60,7 +60,15 @@
                   "async"
                 ],
                 "return_type": "System.Threading.Tasks.Task"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             },
             {
               "scope_type": "method",
@@ -80,6 +88,12 @@
                 "end_column": 999
               },
               "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
                 {
                   "name": "id",
                   "type": "System.Int32",
@@ -111,6 +125,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+<DoAsyncWork>d__3",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",
@@ -162,7 +184,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             },
             {
               "scope_type": "class",
@@ -243,6 +273,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+Person",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "Name",
                       "type": "System.String",
                       "symbol_type": "arg",
@@ -278,7 +314,15 @@
                     "return_type": "System.String",
                     "start_column": 999,
                     "end_column": 999
-                  }
+                  },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+Person",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ]
                 }
               ]
             },
@@ -347,6 +391,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+Address",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "Name",
                       "type": "System.String",
                       "symbol_type": "arg",
@@ -376,7 +426,15 @@
                     "return_type": "System.String",
                     "start_column": 999,
                     "end_column": 999
-                  }
+                  },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.HoistedLocalsAndArgsInStateMachine+Address",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ]
                 }
               ]
             }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithClosure.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -52,6 +60,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithClosure+<>c__DisplayClass0_0",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",
@@ -103,7 +119,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithFieldClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithFieldClosure.verified.txt
@@ -49,7 +49,15 @@
                 "return_type": "System.Void",
                 "start_column": 999,
                 "end_column": 999
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithFieldClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             },
             {
               "scope_type": "method",
@@ -65,6 +73,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithFieldClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -80,6 +96,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithFieldClosure",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithStaticFieldClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithStaticFieldClosure.verified.txt
@@ -52,7 +52,15 @@
                 "return_type": "System.Void",
                 "start_column": 999,
                 "end_column": 999
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithStaticFieldClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             },
             {
               "scope_type": "method",
@@ -68,6 +76,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithStaticFieldClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -83,6 +99,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithStaticFieldClosure+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithoutClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LambdaWithoutClosure.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithoutClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -52,6 +60,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithoutClosure+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",
@@ -109,7 +125,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LambdaWithoutClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LocalConstants.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LocalConstants.verified.txt
@@ -39,6 +39,12 @@
               },
               "symbols": [
                 {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LocalConstants",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
+                {
                   "name": "arg",
                   "type": "System.Double",
                   "symbol_type": "arg",
@@ -124,6 +130,12 @@
               },
               "symbols": [
                 {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LocalConstants",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
+                {
                   "name": "result",
                   "type": "System.Double",
                   "symbol_type": "arg",
@@ -153,7 +165,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LocalConstants",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LocalFunctionWithClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LocalFunctionWithClosure.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LocalFunctionWithClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -99,7 +107,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LocalFunctionWithClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LocalFunctionWithoutClosure.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.LocalFunctionWithoutClosure.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LocalFunctionWithoutClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -106,7 +114,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.LocalFunctionWithoutClosure",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleClosuresMultipleHoisted.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleClosuresMultipleHoisted.verified.txt
@@ -39,6 +39,12 @@
               },
               "symbols": [
                 {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
+                {
                   "name": "argument1",
                   "type": "System.Int32",
                   "symbol_type": "arg",
@@ -68,6 +74,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "t1",
                       "type": "System.Int32",
                       "symbol_type": "arg",
@@ -90,6 +102,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "t2",
                       "type": "System.Int32",
@@ -114,6 +132,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "i1",
                       "type": "System.Int32",
                       "symbol_type": "arg",
@@ -137,6 +161,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "i2",
                       "type": "System.Int32",
                       "symbol_type": "arg",
@@ -159,6 +189,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "i3",
                       "type": "System.Int32",
@@ -188,6 +224,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted+<>c__DisplayClass0_0",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "i5",
                       "type": "System.Int32",
@@ -226,7 +268,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleClosuresMultipleHoisted",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleHoistedLocals.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleHoistedLocals.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleHoistedLocals",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -52,6 +60,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleHoistedLocals+<>c__DisplayClass0_0",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",
@@ -103,7 +119,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleHoistedLocals",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleHoistedLocalsInStateMachine.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleHoistedLocalsInStateMachine.verified.txt
@@ -40,6 +40,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleHoistedLocalsInStateMachine",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -58,6 +66,14 @@
                     "start_column": 999,
                     "end_column": 999
                   },
+                  "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleHoistedLocalsInStateMachine+<DoAsyncWork>d__0",
+                      "symbol_type": "arg",
+                      "line": 0
+                    }
+                  ],
                   "scopes": [
                     {
                       "scope_type": "local",
@@ -121,7 +137,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleHoistedLocalsInStateMachine",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleScopes.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.MultipleScopes.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleScopes",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "local",
@@ -164,7 +172,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.MultipleScopes",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.NestedFluentLinq.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.NestedFluentLinq.verified.txt
@@ -37,6 +37,14 @@
                 "start_column": 999,
                 "end_column": 999
               },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ],
               "scopes": [
                 {
                   "scope_type": "closure",
@@ -53,6 +61,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "a",
                       "type": "System.Int32",
@@ -77,6 +91,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "b",
                       "type": "System.Int32",
                       "symbol_type": "arg",
@@ -99,6 +119,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "c",
                       "type": "System.Int32",
@@ -123,6 +149,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "d",
                       "type": "System.Int32",
                       "symbol_type": "arg",
@@ -146,6 +178,12 @@
                   },
                   "symbols": [
                     {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
+                    {
                       "name": "e",
                       "type": "System.Int32",
                       "symbol_type": "arg",
@@ -168,6 +206,12 @@
                     "end_column": 999
                   },
                   "symbols": [
+                    {
+                      "name": "this",
+                      "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq+<>c",
+                      "symbol_type": "arg",
+                      "line": 0
+                    },
                     {
                       "name": "f",
                       "type": "System.Int32",
@@ -212,7 +256,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.NestedFluentLinq",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.PartialClass.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.PartialClass.verified.txt
@@ -66,7 +66,15 @@
                 "return_type": "System.Void",
                 "start_column": 999,
                 "end_column": 999
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.PartialClass",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             },
             {
               "scope_type": "method",
@@ -83,6 +91,12 @@
                 "end_column": 999
               },
               "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.PartialClass",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
                 {
                   "name": "i",
                   "type": "System.Int32",
@@ -132,6 +146,12 @@
                 "end_column": 999
               },
               "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.PartialClass",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
                 {
                   "name": "i",
                   "type": "System.Int32",

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.SameLocalNameDifferentScope.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolExtractor/Approvals/SymbolExtractorTest.SameLocalNameDifferentScope.verified.txt
@@ -39,6 +39,12 @@
               },
               "symbols": [
                 {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.SameLocalNameDifferentScope",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
+                {
                   "name": "arg",
                   "type": "System.Double",
                   "symbol_type": "arg",
@@ -118,6 +124,12 @@
               },
               "symbols": [
                 {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.SameLocalNameDifferentScope",
+                  "symbol_type": "arg",
+                  "line": 0
+                },
+                {
                   "name": "result",
                   "type": "System.Double",
                   "symbol_type": "arg",
@@ -141,7 +153,15 @@
                   "sanitized"
                 ],
                 "return_type": "System.Void"
-              }
+              },
+              "symbols": [
+                {
+                  "name": "this",
+                  "type": "Datadog.Trace.Tests.Debugger.SymbolsTests.TestSamples.SameLocalNameDifferentScope",
+                  "symbol_type": "arg",
+                  "line": 0
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
## Summary of changes
Add the hidden `this` parameter of instance method to the method arguments symbols

## Test coverage
All existing symbol tests
