### PR TITLE
[ASM] Improved Unsafe Encoder readability 

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Xml.Linq;
 using Datadog.Trace.AppSec.Waf;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.Logging;
@@ -20,6 +21,7 @@ using Datadog.Trace.Util;
 using Datadog.Trace.VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 using Datadog.Trace.Vendors.Serilog.Events;
+using Datadog.Trace.Vendors.StatsdClient.Utils;
 
 namespace Datadog.Trace.AppSec.WafEncoding
 {
@@ -64,270 +66,74 @@ namespace Datadog.Trace.AppSec.WafEncoding
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 
+        // public IEncodeResult Encode<TInstance>(TInstance? o, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true)
+        // {
+        //    var lstPointers = new List<IntPtr>();
+        //    var pool = Pool;
+        //    var result = Encode(o, lstPointers, remainingDepth, key, applySafetyLimits, pool: pool);
+        //    return new EncodeResult(lstPointers, pool, ref result);
+        // }
+
         public IEncodeResult Encode<TInstance>(TInstance? o, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true)
         {
-            var lstPointers = new List<IntPtr>();
-            var pool = Pool;
-            var result = Encode(o, lstPointers, remainingDepth, key, applySafetyLimits, pool: pool);
-            return new EncodeResult(lstPointers, pool, ref result);
+            var context = new EncoderContext(applySafetyLimits, Pool);
+            var result = Encode(ref context, remainingDepth, key, o);
+            return new EncodeResult(context.Buffers, context.Pool, ref result);
         }
 
-        public unsafe DdwafObjectStruct Encode<TInstance>(TInstance? o, List<IntPtr> argToFree, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true, UnmanagedMemoryPool? pool = null)
+        // -----------------------------------
+        internal DdwafObjectStruct Encode<TInstance>(TInstance? o, List<IntPtr> argToFree, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true, UnmanagedMemoryPool? pool = null)
         {
-            pool ??= Pool;
+            var context = new EncoderContext(applySafetyLimits, Pool);
+            return Encode(ref context, remainingDepth, key, o);
+        }
 
-            DdwafObjectStruct ProcessKeyValuePairs<TKey, TValue>(IEnumerable<KeyValuePair<TKey, TValue>> enumerableDic, int count, delegate*<KeyValuePair<TKey, TValue>, string?> getKey, delegate*<KeyValuePair<TKey, TValue>, object?> getValue)
-                where TKey : notnull
-            {
-                var ddWafObjectMap = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP };
-                if (!string.IsNullOrEmpty(key))
-                {
-                    var convertToUtf8 = ConvertToUtf8(key!, false);
-                    ddWafObjectMap.ParameterName = convertToUtf8.Item1;
-                    ddWafObjectMap.ParameterNameLength = (ulong)key!.Length;
-                }
-
-                if (applySafetyLimits)
-                {
-                    if (remainingDepth-- <= 0)
-                    {
-                        string GetItemsAsString()
-                        {
-                            var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-                            foreach (var x in enumerableDic)
-                            {
-                                sb.Append($"{getKey(x)}, {getValue(x)}, ");
-                            }
-
-                            if (sb.Length > 0)
-                            {
-                                sb.Remove(sb.Length - 2, 2);
-                            }
-
-                            return StringBuilderCache.GetStringAndRelease(sb);
-                        }
-
-                        TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ObjectTooDeep);
-                        if (Log.IsEnabled(LogEventLevel.Debug))
-                        {
-                            Log.Debug("EncodeDictionary: object graph too deep, truncating nesting {Items}", GetItemsAsString());
-                        }
-
-                        return ddWafObjectMap;
-                    }
-
-                    if (count > WafConstants.MaxContainerSize)
-                    {
-                        TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
-                        if (Log.IsEnabled(LogEventLevel.Debug))
-                        {
-                            Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
-                        }
-                    }
-                }
-
-                var childrenCount = !applySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
-                var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
-                var childrenData = childrenFromPool ? pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
-
-                if (enumerableDic is IDictionary)
-                {
-                    var typeKVP = typeof(KeyValuePair<TKey, TValue>);
-                    if (typeKVP == typeof(KeyValuePair<string, string>))
-                    {
-                        EnumerateItems<string, string>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, object>))
-                    {
-                        EnumerateItems<string, object>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, string[]>))
-                    {
-                        EnumerateItems<string, string[]>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, List<string>>))
-                    {
-                        EnumerateItems<string, List<string>>();
-                    }
-                    else if (typeKVP == typeof(KeyValuePair<string, JToken>))
-                    {
-                        EnumerateItems<string, JToken>();
-                    }
-                    else
-                    {
-                        EnumerateItems<TKey, TValue>();
-                    }
-
-                    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                    void EnumerateItems<TKeySource, TValueSource>()
-                        where TKeySource : notnull
-                    {
-                        var itemData = childrenData;
-                        var dic = (Dictionary<TKeySource, TValueSource>)enumerableDic;
-                        var maxChildrenCount = childrenCount;
-                        for (var i = 0; i < maxChildrenCount; i++)
-                        {
-                            var originalKeyValue = dic.ElementAt(i);
-                            var keyValue = VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.As<KeyValuePair<TKeySource, TValueSource>, KeyValuePair<TKey, TValue>>(ref originalKeyValue);
-                            var key = getKey(keyValue);
-                            if (string.IsNullOrEmpty(key))
-                            {
-                                childrenCount--;
-                                if (Log.IsEnabled(LogEventLevel.Debug))
-                                {
-                                    Log.Debug("EncodeDictionary: ignoring dictionary member with null name");
-                                }
-
-                                continue;
-                            }
-
-                            *(DdwafObjectStruct*)itemData = Encode(getValue(keyValue!), argToFree, applySafetyLimits: applySafetyLimits, key: key, remainingDepth: remainingDepth, pool: pool);
-                            itemData += ObjectStructSize;
-                        }
-                    }
-                }
-                else
-                {
-                    var itemData = childrenData;
-                    var maxChildrenCount = childrenCount;
-
-                    for (var i = 0; i < maxChildrenCount; i++)
-                    {
-                        var keyValue = enumerableDic.ElementAt(i);
-                        var key = getKey(keyValue);
-                        if (string.IsNullOrEmpty(key))
-                        {
-                            childrenCount--;
-                            if (Log.IsEnabled(LogEventLevel.Debug))
-                            {
-                                Log.Debug("EncodeDictionary: ignoring dictionary member with null name");
-                            }
-
-                            continue;
-                        }
-
-                        *(DdwafObjectStruct*)itemData = Encode(getValue(keyValue), argToFree, applySafetyLimits: applySafetyLimits, key: key, remainingDepth: remainingDepth, pool: pool);
-                        itemData += ObjectStructSize;
-                    }
-                }
-
-                ddWafObjectMap.Array = childrenData;
-                ddWafObjectMap.NbEntries = (ulong)childrenCount;
-                argToFree.Add(childrenData);
-                return ddWafObjectMap;
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            Tuple<IntPtr, int> ConvertToUtf8(string s, bool applySafety)
-            {
-                IntPtr unmanagedMemory;
-                int writtenBytes;
-                var length = s.Length;
-                if (applySafety || length <= WafConstants.MaxStringLength)
-                {
-                    length = Math.Min(length, WafConstants.MaxStringLength);
-                    unmanagedMemory = pool.Rent();
-                    fixed (char* chrPtr = s)
-                    {
-                        writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, MaxBytesForMaxStringLength);
-                    }
-                }
-                else
-                {
-                    var bytesCount = System.Text.Encoding.UTF8.GetMaxByteCount(length) + 1;
-                    unmanagedMemory = Marshal.AllocCoTaskMem(bytesCount);
-                    fixed (char* chrPtr = s)
-                    {
-                        writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, bytesCount);
-                    }
-                }
-
-                Marshal.WriteByte(unmanagedMemory, writtenBytes, (byte)'\0');
-                argToFree.Add(unmanagedMemory);
-                return new Tuple<IntPtr, int>(unmanagedMemory, length);
-            }
-
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            DdwafObjectStruct GetStringObject(string value)
-            {
-                var convertToUtf8 = ConvertToUtf8(value, applySafetyLimits);
-                var ddWafObject = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_STRING, Array = convertToUtf8.Item1, NbEntries = (ulong)convertToUtf8.Item2 };
-                return ddWafObject;
-            }
+        private static unsafe DdwafObjectStruct Encode<TInstance>(ref EncoderContext context, int remainingDepth, string? key, TInstance? o)
+        {
+            // pool ??= Pool;
 
             DdwafObjectStruct ddwafObjectStruct;
 
             switch (o)
             {
                 case string str:
-                {
-                    ddwafObjectStruct = GetStringObject(str);
+                    ddwafObjectStruct = GetStringObject(ref context, str);
                     break;
-                }
-
                 case JValue:
-                {
-                    ddwafObjectStruct = GetStringObject(o?.ToString() ?? string.Empty);
+                    ddwafObjectStruct = GetStringObject(ref context, o?.ToString() ?? string.Empty);
                     break;
-                }
-
                 case null:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_NULL };
                     break;
-                }
-
                 case ulong u:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED, UintValue = u };
                     break;
