### PR TITLE
[ASM][IAST] Fix System.Text.Json: Properly implement GetRawText() aspect

### DIFF
--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/AspectsDefinitionsGenerator/AspectsDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/AspectsDefinitionsGenerator/AspectsDefinitions.g.cs
@@ -263,7 +263,7 @@ namespace Datadog.Trace.ClrProfiler
 "[AspectClass(\"System.Text.Json\",[None],Source,[])] Datadog.Trace.Iast.Aspects.System.Text.Json.JsonDocumentAspects",
 "  [AspectMethodReplace(\"System.Text.Json.JsonDocument::Parse(System.String,System.Text.Json.JsonDocumentOptions)\",\"\",[0],[False],[None],Default,[])] Parse(System.String,System.Text.Json.JsonDocumentOptions)",
 "  [AspectMethodReplace(\"System.Text.Json.JsonElement::GetString()\",\"\",[0],[True],[None],Default,[])] GetString(System.Object)",
-"  [AspectMethodReplace(\"System.Text.Json.JsonElement::GetRawText()\",\"\",[0],[True],[None],Default,[])] GetString(System.Object)",
+"  [AspectMethodReplace(\"System.Text.Json.JsonElement::GetRawText()\",\"\",[0],[True],[None],Default,[])] GetRawText(System.Object)",
 "[AspectClass(\"System.Web\",[None],Sink,[UnvalidatedRedirect])] Datadog.Trace.Iast.Aspects.System.Web.HttpResponseAspect",
 "  [AspectMethodInsertBefore(\"System.Web.HttpResponse::Redirect(System.String)\",\"\",[0],[False],[None],Default,[])] Redirect(System.String)",
 "  [AspectMethodInsertBefore(\"System.Web.HttpResponse::Redirect(System.String,System.Boolean)\",\"\",[1],[False],[None],Default,[])] Redirect(System.String)",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/AspectsDefinitionsGenerator/AspectsDefinitions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/AspectsDefinitionsGenerator/AspectsDefinitions.g.cs
@@ -261,7 +261,7 @@ namespace Datadog.Trace.ClrProfiler
 "[AspectClass(\"System.Text.Json\",[None],Source,[])] Datadog.Trace.Iast.Aspects.System.Text.Json.JsonDocumentAspects",
 "  [AspectMethodReplace(\"System.Text.Json.JsonDocument::Parse(System.String,System.Text.Json.JsonDocumentOptions)\",\"\",[0],[False],[None],Default,[])] Parse(System.String,System.Text.Json.JsonDocumentOptions)",
 "  [AspectMethodReplace(\"System.Text.Json.JsonElement::GetString()\",\"\",[0],[True],[None],Default,[])] GetString(System.Object)",
-"  [AspectMethodReplace(\"System.Text.Json.JsonElement::GetRawText()\",\"\",[0],[True],[None],Default,[])] GetString(System.Object)",
+"  [AspectMethodReplace(\"System.Text.Json.JsonElement::GetRawText()\",\"\",[0],[True],[None],Default,[])] GetRawText(System.Object)",
 "[AspectClass(\"System.Web\",[None],Sink,[UnvalidatedRedirect])] Datadog.Trace.Iast.Aspects.System.Web.HttpResponseAspect",
 "  [AspectMethodInsertBefore(\"System.Web.HttpResponse::Redirect(System.String)\",\"\",[0],[False],[None],Default,[])] Redirect(System.String)",
 "  [AspectMethodInsertBefore(\"System.Web.HttpResponse::Redirect(System.String,System.Boolean)\",\"\",[1],[False],[None],Default,[])] Redirect(System.String)",

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/IJsonElement.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Text.Json/IJsonElement.cs
@@ -15,4 +15,6 @@ internal interface IJsonElement
     object Parent { get; }
 
     public string GetString();
+
+    public string GetRawText();
 }

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Json/JsonDocumentTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Json/JsonDocumentTests.cs
@@ -86,7 +86,7 @@ public class JsonDocumentTests : InstrumentationTestsBase
         var value = element.GetProperty("key");
         var str = value.GetRawText();
 
-        Assert.Equal("value", str);
+        Assert.Equal("\"value\"", str);
         AssertTainted(str);
     }
 


### PR DESCRIPTION
## Summary of changes

Fix the aspect method for `System.Text.Json.JsonElement::GetRawText()`.
The original method called always was `GetString()` and not `GetRawText()`.

## Reason for change

The aspect method for GetRawText() wasn't properly implemented.

## Implementation details

Implement the GetRawText() aspect method in its own method, so the correct original method can be called.

## Test coverage

Fixed a test that didn't compare the resulting string value with a real returned one without instrumentation.