### PR TITLE
Disable automatic flush in AgentWriterTests.FaultyApi

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -236,7 +236,6 @@ namespace Datadog.Trace.Tests.Agent
             // Also, it should free the faulty buffer
             var api = new Mock<IApi>();
             var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, automaticFlush: false);
-            var mutex = new ManualResetEventSlim();
 
             api.Setup(a => a.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()))
                .Returns(() => throw new InvalidOperationException());

--- a/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/AgentWriterTests.cs
@@ -230,28 +230,26 @@ namespace Datadog.Trace.Tests.Agent
         }
 
         [Fact]
-        public Task FaultyApi()
+        public async Task FaultyApi()
         {
             // The flush thread should be able to recover from an error when calling the API
             // Also, it should free the faulty buffer
             var api = new Mock<IApi>();
-            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null);
+            var agent = new AgentWriter(api.Object, statsAggregator: null, statsd: null, automaticFlush: false);
             var mutex = new ManualResetEventSlim();
-
-            agent.Flushed += () => mutex.Set();
 
             api.Setup(a => a.SendTracesAsync(It.IsAny<ArraySegment<byte>>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<long>(), It.IsAny<long>()))
                .Returns(() => throw new InvalidOperationException());
 
             agent.WriteTrace(CreateTraceChunk(1));
 
-            mutex.Wait();
+            await agent.FlushTracesAsync();
 
             agent.ActiveBuffer.Should().BeSameAs(agent.FrontBuffer);
             agent.FrontBuffer.IsEmpty.Should().BeTrue();
             agent.BackBuffer.IsEmpty.Should().BeTrue();
 
-            return agent.FlushAndCloseAsync();
+            await agent.FlushAndCloseAsync();
         }
 
         [Fact]


### PR DESCRIPTION
## Summary of changes

Switch the FaultyApi test to use manual flush instead of automatic flush for better predictability.

## Reason for change

It looks like the test is flaky (though 1 failure in 3 years is a fairly good rate IMO).

## Test coverage

We'll see three years from now if it fails again.