### PR TITLE
Fix dependabot and improve `GeneratePackageVersions`

### DIFF
--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -44,3 +44,15 @@ jobs:
           reviewers: "DataDog/apm-dotnet"
           body: |
             Updates the package versions for integration tests.
+            
+      - name: Send Slack notification about generating failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # This data can be any valid JSON from a previous step in the GitHub Action
+          payload: |
+            {
+              "github_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBOOK_URL_GENERATEPACKAGEVERSIONS }}

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -1,13 +1,15 @@
 name: Auto bump test package versions
 
 on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight
   pull_request_target:
     branches: [master, main]
   workflow_dispatch:
 
 jobs:
   bump_package_versions:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.pull_request.head.ref, 'dependabot/nuget/tracer/dependabot/') == true
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.event.pull_request.head.ref, 'dependabot/nuget/tracer/dependabot/') == true
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -253,6 +253,12 @@ partial class Build
 
            var outputPath = TracerDirectory / "build" / "supported_versions.json";
            await GenerateSupportMatrix.GenerateInstrumentationSupportMatrix(outputPath, distinctIntegrations);
+           
+           Logger.Information("Verifying that updated dependabot file is valid...");
+
+           var tempProjectFile = TempDirectory / "dependabot_test" / "Project.csproj";
+           CopyFile(dependabotProj, tempProjectFile, FileExistsPolicy.Overwrite);
+           DotNetRestore(x => x.SetProjectFile(tempProjectFile));
        });
     
     Target GenerateSpanDocumentation => _ => _

--- a/tracer/build/_build/Honeypot/Datadog.Dependabot.Honeypot.template
+++ b/tracer/build/_build/Honeypot/Datadog.Dependabot.Honeypot.template
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Datadog.Dependabot.Honeypot</RootNamespace>
   </PropertyGroup>
 

--- a/tracer/dependabot/Datadog.Dependabot.Integrations.csproj
+++ b/tracer/dependabot/Datadog.Dependabot.Integrations.csproj
@@ -1,345 +1,336 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Datadog.Dependabot.Honeypot</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Integration: System.Data -->
-    <!-- Assembly: System.Data -->
-    <!-- Latest package https://www.nuget.org/packages/System.Data.SqlClient/4.8.6 -->
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-
-    <!-- Integration: System.Data.Common -->
-    <!-- Assembly: System.Data.Common -->
-    <!-- Latest package https://www.nuget.org/packages/System.Data.Common/4.3.0 -->
-    <PackageReference Include="System.Data.Common" Version="4.3.0" />
-
     <!-- Integration: AerospikeClient -->
-    <!-- Assembly: AerospikeClient -->
+    <!--    Assembly: AerospikeClient -->
     <!-- Latest package https://www.nuget.org/packages/Aerospike.Client/7.2.0 -->
     <PackageReference Include="Aerospike.Client" Version="7.2.0" />
 
-    <!-- Integration: Microsoft.AspNetCore.StaticFiles -->
-    <!-- Assembly: Microsoft.AspNetCore.StaticFiles -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.StaticFiles/2.2.0 -->
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+    <!-- Integration: Amazon.Lambda.RuntimeSupport -->
+    <!--    Assembly: Amazon.Lambda.RuntimeSupport -->
+    <!-- Latest package https://www.nuget.org/packages/Amazon.Lambda.RuntimeSupport/1.10.0 -->
+    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
 
-    <!-- Integration: System.Web.Mvc -->
-    <!-- Assembly: System.Web.Mvc -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNet.Mvc/5.3.0 -->
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
+    <!-- Integration: AWSSDK.Core -->
+    <!--    Assembly: AWSSDK.Core -->
+    <!-- Latest package https://www.nuget.org/packages/AWSSDK.Core/3.7.304.2 -->
+    <PackageReference Include="AWSSDK.Core" Version="3.7.304.2" />
 
     <!-- Integration: AWSSDK.DynamoDBv2 -->
-    <!-- Assembly: AWSSDK.DynamoDBv2 -->
+    <!--    Assembly: AWSSDK.DynamoDBv2 -->
     <!-- Latest package https://www.nuget.org/packages/AWSSDK.DynamoDBv2/3.7.303.7 -->
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.303.7" />
 
     <!-- Integration: AWSSDK.Kinesis -->
