### PR TITLE
Refactor `LifetimeManager` callbacks for `UnhandledException`

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -17,7 +17,6 @@ src/Datadog.Trace/IScopeRawAccess.cs
 src/Datadog.Trace/ISpan.cs
 src/Datadog.Trace/ISpanContext.cs
 src/Datadog.Trace/ITracer.cs
-src/Datadog.Trace/LifetimeManager.cs
 src/Datadog.Trace/Metrics.cs
 src/Datadog.Trace/NativeLoader.cs
 src/Datadog.Trace/OSPlatformName.cs

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -484,7 +484,7 @@ namespace Datadog.Trace.AppSec
 
         internal IContext? CreateAdditiveContext() => _waf?.CreateContext();
 
-        private void RunShutdown()
+        private void RunShutdown(Exception? ex)
         {
             if (_rcmSubscription != null)
             {

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -157,14 +157,14 @@ namespace Datadog.Trace.Ci
                 {
                     Log.Information("ITR: Update and uploading git tree metadata and getting skippable tests.");
                     _skippableTestsTask = GetIntelligentTestRunnerSkippableTestsAsync();
-                    LifetimeManager.Instance.AddAsyncShutdownTask(ex => _skippableTestsTask);
+                    LifetimeManager.Instance.AddAsyncShutdownTask(_ => _skippableTestsTask);
                 }
                 else if (settings.GitUploadEnabled != false)
                 {
                     // Update and upload git tree metadata.
                     Log.Information("ITR: Update and uploading git tree metadata.");
                     var tskItrUpdate = UploadGitMetadataAsync();
-                    LifetimeManager.Instance.AddAsyncShutdownTask(ex => tskItrUpdate);
+                    LifetimeManager.Instance.AddAsyncShutdownTask(_ => tskItrUpdate);
                 }
             }
             else if (settings.IntelligentTestRunnerEnabled)
@@ -848,7 +848,7 @@ namespace Datadog.Trace.Ci
             public DiscoveryAgentConfigurationCallback(IDiscoveryService discoveryService)
             {
                 _manualResetEventSlim = new ManualResetEventSlim();
-                LifetimeManager.Instance.AddShutdownTask(ex => _manualResetEventSlim.Set());
+                LifetimeManager.Instance.AddShutdownTask(_ => _manualResetEventSlim.Set());
                 _discoveryService = discoveryService;
                 _callback = CallBack;
                 _agentConfiguration = null;

--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -157,14 +157,14 @@ namespace Datadog.Trace.Ci
                 {
                     Log.Information("ITR: Update and uploading git tree metadata and getting skippable tests.");
                     _skippableTestsTask = GetIntelligentTestRunnerSkippableTestsAsync();
-                    LifetimeManager.Instance.AddAsyncShutdownTask(() => _skippableTestsTask);
+                    LifetimeManager.Instance.AddAsyncShutdownTask(ex => _skippableTestsTask);
                 }
                 else if (settings.GitUploadEnabled != false)
                 {
                     // Update and upload git tree metadata.
                     Log.Information("ITR: Update and uploading git tree metadata.");
                     var tskItrUpdate = UploadGitMetadataAsync();
-                    LifetimeManager.Instance.AddAsyncShutdownTask(() => tskItrUpdate);
+                    LifetimeManager.Instance.AddAsyncShutdownTask(ex => tskItrUpdate);
                 }
             }
             else if (settings.IntelligentTestRunnerEnabled)
@@ -536,12 +536,10 @@ namespace Datadog.Trace.Ci
             _skippableTestsBySuiteAndName = null;
         }
 