-                }
-
                 case uint u:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_UNSIGNED, UintValue = u };
                     break;
-                }
-
                 case int i:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED, IntValue = i };
                     break;
-                }
-
                 case long u:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_SIGNED, IntValue = u };
                     break;
-                }
-
                 case decimal d:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = (double)d };
                     break;
-                }
-
                 case double d:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = d };
                     break;
-                }
-
                 case float d:
-                {
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_DOUBLE, DoubleValue = d };
                     break;
-                }
-
                 case bool b:
                     ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_BOOL, ByteValue = b ? (byte)1 : (byte)0 };
                     break;
-
                 case IEnumerable<KeyValuePair<string, object>> objDict:
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, object>> ?? objDict.ToList();
                     var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey1, &GetValue1);
+                    ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey1, &GetValue1);
                     static string GetKey1(KeyValuePair<string, object> item) => item.Key;
                     static object GetValue1(KeyValuePair<string, object> item) => item.Value;
                     break;
@@ -337,7 +143,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, bool>> ?? objDict.ToList();
                     var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey1, &GetValue1);
+                    ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey1, &GetValue1);
                     static string GetKey1(KeyValuePair<string, bool> item) => item.Key;
                     static object GetValue1(KeyValuePair<string, bool> item) => item.Value;
                     break;