-    <!-- Assembly: AWSSDK.Kinesis -->
+    <!--    Assembly: AWSSDK.Kinesis -->
     <!-- Latest package https://www.nuget.org/packages/AWSSDK.Kinesis/3.7.301.85 -->
     <PackageReference Include="AWSSDK.Kinesis" Version="3.7.301.85" />
 
-    <!-- Integration: AWSSDK.Core -->
-    <!-- Assembly: AWSSDK.Core -->
-    <!-- Latest package https://www.nuget.org/packages/AWSSDK.Core/3.7.304.2 -->
-    <PackageReference Include="AWSSDK.Core" Version="3.7.304.2" />
-
     <!-- Integration: AWSSDK.SimpleNotificationService -->
-    <!-- Assembly: AWSSDK.SimpleNotificationService -->
+    <!--    Assembly: AWSSDK.SimpleNotificationService -->
     <!-- Latest package https://www.nuget.org/packages/AWSSDK.SimpleNotificationService/3.7.301.40 -->
     <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.301.40" />
 
     <!-- Integration: AWSSDK.SQS -->
-    <!-- Assembly: AWSSDK.SQS -->
+    <!--    Assembly: AWSSDK.SQS -->
     <!-- Latest package https://www.nuget.org/packages/AWSSDK.SQS/3.7.301.5 -->
     <PackageReference Include="AWSSDK.SQS" Version="3.7.301.5" />
 
     <!-- Integration: Azure.Messaging.ServiceBus -->
-    <!-- Assembly: Azure.Messaging.ServiceBus -->
+    <!--    Assembly: Azure.Messaging.ServiceBus -->
     <!-- Latest package https://www.nuget.org/packages/Azure.Messaging.ServiceBus/7.17.5 -->
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
 
-    <!-- Integration: Microsoft.Azure.Cosmos.Client -->
-    <!-- Assembly: Microsoft.Azure.Cosmos.Client -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.39.1 -->
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.1" />
+    <!-- Integration: Confluent.Kafka -->
+    <!--    Assembly: Confluent.Kafka -->
+    <!-- Latest package https://www.nuget.org/packages/Confluent.Kafka/2.4.0 -->
+    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
 
     <!-- Integration: Couchbase.NetClient -->
-    <!-- Assembly: Couchbase.NetClient -->
+    <!--    Assembly: Couchbase.NetClient -->
     <!-- Latest package https://www.nuget.org/packages/CouchbaseNetClient/3.5.2 -->
     <PackageReference Include="CouchbaseNetClient" Version="3.5.2" />
 
     <!-- Integration: Elasticsearch.Net -->
-    <!-- Assembly: Elasticsearch.Net -->
+    <!--    Assembly: Elasticsearch.Net -->
     <!-- Latest package https://www.nuget.org/packages/Elasticsearch.Net/7.17.5 -->
     <PackageReference Include="Elasticsearch.Net" Version="7.17.5" />
 
+    <!-- Integration: Google.Protobuf -->
+    <!--    Assembly: Google.Protobuf -->
+    <!-- Latest package https://www.nuget.org/packages/Google.Protobuf/3.26.1 -->
+    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
+
     <!-- Integration: GraphQL -->
-    <!-- Assembly: GraphQL -->
+    <!--    Assembly: GraphQL -->
     <!-- Latest package https://www.nuget.org/packages/GraphQL/7.8.0 -->
     <PackageReference Include="GraphQL" Version="7.8.0" />
 
     <!-- Integration: GraphQL.SystemReactive -->
-    <!-- Assembly: GraphQL.SystemReactive -->
+    <!--    Assembly: GraphQL.SystemReactive -->
     <!-- Latest package https://www.nuget.org/packages/GraphQL.SystemReactive/4.8.0 -->
     <PackageReference Include="GraphQL.SystemReactive" Version="4.8.0" />
 
-    <!-- Integration: Google.Protobuf -->
-    <!-- Assembly: Google.Protobuf -->
-    <!-- Latest package https://www.nuget.org/packages/Google.Protobuf/3.26.1 -->
-    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
-
     <!-- Integration: Grpc.Core -->
-    <!-- Assembly: Grpc.Core -->
+    <!--    Assembly: Grpc.Core -->
     <!-- Latest package https://www.nuget.org/packages/Grpc/2.46.6 -->
     <PackageReference Include="Grpc" Version="2.46.6" />
 
