### PR TITLE
[CIVisibility] Fix test.command tag value

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -7,6 +7,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
+using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.Logging;
 using Spectre.Console;
 
@@ -48,6 +49,13 @@ namespace Datadog.Trace.Tools.Runner
             // Final command to execute
             var arguments = Utils.GetArgumentsAsString(initResults.Arguments);
             var command = $"{program} {arguments}".Trim();
+
+            // Propagate original test command and working directory
+            if (initResults.ProfilerEnvironmentVariables is { } profilerEnvironmentVariables)
+            {
+                profilerEnvironmentVariables[TestSuiteVisibilityTags.TestSessionCommandEnvironmentVariable] = Environment.CommandLine;
+                profilerEnvironmentVariables[TestSuiteVisibilityTags.TestSessionWorkingDirectoryEnvironmentVariable] = Environment.CurrentDirectory;
+            }
 
             // Run child process
             AnsiConsole.WriteLine("Running: " + command);

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
@@ -60,7 +60,19 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
             // We create a test session if the flag is turned on (agentless or evp proxy)
             if (agentless || isEvpProxy)
             {
-                var session = TestSession.InternalGetOrCreate(Environment.CommandLine, null, null, null, true);
+                // Try to load the command line propagated from the dd-trace ci run command
+                if (EnvironmentHelpers.GetEnvironmentVariable(TestSuiteVisibilityTags.TestSessionCommandEnvironmentVariable) is not { Length: > 0 } commandLine)
+                {
+                    commandLine = Environment.CommandLine;
+                }
+
+                // Try to load the working directory propagated from the dd-trace ci run command
+                if (EnvironmentHelpers.GetEnvironmentVariable(TestSuiteVisibilityTags.TestSessionWorkingDirectoryEnvironmentVariable) is not { Length: > 0 } workingDirectory)
+                {
+                    workingDirectory = Environment.CurrentDirectory;
+                }
+
+                var session = TestSession.InternalGetOrCreate(commandLine, workingDirectory, null, null, true);
                 session.SetTag(IntelligentTestRunnerTags.TestTestsSkippingEnabled, ciVisibilitySettings.TestsSkippingEnabled == true ? "true" : "false");
                 session.SetTag(CodeCoverageTags.Enabled, ciVisibilitySettings.CodeCoverageEnabled == true ? "true" : "false");
                 if (ciVisibilitySettings.EarlyFlakeDetectionEnabled == true)


### PR DESCRIPTION
## Summary of changes

This PR fixes the `test.command` value in CI Visibility spans.

## Reason for change

Currently we are creating the TestSession object by instrumenting the `dotnet` command, so an example of the value we get  looks like:

<img width="586" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/4e5bf041-9b86-4548-8401-6d7fbda5f4ee">

The `test.command` tag should be closer to the command written by the customer when running their tests. Something that's not happening here.

With the fix now the `test.command` value is reported as:

<img width="615" alt="image" src="https://github.com/DataDog/dd-trace-dotnet/assets/69803/2d0d97cf-33cd-4e67-ae32-4d63ba767888">



## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
