### PR TITLE
[Tests] add null checks in `VerifyHelper`

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable  enable
+
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -58,23 +60,23 @@ namespace Datadog.Trace.TestHelpers
                     new PathInfo(directory: Path.Combine(projectDirectory, "..", "snapshots")));
         }
 
-        public static VerifySettings GetSpanVerifierSettings(params object[] parameters) => GetSpanVerifierSettings(null, parameters);
+        public static VerifySettings GetSpanVerifierSettings(params object[] parameters) => GetSpanVerifierSettings(scrubbers: null, parameters);
 
-        public static VerifySettings GetSpanVerifierSettings(IEnumerable<(Regex RegexPattern, string Replacement)> scrubbers, object[] parameters)
+        public static VerifySettings GetSpanVerifierSettings(IEnumerable<(Regex RegexPattern, string Replacement)>? scrubbers, object[] parameters)
             => GetSpanVerifierSettings(scrubbers, parameters, ScrubStringTags, ScrubNumericTags, ciVisStringTagsScrubber: null, ciVisNumericTagsScrubber: null);
 
-        public static VerifySettings GetCIVisibilitySpanVerifierSettings(params object[] parameters) => GetCIVisibilitySpanVerifierSettings(null, parameters);
+        public static VerifySettings GetCIVisibilitySpanVerifierSettings(params object[] parameters) => GetCIVisibilitySpanVerifierSettings(scrubbers: null, parameters);
 
-        public static VerifySettings GetCIVisibilitySpanVerifierSettings(IEnumerable<(Regex RegexPattern, string Replacement)> scrubbers, object[] parameters)
+        public static VerifySettings GetCIVisibilitySpanVerifierSettings(IEnumerable<(Regex RegexPattern, string Replacement)>? scrubbers, object[] parameters)
             => GetSpanVerifierSettings(scrubbers, parameters, ScrubCIVisibilityTags, ScrubCIVisibilityMetrics, ScrubCIVisibilityTags, ScrubCIVisibilityMetrics);
 
         public static VerifySettings GetSpanVerifierSettings(
-            IEnumerable<(Regex RegexPattern, string Replacement)> scrubbers,
+            IEnumerable<(Regex RegexPattern, string Replacement)>? scrubbers,
             object[] parameters,
-            ConvertMember<MockSpan, Dictionary<string, string>> apmStringTagsScrubber,
-            ConvertMember<MockSpan, Dictionary<string, double>> apmNumericTagsScrubber,
-            ConvertMember<MockCIVisibilityTest, Dictionary<string, string>> ciVisStringTagsScrubber,
-            ConvertMember<MockCIVisibilityTest, Dictionary<string, double>> ciVisNumericTagsScrubber)
+            ConvertMember<MockSpan, Dictionary<string, string>?> apmStringTagsScrubber,
+            ConvertMember<MockSpan, Dictionary<string, double>?> apmNumericTagsScrubber,
+            ConvertMember<MockCIVisibilityTest, Dictionary<string, string>?>? ciVisStringTagsScrubber,
+            ConvertMember<MockCIVisibilityTest, Dictionary<string, double>?>? ciVisNumericTagsScrubber)
         {
             var settings = new VerifySettings();
 
@@ -127,7 +129,7 @@ namespace Datadog.Trace.TestHelpers
         public static SettingsTask VerifySpans(
             IReadOnlyCollection<MockSpan> spans,
             VerifySettings settings,
-            Func<IReadOnlyCollection<MockSpan>, IOrderedEnumerable<MockSpan>> orderSpans = null)
+            Func<IReadOnlyCollection<MockSpan>, IOrderedEnumerable<MockSpan>>? orderSpans = null)
         {
             // Ensure a static ordering for the spans
             var orderedSpans = orderSpans?.Invoke(spans) ??
@@ -191,7 +193,7 @@ namespace Datadog.Trace.TestHelpers
             settings.AddScrubber(builder => ReplaceSimple(builder, oldValue, newValue));
         }
 
-        public static Dictionary<string, string> ScrubStringTags(MockSpan span, Dictionary<string, string> tags)
+        public static Dictionary<string, string>? ScrubStringTags(MockSpan span, Dictionary<string, string>? tags)
         {
             return tags
                   // remove propagated tags because their positions in the snapshots are not stable
@@ -211,7 +213,7 @@ namespace Datadog.Trace.TestHelpers
                   .ToDictionary(x => x.Key, x => x.Value);
         }
 