+    <!-- Integration: Grpc.AspNetCore.Server -->
+    <!--    Assembly: Grpc.AspNetCore.Server -->
+    <!-- Integration: Grpc.Net.Client -->
+    <!--    Assembly: Grpc.Net.Client -->
+    <!-- Latest package https://www.nuget.org/packages/Grpc.AspNetCore/2.62.0 -->
+    <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
+
     <!-- Integration: HotChocolate.Execution -->
-    <!-- Assembly: HotChocolate.Execution -->
+    <!--    Assembly: HotChocolate.Execution -->
     <!-- Latest package https://www.nuget.org/packages/HotChocolate.AspNetCore/13.9.4 -->
     <PackageReference Include="HotChocolate.AspNetCore" Version="13.9.4" />
 
-    <!-- Integration: System.Net.Http -->
-    <!-- Assembly: System.Net.Http -->
-    <!-- Latest package https://www.nuget.org/packages/System.Net.Http/4.3.4 -->
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-
-    <!-- Integration: System.Net.Http.WinHttpHandler -->
-    <!-- Assembly: System.Net.Http.WinHttpHandler -->
-    <!-- Latest package https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/8.0.0 -->
-    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
-
     <!-- Integration: amqmdnetstd -->
-    <!-- Assembly: amqmdnetstd -->
+    <!--    Assembly: amqmdnetstd -->
     <!-- Latest package https://www.nuget.org/packages/IBMMQDotnetClient/9.3.5.1 -->
     <PackageReference Include="IBMMQDotnetClient" Version="9.3.5.1" />
 
-    <!-- Integration: Microsoft.Extensions.Logging -->
-    <!-- Assembly: Microsoft.Extensions.Logging -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Logging/8.0.0 -->
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-
-    <!-- Integration: Microsoft.Extensions.Logging.Abstractions -->
-    <!-- Assembly: Microsoft.Extensions.Logging.Abstractions -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/8.0.1 -->
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-
-    <!-- Integration: Microsoft.Extensions.Telemetry -->
-    <!-- Assembly: Microsoft.Extensions.Telemetry -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Telemetry/8.5.0 -->
-    <PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.5.0" />
-
-    <!-- Integration: Confluent.Kafka -->
-    <!-- Assembly: Confluent.Kafka -->
-    <!-- Latest package https://www.nuget.org/packages/Confluent.Kafka/2.4.0 -->
-    <PackageReference Include="Confluent.Kafka" Version="2.4.0" />
-
     <!-- Integration: log4net -->
-    <!-- Assembly: log4net -->
+    <!--    Assembly: log4net -->
     <!-- Latest package https://www.nuget.org/packages/log4net/2.0.17 -->
     <PackageReference Include="log4net" Version="2.0.17" />
 