-        private static async Task ShutdownAsync()
+        private static async Task ShutdownAsync(Exception? exception)
         {
             // Let's close any opened test, suite, modules and sessions before shutting down to avoid losing any data.
             // But marking them as failed.
-
-            var exception = LifetimeManager.Instance.CurrentException;
 
             foreach (var test in Test.ActiveTests)
             {
@@ -850,7 +848,7 @@ namespace Datadog.Trace.Ci
             public DiscoveryAgentConfigurationCallback(IDiscoveryService discoveryService)
             {
                 _manualResetEventSlim = new ManualResetEventSlim();
-                LifetimeManager.Instance.AddShutdownTask(() => _manualResetEventSlim.Set());
+                LifetimeManager.Instance.AddShutdownTask(ex => _manualResetEventSlim.Set());
                 _discoveryService = discoveryService;
                 _callback = CallBack;
                 _agentConfiguration = null;

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -533,7 +533,7 @@ namespace Datadog.Trace.ClrProfiler
         {
             var tc = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             // Stop waiting if we're shutting down
-            LifetimeManager.Instance.AddShutdownTask(ex => tc.TrySetResult(false));
+            LifetimeManager.Instance.AddShutdownTask(_ => tc.TrySetResult(false));
 
             discoveryService.SubscribeToChanges(Callback);
             return await tc.Task.ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -234,7 +234,7 @@ namespace Datadog.Trace.ClrProfiler
             Log.Debug("Legacy Initialization finished.");
         }
 
-        private static void RunShutdown()
+        private static void RunShutdown(Exception ex)
         {
             InstrumentationDefinitions.Dispose();
             NativeCallTargetUnmanagedMemoryHelper.Free();
@@ -533,7 +533,7 @@ namespace Datadog.Trace.ClrProfiler
         {
             var tc = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             // Stop waiting if we're shutting down
-            LifetimeManager.Instance.AddShutdownTask(() => tc.TrySetResult(false));
+            LifetimeManager.Instance.AddShutdownTask(ex => tc.TrySetResult(false));
 
             discoveryService.SubscribeToChanges(Callback);
             return await tc.Task.ConfigureAwait(false);

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
@@ -135,7 +135,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             _snapshotSink.Add(probeId, snapshot);
         }
 
-        public static void Dispose()
+        public static void Dispose(Exception? ex)
         {
             ExceptionTrackManager.Dispose();
             _uploader?.Dispose();

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -182,7 +182,7 @@ namespace Datadog.Trace.Debugger
                 return _snapshotUploader.StartFlushingAsync();
             }
 
-            void ShutdownTask()
+            void ShutdownTask(Exception ex)
             {
                 _discoveryService.RemoveSubscription(DiscoveryCallback);
                 _snapshotUploader.Dispose();

--- a/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
@@ -113,7 +113,7 @@ internal class HardcodedSecretsAnalyzer : IDisposable
             if (_instance == null)
             {
                 _instance = new HardcodedSecretsAnalyzer(regexTimeout);
-                LifetimeManager.Instance.AddShutdownTask(ex => _instance.Dispose());
+                LifetimeManager.Instance.AddShutdownTask(_ => _instance.Dispose());
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/Iast/Analyzers/HardcodedSecretsAnalyzer.cs
@@ -113,7 +113,7 @@ internal class HardcodedSecretsAnalyzer : IDisposable
             if (_instance == null)
             {
                 _instance = new HardcodedSecretsAnalyzer(regexTimeout);
-                LifetimeManager.Instance.AddShutdownTask(_instance.Dispose);
+                LifetimeManager.Instance.AddShutdownTask(ex => _instance.Dispose());
             }
         }
     }

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
@@ -19,7 +21,7 @@ namespace Datadog.Trace
     internal class LifetimeManager
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<LifetimeManager>();
-        private static LifetimeManager _instance;
+        private static LifetimeManager? _instance;
         private readonly ConcurrentQueue<object> _shutdownHooks = new();
 
         public LifetimeManager()
@@ -60,7 +62,7 @@ namespace Datadog.Trace
 
         public TimeSpan TaskTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
-        public Exception CurrentException { get; private set; }
+        public Exception? CurrentException { get; private set; }
 
         public void AddShutdownTask(Action action)
         {
@@ -72,13 +74,13 @@ namespace Datadog.Trace
             _shutdownHooks.Enqueue(func);
         }
 
-        private void CurrentDomain_ProcessExit(object sender, EventArgs e)
+        private void CurrentDomain_ProcessExit(object? sender, EventArgs e)
         {
             RunShutdownTasks();
             AppDomain.CurrentDomain.ProcessExit -= CurrentDomain_ProcessExit;
         }
 
-        private void CurrentDomain_UnhandledException(object sender, UnhandledExceptionEventArgs e)
+        private void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
         {
             Log.Warning("Application threw an unhandled exception: {Exception}", e.ExceptionObject);
             CurrentException = e.ExceptionObject as Exception;
@@ -86,13 +88,13 @@ namespace Datadog.Trace
             AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;
         }
 
-        private void Console_CancelKeyPress(object sender, ConsoleCancelEventArgs e)
+        private void Console_CancelKeyPress(object? sender, ConsoleCancelEventArgs e)
         {
             RunShutdownTasks();
             Console.CancelKeyPress -= Console_CancelKeyPress;
         }
 
-        private void CurrentDomain_DomainUnload(object sender, EventArgs e)
+        private void CurrentDomain_DomainUnload(object? sender, EventArgs e)
         {
             RunShutdownTasks();
             AppDomain.CurrentDomain.DomainUnload -= CurrentDomain_DomainUnload;
@@ -138,7 +140,7 @@ namespace Datadog.Trace
                 DatadogLogging.CloseAndFlush();
             }
 
-            static void SetSynchronizationContext(SynchronizationContext context)
+            static void SetSynchronizationContext(SynchronizationContext? context)
             {
                 if (!AppDomain.CurrentDomain.IsFullyTrusted)
                 {

--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -56,7 +56,7 @@ namespace Datadog.Trace
         {
             get
             {
-                return LazyInitializer.EnsureInitialized(ref _instance);
+                return LazyInitializer.EnsureInitialized(ref _instance)!;
             }
         }
 

--- a/tracer/src/Datadog.Trace/TraceClock.cs
+++ b/tracer/src/Datadog.Trace/TraceClock.cs
@@ -24,7 +24,7 @@ internal sealed class TraceClock
     static TraceClock()
     {
         TokenSource = new CancellationTokenSource();
-        LifetimeManager.Instance.AddShutdownTask(ex => TokenSource.Cancel());
+        LifetimeManager.Instance.AddShutdownTask(_ => TokenSource.Cancel());
         _instance = new TraceClock();
         _ = UpdateClockAsync();
     }

--- a/tracer/src/Datadog.Trace/TraceClock.cs
+++ b/tracer/src/Datadog.Trace/TraceClock.cs
@@ -24,7 +24,7 @@ internal sealed class TraceClock
     static TraceClock()
     {
         TokenSource = new CancellationTokenSource();
-        LifetimeManager.Instance.AddShutdownTask(() => TokenSource.Cancel());
+        LifetimeManager.Instance.AddShutdownTask(ex => TokenSource.Cancel());
         _instance = new TraceClock();
         _ = UpdateClockAsync();
     }

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -662,7 +662,7 @@ namespace Datadog.Trace
             _heartbeatTimer = new Timer(HeartbeatCallback, state: null, dueTime: TimeSpan.Zero, period: TimeSpan.FromMinutes(1));
         }
 
-        private static Task RunShutdownTasksAsync() => RunShutdownTasksAsync(_instance, _heartbeatTimer);
+        private static Task RunShutdownTasksAsync(Exception ex) => RunShutdownTasksAsync(_instance, _heartbeatTimer);
 
         private static async Task RunShutdownTasksAsync(TracerManager instance, Timer heartbeatTimer)
         {

--- a/tracer/src/Datadog.Trace/Util/AsyncUtil.cs
+++ b/tracer/src/Datadog.Trace/Util/AsyncUtil.cs
@@ -73,6 +73,30 @@ internal static class AsyncUtil
     }
 
     /// <summary>
+    /// Executes an async Task method which has a void return value synchronously
+    /// USAGE: AsyncUtil.RunSync(ex => AsyncMethod(ex), new Exception(), millisecondsTimeout);
+    /// </summary>
+    /// <param name="task">Task method to execute</param>
+    /// <param name="state">State that is passed to the running function</param>
+    /// <param name="millisecondsTimeout">Timeout in milliseconds</param>
+    public static void RunSync<T>(Func<T, Task> task, T state, int millisecondsTimeout)
+    {
+        _taskFactory
+           .StartNew(TaskWithTimeoutAsync)
+           .Unwrap()
+           .GetAwaiter()
+           .GetResult();
+
+        Task TaskWithTimeoutAsync()
+        {
+            var runTask = task(state);
+            return runTask.IsCompleted
+                       ? runTask
+                       : runTask.WaitAsync(TimeSpan.FromMilliseconds(millisecondsTimeout));
+        }
+    }
+
+    /// <summary>
     /// Executes an async Task[T] method which has a T return type synchronously
     /// USAGE: T result = AsyncUtil.RunSync(() => AsyncMethod[T]());
     /// </summary>


### PR DESCRIPTION
## Summary of changes

- Change the callbacks from `Action`/`Func<Task>` to `Action<Exception?>`/`Func<Exception?, Task`

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/5549 we needed to track when the application was shutting down from an UnhandledException, and use this information in the shutdown callbacks. That PR added a public static property for simplicity. This PR refactors that slightly, so that there's no static state to check, and instead we pass the `Exception` directly to the callbacks.

## Implementation details

Mostly just changed the definition of the callbacks to accept an `Exception?`. 

I considered creating a "context" object something like this:

```csharp
public class ShutdownContext
{
    public Exception UnhandledException { get; }
}
```

which would be future-proof, but it seems a bit overkill at this stage, especially as it's an easy refactoring to make.

## Test coverage

Covered by existing tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
