### PR TITLE
Make crash tracking opt-out

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -129,6 +129,27 @@ steps:
   condition: succeededOrFailed()
   continueOnError: true
 
+# Run crash tests
+- ${{ if eq(parameters.isLinux, true) }}:
+  - bash: |
+      LOGS=$(docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
+      echo $LOGS
+
+      # check logs for evidence of crash detection in the output
+      expected="The crash may have been caused by automatic instrumentation"
+      if [[ $LOGS == *"$expected"* ]]; then
+        echo "Correctly found evidence of crash detection"
+      else
+        echo "Did not find required evidence of crash detection running"
+        exit 1;
+      fi
+
+    env:
+      dockerTag: $(dockerTag)
+      DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
+    displayName: Check logs for evidence of crash output
+    condition: eq(variables['runCrashTest'], 'true')
+
 - ${{ if eq(parameters.isLinux, true) }}:
     - script: |
         sudo chmod -R 644 tracer/build_data/dumps/* || true

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -83,7 +83,11 @@ const char* getLibraryPath()
 
 int isAlpine()
 {
-    // TODO
+    if (access("/etc/alpine-release", F_OK) == 0)
+    {
+        return 1;
+    }
+
     return 0;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 /* dl_iterate_phdr wrapper
 The .NET profiler on Linux uses a classic signal-based approach to collect thread callstack.

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -59,13 +59,206 @@ unsigned long long dd_inside_wrapped_functions()
     return functions_entered_counter;
 }
 
+#if defined(__aarch64__)
+const char* DdDotnetFolder = "linux-arm64";
+const char* DdDotnetMuslFolder = "linux-musl-arm64";
+#else
+const char* DdDotnetFolder = "linux-x64";
+const char* DdDotnetMuslFolder = "linux-musl-x64";
+#endif
+
+char* crashHandler = NULL;
+
+const char* getLibraryPath()
+{
+    Dl_info dl_info;
+
+    if (dladdr((void*)getLibraryPath, &dl_info))
+    {
+        return dl_info.dli_fname;
+    }
+    
+    return NULL;
+}
+
+int isAlpine()
+{
+    // TODO
+    return 0;
+}
+
+char* appendToPath(const char* folder, const char* suffix)
+{
+    int length = strlen(folder) + strlen(suffix);
+
+    char* result = malloc(length + 1);
+
+    if (result == NULL)
+    {
+        return NULL;
+    }
+
+    strcpy(result, folder);
+    strcpy(result + strlen(folder), suffix);
+
+    return result;
+}
+
+char* getFolder(const char* path)
+{
+    char* lastSlash = strrchr(path, '/');
+    if (lastSlash == NULL)
+    {
+        return "";
+    }
+
+    // Copying the last subfolder to a new string
+    int length = lastSlash - path;
+    char* folder = malloc(length + 1);
+
+    if (folder == NULL)
+    {
+        return NULL; // Memory allocation failed
+    }
+
+    strncpy(folder, path, length);
+    folder[length] = '\0';
+
+    return folder;
+}
+
+char* getSubfolder(const char* path)
+{
+    char* lastSlash = strrchr(path, '/');
+    if (lastSlash == NULL) {
+        return NULL; // No slash found, path does not contain subfolders
+    }
+
+    // Finding the last but one slash
+    char* temp = lastSlash - 1;
+    while (temp >= path && *temp != '/') {
+        temp--;
+    }
+
+    if (temp < path)
+    {
+        // No leading slash, that's weird
+        return NULL;
+    }
+
+    // Increment to move past the slash
+    temp++;
+
+    // Copying the last subfolder to a new string
+    int folderLength = lastSlash - temp;
+    char* subfolder = malloc(folderLength + 1);
+
+    if (subfolder == NULL)
+    {
+        return NULL; // Memory allocation failed
+    }
+
+    strncpy(subfolder, temp, folderLength);
+    subfolder[folderLength] = '\0';
+
+    return subfolder;
+}
+
 __attribute__((constructor))
-void initLibrary(void) {
+void initLibrary(void)
+{
+    const char* crashHandlerEnabled = getenv("DD_TRACE_CRASH_HANDLER_ENABLED");
+
+    if (crashHandlerEnabled != NULL)
+    {
+        if (strcasecmp(crashHandlerEnabled, "no") == 0
+         || strcasecmp(crashHandlerEnabled, "false") == 0
+         || strcasecmp(crashHandlerEnabled, "0") == 0)
+        {
+            // Early nope
+            return;
+        }
+    }
+
     // If crashtracking is enabled, check the value of DOTNET_DbgEnableMiniDump
     // If set, set DD_TRACE_CRASH_HANDLER_PASSTHROUGH to indicate dd-dotnet that it should call createdump
     // If not set, set it to 1 so that .NET calls createdump in case of crash
     // (and we will redirect the call to dd-dotnet)
-    char* crashHandler = getenv("DD_TRACE_CRASH_HANDLER");
+    const char* crashHandlerEnv = getenv("DD_TRACE_CRASH_HANDLER");
+
+    if (crashHandlerEnv == NULL || crashHandlerEnv[0] == '\0')
+    {
+        // The path to the crash handler is not set, try to deduce it
+        const char* libraryPath = getLibraryPath();
+
+        if (libraryPath != NULL)
+        {            
+            // If the library is in linux-x64 or linux-musl-x64, we use that folder
+            // Otherwise, if the library is in continuousprofiler, we have to call isAlpine()
+            // and use either ../linux-x64/ or ../linux-musl-x64/, or their ARM64 equivalent
+            char* subFolder = getSubfolder(libraryPath);
+
+            if (subFolder != NULL)
+            {
+                char* newCrashHandler = NULL;
+
+                if (strcmp(subFolder, DdDotnetFolder) == 0
+                    || strcmp(subFolder, DdDotnetMuslFolder) == 0)
+                {
+                    // We use the dd-dotnet in that same folder
+                    char* folder = getFolder(libraryPath);
+
+                    if (folder != NULL)
+                    {
+                        asprintf(&newCrashHandler, "%s/dd-dotnet", folder);
+                        free(folder);
+                    }
+                }
+                else if (strcmp(subFolder, "continuousprofiler") == 0)
+                {
+                    char* folder = getFolder(libraryPath);
+
+                    if (folder != NULL)
+                    {
+                        const char* currentDdDotnetFolder;
+
+                        if (isAlpine() == 0)
+                        {
+                            currentDdDotnetFolder = DdDotnetFolder;
+                        }
+                        else
+                        {
+                            currentDdDotnetFolder = DdDotnetMuslFolder;
+                        }
+
+                        asprintf(&newCrashHandler, "%s/../%s/dd-dotnet", folder, currentDdDotnetFolder);
+                        free(folder);
+                    }
+                }
+
+                free(subFolder);
+
+                if (newCrashHandler != NULL)
+                {
+                    // Make sure the file exists and has execute permissions
+                    if (access(newCrashHandler, X_OK) == 0)
+                    {
+                        crashHandler = newCrashHandler;
+                    }
+                    else
+                    {
+                        free(newCrashHandler);
+                    }
+                }
+            }
+        }
+    }
+    else
+    {
+        // The environment variables can change during the lifetime of the process,
+        // so make a copy of the string
+        crashHandler = strdup(crashHandlerEnv);
+    }
 
     if (crashHandler != NULL && crashHandler[0] != '\0')
     {
@@ -169,25 +362,16 @@ int dladdr(const void* addr_arg, Dl_info* info)
 /* Function pointers to hold the value of the glibc functions */
 static int (*__real_execve)(const char* pathname, char* const argv[], char* const envp[]) = NULL;
 
-static char* ddTracePath = NULL;
-
 int execve(const char* pathname, char* const argv[], char* const envp[])
 {
     if (__real_execve == NULL)
     {
         __real_execve = dlsym(RTLD_NEXT, "execve");
-
-        ddTracePath = getenv("DD_TRACE_CRASH_HANDLER");
-
-        if (ddTracePath != NULL && ddTracePath[0] == '\0')
-        {
-            ddTracePath = NULL;
-        }
     }
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
-    if (ddTracePath != NULL && pathname != NULL)
+    if (crashHandler != NULL && pathname != NULL)
     {
         size_t length = strlen(pathname);
 
@@ -204,7 +388,7 @@ int execve(const char* pathname, char* const argv[], char* const envp[])
 
             // By convention, argv[0] contains the name of the executable
             // Insert createdump as the first actual argument
-            newArgv[0] = ddTracePath;
+            newArgv[0] = crashHandler;
             newArgv[1] = "createdump";
 
             // Copy the remaining arguments
@@ -237,7 +421,7 @@ int execve(const char* pathname, char* const argv[], char* const envp[])
             }
             new_envp[index] = NULL; // NULL terminate the array
 
-            int result = __real_execve(ddTracePath, newArgv, new_envp);
+            int result = __real_execve(crashHandler, newArgv, new_envp);
 
             free(newArgv);
             free(new_envp);

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -219,7 +219,7 @@ void initLibrary(void)
                         free(folder);
                     }
                 }