@@ -347,7 +153,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, string>> ?? objDict.ToList();
                     var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey2, &GetValue2);
+                    ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey2, &GetValue2);
                     static string GetKey2(KeyValuePair<string, string> item) => item.Key;
                     static object GetValue2(KeyValuePair<string, string> item) => item.Value;
                     break;
@@ -357,7 +163,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, JToken>> ?? objDict.ToList();
                     var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey3, &GetValue3);
+                    ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey3, &GetValue3);
                     static string GetKey3(KeyValuePair<string, JToken> item) => item.Key;
                     static object GetValue3(KeyValuePair<string, JToken> item) => item.Value;
                     break;
@@ -367,7 +173,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, string[]>> ?? objDict.ToList();
                     var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey4, &GetValue4);
+                    ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey4, &GetValue4);
                     static string GetKey4(KeyValuePair<string, string[]> item) => item.Key;
                     static object GetValue4(KeyValuePair<string, string[]> item) => item.Value;
                     break;
@@ -377,7 +183,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, List<string>>> ?? objDict.ToList();
                     var count = collectionDict.Count;
-                    ddwafObjectStruct = ProcessKeyValuePairs(collectionDict, count, &GetKey5, &GetValue5);
+                    ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey5, &GetValue5);
                     static string GetKey5(KeyValuePair<string, List<string>> item) => item.Key;
                     static object GetValue5(KeyValuePair<string, List<string>> item) => item.Value;
                     break;
