### PR TITLE
[CIVisibility] Tag profiles created by BenchmarkDotnet integration and add the IgnoreProfileAttribute

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3120,9 +3120,7 @@ stages:
       displayName: RunBenchmarks
       env:
         DD_CIVISIBILITY_AGENTLESS_ENABLED: true
-        # Currently, enabling profiling enables the CI Visibility tracer to enable code hotspots.
-        # We may be able to mitigate that in the future, but disabling it for now.
-        DD_PROFILING_ENABLED: false
+        DD_PROFILING_ENABLED: true
         DD_API_KEY: $(ddApiKey)
         DD_DOTNET_TRACER_HOME: $(monitoringHome)
 

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogDiagnoserAttribute.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/DatadogDiagnoserAttribute.cs
@@ -9,7 +9,7 @@ using BenchmarkDotNet.Configs;
 namespace Datadog.Trace.BenchmarkDotNet;
 
 /// <summary>
-/// Datadog BenchmarkDotNet diagnoser
+/// Datadog BenchmarkDotNet diagnoser attribute
 /// </summary>
 public class DatadogDiagnoserAttribute : Attribute, IConfigSource
 {

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/IgnoreProfileAttribute.cs
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/IgnoreProfileAttribute.cs
@@ -1,0 +1,16 @@
+// <copyright file="IgnoreProfileAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+
+namespace Datadog.Trace.BenchmarkDotNet;
+
+/// <summary>
+/// Attribute to ignore the Datadog profiler on a given Benchmark method or class
+/// </summary>
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+public class IgnoreProfileAttribute : Attribute
+{
+}

--- a/tracer/test/Datadog.Trace.BenchmarkDotNet.Tests/Snapshots/PublicApiTests.Datadog.Trace.BenchmarkDotNet.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.BenchmarkDotNet.Tests/Snapshots/PublicApiTests.Datadog.Trace.BenchmarkDotNet.PublicApiHasNotChanged.verified.txt
@@ -26,4 +26,9 @@ namespace Datadog.Trace.BenchmarkDotNet
     {
         public static BenchmarkDotNet.Configs.IConfig WithDatadog(this BenchmarkDotNet.Configs.IConfig config) { }
     }
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Method | System.AttributeTargets.All)]
+    public class IgnoreProfileAttribute : System.Attribute
+    {
+        public IgnoreProfileAttribute() { }
+    }
 }

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecBodyBenchmark.cs
@@ -10,6 +10,7 @@ using Datadog.Trace.AppSec.Waf;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec.Coordinator;
+using Datadog.Trace.BenchmarkDotNet;
 using Datadog.Trace.Configuration;
 using SecurityCoordinator = Datadog.Trace.AppSec.Coordinator.SecurityCoordinator;
 #if NETFRAMEWORK
@@ -25,6 +26,7 @@ namespace Benchmarks.Trace.Asm
     [MemoryDiagnoser]
     [BenchmarkAgent7]
     [BenchmarkCategory(Constants.AppSecCategory)]
+    [IgnoreProfile]
     public class AppSecBodyBenchmark
     {
         private static readonly Security _security;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Asm/AppSecWafBenchmark.cs
@@ -12,12 +12,14 @@ using Datadog.Trace;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
+using Datadog.Trace.BenchmarkDotNet;
 
 namespace Benchmarks.Trace.Asm;
 
 [MemoryDiagnoser]
 [BenchmarkAgent7]
 [BenchmarkCategory(Constants.AppSecCategory)]
+[IgnoreProfile]
 public class AppSecWafBenchmark
 {
     private const int TimeoutMicroSeconds = 1_000_000;

--- a/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/Iast/StringAspectsBenchmark.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using Datadog.Trace;
+using Datadog.Trace.BenchmarkDotNet;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Iast;
@@ -20,6 +21,7 @@ namespace Benchmarks.Trace.Iast;
 [MemoryDiagnoser]
 [BenchmarkAgent7]
 [BenchmarkCategory(Constants.AppSecCategory)]
+[IgnoreProfile]
 public class StringAspectsBenchmark
 {
     private const int TimeoutMicroSeconds = 1_000_000;


### PR DESCRIPTION
## Summary of changes

This PR tags Datadog profiles created by the BenchmarkDotnet integration with the CIVisibility origin and also adds a new `IgnoreProfilerAttribute` attribute to skip individual benchmark case or classes from the Datadog Profiler.

Also enables dogfooding of the integration.

## Reason for change

- We need to tag the profiles generated by the BenchmarkDotnet integration for billing purposes.
- In the dogfooding we discover some conflict with the BenchmarkDotnet integration due the CIVisibility mode environment variable changing the Tracer behaviour (this only happens because we are dogfooding). With the `IgnoreProfileAttribute` we are able to just switch off the integration on all these problematic benchmark tests.