-                else if (strcmp(subFolder, "continuousprofiler") == 0)
+                else
                 {
                     char* folder = getFolder(libraryPath);
 
@@ -236,7 +236,17 @@ void initLibrary(void)
                             currentDdDotnetFolder = DdDotnetMuslFolder;
                         }
 
-                        asprintf(&newCrashHandler, "%s/../%s/dd-dotnet", folder, currentDdDotnetFolder);
+                        if (strcmp(subFolder, "continuousprofiler") == 0)
+                        {
+                            // If we're in continuousprofiler, we need to go up one folder
+                            asprintf(&newCrashHandler, "%s/../%s/dd-dotnet", folder, currentDdDotnetFolder);
+                        }
+                        else
+                        {
+                            // Assume we're at the root
+                            asprintf(&newCrashHandler, "%s/%s/dd-dotnet", folder, currentDdDotnetFolder);
+                        }
+                        
                         free(folder);
                     }
                 }

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2436,6 +2436,9 @@ partial class Build
            // There's a race in the profiler where unwinding when the thread is running
            knownPatterns.Add(new(@".*Failed to walk \d+ stacks for sampled exception:\s+CORPROF_E_STACKSNAPSHOT_UNSAFE", RegexOptions.Compiled));
 
+           // This one is caused by the intentional crash in the crash tracking smoke test
+           knownPatterns.Add(new("Application threw an unhandled exception: System.BadImageFormatException: Expected", RegexOptions.Compiled));
+           
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });
 

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -399,20 +399,20 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-buster-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bionic"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-bionic"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-buster-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bionic"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-bionic"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
                         },
                         installer: "datadog-dotnet-apm*_amd64.deb",
                         installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb",