@@ -385,135 +191,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
                 case IEnumerable enumerable:
                 {
-                    ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_ARRAY };
-
-                    if (applySafetyLimits && remainingDepth-- <= 0)
-                    {
-                        TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ObjectTooDeep);
-                        if (Log.IsEnabled(LogEventLevel.Debug))
-                        {
-                            Log.Debug("EncodeList: object graph too deep, truncating nesting {Items}", string.Join(", ", enumerable));
-                        }
-
-                        break;
-                    }
-
-                    if (enumerable is IList { Count: var count } listInstance)
-                    {
-                        if (applySafetyLimits && count > WafConstants.MaxContainerSize)
-                        {
-                            TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
-                            if (Log.IsEnabled(LogEventLevel.Debug))
-                            {
-                                Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
-                            }
-                        }
-
-                        var childrenCount = !applySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
-                        var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
-                        var childrenData = childrenFromPool ? pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
-
-                        // Avoid boxing of known values types from the switch above
-                        switch (listInstance)
-                        {
-                            case IList<bool> boolCollection:
-                                EnumerateAndEncode(boolCollection);
-                                break;
-                            case IList<decimal> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<double> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<float> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<int> intCollection:
-                                EnumerateAndEncode(intCollection);
-                                break;
-                            case IList<uint> uintCollection:
-                                EnumerateAndEncode(uintCollection);
-                                break;
-                            case IList<long> longCollection:
-                                EnumerateAndEncode(longCollection);
-                                break;
-                            case IList<ulong> ulongCollection:
-                                EnumerateAndEncode(ulongCollection);
-                                break;
-                            default:
-                                EnumerateAndEncodeIList(listInstance);
-                                break;
-                        }
-
-                        ddwafObjectStruct.Array = childrenData;
-                        ddwafObjectStruct.NbEntries = (ulong)childrenCount;
-                        argToFree.Add(childrenData);
-
-                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                        void EnumerateAndEncode<T>(IList<T> lstInstance)
-                        {
-                            var itemData = childrenData;
-                            for (var idx = 0; idx < childrenCount; idx++)
-                            {
-                                *(DdwafObjectStruct*)itemData = Encode(lstInstance[idx], argToFree, applySafetyLimits: applySafetyLimits, remainingDepth: remainingDepth, pool: pool);
-                                itemData += ObjectStructSize;
-                            }
-                        }
-
-                        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                        void EnumerateAndEncodeIList(IList lstInstance)
-                        {
-                            var itemData = childrenData;
-                            for (var idx = 0; idx < childrenCount; idx++)
-                            {
-                                *(DdwafObjectStruct*)itemData = Encode(lstInstance[idx], argToFree, applySafetyLimits: applySafetyLimits, remainingDepth: remainingDepth, pool: pool);
-                                itemData += ObjectStructSize;
-                            }
-                        }
-                    }
-                    else
-                    {
-                        var childrenCount = 0;
-                        // Let's enumerate first.
-                        foreach (var val in enumerable)
-                        {
-                            childrenCount++;
-                            if (applySafetyLimits && childrenCount == WafConstants.MaxContainerSize)
-                            {
-                                TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
-                                if (Log.IsEnabled(LogEventLevel.Debug))
-                                {
-                                    Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
-                                }
-
-                                break;
-                            }
-                        }
-
-                        if (childrenCount > 0)
-                        {
-                            var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
-                            var childrenData = childrenFromPool ? pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
-                            var itemData = childrenData;
-                            var idx = 0;
-                            foreach (var val in enumerable)
-                            {
-                                if (idx > childrenCount)
-                                {
-                                    break;
-                                }
-
-                                *(DdwafObjectStruct*)itemData = Encode(val, argToFree, applySafetyLimits: applySafetyLimits, remainingDepth: remainingDepth, pool: pool);
-                                itemData += ObjectStructSize;
-                                idx++;
-                            }
-
-                            ddwafObjectStruct.Array = childrenData;
-                            ddwafObjectStruct.NbEntries = (ulong)childrenCount;
-                            argToFree.Add(childrenData);
-                        }
-                    }
-
+                    ddwafObjectStruct = ProcessIEnumerable(ref context, remainingDepth, enumerable);
                     break;
                 }
 
@@ -523,17 +201,372 @@ namespace Datadog.Trace.AppSec.WafEncoding
                         Log.Warning("Couldn't encode object of unknown type {Type}, falling back to ToString", o.GetType());
                     }
 
-                    ddwafObjectStruct = GetStringObject(string.Empty);
+                    ddwafObjectStruct = GetStringObject(ref context, string.Empty);
                     break;
             }
 
             if (!string.IsNullOrEmpty(key))
             {
-                ddwafObjectStruct.ParameterName = ConvertToUtf8(key!, false).Item1;
+                ddwafObjectStruct.ParameterName = ConvertToUtf8(ref context, key!, false).Item1;
                 ddwafObjectStruct.ParameterNameLength = (ulong)key!.Length;
             }
 
             return ddwafObjectStruct;
