### PR TITLE
Don't instrument most `dotnet` SDK calls

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -199,8 +199,8 @@ namespace datadog::shared::nativeloader
                         {
                             const auto current_token = tokenized_command_line[i];
                             if(!current_token.empty() &&
-                                (current_token.ends_with(WStr("csc.dll"))
-                                    || current_token.ends_with(WStr("VBCSCompiler.dll"))))
+                                (EndsWith(current_token, WStr("csc.dll"))
+                                    || EndsWith(current_token, WStr("VBCSCompiler.dll"))))
                             {
                                 is_ignored_command = true;
                                 break;

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -158,13 +158,16 @@ namespace datadog::shared::nativeloader
             // We don't want to instrument _build_ processes in dotnet by default, as they generally
             // don't give useful information, add latency, and risk triggering bugs in the runtime,
             // particularly around shutdown, like this one: https://github.com/dotnet/runtime/issues/55441
-            const auto process_command_line = GetCurrentProcessCommandLine();
+            const auto command_line = GetCurrentProcessCommandLine();
+            const auto process_command_line = std::get<0>(command_line);
+            const auto command_line_arguments = std::get<1>(command_line);
             Log::Info("Process CommandLine: ", process_command_line);
 
             if (!process_command_line.empty())
             {
                 const auto isDotNetProcess = process_name == WStr("dotnet") || process_name == WStr("dotnet.exe");
-                if (isDotNetProcess)
+                const auto arg_count = command_line_arguments.size();
+                if (isDotNetProcess && arg_count > 1)
                 {
                     // Exclude:
                     // - dotnet build, dotnet build myproject.csproj etc  
@@ -185,45 +188,40 @@ namespace datadog::shared::nativeloader
                     // i.e. dotnet test
                     // i.e. dotnet vstest
                     // i.e. dotnet exec (except specific commands)
-                    int arg_count;
-                    const auto command_line_arguments = GetCurrentProcessCommandLineArguments(&arg_count);
                     bool is_ignored_command = false;
-                    if(arg_count > 1)
+                    const auto arg1 = command_line_arguments[1];
+                    if(arg1 == WStr("exec"))
                     {
-                        const auto arg1 = command_line_arguments[1];
-                        if(arg1 == WStr("exec"))
+                        // compiler is invoked with arguments something like this:
+                        // dotnet exec /usr/share/dotnet/sdk/6.0.400/Roslyn/bincore/csc.dll /noconfig @/tmp/tmp8895f601306443a6a54388ecc6dcfc44.rsp
+                        // so we check the arguments to see if any of them are an invocation of one of the dlls we want to ignore.
+                        // We don't just check the second argument because the command could set additional flags
+                        // for the exec function
+                        for (int i = 2; i < arg_count; ++i)
                         {
-                            // compiler is invoked with arguments something like this:
-                            // dotnet exec /usr/share/dotnet/sdk/6.0.400/Roslyn/bincore/csc.dll /noconfig @/tmp/tmp8895f601306443a6a54388ecc6dcfc44.rsp
-                            // so we check the arguments to see if any of them are an invocation of one of the dlls we want to ignore.
-                            // We don't just check the second argument because the command could set additional flags
-                            // for the exec function
-                            for (int i = 2; i < arg_count; ++i)
+                            const auto current_arg = command_line_arguments[i];
+                            if(!current_arg.empty() &&
+                                (current_arg.ends_with(WStr("csc.dll"))
+                                    || current_arg.ends_with(WStr("VBCSCompiler.dll"))))
                             {
-                                const auto current_arg = command_line_arguments[i];
-                                if(!current_arg.empty() &&
-                                    (current_arg.ends_with(WStr("csc.dll"))
-                                        || current_arg.ends_with(WStr("VBCSCompiler.dll"))))
-                                {
-                                    is_ignored_command = true;
-                                    break;
-                                }
+                                is_ignored_command = true;
+                                break;
                             }
                         }
-                        else if(!arg1.empty())
-                        {
-                            is_ignored_command =
-                                arg1 == WStr("build") ||
-                                arg1 == WStr("build-server") ||
-                                arg1 == WStr("clean") ||
-                                arg1 == WStr("msbuild") ||
-                                arg1 == WStr("new") ||
-                                arg1 == WStr("nuget") ||
-                                arg1 == WStr("pack") ||
-                                arg1 == WStr("publish") ||
-                                arg1 == WStr("restore") ||
-                                arg1 == WStr("tool");
-                        }
+                    }
+                    else if(!arg1.empty())
+                    {
+                        is_ignored_command =
+                            arg1 == WStr("build") ||
+                            arg1 == WStr("build-server") ||
+                            arg1 == WStr("clean") ||
+                            arg1 == WStr("msbuild") ||
+                            arg1 == WStr("new") ||
+                            arg1 == WStr("nuget") ||
+                            arg1 == WStr("pack") ||
+                            arg1 == WStr("publish") ||
+                            arg1 == WStr("restore") ||
+                            arg1 == WStr("tool");
                     }
 
                     if (is_ignored_command)

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -158,14 +158,14 @@ namespace datadog::shared::nativeloader
             // We don't want to instrument _build_ processes in dotnet by default, as they generally
             // don't give useful information, add latency, and risk triggering bugs in the runtime,
             // particularly around shutdown, like this one: https://github.com/dotnet/runtime/issues/55441
-           const auto [command_line , process_command_line]  = GetCurrentProcessCommandLine();
+           const auto [process_command_line , tokenized_command_line]  = GetCurrentProcessCommandLine();
             Log::Info("Process CommandLine: ", process_command_line);
 
             if (!process_command_line.empty())
             {
                 const auto isDotNetProcess = process_name == WStr("dotnet") || process_name == WStr("dotnet.exe");
-                const auto arg_count = command_line_arguments.size();
-                if (isDotNetProcess && arg_count > 1)
+                const auto token_count = tokenized_command_line.size();
+                if (isDotNetProcess && token_count > 1)
                 {
                     // Exclude:
                     // - dotnet build, dotnet build myproject.csproj etc  
@@ -187,39 +187,39 @@ namespace datadog::shared::nativeloader
                     // i.e. dotnet vstest
                     // i.e. dotnet exec (except specific commands)
                     bool is_ignored_command = false;
-                    const auto arg1 = command_line_arguments[1];
-                    if(arg1 == WStr("exec"))
+                    const auto token1 = tokenized_command_line[1];
+                    if(token1 == WStr("exec"))
                     {
                         // compiler is invoked with arguments something like this:
                         // dotnet exec /usr/share/dotnet/sdk/6.0.400/Roslyn/bincore/csc.dll /noconfig @/tmp/tmp8895f601306443a6a54388ecc6dcfc44.rsp
                         // so we check the arguments to see if any of them are an invocation of one of the dlls we want to ignore.
                         // We don't just check the second argument because the command could set additional flags
                         // for the exec function
-                        for (int i = 2; i < arg_count; ++i)
+                        for (int i = 2; i < token_count; ++i)
                         {
-                            const auto current_arg = command_line_arguments[i];
-                            if(!current_arg.empty() &&
-                                (current_arg.ends_with(WStr("csc.dll"))
-                                    || current_arg.ends_with(WStr("VBCSCompiler.dll"))))
+                            const auto current_token = tokenized_command_line[i];
+                            if(!current_token.empty() &&
+                                (current_token.ends_with(WStr("csc.dll"))
+                                    || current_token.ends_with(WStr("VBCSCompiler.dll"))))
                             {
                                 is_ignored_command = true;
                                 break;
                             }
                         }
                     }
-                    else if(!arg1.empty())
+                    else if(!token1.empty())
                     {
                         is_ignored_command =
-                            arg1 == WStr("build") ||
-                            arg1 == WStr("build-server") ||
-                            arg1 == WStr("clean") ||
-                            arg1 == WStr("msbuild") ||
-                            arg1 == WStr("new") ||
-                            arg1 == WStr("nuget") ||
-                            arg1 == WStr("pack") ||
-                            arg1 == WStr("publish") ||
-                            arg1 == WStr("restore") ||
-                            arg1 == WStr("tool");
+                            token1 == WStr("build") ||
+                            token1 == WStr("build-server") ||
+                            token1 == WStr("clean") ||
+                            token1 == WStr("msbuild") ||
+                            token1 == WStr("new") ||
+                            token1 == WStr("nuget") ||
+                            token1 == WStr("pack") ||
+                            token1 == WStr("publish") ||
+                            token1 == WStr("restore") ||
+                            token1 == WStr("tool");
                     }
 
                     if (is_ignored_command)

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -158,9 +158,7 @@ namespace datadog::shared::nativeloader
             // We don't want to instrument _build_ processes in dotnet by default, as they generally
             // don't give useful information, add latency, and risk triggering bugs in the runtime,
             // particularly around shutdown, like this one: https://github.com/dotnet/runtime/issues/55441
-            const auto command_line = GetCurrentProcessCommandLine();
-            const auto process_command_line = std::get<0>(command_line);
-            const auto command_line_arguments = std::get<1>(command_line);
+           const auto [command_line , process_command_line]  = GetCurrentProcessCommandLine();
             Log::Info("Process CommandLine: ", process_command_line);
 
             if (!process_command_line.empty())

--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -156,7 +156,7 @@ inline std::tuple<WSTRING, std::vector<WSTRING>> GetCurrentProcessCommandLine()
         name = name + " " + currentArg;
     }
 
-    return { name, args };
+    return { Trim(ToWSTRING(name)), args };
 #else
     std::string cmdline;
     char buf[1024];

--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -149,7 +149,7 @@ inline std::tuple<WSTRING, std::vector<WSTRING>> GetCurrentProcessCommandLine()
     int argCount = *_NSGetArgc();
     char** arguments = *_NSGetArgv();
 
-    for (int i = 0; i < argCount; i++)
+    for (int i = 0; i < *argCount; i++)
     {
         const auto currentArg = std::string(arguments[i]);
         args.push_back(Trim(ToWSTRING(currentArg)));

--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -149,7 +149,7 @@ inline std::tuple<WSTRING, std::vector<WSTRING>> GetCurrentProcessCommandLine()
     int argCount = *_NSGetArgc();
     char** arguments = *_NSGetArgv();
 
-    for (int i = 0; i < *argCount; i++)
+    for (int i = 0; i < argCount; i++)
     {
         const auto currentArg = std::string(arguments[i]);
         args.push_back(Trim(ToWSTRING(currentArg)));

--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -169,11 +169,11 @@ inline std::tuple<WSTRING, std::vector<WSTRING>> GetCurrentProcessCommandLine()
             cmdline.append(buf, len);
         }
     }
+    fclose(fp);
 
     std::string name;
     std::stringstream tokens(cmdline);
     std::string tmp;
-    int i = 0;
     while (getline(tokens, tmp, '\0'))
     {
         name = name + " " + tmp;

--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -168,8 +168,9 @@ inline std::tuple<WSTRING, std::vector<WSTRING>> GetCurrentProcessCommandLine()
         {
             cmdline.append(buf, len);
         }
+
+        fclose(fp);
     }
-    fclose(fp);
 
     std::string name;
     std::stringstream tokens(cmdline);

--- a/shared/src/native-src/pal.h
+++ b/shared/src/native-src/pal.h
@@ -156,7 +156,7 @@ inline std::tuple<WSTRING, std::vector<WSTRING>> GetCurrentProcessCommandLine()
         name = name + " " + currentArg;
     }
 
-    return { cmdLine, args };
+    return { name, args };
 #else
     std::string cmdline;
     char buf[1024];

--- a/shared/src/native-src/string.cpp
+++ b/shared/src/native-src/string.cpp
@@ -130,7 +130,17 @@ namespace shared {
         return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
     }
 
+    bool EndsWith(const WSTRING& str, const WSTRING& suffix)
+    {
+        return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
+    }
+
     bool StartsWith(const std::string &str, const std::string &prefix)
+    {
+        return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
+    }
+
+    bool StartsWith(const WSTRING &str, const WSTRING &prefix)
     {
         return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
     }

--- a/shared/src/native-src/string.h
+++ b/shared/src/native-src/string.h
@@ -57,8 +57,10 @@ WSTRING ToWSTRING(uint64_t i);
 bool TryParse(WSTRING const& s, int& result);
 
 bool EndsWith(const std::string& str, const std::string& suffix);
-
 bool StartsWith(const std::string& str, const std::string& prefix);
+
+bool EndsWith(const WSTRING& str, const WSTRING& suffix);
+bool StartsWith(const WSTRING& str, const WSTRING& prefix);
 
 template <typename TChar>
 std::basic_string<TChar> ReplaceString(std::basic_string<TChar> subject, const std::basic_string<TChar>& search,

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -71,7 +71,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     const auto process_name = shared::GetCurrentProcessName();
     Logger::Info("ProcessName: ", process_name);
 
-    const auto [process_command_line , command_line_arguments ] = GetCurrentProcessCommandLine();
+    const auto [process_command_line , tokenized_command_line ] = GetCurrentProcessCommandLine();
     Logger::Info("Process CommandLine: ", process_command_line);
 
     // CI visibility checks
@@ -83,10 +83,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
             is_ci_visibility_enabled)
         {
             const auto isDotNetProcess = process_name == WStr("dotnet") || process_name == WStr("dotnet.exe");
-            const auto arg_count = command_line_arguments.size();
+            const auto token_count = tokenized_command_line.size();
             if (isDotNetProcess &&
-                arg_count > 1 &&
-                command_line_arguments[1] != WStr("test") &&
+                token_count > 1 &&
+                tokenized_command_line[1] != WStr("test") &&
                 // these are executed with exec, so we could check for that, but the
                 // below check is more conservative, so leaving at that
                 process_command_line.find(WStr("testhost")) == WSTRING::npos &&

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -96,7 +96,6 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
                     "mode, the name is 'dotnet' but the commandline doesn't contain 'testhost'");
                 return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
             }
-                
         }
     }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -71,9 +71,7 @@ HRESULT STDMETHODCALLTYPE CorProfiler::Initialize(IUnknown* cor_profiler_info_un
     const auto process_name = shared::GetCurrentProcessName();
     Logger::Info("ProcessName: ", process_name);
 
-    const auto command_line = GetCurrentProcessCommandLine();
-    const auto process_command_line = std::get<0>(command_line);
-    const auto command_line_arguments = std::get<1>(command_line);
+    const auto [process_command_line , command_line_arguments ] = GetCurrentProcessCommandLine();
     Logger::Info("Process CommandLine: ", process_command_line);
 
     // CI visibility checks

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -1,0 +1,144 @@
+﻿// <copyright file="InstrumentationTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+// There's nothing .NET 8 specific here, it's just that it's identical for all runtimes
+// so there's not really any point in testing it repeatedly
+#if NET8_0
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests
+{
+    public class InstrumentationTests : TestHelper
+    {
+        public InstrumentationTests(ITestOutputHelper output)
+            : base("Instrumentation.Tests", output) // Using a random name here, it doesn't matter
+        {
+            SetServiceVersion("1.0.0");
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task DoesNotInstrumentDotnetBuild()
+        {
+            // run the azure function
+            var workingDir = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
+            Directory.CreateDirectory(workingDir);
+
+            Output.WriteLine("Using workingDirectory: " + workingDir);
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+
+            var logDir = await RunDotnet("new console -n instrumentation_test -o . --no-restore");
+            AssertNotInstrumented(agent, logDir);
+
+            logDir = await RunDotnet("restore");
+            AssertNotInstrumented(agent, logDir);
+
+            logDir = await RunDotnet("build");
+            AssertNotInstrumented(agent, logDir);
+
+            logDir = await RunDotnet("publish");
+            AssertNotInstrumented(agent, logDir);
+
+            return;
+
+            Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task InstrumentsDotNetRun()
+        {
+            // run the azure function
+            var workingDir = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
+            Directory.CreateDirectory(workingDir);
+
+            Output.WriteLine("Using workingDirectory: " + workingDir);
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+
+            var logDir = await RunDotnet("new console -n instrumentation_test -o . --no-restore");
+            AssertNotInstrumented(agent, logDir);
+
+            // this _should_ be instrumented so we expect managed data.
+            // we also expect telemetry, but we end the app so quickly there's a risk of flake
+            logDir = await RunDotnet("run");
+            Directory.GetFiles(logDir).Should().Contain(filename => Path.GetFileName(filename).StartsWith("dotnet-tracer-managed-instrumentation_test-"));
+            agent.Telemetry.Should().NotBeEmpty();
+
+            return;
+
+            Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task InstrumentsDotNetTest()
+        {
+            // run the azure function
+            var workingDir = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
+            Directory.CreateDirectory(workingDir);
+
+            Output.WriteLine("Using workingDirectory: " + workingDir);
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+
+            var logDir = await RunDotnet("new xunit -n instrumentation_test -o . --no-restore");
+            AssertNotInstrumented(agent, logDir);
+
+            // this _should_ be instrumented so we expect managed data.
+            // we also expect telemetry, but we end the app so quickly there's a risk of flake
+            logDir = await RunDotnet("test");
+            Directory.GetFiles(logDir).Should().Contain(filename => Path.GetFileName(filename).StartsWith("dotnet-tracer-managed-testhost-"));
+            agent.Telemetry.Should().NotBeEmpty();
+
+            return;
+
+            Task<string> RunDotnet(string arguments) => RunDotnetCommand(workingDir, agent, arguments);
+        }
+
+        private async Task<string> RunDotnetCommand(string workingDirectory, MockTracerAgent mockTracerAgent, string arguments)
+        {
+            // Create unique folder for easier post-mortem analysis
+            var logDir = $"{workingDirectory}_logs_{Path.GetFileNameWithoutExtension(Path.GetRandomFileName())}";
+            Output.WriteLine("Running: dotnet " + arguments);
+            Output.WriteLine("Using logDirectory: " + logDir);
+
+            Directory.CreateDirectory(logDir);
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+
+            using var process = await ProfilerHelper.StartProcessWithProfiler(
+                                    executable: EnvironmentHelper.GetDotnetExe(),
+                                    EnvironmentHelper,
+                                    mockTracerAgent,
+                                    arguments,
+                                    workingDirectory: workingDirectory); // points to the sample project
+
+            using var helper = new ProcessHelper(process);
+
+            WaitForProcessResult(helper);
+            return logDir;
+        }
+
+        private void AssertNotInstrumented(MockTracerAgent mockTracerAgent, string logDir)
+        {
+            // should have bailed out, but we still write logs to the native loader log
+            // _and_ the native tracer/profiler (because they're initialized), so important
+            // point is we don't have managed logs, and no spans or telemetry
+            Directory.GetFiles(logDir).Should().NotContain(filename => Path.GetFileName(filename).StartsWith("dotnet-tracer-managed-dotnet-"));
+            mockTracerAgent.Spans.Should().BeEmpty();
+            mockTracerAgent.Telemetry.Should().BeEmpty();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary of changes

If we detect that we're running a .NET SDK command, bail-out of instrumentation

## Reason for change

There are [bugs in the runtime](https://github.com/dotnet/runtime/issues/55441), particularly around event pipes, which can cause crashes on exit. Instrumenting .NET SDK commands (like `build` or `restore`) is unlikely to be of benefit to customers, will increase latency, and comes at the risk of stability issues, so makes sense to bail out. This is particularly important in auto-instrumentation/single step scenarios.

Note that there are obviously some `dotnet` commands we _do_ want to instrument:
- If we're in CI Visibility mode, we need to instrument `dotnet test` and `exec testhost`
  - The previous checks for this were much fuzzier then added here, but also missed some edge-cases
  - I kept some of the fuzziness there, to reduce the risk of suddenly not implementing somewhere
- I have kept `dotnet run` as instrumented, although AFAICT, it always calls `exec MyApp.exe` or similar so we theoretically wouldn't need to? Seemed safer to keep it though
- Only bailing out of `dotnet exec` for _known_ commands like csc.dll and VBCSCompiler.exe

## Implementation details

- Changed the `GetCurrentProcessCommandLine()` function to return both the "full" command line as well as the individual arguments

## Test coverage

Added integration checks to confirm that we don't instrument the following:

```
dotnet new
dotnet build
dotnet restore
dotnet publish
```

But that we _do_ instrument 

```
dotnet run
dotnet test
```

All our existing tests cover the standard mode of `dotnet MyApp.dll`

## Other details

Hopefully resolves internal ticket: https://datadoghq.atlassian.net/browse/AIT-9034

These are example logs from the native loader for a `dotnet build` command:

```bash
[2024-05-15 10:24:54.054 | info | PId: 57932 | TId: 48116] Process CommandLine: "C:\Program Files\dotnet\dotnet.exe" exec "C:\Program Files\dotnet\sdk\8.0.104\Roslyn\bincore\VBCSCompiler.dll" "-pipename:ym28Y6mOAJLWuk5DKlOyc5M0M_UKI+jCaZbVAPH_xF8"
[2024-05-15 10:24:54.055 | info | PId: 57932 | TId: 48116] The Tracer Profiler has been disabled because the process is 'dotnet' but an unsupported command was detected
```

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