@@ -424,18 +424,18 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "35-5.0"),
-                            (publishFramework: TargetFramework.NET5_0, "34-5.0"),
-                            (publishFramework: TargetFramework.NET5_0, "33-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "34-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "33-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "29-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "35-5.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "34-5.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "34-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "33-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "29-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -447,18 +447,18 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.13"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.13"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.13"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.13"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         installer: "datadog-dotnet-apm*-musl.tar.gz",
                         installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*-musl.tar.gz",
@@ -470,13 +470,13 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "centos",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "7-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "7-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "7-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "7-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "7-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -488,12 +488,12 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "rhel",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "8-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "8-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "8-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "8-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "8-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "8-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -505,13 +505,13 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "centos-stream",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
                             // (publishFramework: TargetFramework.NET7_0, "9-7.0"), Not updated from RC1 yet
-                            (publishFramework: TargetFramework.NET6_0, "9-6.0"),
-                            (publishFramework: TargetFramework.NET6_0, "8-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "8-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
+                            new (publishFramework: TargetFramework.NET6_0, "9-6.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "8-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "8-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -523,13 +523,13 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "opensuse",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "15-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "15-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "15-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -550,10 +550,10 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
                         },
                         installer: null,
                         installCmd: null,
@@ -574,14 +574,15 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            // https://github.com/dotnet/runtime/issues/66707
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb",
                         installCmd: "dpkg -i ./datadog-dotnet-apm_*_arm64.deb",
@@ -593,11 +594,12 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "35-5.0"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            // https://github.com/dotnet/runtime/issues/66707
+                            new (publishFramework: TargetFramework.NET5_0, "35-5.0", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm*-1.aarch64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.aarch64.rpm",
@@ -610,12 +612,13 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian_tar",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            // https://github.com/dotnet/runtime/issues/66707
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb", // we advise customers to install the .deb in this case
                         installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*.arm64.tar.gz",
@@ -636,10 +639,10 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
                         },
                         installer: null,
                         installCmd: null,
@@ -656,7 +659,7 @@ partial class Build : NukeBuild
                 void AddToLinuxSmokeTestsMatrix(
                     Dictionary<string, object> matrix,
                     string shortName,
-                    (string publishFramework, string runtimeTag)[] images,
+                    SmokeTestImage[] images,
                     string installer,
                     string installCmd,
                     string linuxArtifacts,
@@ -666,7 +669,7 @@ partial class Build : NukeBuild
                 {
                     foreach (var image in images)
                     {
-                        var dockerTag = $"{shortName}_{image.runtimeTag.Replace('.', '_')}";
+                        var dockerTag = $"{shortName}_{image.RuntimeTag.Replace('.', '_')}";
                         matrix.Add(
                             dockerTag,
                             new
@@ -675,9 +678,10 @@ partial class Build : NukeBuild
                                 expectedPath = runtimeId,
                                 installCmd = installCmd,
                                 dockerTag = dockerTag,
-                                publishFramework = image.publishFramework,
+                                publishFramework = image.PublishFramework,
                                 linuxArtifacts = linuxArtifacts,
-                                runtimeImage = $"{dockerName}:{image.runtimeTag}"
+                                runCrashTest = image.RunCrashTest ? "true" : "false",
+                                runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
                 }
@@ -689,17 +693,17 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -709,13 +713,13 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "33-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -725,15 +729,15 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         relativeProfilerPath: "datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-musl-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -743,13 +747,13 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "centos",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "7-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "7-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "7-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "7-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "7-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -759,13 +763,13 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "opensuse",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "15-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "15-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "15-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -784,17 +788,17 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
                         relativeProfilerPath: "datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-arm64/Datadog.Linux.ApiWrapper.x64.so",
@@ -809,7 +813,7 @@ partial class Build : NukeBuild
                 void AddToNuGetSmokeTestsMatrix(
                     Dictionary<string, object> matrix,
                     string shortName,
-                    (string publishFramework, string runtimeTag)[] images,
+                    SmokeTestImage[] images,
                     string relativeProfilerPath,
                     string relativeApiWrapperPath,
                     string dockerName
@@ -817,16 +821,17 @@ partial class Build : NukeBuild
                 {
                     foreach (var image in images)
                     {
-                        var dockerTag = $"{shortName}_{image.runtimeTag.Replace('.', '_')}";
+                        var dockerTag = $"{shortName}_{image.RuntimeTag.Replace('.', '_')}";
                         matrix.Add(
                             dockerTag,
                             new
                             {
                                 dockerTag = dockerTag,
-                                publishFramework = image.publishFramework,
+                                publishFramework = image.PublishFramework,
                                 relativeProfilerPath = relativeProfilerPath,
                                 relativeApiWrapperPath = relativeApiWrapperPath,
-                                runtimeImage = $"{dockerName}:{image.runtimeTag}"
+                                runCrashTest = image.RunCrashTest ? "true" : "false",
+                                runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
                 }
@@ -838,17 +843,17 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
@@ -857,13 +862,13 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "33-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "andrewlock/dotnet-fedora"
@@ -872,15 +877,15 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"), 
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"), 
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         platformSuffix: "linux-musl-x64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
@@ -889,13 +894,13 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "centos",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "7-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "7-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "7-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "7-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "7-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "andrewlock/dotnet-centos"
@@ -904,13 +909,13 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "opensuse",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "15-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "15-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "15-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "andrewlock/dotnet-opensuse"
@@ -928,17 +933,17 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
                         platformSuffix: "linux-arm64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
@@ -956,15 +961,15 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
@@ -973,11 +978,11 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.15"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.15"),
                         },
                         platformSuffix: "linux-musl-x64",
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
@@ -991,22 +996,23 @@ partial class Build : NukeBuild
                 void AddToDotNetToolSmokeTestsMatrix(
                     Dictionary<string, object> matrix,
                     string shortName,
-                    (string publishFramework, string runtimeTag)[] images,
+                    SmokeTestImage[] images,
                     string platformSuffix,
                     string dockerName
                 )
                 {
                     foreach (var image in images)
                     {
-                        var dockerTag = $"{shortName}_{image.runtimeTag.Replace('.', '_')}";
+                        var dockerTag = $"{shortName}_{image.RuntimeTag.Replace('.', '_')}";
                         matrix.Add(
                             dockerTag,
                             new
                             {
                                 dockerTag = dockerTag,
-                                publishFramework = image.publishFramework,
+                                publishFramework = image.PublishFramework,
                                 platformSuffix = platformSuffix,
-                                runtimeImage = $"{dockerName}:{image.runtimeTag}"
+                                runCrashTest = image.RunCrashTest ? "true" : "false",
+                                runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
                 }
@@ -1020,25 +1026,25 @@ partial class Build : NukeBuild
                         (MSBuildTargetPlatform.x64, true),
                         (MSBuildTargetPlatform.x86, true)
                     };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform.platform}_{image.runtimeTag.Replace('.', '_')}_{(platform.enable32Bit ? "32bit" : "64bit")}"
+                                     let dockerTag = $"{platform.platform}_{image.RuntimeTag.Replace('.', '_')}_{(platform.enable32Bit ? "32bit" : "64bit")}"
                                      let channel32Bit = platform.enable32Bit
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform.platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1053,26 +1059,26 @@ partial class Build : NukeBuild
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";
 
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
                                      let channel32Bit = platform == MSBuildTargetPlatform.x86
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          relativeProfilerPath = $"win-{platform}/Datadog.Trace.ClrProfiler.Native.dll",
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1087,26 +1093,26 @@ partial class Build : NukeBuild
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";
 
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
                                      let channel32Bit = platform == MSBuildTargetPlatform.x86
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          relativeProfilerPath = $"datadog/win-{platform}/Datadog.Trace.ClrProfiler.Native.dll",
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1121,25 +1127,25 @@ partial class Build : NukeBuild
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";
 
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
                                      let channel32Bit = platform == MSBuildTargetPlatform.x86
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1304,5 +1310,19 @@ partial class Build : NukeBuild
               .Git($"diff --name-only \"{baseCommit}\"")
               .Select(output => output.Text)
               .ToArray();
+    }
+
+    class SmokeTestImage
+    {
+        public SmokeTestImage(string publishFramework, string runtimeTag, bool runCrashTest = true)
+        {
+            PublishFramework = publishFramework;
+            RuntimeTag = runtimeTag;
+            RunCrashTest = runCrashTest;
+        }
+
+        public string PublishFramework { get; init; }
+        public string RuntimeTag { get; init; }
+        public bool RunCrashTest { get; init; }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.Runner/CheckCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/CheckCommand.cs
@@ -42,20 +42,8 @@ namespace Datadog.Trace.Tools.Runner
 
         private void Execute(InvocationContext context)
         {
-            var tracerHome = Utils.GetHomePath(_applicationContext.RunnerFolder);
-
             // pick the right one depending on the platform
-            var ddDotnet = (platform: _applicationContext.Platform, arch: RuntimeInformation.OSArchitecture, musl: Utils.IsAlpine()) switch
-            {
-                (Platform.Windows, Architecture.X64, _) => Path.Combine(tracerHome, "win-x64", "dd-dotnet.exe"),
-                (Platform.Windows, Architecture.X86, _) => Path.Combine(tracerHome, "win-x64", "dd-dotnet.exe"),
-                (Platform.Linux, Architecture.X64, false) => Path.Combine(tracerHome, "linux-x64", "dd-dotnet"),
-                (Platform.Linux, Architecture.X64, true) => Path.Combine(tracerHome, "linux-musl-x64", "dd-dotnet"),
-                (Platform.Linux, Architecture.Arm64, false) => Path.Combine(tracerHome, "linux-arm64", "dd-dotnet"),
-                (Platform.Linux, Architecture.Arm64, true) => Path.Combine(tracerHome, "linux-musl-arm64", "dd-dotnet"),
-                var other => throw new NotSupportedException(
-                    $"Unsupported platform/architecture combination: ({other.platform}{(other.musl ? " musl" : string.Empty)}/{other.arch})")
-            };
+            var ddDotnet = Utils.GetDdDotnetPath(_applicationContext);
 
             if (!File.Exists(ddDotnet))
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.Tools.Runner
                 // Make dd-dotnet executable
                 var ddDotnet = Utils.GetDdDotnetPath(applicationContext);
 
-                if (File.Exists(ddDotnet))
+                if (ddDotnet != null && File.Exists(ddDotnet))
                 {
                     // Make sure the dd-dotnet binary is executable
                     System.Diagnostics.Process.Start("chmod", $"+x {ddDotnet}")!.WaitForExit();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Program.cs
@@ -58,6 +58,18 @@ namespace Datadog.Trace.Tools.Runner
             AppDomain.CurrentDomain.ProcessExit += (_, _) => CurrentDomain_ProcessExit(applicationContext);
             AppDomain.CurrentDomain.DomainUnload += (_, _) => CurrentDomain_ProcessExit(applicationContext);
 
+            if (applicationContext.Platform == Platform.Linux)
+            {
+                // Make dd-dotnet executable
+                var ddDotnet = Utils.GetDdDotnetPath(applicationContext);
+
+                if (File.Exists(ddDotnet))
+                {
+                    // Make sure the dd-dotnet binary is executable
+                    System.Diagnostics.Process.Start("chmod", $"+x {ddDotnet}")!.WaitForExit();
+                }
+            }
+
             IEnumerable<HelpSectionDelegate> GetLayout(HelpContext context)
             {
                 yield return HelpBuilder.Default.SynopsisSection();

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -46,6 +46,11 @@ namespace Datadog.Trace.Tools.Runner
         {
             var tracerHome = GetHomePath(applicationContext.RunnerFolder);
 
+            if (tracerHome == null)
+            {
+                return null;
+            }
+
             // pick the right one depending on the platform
             var ddDotnet = (platform: applicationContext.Platform, arch: RuntimeInformation.OSArchitecture, musl: IsAlpine()) switch
             {

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.2.525301" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="3.2.527301" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="Spectre.Console" Version="0.43.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -226,12 +226,14 @@ public class CreatedumpTests : ConsoleTestHelper
         report["siginfo"]!["signum"]!.Value<string>().Should().Be("6");
     }
 
+#if !NETFRAMEWORK
     [SkippableFact]
     public async Task WorksFromContinuousprofiler()
     {
         // Check that we're still able to locate dd-dotnet when LD_PRELOAD points to the continuousprofiler folder
 
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+        SkipOn.Platform(SkipOn.PlatformValue.Windows);
 
         using var reportFile = new TemporaryFile();
 
@@ -249,6 +251,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         File.Exists(reportFile.Path).Should().BeTrue();
     }
+#endif
 
     [SkippableFact]
     public async Task IgnoreNonDatadogCrashes()

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -49,21 +49,6 @@ public class CreatedumpTests : ConsoleTestHelper
         }
     }
 
-    private static (string Key, string Value) LdPreloadConfigAlt
-    {
-        get
-        {
-            var path = Path.Combine(EnvironmentHelper.GetMonitoringHomePath(), "continuousprofiler", "Datadog.Linux.ApiWrapper.x64.so");
-
-            if (!File.Exists(path))
-            {
-                throw new FileNotFoundException($"LD wrapper not found at path {path}. Ensure you have built the profiler home directory using BuildProfilerHome");
-            }
-
-            return ("LD_PRELOAD", path);
-        }
-    }
-
     private static (string Key, string Value)[] CreatedumpConfig => [("COMPlus_DbgEnableMiniDump", "1"), ("COMPlus_DbgMiniDumpName", "/dev/null")];
 
     [SkippableTheory]

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -69,7 +69,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         using var reportFile = new TemporaryFile();
 
-        (string, string)[] args = [LdPreloadConfig, ..CreatedumpConfig, ("DD_TRACE_CRASH_HANDLER_PASSTHROUGH", passthrough), ..CrashReportConfig(reportFile)];
+        (string, string)[] args = [LdPreloadConfig, ..CreatedumpConfig, ("DD_TRACE_CRASH_HANDLER_PASSTHROUGH", passthrough), CrashReportConfig(reportFile)];
 
         using var helper = await StartConsoleWithArgs("crash-datadog", args);
 
@@ -101,7 +101,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         using var reportFile = new TemporaryFile();
 
-        (string, string)[] args = [LdPreloadConfig];
+        (string, string)[] args = [LdPreloadConfig, ("DD_TRACE_CRASH_HANDLER_ENABLED", "0")];
 
         if (enableCrashDumps)
         {
@@ -140,7 +140,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         using var reportFile = new TemporaryFile();
 
-        (string, string)[] args = [LdPreloadConfig, ..CrashReportConfig(reportFile)];
+        (string, string)[] args = [LdPreloadConfig, CrashReportConfig(reportFile)];
 
         if (crashdumpEnabled)
         {
@@ -187,7 +187,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         using var helper = await StartConsoleWithArgs(
                                "crash-datadog",
-                               [LdPreloadConfig, ..CrashReportConfig(reportFile)]);
+                               [LdPreloadConfig, CrashReportConfig(reportFile)]);
 
         await helper.Task;
 
@@ -220,7 +220,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         using var helper = await StartConsoleWithArgs(
                                "crash",
-                               [LdPreloadConfig, ..CrashReportConfig(reportFile)]);
+                               [LdPreloadConfig, CrashReportConfig(reportFile)]);
 
         await helper.Task;
 
@@ -240,7 +240,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         using var helper = await StartConsoleWithArgs(
                                "crash-datadog",
-                               [LdPreloadConfig, ..CrashReportConfig(reportFile)]);
+                               [LdPreloadConfig, CrashReportConfig(reportFile)]);
 
         await helper.Task;
 
@@ -303,20 +303,9 @@ public class CreatedumpTests : ConsoleTestHelper
         }
     }
 
-    private static (string Key, string Value)[] CrashReportConfig(TemporaryFile reportFile)
+    private static (string Key, string Value) CrashReportConfig(TemporaryFile reportFile)
     {
-        var ddDotnetPath = Utils.GetDdDotnetPath();
-
-        if (!File.Exists(ddDotnetPath))
-        {
-            throw new FileNotFoundException($"dd-dotnet not found at path {ddDotnetPath}");
-        }
-
-        return
-        [
-            ("DD_TRACE_CRASH_HANDLER", ddDotnetPath),
-            ("DD_TRACE_CRASH_OUTPUT", reportFile.Url)
-        ];
+        return ("DD_TRACE_CRASH_OUTPUT", reportFile.Url);
     }
 
     private class TemporaryFile : IDisposable

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
@@ -3,10 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
-using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,26 +15,5 @@ public class CustomTestFramework : TestHelpers.CustomTestFramework
     public CustomTestFramework(IMessageSink messageSink)
         : base(messageSink)
     {
-#if !NETFRAMEWORK
-        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            var monitoringHomePath = EnvironmentHelper.GetMonitoringHomePath();
-            var continuousProfilerPath = Path.Combine(monitoringHomePath, "continuousprofiler");
-
-            if (!Directory.Exists(continuousProfilerPath))
-            {
-                Directory.CreateDirectory(continuousProfilerPath);
-            }
-
-            var apiWrapperPath = Utils.GetApiWrapperPath();
-            var apiWrapperName = Path.GetFileName(apiWrapperPath);
-            var continuousProfilerApiWrapperPath = Path.Combine(continuousProfilerPath, apiWrapperName);
-
-            if (!File.Exists(continuousProfilerApiWrapperPath))
-            {
-                Directory.CreateSymbolicLink(continuousProfilerApiWrapperPath, apiWrapperPath);
-            }
-        }
-#endif
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.IO;
+using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -15,5 +17,21 @@ public class CustomTestFramework : TestHelpers.CustomTestFramework
     public CustomTestFramework(IMessageSink messageSink)
         : base(messageSink)
     {
+        var monitoringHomePath = EnvironmentHelper.GetMonitoringHomePath();
+        var continuousProfilerPath = Path.Combine(monitoringHomePath, "continuousprofiler");
+
+        if (!Directory.Exists(continuousProfilerPath))
+        {
+            Directory.CreateDirectory(continuousProfilerPath);
+        }
+
+        var apiWrapperPath = Utils.GetApiWrapperPath();
+        var apiWrapperName = Path.GetFileName(apiWrapperPath);
+        var continuousProfilerApiWrapperPath = Path.Combine(continuousProfilerPath, apiWrapperName);
+
+        if (!File.Exists(continuousProfilerApiWrapperPath))
+        {
+            Directory.CreateSymbolicLink(continuousProfilerApiWrapperPath, apiWrapperPath);
+        }
     }
 }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CustomTestFramework.cs
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -17,21 +19,26 @@ public class CustomTestFramework : TestHelpers.CustomTestFramework
     public CustomTestFramework(IMessageSink messageSink)
         : base(messageSink)
     {
-        var monitoringHomePath = EnvironmentHelper.GetMonitoringHomePath();
-        var continuousProfilerPath = Path.Combine(monitoringHomePath, "continuousprofiler");
-
-        if (!Directory.Exists(continuousProfilerPath))
+#if !NETFRAMEWORK
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Directory.CreateDirectory(continuousProfilerPath);
-        }
+            var monitoringHomePath = EnvironmentHelper.GetMonitoringHomePath();
+            var continuousProfilerPath = Path.Combine(monitoringHomePath, "continuousprofiler");
 
-        var apiWrapperPath = Utils.GetApiWrapperPath();
-        var apiWrapperName = Path.GetFileName(apiWrapperPath);
-        var continuousProfilerApiWrapperPath = Path.Combine(continuousProfilerPath, apiWrapperName);
+            if (!Directory.Exists(continuousProfilerPath))
+            {
+                Directory.CreateDirectory(continuousProfilerPath);
+            }
 
-        if (!File.Exists(continuousProfilerApiWrapperPath))
-        {
-            Directory.CreateSymbolicLink(continuousProfilerApiWrapperPath, apiWrapperPath);
+            var apiWrapperPath = Utils.GetApiWrapperPath();
+            var apiWrapperName = Path.GetFileName(apiWrapperPath);
+            var continuousProfilerApiWrapperPath = Path.Combine(continuousProfilerPath, apiWrapperName);
+
+            if (!File.Exists(continuousProfilerApiWrapperPath))
+            {
+                Directory.CreateSymbolicLink(continuousProfilerApiWrapperPath, apiWrapperPath);
+            }
         }
+#endif
     }
 }

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -43,7 +43,7 @@ namespace AspNetCoreSmokeTest
                 .ConfigureServices(ConfigureServices)
                 .ConfigureWebHostDefaults(webBuilder => webBuilder.Configure(Configure));
 
-        private static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+        private static void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers()
                     .AddApplicationPart(typeof(ValuesController).Assembly);

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -20,6 +20,11 @@ namespace AspNetCoreSmokeTest
                 Console.WriteLine("Error: Profiler is required and is not loaded.");
                 return 1;
             }
+
+            if(Environment.GetEnvironmentVariable("CRASH_APP_ON_STARTUP") == "1")
+            {
+                throw new BadImageFormatException("Expected");
+            }
             
             Console.WriteLine("Process details: ");
             Console.WriteLine($"Framework: {RuntimeInformation.FrameworkDescription}");
@@ -38,7 +43,7 @@ namespace AspNetCoreSmokeTest
                 .ConfigureServices(ConfigureServices)
                 .ConfigureWebHostDefaults(webBuilder => webBuilder.Configure(Configure));
 
-        private static void ConfigureServices(IServiceCollection services)
+        private static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
         {
             services.AddControllers()
                     .AddApplicationPart(typeof(ValuesController).Assembly);


### PR DESCRIPTION
## Summary of changes

Change crash-tracking from opt-in to opt-out.

Crash-tracking can be disabled by setting `DD_TRACE_CRASH_HANDLER_ENABLED=0`  or disabling the telemetry.

## Reason for change

Increase adoption.

## Implementation details

To make it opt-out, the LD_PRELOAD module needs to locate `dd-dotnet` by itself. It does so by getting the location of the LD_PRELOAD module (using `dladdr`), and then applying the following logic:
 - If the LD_PRELOAD module is in `linux-x64` or `linux-musl-x64`, look for `dd-dotnet` in the same folder
 - If the LD_PRELOAD module is in `continuousprofiler`, check if running on Alpine and look for `dd-dotnet` in `../linux-x64` or `../linux-musl-x64`
 - Use `linux-arm64`/`linux-musl-arm64` on ARM64

## Test coverage

Added an integration test for the LD_PRELOAD pointing to `continuousprofiler`. Smoke tests added by Andrew.