+        }
+
+        private static unsafe DdwafObjectStruct ProcessIEnumerable(ref EncoderContext context, int remainingDepth, IEnumerable enumerable)
+        {
+            var ddwafObjectStruct = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_ARRAY };
+
+            if (context.ApplySafetyLimits && remainingDepth-- <= 0)
+            {
+                TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ObjectTooDeep);
+                if (Log.IsEnabled(LogEventLevel.Debug))
+                {
+                    Log.Debug("EncodeList: object graph too deep, truncating nesting {Items}", string.Join(", ", enumerable));
+                }
+
+                return ddwafObjectStruct;
+            }
+
+            if (enumerable is IList { Count: var count } listInstance)
+            {
+                if (context.ApplySafetyLimits && count > WafConstants.MaxContainerSize)
+                {
+                    TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                    }
+                }
+
+                var childrenCount = !context.ApplySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
+                var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
+                var childrenData = childrenFromPool ? context.Pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
+
+                // Avoid boxing of known values types from the switch above
+                switch (listInstance)
+                {
+                    case IList<bool> boolCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, boolCollection, childrenData, childrenCount);
+                        break;
+                    case IList<decimal> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection, childrenData, childrenCount);
+                        break;
+                    case IList<double> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection, childrenData, childrenCount);
+                        break;
+                    case IList<float> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection, childrenData, childrenCount);
+                        break;
+                    case IList<int> intCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, intCollection, childrenData, childrenCount);
+                        break;
+                    case IList<uint> uintCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, uintCollection, childrenData, childrenCount);
+                        break;
+                    case IList<long> longCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, longCollection, childrenData, childrenCount);
+                        break;
+                    case IList<ulong> ulongCollection:
+                        EnumerateAndEncode(ref context, remainingDepth, ulongCollection, childrenData, childrenCount);
+                        break;
+                    default:
+                        EnumerateAndEncodeIList(ref context, remainingDepth, listInstance, childrenData, childrenCount);
+                        break;
+                }
+
+                ddwafObjectStruct.Array = childrenData;
+                ddwafObjectStruct.NbEntries = (ulong)childrenCount;
+                context.Buffers.Add(childrenData);
+            }
+            else
+            {
+                var childrenCount = 0;
+                // Let's enumerate first.
+                foreach (var val in enumerable)
+                {
+                    childrenCount++;
+                    if (context.ApplySafetyLimits && childrenCount == WafConstants.MaxContainerSize)
+                    {
+                        TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                        }
+
+                        break;
+                    }
+                }
+
+                if (childrenCount > 0)
+                {
+                    var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
+                    var childrenData = childrenFromPool ? context.Pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
+                    var itemData = childrenData;
+                    var idx = 0;
+                    foreach (var val in enumerable)
+                    {
+                        if (idx > childrenCount)
+                        {
+                            break;
+                        }
+
+                        *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, null, val);
+                        itemData += ObjectStructSize;
+                        idx++;
+                    }
+
+                    ddwafObjectStruct.Array = childrenData;
+                    ddwafObjectStruct.NbEntries = (ulong)childrenCount;
+                    context.Buffers.Add(childrenData);
+                }
+            }
+
+            return ddwafObjectStruct;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void EnumerateAndEncode<T>(ref EncoderContext context, int remainingDepth, IList<T> lstInstance, IntPtr childrenData, int childrenCount)
+        {
+            var itemData = childrenData;
+            for (var idx = 0; idx < childrenCount; idx++)
+            {
+                *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, null, lstInstance[idx]);
+                itemData += ObjectStructSize;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void EnumerateAndEncodeIList(ref EncoderContext context, int remainingDepth, IList lstInstance, IntPtr childrenData, int childrenCount)
+        {
+            var itemData = childrenData;
+            for (var idx = 0; idx < childrenCount; idx++)
+            {
+                *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, null, lstInstance[idx]);
+                itemData += ObjectStructSize;
+            }
+        }
+
+        private static unsafe DdwafObjectStruct ProcessKeyValuePairs<TKey, TValue>(ref EncoderContext context, int remainingDepth, string? key, IEnumerable<KeyValuePair<TKey, TValue>> enumerableDic, int count, delegate*<KeyValuePair<TKey, TValue>, string?> getKey, delegate*<KeyValuePair<TKey, TValue>, object?> getValue)
+            where TKey : notnull
+        {
+            var ddWafObjectMap = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP };
+            if (!string.IsNullOrEmpty(key))
+            {
+                var convertToUtf8 = ConvertToUtf8(ref context, key!, false);
+                ddWafObjectMap.ParameterName = convertToUtf8.Item1;
+                ddWafObjectMap.ParameterNameLength = (ulong)key!.Length;
+            }
+
+            if (context.ApplySafetyLimits)
+            {
+                if (remainingDepth-- <= 0)
+                {
+                    string GetItemsAsString()
+                    {
+                        var sb = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
+                        foreach (var x in enumerableDic)
+                        {
+                            sb.Append($"{getKey(x)}, {getValue(x)}, ");
+                        }
+
+                        if (sb.Length > 0)
+                        {
+                            sb.Remove(sb.Length - 2, 2);
+                        }
+
+                        return StringBuilderCache.GetStringAndRelease(sb);
+                    }
+
+                    TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ObjectTooDeep);
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        Log.Debug("EncodeDictionary: object graph too deep, truncating nesting {Items}", GetItemsAsString());
+                    }
+
+                    return ddWafObjectMap;
+                }
+
+                if (count > WafConstants.MaxContainerSize)
+                {
+                    TelemetryFactory.Metrics.RecordCountInputTruncated(MetricTags.TruncationReason.ListOrMapTooLarge);
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        Log.Debug<int>("EncodeList: list too long, it will be truncated, MaxMapOrArrayLength {MaxMapOrArrayLength}", WafConstants.MaxContainerSize);
+                    }
+                }
+            }
+
+            var childrenCount = !context.ApplySafetyLimits || count < WafConstants.MaxContainerSize ? count : WafConstants.MaxContainerSize;
+            var childrenFromPool = ObjectStructSize * childrenCount < MaxBytesForMaxStringLength;
+            var childrenData = childrenFromPool ? context.Pool.Rent() : Marshal.AllocCoTaskMem(ObjectStructSize * childrenCount);
+
+            if (enumerableDic is IDictionary iDic)
+            {
+                var typeKVP = typeof(KeyValuePair<TKey, TValue>);
+                if (typeKVP == typeof(KeyValuePair<string, string>))
+                {
+                    EnumerateIDictionaryItems<string, string>(
+                        ref context,
+                        remainingDepth,
+                        iDic,
+                        (delegate*<KeyValuePair<string, string>, string?>)getKey,
+                        (delegate*<KeyValuePair<string, string>, object?>)getValue,
+                        childrenData,
+                        childrenCount);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, object>))
+                {
+                    EnumerateIDictionaryItems<string, object>(
+                        ref context,
+                        remainingDepth,
+                        iDic,
+                        (delegate*<KeyValuePair<string, object>, string?>)getKey,
+                        (delegate*<KeyValuePair<string, object>, object?>)getValue,
+                        childrenData,
+                        childrenCount);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, string[]>))
+                {
+                    EnumerateIDictionaryItems<string, string[]>(
+                        ref context,
+                        remainingDepth,
+                        iDic,
+                        (delegate*<KeyValuePair<string, string[]>, string?>)getKey,
+                        (delegate*<KeyValuePair<string, string[]>, object?>)getValue,
+                        childrenData,
+                        childrenCount);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, List<string>>))
+                {
+                    EnumerateIDictionaryItems<string, List<string>>(
+                        ref context,
+                        remainingDepth,
+                        iDic,
+                        (delegate*<KeyValuePair<string, List<string>>, string?>)getKey,
+                        (delegate*<KeyValuePair<string, List<string>>, object?>)getValue,
+                        childrenData,
+                        childrenCount);
+                }
+                else if (typeKVP == typeof(KeyValuePair<string, JToken>))
+                {
+                    EnumerateIDictionaryItems<string, JToken>(
+                        ref context,
+                        remainingDepth,
+                        iDic,
+                        (delegate*<KeyValuePair<string, JToken>, string?>)getKey,
+                        (delegate*<KeyValuePair<string, JToken>, object?>)getValue,
+                        childrenData,
+                        childrenCount);
+                }
+                else
+                {
+                    EnumerateIDictionaryItems<string, TValue>(
+                        ref context,
+                        remainingDepth,
+                        iDic,
+                        (delegate*<KeyValuePair<string, TValue>, string?>)getKey,
+                        (delegate*<KeyValuePair<string, TValue>, object?>)getValue,
+                        childrenData,
+                        childrenCount);
+                }
+            }
+            else
+            {
+                var itemData = childrenData;
+                var maxChildrenCount = childrenCount;
+
+                for (var i = 0; i < maxChildrenCount; i++)
+                {
+                    var element = enumerableDic.ElementAt(i);
+                    var elementKey = getKey(element);
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        childrenCount--;
+                        if (Log.IsEnabled(LogEventLevel.Debug))
+                        {
+                            Log.Debug("EncodeDictionary: ignoring dictionary member with null name");
+                        }
+
+                        continue;
+                    }
+
+                    *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, elementKey, getValue(element));
+                    itemData += ObjectStructSize;
+                }
+            }
+
+            ddWafObjectMap.Array = childrenData;
+            ddWafObjectMap.NbEntries = (ulong)childrenCount;
+            context.Buffers.Add(childrenData);
+            return ddWafObjectMap;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe void EnumerateIDictionaryItems<TKey, TValue>(ref EncoderContext context, int remainingDepth, IDictionary enumerableDic, delegate*<KeyValuePair<TKey, TValue>, string?> getKey, delegate*<KeyValuePair<TKey, TValue>, object?> getValue, IntPtr childrenData, int childrenCount)
+            where TKey : notnull
+        {
+            var itemData = childrenData;
+            var dic = (Dictionary<TKey, TValue>)enumerableDic;
+            var maxChildrenCount = childrenCount;
+            for (var i = 0; i < maxChildrenCount; i++)
+            {
+                var originalKeyValue = dic.ElementAt(i);
+                var keyValue = VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.As<KeyValuePair<TKey, TValue>, KeyValuePair<TKey, TValue>>(ref originalKeyValue);
+                var key = getKey(keyValue);
+                if (string.IsNullOrEmpty(key))
+                {
+                    childrenCount--;
+                    if (Log.IsEnabled(LogEventLevel.Debug))
+                    {
+                        Log.Debug("EncodeDictionary: ignoring dictionary member with null name");
+                    }
+
+                    continue;
+                }
+
+                *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, key, getValue(keyValue!));
+                itemData += ObjectStructSize;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe Tuple<IntPtr, int> ConvertToUtf8(ref EncoderContext context, string s, bool applySafety)
+        {
+            IntPtr unmanagedMemory;
+            int writtenBytes;
+            var length = s.Length;
+            if (applySafety || length <= WafConstants.MaxStringLength)
+            {
+                length = Math.Min(length, WafConstants.MaxStringLength);
+                unmanagedMemory = context.Pool.Rent();
+                fixed (char* chrPtr = s)
+                {
+                    writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, MaxBytesForMaxStringLength);
+                }
+            }
+            else
+            {
+                var bytesCount = System.Text.Encoding.UTF8.GetMaxByteCount(length) + 1;
+                unmanagedMemory = Marshal.AllocCoTaskMem(bytesCount);
+                fixed (char* chrPtr = s)
+                {
+                    writtenBytes = System.Text.Encoding.UTF8.GetBytes(chrPtr, length, (byte*)unmanagedMemory, bytesCount);
+                }
+            }
+
+            Marshal.WriteByte(unmanagedMemory, writtenBytes, (byte)'\0');
+            context.Buffers.Add(unmanagedMemory);
+            return new Tuple<IntPtr, int>(unmanagedMemory, length);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static unsafe DdwafObjectStruct GetStringObject(ref EncoderContext context, string value)
+        {
+            var convertToUtf8 = ConvertToUtf8(ref context, value, context.ApplySafetyLimits);
+            var ddWafObject = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_STRING, Array = convertToUtf8.Item1, NbEntries = (ulong)convertToUtf8.Item2 };
+            return ddWafObject;
         }
 
         private static void FormatArgsInternal(object o, StringBuilder sb)