-    <!-- Integration: MongoDB.Driver.Core -->
-    <!-- Assembly: MongoDB.Driver.Core -->
-    <!-- Latest package https://www.nuget.org/packages/MongoDB.Driver.Core/2.25.0 -->
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.25.0" />
-
-    <!-- Integration: MongoDB.Driver.Core -->
-    <!-- Assembly: MongoDB.Driver.Core -->
-    <!-- Latest package https://www.nuget.org/packages/MongoDB.Driver/2.25.0 -->
-    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
-
-    <!-- Integration: Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter -->
-    <!-- Assembly: Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter -->
-    <!-- Latest package https://www.nuget.org/packages/MSTest.TestAdapter/3.3.1 -->
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-
-    <!-- Integration: Microsoft.VisualStudio.TestPlatform.TestFramework -->
-    <!-- Assembly: Microsoft.VisualStudio.TestPlatform.TestFramework -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.VisualStudio.TestPlatform/14.0.0.1 -->
-    <PackageReference Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0.1" />
-
-    <!-- Integration: MySql.Data -->
-    <!-- Assembly: MySql.Data -->
-    <!-- Latest package https://www.nuget.org/packages/MySql.Data/8.4.0 -->
-    <PackageReference Include="MySql.Data" Version="8.4.0" />
-
-    <!-- Integration: MySqlConnector -->
-    <!-- Assembly: MySqlConnector -->
-    <!-- Latest package https://www.nuget.org/packages/MySqlConnector/2.3.7 -->
-    <PackageReference Include="MySqlConnector" Version="2.3.7" />
-
-    <!-- Integration: NLog -->
-    <!-- Assembly: NLog -->
-    <!-- Latest package https://www.nuget.org/packages/NLog/5.3.2 -->
-    <PackageReference Include="NLog" Version="5.2.8" />
-
-    <!-- Integration: Npgsql -->
-    <!-- Assembly: Npgsql -->
-    <!-- Latest package https://www.nuget.org/packages/Npgsql/8.0.3 -->
-    <PackageReference Include="Npgsql" Version="8.0.3" />
-
-    <!-- Integration: nunit.framework -->
-    <!-- Assembly: nunit.framework -->
-    <!-- Latest package https://www.nuget.org/packages/NUnit/4.1.0 -->
-    <PackageReference Include="NUnit" Version="4.1.0" />
-
-    <!-- Integration: OpenTelemetry -->
-    <!-- Assembly: OpenTelemetry -->
-    <!-- Latest package https://www.nuget.org/packages/OpenTelemetry/1.8.1 -->
-    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
-
-    <!-- Integration: OpenTelemetry.Api -->
-    <!-- Assembly: OpenTelemetry.Api -->
-    <!-- Latest package https://www.nuget.org/packages/OpenTelemetry.Api/1.8.1 -->
-    <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
-
-    <!-- Integration: Oracle.ManagedDataAccess -->
-    <!-- Assembly: Oracle.ManagedDataAccess -->
-    <!-- Latest package https://www.nuget.org/packages/Oracle.ManagedDataAccess/23.4.0 -->
-    <PackageReference Include="Oracle.ManagedDataAccess" Version="23.4.0" />
-
-    <!-- Integration: RabbitMQ.Client -->
-    <!-- Assembly: RabbitMQ.Client -->
-    <!-- Latest package https://www.nuget.org/packages/RabbitMQ.Client/6.8.1 -->
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
-
-    <!-- Integration: WebDriver -->
-    <!-- Assembly: WebDriver -->
-    <!-- Latest package https://www.nuget.org/packages/Selenium.WebDriver/4.21.0 -->
-    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
-
-    <!-- Integration: Serilog -->
-    <!-- Assembly: Serilog -->
-    <!-- Latest package https://www.nuget.org/packages/Serilog/3.1.1 -->
-    <PackageReference Include="Serilog" Version="3.1.1" />
-
-    <!-- Integration: ServiceStack.Redis -->
-    <!-- Assembly: ServiceStack.Redis -->
-    <!-- Latest package https://www.nuget.org/packages/ServiceStack.Redis/8.2.2 -->
-    <PackageReference Include="ServiceStack.Redis" Version="8.2.2" />
-
-    <!-- Integration: Microsoft.Data.SqlClient -->
-    <!-- Assembly: Microsoft.Data.SqlClient -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.2.0 -->
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
-
-    <!-- Integration: System.Data.SqlClient -->
-    <!-- Assembly: System.Data.SqlClient -->
-    <!-- Latest package https://www.nuget.org/packages/System.Data.SqlClient/4.8.6 -->
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
-
-    <!-- Integration: Microsoft.Data.Sqlite -->
-    <!-- Assembly: Microsoft.Data.Sqlite -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Data.Sqlite/8.0.5 -->
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.5" />
-
-    <!-- Integration: System.Data.SQLite -->
-    <!-- Assembly: System.Data.SQLite -->
-    <!-- Latest package https://www.nuget.org/packages/System.Data.SQLite/1.0.118 -->
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
-
-    <!-- Integration: StackExchange.Redis -->
-    <!-- Assembly: StackExchange.Redis -->
-    <!-- Latest package https://www.nuget.org/packages/StackExchange.Redis/2.7.33 -->
-    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
-
-    <!-- Integration: StackExchange.Redis.StrongName -->
-    <!-- Assembly: StackExchange.Redis.StrongName -->
-    <!-- Latest package https://www.nuget.org/packages/StackExchange.Redis.StrongName/1.2.6 -->
-    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
-
-    <!-- Integration: Microsoft.VisualStudio.TestPlatform.Common -->
-    <!-- Assembly: Microsoft.VisualStudio.TestPlatform.Common -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.VisualStudio.TestPlatform/14.0.0.1 -->
-    <PackageReference Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0.1" />
-
-    <!-- Integration: System.ServiceModel -->
-    <!-- Assembly: System.ServiceModel -->
-    <!-- Latest package https://www.nuget.org/packages/System.ServiceModel.Http/8.0.0 -->
-    <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" />
-
-    <!-- Integration: System.Net.Requests -->
-    <!-- Assembly: System.Net.Requests -->
-    <!-- Latest package https://www.nuget.org/packages/System.Net.Requests/4.3.0 -->
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-
-    <!-- Integration: xunit.execution.desktop -->
-    <!-- Assembly: xunit.execution.desktop -->
-    <!-- Latest package https://www.nuget.org/packages/xunit/2.8.0 -->
-    <PackageReference Include="xunit" Version="2.8.0" />
-
-    <!-- Integration: xunit.execution.dotnet -->
-    <!-- Assembly: xunit.execution.dotnet -->
-    <!-- Latest package https://www.nuget.org/packages/xunit.extensibility.execution/2.8.0 -->
-    <PackageReference Include="xunit.extensibility.execution" Version="2.8.0" />
+    <!-- Integration: System.Web.Mvc -->
+    <!--    Assembly: System.Web.Mvc -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNet.Mvc/5.3.0 -->
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
 
     <!-- Integration: Microsoft.AspNetCore.Authentication.Abstractions -->
