### PR TITLE
Run the package version bump on a schedule

### DIFF
--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -1,13 +1,15 @@
 name: Auto bump test package versions
 
 on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
   pull_request_target:
     branches: [master, main]
   workflow_dispatch:
 
 jobs:
   bump_package_versions:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.head.ref, 'dependabot/nuget/tracer/dependabot/') == true
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.event.pull_request.head.ref, 'dependabot/nuget/tracer/dependabot/') == true
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary of changes

Runs the test package version bump script every week

## Reason for change

Our dependabot PRs have stopped for some reason... they're configured, we don't have a lot of built up PRs, so no idea why they're not working... So this is a workaround...

## Implementation details

Add an additional schedule to the PR

## Test coverage

We'll see if it works on Sunday

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