@@ -643,6 +676,19 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
             sb.Append(" ]");
             return sb;
+        }
+
+        private struct EncoderContext
+        {
+            public readonly bool ApplySafetyLimits;
+            public readonly UnmanagedMemoryPool Pool;
+            public readonly List<IntPtr> Buffers = new List<IntPtr>();
+
+            public EncoderContext(bool applySafetyLimits, UnmanagedMemoryPool pool)
+            {
+                ApplySafetyLimits = applySafetyLimits;
+                Pool = pool;
+            }
         }
 
         public class EncodeResult : IEncodeResult

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -76,7 +76,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
         // -----------------------------------
         internal DdwafObjectStruct Encode<TInstance>(TInstance? o, List<IntPtr> argToFree, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true, UnmanagedMemoryPool? pool = null)
         {
-            var context = new EncoderContext(applySafetyLimits, Pool, argToFree);
+            var context = new EncoderContext(applySafetyLimits, pool ?? Pool, argToFree);
             return Encode(ref context, remainingDepth, key, o);
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -66,17 +66,9 @@ namespace Datadog.Trace.AppSec.WafEncoding
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 
-        // public IEncodeResult Encode<TInstance>(TInstance? o, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true)
-        // {
-        //    var lstPointers = new List<IntPtr>();
-        //    var pool = Pool;
-        //    var result = Encode(o, lstPointers, remainingDepth, key, applySafetyLimits, pool: pool);
-        //    return new EncodeResult(lstPointers, pool, ref result);
-        // }
-
         public IEncodeResult Encode<TInstance>(TInstance? o, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true)
         {
-            var context = new EncoderContext(applySafetyLimits, Pool);
+            var context = new EncoderContext(applySafetyLimits, Pool, new List<IntPtr>());
             var result = Encode(ref context, remainingDepth, key, o);
             return new EncodeResult(context.Buffers, context.Pool, ref result);
         }
@@ -84,7 +76,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
         // -----------------------------------
         internal DdwafObjectStruct Encode<TInstance>(TInstance? o, List<IntPtr> argToFree, int remainingDepth = WafConstants.MaxContainerDepth, string? key = null, bool applySafetyLimits = true, UnmanagedMemoryPool? pool = null)
         {
-            var context = new EncoderContext(applySafetyLimits, Pool);
+            var context = new EncoderContext(applySafetyLimits, Pool, argToFree);
             return Encode(ref context, remainingDepth, key, o);
         }
 
@@ -680,12 +672,13 @@ namespace Datadog.Trace.AppSec.WafEncoding
         {
             public readonly bool ApplySafetyLimits;
             public readonly UnmanagedMemoryPool Pool;
-            public readonly List<IntPtr> Buffers = new List<IntPtr>();
+            public readonly List<IntPtr> Buffers;
 
-            public EncoderContext(bool applySafetyLimits, UnmanagedMemoryPool pool)
+            public EncoderContext(bool applySafetyLimits, UnmanagedMemoryPool pool, List<IntPtr> buffers)
             {
                 ApplySafetyLimits = applySafetyLimits;
                 Pool = pool;
+                Buffers = buffers;
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -122,7 +122,6 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 case IEnumerable<KeyValuePair<string, object>> objDict:
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, object>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
                     ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey1, &GetValue1);
                     static string GetKey1(KeyValuePair<string, object> item) => item.Key;
                     static object GetValue1(KeyValuePair<string, object> item) => item.Value;
@@ -132,7 +131,6 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 case IEnumerable<KeyValuePair<string, bool>> objDict:
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, bool>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
                     ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey1, &GetValue1);
                     static string GetKey1(KeyValuePair<string, bool> item) => item.Key;
                     static object GetValue1(KeyValuePair<string, bool> item) => item.Value;
@@ -142,7 +140,6 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 case IEnumerable<KeyValuePair<string, string>> objDict:
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, string>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
                     ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey2, &GetValue2);
                     static string GetKey2(KeyValuePair<string, string> item) => item.Key;
                     static object GetValue2(KeyValuePair<string, string> item) => item.Value;
