### PR TITLE
[CIVisibility] Add a code coverage injection session tag

### DIFF
--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -9,9 +9,13 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
-using Datadog.Trace.Ci.Configuration;
 using Datadog.Trace.Ci.Coverage.Exceptions;
+using Datadog.Trace.Ci.Ipc;
+using Datadog.Trace.Ci.Ipc.Messages;
+using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ClrProfiler;
+using Datadog.Trace.Propagators;
+using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
@@ -295,6 +299,33 @@ namespace Datadog.Trace.Coverage.Collector
             }
 
             _logger?.Warning($"Processed {numAssemblies} assemblies in folder: {folder}");
+
+            // The following is just a best effor approach to indicate the test session that
+            // we sucessfully instrumented all assemblies to collect code coverage.
+            // Is not part of the spec but useful for support tickets.
+            // If we instrument at least 1 assembly we extract session variables (from out of process sessions)
+            // and try to send a message to the IPC server for setting the test.code_coverage.injected tag.
+            if (numAssemblies > 0 &&
+                SpanContextPropagator.Instance.Extract(
+                    EnvironmentHelpers.GetEnvironmentVariables(),
+                    new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor)) is { } sessionContext)
+            {
+                try
+                {
+                    var name = $"session_{sessionContext.SpanId}";
+                    _logger?.Debug($"CoverageCollector.Enabling IPC client: {name} and sending injection tags");
+                    using var ipcClient = new IpcClient(name);
+                    ipcClient.TrySendMessage(new SetSessionTagMessage(CodeCoverageTags.Instrumented, "true"));
+                }
+                catch (Exception ex)
+                {
+                    _logger?.Debug("Error enabling IPC client and sending coverage data: " + ex);
+                }
+            }
+            else
+            {
+                _logger?.Debug($"CoverageCollector.Test session context cannot be found, skipping IPC client and sending injection tags");
+            }
         }
 
         /// <inheritdoc />

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -300,7 +300,7 @@ namespace Datadog.Trace.Coverage.Collector
 
             _logger?.Warning($"Processed {numAssemblies} assemblies in folder: {folder}");
 
-            // The following is just a best effor approach to indicate the test session that
+            // The following is just a best effort approach to indicate in the test session that
             // we sucessfully instrumented all assemblies to collect code coverage.
             // Is not part of the spec but useful for support tickets.
             // If we instrument at least 1 assembly we extract session variables (from out of process sessions)

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -303,7 +303,7 @@ namespace Datadog.Trace.Coverage.Collector
             // The following is just a best effort approach to indicate in the test session that
             // we sucessfully instrumented all assemblies to collect code coverage.
             // Is not part of the spec but useful for support tickets.
-            // If we instrument at least 1 assembly we extract session variables (from out of process sessions)
+            // We try to extract session variables (from out of process sessions)
             // and try to send a message to the IPC server for setting the test.code_coverage.injected tag.
             if (SpanContextPropagator.Instance.Extract(
                     EnvironmentHelpers.GetEnvironmentVariables(),

--- a/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
+++ b/tracer/src/Datadog.Trace.Coverage.collector/CoverageCollector.cs
@@ -305,8 +305,7 @@ namespace Datadog.Trace.Coverage.Collector
             // Is not part of the spec but useful for support tickets.
             // If we instrument at least 1 assembly we extract session variables (from out of process sessions)
             // and try to send a message to the IPC server for setting the test.code_coverage.injected tag.
-            if (numAssemblies > 0 &&
-                SpanContextPropagator.Instance.Extract(
+            if (SpanContextPropagator.Instance.Extract(
                     EnvironmentHelpers.GetEnvironmentVariables(),
                     new DictionaryGetterAndSetter(DictionaryGetterAndSetter.EnvironmentVariableKeyProcessor)) is { } sessionContext)
             {
@@ -315,7 +314,7 @@ namespace Datadog.Trace.Coverage.Collector
                     var name = $"session_{sessionContext.SpanId}";
                     _logger?.Debug($"CoverageCollector.Enabling IPC client: {name} and sending injection tags");
                     using var ipcClient = new IpcClient(name);
-                    ipcClient.TrySendMessage(new SetSessionTagMessage(CodeCoverageTags.Instrumented, "true"));
+                    ipcClient.TrySendMessage(new SetSessionTagMessage(CodeCoverageTags.Instrumented, numAssemblies > 0 ? "true" : "false"));
                 }
                 catch (Exception ex)
                 {

--- a/tracer/src/Datadog.Trace/Ci/Tags/CodeCoverageTags.cs
+++ b/tracer/src/Datadog.Trace/Ci/Tags/CodeCoverageTags.cs
@@ -19,4 +19,9 @@ internal static class CodeCoverageTags
     /// Code coverage global percentage value
     /// </summary>
     public const string PercentageOfTotalLines = "test.code_coverage.lines_pct";
+
+    /// <summary>
+    /// Test Session Code Coverage is instrumented flag
+    /// </summary>
+    public const string Instrumented = "test.code_coverage.instrumented";
 }


### PR DESCRIPTION
## Summary of changes

This PR adds a TestSession tag (using IPC) from the code coverage collector to indicate that we were able to rewrite the bytecode with our custom code coverage library.

## Reason for change

We automatically inject the DataCollector when Intelligent Test Runner is enabled, but we currently don't have a way to detect if the data collector did his job, with this tag along with the previous ones we are able to know if a test session had the code coverage enabled and if the datacollector processed the assemblies. Something very useful for support tickets.