-    <!-- Assembly: Microsoft.AspNetCore.Authentication.Abstractions -->
+    <!--    Assembly: Microsoft.AspNetCore.Authentication.Abstractions -->
     <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.Abstractions/2.2.0 -->
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
 
-    <!-- Integration: Microsoft.AspNetCore.Identity -->
-    <!-- Assembly: Microsoft.AspNetCore.Identity -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Identity/2.2.0 -->
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-
-    <!-- Integration: Microsoft.AspNetCore.Mvc.Core -->
-    <!-- Assembly: Microsoft.AspNetCore.Mvc.Core -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Core/2.2.5 -->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-
-    <!-- Integration: Microsoft.AspNetCore.Server.IIS -->
-    <!-- Assembly: Microsoft.AspNetCore.Server.IIS -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Server.IIS/2.2.6 -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="2.2.6" />
-
-    <!-- Integration: Microsoft.AspNetCore.Server.Kestrel.Core -->
-    <!-- Assembly: Microsoft.AspNetCore.Server.Kestrel.Core -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0 -->
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
-
-    <!-- Integration: Microsoft.Extensions.Identity.Core -->
-    <!-- Assembly: Microsoft.Extensions.Identity.Core -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Identity.Core/8.0.5 -->
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.5" />
-
-    <!-- Integration: Amazon.Lambda.RuntimeSupport -->
-    <!-- Assembly: Amazon.Lambda.RuntimeSupport -->
-    <!-- Latest package https://www.nuget.org/packages/Amazon.Lambda.RuntimeSupport/1.10.0 -->
-    <PackageReference Include="Amazon.Lambda.RuntimeSupport" Version="1.10.0" />
-
-    <!-- Integration: Microsoft.Azure.WebJobs.Host -->
-    <!-- Assembly: Microsoft.Azure.WebJobs.Host -->
-    <!-- Latest package https://www.nuget.org/packages/Microsoft.Azure.WebJobs/3.0.39 -->
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
-
-    <!-- Integration: Grpc.AspNetCore.Server -->
-    <!-- Assembly: Grpc.AspNetCore.Server -->
-    <!-- Latest package https://www.nuget.org/packages/Grpc.AspNetCore/2.62.0 -->
-    <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
-
-    <!-- Integration: Grpc.Net.Client -->
-    <!-- Assembly: Grpc.Net.Client -->
-    <!-- Latest package https://www.nuget.org/packages/Grpc.AspNetCore/2.62.0 -->
-    <PackageReference Include="Grpc.AspNetCore" Version="2.62.0" />
-
-    <!-- Integration: Yarp.ReverseProxy -->
-    <!-- Assembly: Yarp.ReverseProxy -->
-    <!-- Latest package https://www.nuget.org/packages/Yarp.ReverseProxy/2.1.0 -->
-    <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
-
     <!-- Integration: Microsoft.AspNetCore.Diagnostics -->
-    <!-- Assembly: Microsoft.AspNetCore.Diagnostics -->
+    <!--    Assembly: Microsoft.AspNetCore.Diagnostics -->
     <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Diagnostics/2.2.0 -->
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.2.0" />
 
     <!-- Integration: Microsoft.AspNetCore.Html.Abstractions -->