@@ -152,7 +149,6 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 case IEnumerable<KeyValuePair<string, JToken>> objDict:
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, JToken>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
                     ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey3, &GetValue3);
                     static string GetKey3(KeyValuePair<string, JToken> item) => item.Key;
                     static object GetValue3(KeyValuePair<string, JToken> item) => item.Value;
@@ -172,7 +168,6 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 case IEnumerable<KeyValuePair<string, List<string>>> objDict:
                 {
                     var collectionDict = objDict as ICollection<KeyValuePair<string, List<string>>> ?? objDict.ToList();
-                    var count = collectionDict.Count;
                     ddwafObjectStruct = ProcessKeyValuePairs(ref context, remainingDepth, key, collectionDict, collectionDict.Count, &GetKey5, &GetValue5);
                     static string GetKey5(KeyValuePair<string, List<string>> item) => item.Key;
                     static object GetValue5(KeyValuePair<string, List<string>> item) => item.Value;

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -90,8 +90,6 @@ namespace Datadog.Trace.AppSec.WafEncoding
 
         private static unsafe DdwafObjectStruct Encode<TInstance>(ref EncoderContext context, int remainingDepth, string? key, TInstance? o)
         {
-            // pool ??= Pool;
-
             DdwafObjectStruct ddwafObjectStruct;
 
             switch (o)
@@ -481,7 +479,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 {
                     var element = enumerableDic.ElementAt(i);
                     var elementKey = getKey(element);
-                    if (string.IsNullOrEmpty(key))
+                    if (string.IsNullOrEmpty(elementKey))
                     {
                         childrenCount--;
                         if (Log.IsEnabled(LogEventLevel.Debug))
@@ -512,10 +510,10 @@ namespace Datadog.Trace.AppSec.WafEncoding
             var maxChildrenCount = childrenCount;
             for (var i = 0; i < maxChildrenCount; i++)
             {
-                var originalKeyValue = dic.ElementAt(i);
-                var keyValue = VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.As<KeyValuePair<TKey, TValue>, KeyValuePair<TKey, TValue>>(ref originalKeyValue);
-                var key = getKey(keyValue);
-                if (string.IsNullOrEmpty(key))
+                var originalElement = dic.ElementAt(i);
+                var element = VendoredMicrosoftCode.System.Runtime.CompilerServices.Unsafe.Unsafe.As<KeyValuePair<TKey, TValue>, KeyValuePair<TKey, TValue>>(ref originalElement);
+                var elementKey = getKey(element);
+                if (string.IsNullOrEmpty(elementKey))
                 {
                     childrenCount--;
                     if (Log.IsEnabled(LogEventLevel.Debug))
@@ -526,7 +524,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                     continue;
                 }
 
-                *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, key, getValue(keyValue!));
+                *(DdwafObjectStruct*)itemData = Encode(ref context, remainingDepth, elementKey, getValue(element!));
                 itemData += ObjectStructSize;
             }
         }


### PR DESCRIPTION
## Summary of changes
Externalized all embedded functions in `Encoder`

## Reason for change
`Encoder` code was a bit difficult to read due to the long embedded functions it contained.

## Implementation details
Created a `EncoderContext `struct passed by ref to all calls.
Externalized all embedded functions passing previously captured data as arguments