### PR TITLE
[Build] Fix chiseled smoke tests jobs + capture coredump when crashing in all smoke tests jobs

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -44,7 +44,7 @@ steps:
       mkdir -p tracer/build_data/snapshots
       mkdir -p tracer/build_data/logs
       mkdir -p tracer/build_data/dumps
-      # make sur that the container have enough rights to write in this folder
+      # make sure that the container have enough rights to write in this folder
       sudo chmod -R 777 tracer/build_data/ || true
     displayName: create test data directories
 - ${{ else }}:

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -128,3 +128,9 @@ steps:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
   condition: succeededOrFailed()
   continueOnError: true
+
+- ${{ if eq(parameters.isLinux, true) }}:
+    - script: |
+        sudo chmod -R 644 tracer/build_data/dumps/* || true
+      displayName: Make dumps uploadable to AzDo
+      condition: succeededOrFailed()

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -39,6 +39,14 @@ steps:
       echo "##vso[task.setvariable variable=START_TEST_AGENT_TARGET]start-test-agent"
       echo "##vso[task.setvariable variable=COMPOSE_PATH]docker-compose.yml"
     displayName: Set env-specific variables
+
+  - script: |
+      mkdir -p tracer/build_data/snapshots
+      mkdir -p tracer/build_data/logs
+      mkdir -p tracer/build_data/dumps
+      # make sur that the container have enough rights to write in this folder
+      sudo chmod -R 777 tracer/build_data/ || true
+    displayName: create test data directories
 - ${{ else }}:
   - bash: |
       echo "##vso[task.setvariable variable=CURL_COMMAND]curl"

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4798,6 +4798,9 @@ stages:
         - script: |
             mkdir -p tracer/build_data/snapshots
             mkdir -p tracer/build_data/logs
+            mkdir -p tracer/build_data/dumps
+            # make sur that the container have enough rights to write in this folder
+            chmod -R 777 tracer/build_data/
           displayName: create test data directories
         
         # Run the "normal" installer smoke tests
@@ -4836,6 +4839,12 @@ stages:
           parameters:
             target: 'dd-dotnet-chiseled-smoke-tests'
             snapshotPrefix: "smoke_test"
+
+        - script: |
+            # Artifacts (log files, coredump...) produced by the container need to have their permission adjusted
+            # for upload
+            chmod -R 777 tracer/build_data/
+          displayName: Adjust permissions to upload artifacts
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -5261,6 +5270,9 @@ stages:
         - script: |
             mkdir -p tracer/build_data/snapshots
             mkdir -p tracer/build_data/logs
+            mkdir -p tracer/build_data/dumps
+            # make sur that the container have enough rights to write in this folder
+            chmod -R 777 tracer/build_data
           displayName: create test data directories
 
         # Run the "normal" installer smoke tests 
@@ -5299,6 +5311,12 @@ stages:
           parameters:
             target: 'dd-dotnet-chiseled-arm64-smoke-tests'
             snapshotPrefix: "smoke_test"
+
+        - script: |
+            # Artifacts (log files, coredump...) produced by the container need to have their permission adjusted
+            # for upload
+            chmod -R 777 tracer/build_data/
+          displayName: Adjust permissions to upload artifacts
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4795,14 +4795,6 @@ stages:
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
 
-        - script: |
-            mkdir -p tracer/build_data/snapshots
-            mkdir -p tracer/build_data/logs
-            mkdir -p tracer/build_data/dumps
-            # make sur that the container have enough rights to write in this folder
-            chmod -R 777 tracer/build_data/
-          displayName: create test data directories
-        
         # Run the "normal" installer smoke tests
         - script: |
             docker-compose -p ddtrace_$(Build.BuildNumber) build \
@@ -4839,12 +4831,6 @@ stages:
           parameters:
             target: 'dd-dotnet-chiseled-smoke-tests'
             snapshotPrefix: "smoke_test"
-
-        - script: |
-            # Artifacts (log files, coredump...) produced by the container need to have their permission adjusted
-            # for upload
-            chmod -R 777 tracer/build_data/
-          displayName: Adjust permissions to upload artifacts
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -5267,14 +5253,6 @@ stages:
             artifact: $(linuxArtifacts)
             path: $(smokeTestAppDir)/artifacts
 
-        - script: |
-            mkdir -p tracer/build_data/snapshots
-            mkdir -p tracer/build_data/logs
-            mkdir -p tracer/build_data/dumps
-            # make sur that the container have enough rights to write in this folder
-            chmod -R 777 tracer/build_data
-          displayName: create test data directories
-
         # Run the "normal" installer smoke tests 
         - script: |
             docker-compose -p ddtrace_$(Build.BuildNumber) build \
@@ -5311,12 +5289,6 @@ stages:
           parameters:
             target: 'dd-dotnet-chiseled-arm64-smoke-tests'
             snapshotPrefix: "smoke_test"
-
-        - script: |
-            # Artifacts (log files, coredump...) produced by the container need to have their permission adjusted
-            # for upload
-            chmod -R 777 tracer/build_data/
-          displayName: Adjust permissions to upload artifacts
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1003,6 +1003,7 @@ services:
     volumes:
       - ./:/project
       - ./tracer/build_data/logs:/var/log/datadog/dotnet
+      - ./tracer/build_data/dumps:/dumps
     environment:
       - dockerTag=${dockerTag:-unset}
       - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -1024,6 +1025,7 @@ services:
     volumes:
       - ./:/project
       - ./tracer/build_data/logs:/var/log/datadog/dotnet
+      - ./tracer/build_data/dumps:/dumps
     environment:
       - dockerTag=${dockerTag:-unset}
       - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -1045,6 +1047,7 @@ services:
     volumes:
       - ./:/project
       - ./tracer/build_data/logs:/var/log/datadog/dotnet
+      - ./tracer/build_data/dumps:/dumps
     environment:
       - dockerTag=${dockerTag:-unset}
       - DD_TRACE_AGENT_URL=http://test-agent:8126

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -863,6 +863,7 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/dumps:/dumps
     environment:
     - dockerTag=${dockerTag:-unset}
     - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -884,6 +885,7 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/dumps:/dumps
     environment:
     - dockerTag=${dockerTag:-unset}
     - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -905,6 +907,7 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/dumps:/dumps
     environment:
     - dockerTag=${dockerTag:-unset}
     - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -924,6 +927,7 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/dumps:/dumps
     environment:
     - dockerTag=${dockerTag:-unset}
     - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -944,6 +948,7 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/dumps:/dumps
     environment:
     - dockerTag=${dockerTag:-unset}
     - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -963,6 +968,7 @@ services:
     volumes:
     - ./:/project
     - ./tracer/build_data/logs:/var/log/datadog/dotnet
+    - ./tracer/build_data/dumps:/dumps
     environment:
     - dockerTag=${dockerTag:-unset}
     - DD_TRACE_AGENT_URL=http://test-agent:8126
@@ -983,6 +989,7 @@ services:
     volumes:
       - ./:/project
       - ./tracer/build_data/logs:/var/log/datadog/dotnet
+      - ./tracer/build_data/dumps:/dumps
     environment:
       - dockerTag=${dockerTag:-unset}
       - DD_TRACE_AGENT_URL=http://test-agent:8126

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -62,6 +62,9 @@ ENV LD_PRELOAD=/opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so
 ENV DD_PROFILING_ENABLED=1
 ENV DD_APPSEC_ENABLED=1
 ENV DD_TRACE_DEBUG=1
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
 
 ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]
 

--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -64,7 +64,7 @@ ENV DD_APPSEC_ENABLED=1
 ENV DD_TRACE_DEBUG=1
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]
 

--- a/tracer/build/_build/docker/smoke.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.dd-dotnet.dockerfile
@@ -37,7 +37,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.

--- a/tracer/build/_build/docker/smoke.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.dd-dotnet.dockerfile
@@ -34,6 +34,11 @@ ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -43,6 +43,11 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 ENV ASPNETCORE_URLS=http://localhost:5000
 
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -46,7 +46,7 @@ ENV ASPNETCORE_URLS=http://localhost:5000
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.

--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -40,7 +40,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.

--- a/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.dockerfile
@@ -37,6 +37,11 @@ ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -40,7 +40,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -37,6 +37,11 @@ ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
@@ -46,6 +46,11 @@ ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+
 # Copy the app across
 COPY --from=builder /src/publish /app/.
 

--- a/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.self-instrument.dockerfile
@@ -49,7 +49,7 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 # Copy the app across
 COPY --from=builder /src/publish /app/.

--- a/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
@@ -38,6 +38,6 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 ENTRYPOINT ["/app/datadog/dd-dotnet.sh", "run", "--set-env", "DD_PROFILING_ENABLED=1","--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--",  "dotnet", "/app/AspNetCoreSmokeTest.dll"]

--- a/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
@@ -35,4 +35,9 @@ ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+
 ENTRYPOINT ["/app/datadog/dd-dotnet.sh", "run", "--set-env", "DD_PROFILING_ENABLED=1","--set-env", "DD_APPSEC_ENABLED=1","--set-env", "DD_TRACE_DEBUG=1", "--",  "dotnet", "/app/AspNetCoreSmokeTest.dll"]

--- a/tracer/build/_build/docker/smoke.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dockerfile
@@ -51,6 +51,6 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 # Capture dumps
 ENV COMPlus_DbgEnableMiniDump=1
 ENV COMPlus_DbgMiniDumpType=4
-ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+ENV DOTNET_DbgMiniDumpName=/dumps/coredump.%t.%p
 
 ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]

--- a/tracer/build/_build/docker/smoke.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dockerfile
@@ -48,4 +48,9 @@ ENV SUPER_SECRET_CANARY=MySuperSecretCanary
 # see https://github.com/DataDog/dd-trace-dotnet/pull/3579
 ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
+# Capture dumps
+ENV COMPlus_DbgEnableMiniDump=1
+ENV COMPlus_DbgMiniDumpType=4
+ENV DOTNET_DbgMiniDumpName=/dumps/chiseled_%t.coredump.%p
+
 ENTRYPOINT ["dotnet", "AspNetCoreSmokeTest.dll"]


### PR DESCRIPTION
## Summary of changes

Fix chiseled smoke tests jobs + allow to capture coredump in case of a crash

## Reason for change

Currently, there is no artifacts (log files, dumps..) produced by the run of the ASP.NET app in the container. This is due to the permission discrepancy: seen by the runner and the docker container.

When the docker container runs, it does not have the permission to write in the log folder.

If we fix this, we need to adjust the permission for the host so it can upload the files (because permissions are different).

+ allow to capture coredump files in case of a crash in all smoke tests jobs
## Implementation details
- Add a `tracer/build_data/dumps` folder to store coredump files.
- Apply `chmod 777` recursively on `tracer/build_data`
- Add .NET coredump environment variables in the smoke tests dockerfiles

## Test coverage

We should see log files for those smoke tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