-    <!-- Assembly: Microsoft.AspNetCore.Html.Abstractions -->
+    <!--    Assembly: Microsoft.AspNetCore.Html.Abstractions -->
     <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Html.Abstractions/2.2.0 -->
     <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
+
+    <!-- Integration: Microsoft.AspNetCore.Identity -->
+    <!--    Assembly: Microsoft.AspNetCore.Identity -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Identity/2.2.0 -->
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
+
+    <!-- Integration: Microsoft.AspNetCore.Mvc.Core -->
+    <!--    Assembly: Microsoft.AspNetCore.Mvc.Core -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Core/2.2.5 -->
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+
+    <!-- Integration: Microsoft.AspNetCore.Server.IIS -->
+    <!--    Assembly: Microsoft.AspNetCore.Server.IIS -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Server.IIS/2.2.6 -->
+    <PackageReference Include="Microsoft.AspNetCore.Server.IIS" Version="2.2.6" />
+
+    <!-- Integration: Microsoft.AspNetCore.Server.Kestrel.Core -->
+    <!--    Assembly: Microsoft.AspNetCore.Server.Kestrel.Core -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.Server.Kestrel.Core/2.2.0 -->
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.2.0" />
+
+    <!-- Integration: Microsoft.AspNetCore.StaticFiles -->
+    <!--    Assembly: Microsoft.AspNetCore.StaticFiles -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.AspNetCore.StaticFiles/2.2.0 -->
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+
+    <!-- Integration: Microsoft.Azure.Cosmos.Client -->
+    <!--    Assembly: Microsoft.Azure.Cosmos.Client -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.39.1 -->
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.1" />
+
+    <!-- Integration: Microsoft.Azure.WebJobs.Host -->
+    <!--    Assembly: Microsoft.Azure.WebJobs.Host -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Azure.WebJobs/3.0.39 -->
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.39" />
+
+    <!-- Integration: Microsoft.Data.SqlClient -->
+    <!--    Assembly: Microsoft.Data.SqlClient -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Data.SqlClient/5.2.0 -->
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+
+    <!-- Integration: Microsoft.Data.Sqlite -->
+    <!--    Assembly: Microsoft.Data.Sqlite -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Data.Sqlite/8.0.5 -->
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.5" />
+
+    <!-- Integration: Microsoft.Extensions.Identity.Core -->
+    <!--    Assembly: Microsoft.Extensions.Identity.Core -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Identity.Core/8.0.5 -->
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.5" />
+
+    <!-- Integration: Microsoft.Extensions.Logging -->
+    <!--    Assembly: Microsoft.Extensions.Logging -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Logging/8.0.0 -->
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+
+    <!-- Integration: Microsoft.Extensions.Logging.Abstractions -->
+    <!--    Assembly: Microsoft.Extensions.Logging.Abstractions -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/8.0.1 -->
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+
+    <!-- Integration: Microsoft.Extensions.Telemetry -->
+    <!--    Assembly: Microsoft.Extensions.Telemetry -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.Extensions.Telemetry/8.5.0 -->
+    <PackageReference Include="Microsoft.Extensions.Telemetry" Version="8.5.0" />
+
+    <!-- Integration: Microsoft.VisualStudio.TestPlatform.Common -->
+    <!--    Assembly: Microsoft.VisualStudio.TestPlatform.Common -->
+    <!-- Integration: Microsoft.VisualStudio.TestPlatform.TestFramework -->
+    <!--    Assembly: Microsoft.VisualStudio.TestPlatform.TestFramework -->
+    <!-- Latest package https://www.nuget.org/packages/Microsoft.VisualStudio.TestPlatform/14.0.0.1 -->
+    <PackageReference Include="Microsoft.VisualStudio.TestPlatform" Version="14.0.0.1" />
+
+    <!-- Integration: MongoDB.Driver.Core -->
+    <!--    Assembly: MongoDB.Driver.Core -->
+    <!-- Latest package https://www.nuget.org/packages/MongoDB.Driver/2.25.0 -->
+    <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
+
+    <!-- Integration: MongoDB.Driver.Core -->
+    <!--    Assembly: MongoDB.Driver.Core -->
+    <!-- Latest package https://www.nuget.org/packages/MongoDB.Driver.Core/2.25.0 -->
+    <PackageReference Include="MongoDB.Driver.Core" Version="2.25.0" />
+
+    <!-- Integration: Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter -->
+    <!--    Assembly: Microsoft.VisualStudio.TestPlatform.MSTest.TestAdapter -->
+    <!-- Latest package https://www.nuget.org/packages/MSTest.TestAdapter/3.3.1 -->
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
+
+    <!-- Integration: MySql.Data -->
+    <!--    Assembly: MySql.Data -->
+    <!-- Latest package https://www.nuget.org/packages/MySql.Data/8.4.0 -->
+    <PackageReference Include="MySql.Data" Version="8.4.0" />
+
+    <!-- Integration: MySqlConnector -->
+    <!--    Assembly: MySqlConnector -->
+    <!-- Latest package https://www.nuget.org/packages/MySqlConnector/2.3.7 -->
+    <PackageReference Include="MySqlConnector" Version="2.3.7" />
+
+    <!-- Integration: NLog -->
+    <!--    Assembly: NLog -->
+    <!-- Latest package https://www.nuget.org/packages/NLog/5.3.2 -->
+    <PackageReference Include="NLog" Version="5.2.8" />
+
+    <!-- Integration: Npgsql -->
+    <!--    Assembly: Npgsql -->
+    <!-- Latest package https://www.nuget.org/packages/Npgsql/8.0.3 -->
+    <PackageReference Include="Npgsql" Version="8.0.3" />
+
+    <!-- Integration: nunit.framework -->
+    <!--    Assembly: nunit.framework -->
+    <!-- Latest package https://www.nuget.org/packages/NUnit/4.1.0 -->
+    <PackageReference Include="NUnit" Version="4.1.0" />
+
+    <!-- Integration: OpenTelemetry -->
+    <!--    Assembly: OpenTelemetry -->
+    <!-- Latest package https://www.nuget.org/packages/OpenTelemetry/1.8.1 -->
+    <PackageReference Include="OpenTelemetry" Version="1.8.1" />
+
+    <!-- Integration: OpenTelemetry.Api -->
+    <!--    Assembly: OpenTelemetry.Api -->
+    <!-- Latest package https://www.nuget.org/packages/OpenTelemetry.Api/1.8.1 -->
+    <PackageReference Include="OpenTelemetry.Api" Version="1.8.1" />
+
+    <!-- Integration: Oracle.ManagedDataAccess -->
+    <!--    Assembly: Oracle.ManagedDataAccess -->
+    <!-- Latest package https://www.nuget.org/packages/Oracle.ManagedDataAccess/23.4.0 -->
+    <PackageReference Include="Oracle.ManagedDataAccess" Version="23.4.0" />
+
+    <!-- Integration: RabbitMQ.Client -->
+    <!--    Assembly: RabbitMQ.Client -->
+    <!-- Latest package https://www.nuget.org/packages/RabbitMQ.Client/6.8.1 -->
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+
+    <!-- Integration: WebDriver -->
+    <!--    Assembly: WebDriver -->
+    <!-- Latest package https://www.nuget.org/packages/Selenium.WebDriver/4.21.0 -->
+    <PackageReference Include="Selenium.WebDriver" Version="4.21.0" />
+
+    <!-- Integration: Serilog -->
+    <!--    Assembly: Serilog -->
+    <!-- Latest package https://www.nuget.org/packages/Serilog/3.1.1 -->
+    <PackageReference Include="Serilog" Version="3.1.1" />
+
+    <!-- Integration: ServiceStack.Redis -->
+    <!--    Assembly: ServiceStack.Redis -->
+    <!-- Latest package https://www.nuget.org/packages/ServiceStack.Redis/8.2.2 -->
+    <PackageReference Include="ServiceStack.Redis" Version="8.2.2" />
+
+    <!-- Integration: StackExchange.Redis -->
+    <!--    Assembly: StackExchange.Redis -->
+    <!-- Latest package https://www.nuget.org/packages/StackExchange.Redis/2.7.33 -->
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
+
+    <!-- Integration: StackExchange.Redis.StrongName -->
+    <!--    Assembly: StackExchange.Redis.StrongName -->
+    <!-- Latest package https://www.nuget.org/packages/StackExchange.Redis.StrongName/1.2.6 -->
+    <PackageReference Include="StackExchange.Redis.StrongName" Version="1.2.6" />
+
+    <!-- Integration: System.Data.Common -->
+    <!--    Assembly: System.Data.Common -->
+    <!-- Latest package https://www.nuget.org/packages/System.Data.Common/4.3.0 -->
+    <PackageReference Include="System.Data.Common" Version="4.3.0" />
+
+    <!-- Integration: System.Data -->
+    <!--    Assembly: System.Data -->
+    <!-- Integration: System.Data.SqlClient -->
+    <!--    Assembly: System.Data.SqlClient -->
+    <!-- Latest package https://www.nuget.org/packages/System.Data.SqlClient/4.8.6 -->
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
+
+    <!-- Integration: System.Data.SQLite -->
+    <!--    Assembly: System.Data.SQLite -->
+    <!-- Latest package https://www.nuget.org/packages/System.Data.SQLite/1.0.118 -->
+    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
+
+    <!-- Integration: System.Net.Http -->
+    <!--    Assembly: System.Net.Http -->
+    <!-- Latest package https://www.nuget.org/packages/System.Net.Http/4.3.4 -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+
+    <!-- Integration: System.Net.Http.WinHttpHandler -->
+    <!--    Assembly: System.Net.Http.WinHttpHandler -->
+    <!-- Latest package https://www.nuget.org/packages/System.Net.Http.WinHttpHandler/8.0.0 -->
+    <PackageReference Include="System.Net.Http.WinHttpHandler" Version="8.0.0" />
+
+    <!-- Integration: System.Net.Requests -->
+    <!--    Assembly: System.Net.Requests -->
+    <!-- Latest package https://www.nuget.org/packages/System.Net.Requests/4.3.0 -->
+    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+
+    <!-- Integration: System.ServiceModel -->
+    <!--    Assembly: System.ServiceModel -->
+    <!-- Latest package https://www.nuget.org/packages/System.ServiceModel.Http/8.0.0 -->
+    <PackageReference Include="System.ServiceModel.Http" Version="4.10.3" />
+
+    <!-- Integration: xunit.execution.desktop -->
+    <!--    Assembly: xunit.execution.desktop -->
+    <!-- Latest package https://www.nuget.org/packages/xunit/2.8.0 -->
+    <PackageReference Include="xunit" Version="2.8.0" />
+
+    <!-- Integration: xunit.execution.dotnet -->
+    <!--    Assembly: xunit.execution.dotnet -->
+    <!-- Latest package https://www.nuget.org/packages/xunit.extensibility.execution/2.8.0 -->
+    <PackageReference Include="xunit.extensibility.execution" Version="2.8.0" />
+
+    <!-- Integration: Yarp.ReverseProxy -->
+    <!--    Assembly: Yarp.ReverseProxy -->
+    <!-- Latest package https://www.nuget.org/packages/Yarp.ReverseProxy/2.1.0 -->
+    <PackageReference Include="Yarp.ReverseProxy" Version="2.1.0" />
 
   </ItemGroup>
 


