### PR TITLE
Remove span count assertions from Azure Function tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AzureFunctionsTests.cs
@@ -161,7 +161,6 @@ public abstract class AzureFunctionsTests : TestHelper
                 var filteredSpans = spans.Where(s => !s.Resource.Equals("Timer ExitApp", StringComparison.OrdinalIgnoreCase)).ToImmutableList();
 
                 using var s = new AssertionScope();
-                filteredSpans.Count.Should().Be(expectedSpanCount);
 
                 await AssertInProcessSpans(filteredSpans);
             }
@@ -193,7 +192,6 @@ public abstract class AzureFunctionsTests : TestHelper
                 var spans = agent.WaitForSpans(expectedSpanCount);
 
                 using var s = new AssertionScope();
-                spans.Count.Should().Be(expectedSpanCount);
 
                 await AssertIsolatedSpans(spans);
             }


### PR DESCRIPTION
## Summary of changes

Remove the count assertion from AzureFunctions tests

## Reason for change

We've seen a couple of flakes from this test where we get `Expected spans.Count to be 21, but found 22.` Unfortunately, this gives us nothing to investigate. We already have snapshots, so this assertion blocks us seeing the more valuable data

## Implementation details

Removed the count assertion

## Test coverage



## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