-        public static Dictionary<string, double> ScrubNumericTags(MockSpan span, Dictionary<string, double> tags)
+        public static Dictionary<string, double>? ScrubNumericTags(MockSpan span, Dictionary<string, double>? tags)
         {
             string[] ignoreKeys =
             [
@@ -225,11 +227,11 @@ namespace Datadog.Trace.TestHelpers
                   .ToDictionary(x => x.Key, x => x.Value);
         }
 
-        public static Dictionary<string, string> ScrubCIVisibilityTags(MockSpan span, Dictionary<string, string> tags) => ScrubCIVisibilityTags(tags);
+        public static Dictionary<string, string>? ScrubCIVisibilityTags(MockSpan span, Dictionary<string, string>? tags) => ScrubCIVisibilityTags(tags);
 
-        public static Dictionary<string, string> ScrubCIVisibilityTags(MockCIVisibilityTest span, Dictionary<string, string> tags) => ScrubCIVisibilityTags(tags);
+        public static Dictionary<string, string>? ScrubCIVisibilityTags(MockCIVisibilityTest span, Dictionary<string, string>? tags) => ScrubCIVisibilityTags(tags);
 
-        public static Dictionary<string, string> ScrubCIVisibilityTags(Dictionary<string, string> tags)
+        public static Dictionary<string, string>? ScrubCIVisibilityTags(Dictionary<string, string>? tags)
         {
             return tags
                   // remove propagated tags because their positions in the snapshots are not stable
@@ -276,11 +278,11 @@ namespace Datadog.Trace.TestHelpers
                   .ToDictionary(x => x.Key, x => x.Value);
         }
 
-        public static Dictionary<string, double> ScrubCIVisibilityMetrics(MockSpan span, Dictionary<string, double> metrics) => ScrubCIVisibilityMetrics(metrics);
+        public static Dictionary<string, double>? ScrubCIVisibilityMetrics(MockSpan span, Dictionary<string, double>? metrics) => ScrubCIVisibilityMetrics(metrics);
 
-        public static Dictionary<string, double> ScrubCIVisibilityMetrics(MockCIVisibilityTest span, Dictionary<string, double> metrics) => ScrubCIVisibilityMetrics(metrics);
+        public static Dictionary<string, double>? ScrubCIVisibilityMetrics(MockCIVisibilityTest span, Dictionary<string, double>? metrics) => ScrubCIVisibilityMetrics(metrics);
 
-        public static Dictionary<string, double> ScrubCIVisibilityMetrics(Dictionary<string, double> metrics)
+        public static Dictionary<string, double>? ScrubCIVisibilityMetrics(Dictionary<string, double>? metrics)
         {
             return metrics
                   .Where(kvp => kvp.Key != Metrics.SamplingAgentDecision)

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -347,8 +347,8 @@ namespace Datadog.Trace.TestHelpers
             // keep the message + the first (scrubbed) location
             var sb = new StringBuilder();
             using StringReader reader = new(Scrubbers.ScrubStackTrace(stackTrace)!);
-            string? line;
-            while ((line = reader.ReadLine()) is not null)
+
+            while (reader.ReadLine() is { } line)
             {
                 if (line.StartsWith("at "))
                 {
@@ -357,9 +357,8 @@ namespace Datadog.Trace.TestHelpers
                     break;
                 }
 
-                sb
-                   .Append(line)
-                   .Append('\n');
+                sb.Append(line)
+                  .Append('\n');
             }
 
             return sb.ToString();

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -198,7 +198,7 @@ namespace Datadog.Trace.TestHelpers
             return tags
                   // remove propagated tags because their positions in the snapshots are not stable
                   // with our span ordering. correct position (first span in every trace chunk) is covered by other tests.
-                  .Where(kvp => !kvp.Key.StartsWith(TagPropagation.PropagatedTagPrefix, StringComparison.Ordinal))
+                 ?.Where(kvp => !kvp.Key.StartsWith(TagPropagation.PropagatedTagPrefix, StringComparison.Ordinal))
                   // We must ignore both `_dd.git.repository_url` and `_dd.git.commit.sha` because we are only setting it on the first span of a trace
                   // no matter what. That means we have unstable snapshot results.
                   .Where(kvp => kvp.Key != Tags.GitRepositoryUrl && kvp.Key != Tags.GitCommitSha)
@@ -222,7 +222,7 @@ namespace Datadog.Trace.TestHelpers
             ];
 
             return tags
-                  .Where(kvp => !ignoreKeys.Contains(kvp.Key))
+                 ?.Where(kvp => !ignoreKeys.Contains(kvp.Key))
                   .OrderBy(x => x.Key)
                   .ToDictionary(x => x.Key, x => x.Value);
         }
@@ -236,7 +236,7 @@ namespace Datadog.Trace.TestHelpers
             return tags
                   // remove propagated tags because their positions in the snapshots are not stable
                   // with our span ordering. correct position (first span in every trace chunk) is covered by other tests.
-                  .Where(kvp => !kvp.Key.StartsWith(TagPropagation.PropagatedTagPrefix, StringComparison.Ordinal))
+                 ?.Where(kvp => !kvp.Key.StartsWith(TagPropagation.PropagatedTagPrefix, StringComparison.Ordinal))
                   // We must ignore both `_dd.git.repository_url` and `_dd.git.commit.sha` because we are only setting it on the first span of a trace
                   // no matter what. That means we have unstable snapshot results.
                   .Where(kvp => kvp.Key != Tags.GitRepositoryUrl && kvp.Key != Tags.GitCommitSha)
@@ -285,7 +285,7 @@ namespace Datadog.Trace.TestHelpers
         public static Dictionary<string, double>? ScrubCIVisibilityMetrics(Dictionary<string, double>? metrics)
         {
             return metrics
-                  .Where(kvp => kvp.Key != Metrics.SamplingAgentDecision)
+                 ?.Where(kvp => kvp.Key != Metrics.SamplingAgentDecision)
                   .Select(
                        kvp => kvp.Key switch
                        {

--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -346,8 +346,8 @@ namespace Datadog.Trace.TestHelpers
         {
             // keep the message + the first (scrubbed) location
             var sb = new StringBuilder();
-            using StringReader reader = new(Scrubbers.ScrubStackTrace(stackTrace));
-            string line;
+            using StringReader reader = new(Scrubbers.ScrubStackTrace(stackTrace)!);
+            string? line;
             while ((line = reader.ReadLine()) is not null)
             {
                 if (line.StartsWith("at "))


### PR DESCRIPTION
## Summary of changes

- add nullability annotations
- add missing null checks

## Reason for change

The new `VerifyHelper.ScrubNumericTags()` added in #5562 introduced a `NullReferenceException` in serverless tests.

## Implementation details

see summary

## Test coverage

it tests itself

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