### PR DESCRIPTION
## Summary of changes

Fixes our broken Dependabot integration

## Reason for change

Our dependabot integration broke at some point, so we haven't been getting notifications for new packages. The reason is that GitHub tries to run a `dotnet restore` on the "honeypot" dependabot project file, and unfortunately it was getting a bunch of errors (and warnings) and bailing out:

```
error NU1202: Package Aerospike.Client 7.2.0 is not compatible with netcoreapp3.1 
error NU1202: Package Yarp.ReverseProxy 2.1.0 is not compatible with netcoreapp3.1
error NU1202: Package Grpc.AspNetCore 2.62.0 is not compatible with netcoreapp3.1
```

So this PR fixes the issue (by bumping the TFM), solves some other warnings (about duplicate entries) and sets up alerts and fallback approaches

## Implementation details

- Bump the TFM to .NET 8 to fix the restore errors. This should cover us for a little while at least
- "Fix" the file generator to group by packagename so we don't duplicate packages when they're referenced in multiple integrations.
- Added a verification stage to the end of the Nuke target that makes sure the generated file _can_ be restored, to hopefully avoid this issue happening again
- Added a "fallback" schedule so we run the tool every week, regardless of dependabot updates
- Send a slack notification if the run fails

## Test coverage

Tested locally a bunch, but we need to merge it before I can check if dependabot is fixed

## Other details

Supersedes https://github.com/DataDog/dd-trace-dotnet/pull/5567

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
