### PR TITLE
Change the crash report tag

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
@@ -59,7 +59,7 @@ int32_t CrashReporting::Initialize()
         return 1;
     }
 
-    return AddTag("severity", "crash");
+    return AddTag("is_crash", "true");
 }
 
 void CrashReporting::SetLastError(ddog_Error error)

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -201,6 +201,8 @@ public class CreatedumpTests : ConsoleTestHelper
 
         var report = JObject.Parse(reportFile.GetContent());
 
+        report["tags"]["is_crash"].Value<string>().Should().Be("true");
+
         var metadataTags = (JArray)report["metadata"]!["tags"];
 
         var exception = metadataTags


### PR DESCRIPTION
## Summary of changes

Use `is_crash: true` instead of `severity: crash` for tagging crash reports.

## Reason for change

`severity` was only a placeholder until we figure out what tag to use.

## Test coverage

Added a check in `CreatedumpTests.WriteCrashReport`