### PR TITLE
[ASM] Update WAF log messages

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -134,19 +134,17 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                 }
 
                 var errorMess = StringBuilderCache.GetStringAndRelease(sb);
-                Log.Warning("WAF initialization failed. Some rules are invalid in rule file {RulesFile}: {ErroringRules}", rulesFile, errorMess);
+                Log.Warning("Some rules are invalid in rule file {RulesFile}: {ErroringRules}", rulesFile, errorMess);
+            }
+
+            // sometimes loaded rules will be 0 if other errors happen above, that's why it should be the fallback log
+            if (initResult.LoadedRules == 0)
+            {
+                Log.Error("DDAS-0003-03: AppSec could not read the rule file {RulesFile}. Reason: All rules are invalid. AppSec will not run any protections in this application.", rulesFile);
             }
             else
             {
-                // sometimes loaded rules will be 0 if other errors happen above, that's why it should be the fallback log
-                if (initResult.LoadedRules == 0)
-                {
-                    Log.Error("DDAS-0003-03: AppSec could not read the rule file {RulesFile}. Reason: All rules are invalid. AppSec will not run any protections in this application.", rulesFile);
-                }
-                else
-                {
-                    Log.Information("DDAS-0015-00: AppSec loaded {LoadedRules} rules from file {RulesFile}.", initResult.LoadedRules, rulesFile);
-                }
+                Log.Information("DDAS-0015-00: AppSec loaded {LoadedRules} rules from file {RulesFile}.", initResult.LoadedRules, rulesFile);
             }
 
             return initResult;


### PR DESCRIPTION
## Summary of changes

When a rule is not loaded because an operator is not supported, an error message is shown and the log does not display the successful information message but the WAF will still work normally. This can lead to errors in system tests that check these messages.

An operator might no be supported if the tracer uses a version of the WAF that does not include that operator. That does not mean that the WAF is going to stop working, it will just ignore that particular rule.

## Reason for change

The messages shown right now are a little bit misleading and makes some tests to fail when they should not.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
