### PR TITLE
Failing serverless tests are not reported in CI

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1822,7 +1822,7 @@ stages:
   jobs:
   - template: steps/update-github-status-jobs.yml
     parameters:
-      jobs: [Test, DockerTest]
+      jobs: [Test, DockerTest, Serverless]
 
   - job: Test
     timeoutInMinutes: 60 #default value


### PR DESCRIPTION
## Summary of changes

Correctly report Serverless stage failures

## Reason for change

The serverless tests broke on `master` ([in this PR](https://github.com/DataDog/dd-trace-dotnet/pull/5562)) but that wasn't _reported_ as a failure because of a missing dependency

## Implementation details

Add the missing dependency

## Test coverage

This PR _should_ fail until we fix those tests...

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
