### PR TITLE
[ASM] Add the span id to the RASP events

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -126,6 +126,10 @@ internal static class RaspModule
 
             foreach (var item in result.Data)
             {
+                // we know that the item is a dictionary because of the way we are deserializing the data
+                // Any item contained in the data list comes from the current RASP call, so
+                // it should be tagged with current span_id
+
                 if (item is Dictionary<string, object> dictionary)
                 {
                     dictionary.Add("span_id", spanId);

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IResult.cs
@@ -5,7 +5,6 @@
 
 #nullable enable
 
-using System;
 using System.Collections.Generic;
 
 namespace Datadog.Trace.AppSec.Waf
@@ -25,7 +24,7 @@ namespace Datadog.Trace.AppSec.Waf
 
         public Dictionary<string, object?>? SendStackInfo { get; }
 
-        IReadOnlyCollection<object>? Data { get; }
+        List<object>? Data { get; }
 
         Dictionary<string, object?>? Actions { get; }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IResult.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.AppSec.Waf
 
         public Dictionary<string, object?>? SendStackInfo { get; }
 
-        List<object>? Data { get; }
+        IReadOnlyCollection<object>? Data { get; }
 
         Dictionary<string, object?>? Actions { get; }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.AppSec.Waf
 
         public bool ShouldReportSchema { get; }
 
-        public List<object>? Data { get; }
+        public IReadOnlyCollection<object>? Data { get; }
 
         public Dictionary<string, object?>? Actions { get; }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
@@ -61,7 +61,7 @@ namespace Datadog.Trace.AppSec.Waf
 
         public bool ShouldReportSchema { get; }
 
-        public IReadOnlyCollection<object>? Data { get; }
+        public List<object>? Data { get; }
 
         public Dictionary<string, object?>? Actions { get; }
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/WafMatch.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/WafMatch.cs
@@ -15,5 +15,8 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
 
         [JsonProperty("rule_matches")]
         public RuleMatch[] RuleMatches { get; set; }
+
+        [JsonProperty("span_id", NullValueHandling = NullValueHandling.Ignore)]
+        internal ulong? SpanId { get; set; }
     }
 }

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -43,6 +43,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private static readonly Regex AppSecErrorCount = new(@"\s*_dd.appsec.event_rules.error_count: 0.0,?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex AppSecRaspWafDuration = new(@"_dd.appsec.rasp.duration: \d+\.0", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex AppSecRaspWafDurationWithBindings = new(@"_dd.appsec.rasp.duration_ext: \d+\.0", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex AppSecSpanIdRegex = (new Regex("\"span_id\":\\d+"));
         private readonly string _testName;
         private readonly HttpClient _httpClient;
         private readonly CookieContainer _cookieContainer;
@@ -144,6 +145,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             settings.AddRegexScrubber(AppSecWafDurationWithBindings, "_dd.appsec.waf.duration_ext: 0.0");
             settings.AddRegexScrubber(AppSecRaspWafDuration, "_dd.appsec.rasp.duration: 0.0");
             settings.AddRegexScrubber(AppSecRaspWafDurationWithBindings, "_dd.appsec.rasp.duration_ext: 0.0");
+            settings.AddRegexScrubber(AppSecSpanIdRegex, "\"span_id\": XXX");
             if (!testInit)
             {
                 settings.AddRegexScrubber(AppSecWafVersion, string.Empty);

--- a/tracer/test/snapshots/Rasp.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetCore2.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetCore2.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetCore5.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetCore5.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -22,7 +22,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/Rasp.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/Rasp.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -23,7 +23,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.origin: appsec,
       _dd.runtime_family: dotnet
     },

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetCore2.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore2.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetCore5.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetCore5.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -45,7 +45,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Classic.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -22,7 +22,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.Lfi_url=-Iast-GetFileContent-file=-etc-password_exploit=Lfi.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-001-001","name":"Path traversal attack","tags":{"category":"vulnerability_trigger","type":"lfi"}},"rule_matches":[{"operator":"lfi_detector","operator_value":"","parameters":[{"address":null,"highlight":["/etc/password"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttack-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -46,7 +46,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {

--- a/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
+++ b/tracer/test/snapshots/RaspIast.AspNetMvc5.Integrated.SSRF_url=-Iast-SsrfAttackNoCatch-host=127.0.0.1_exploit=SSRF.verified.txt
@@ -23,7 +23,7 @@
       language: dotnet,
       runtime-id: Guid_1,
       span.kind: server,
-      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}]}]},
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"rasp-002-001","name":"Server-side request forgery","tags":{"category":"vulnerability_trigger","type":"ssrf"}},"rule_matches":[{"operator":"ssrf_detector","operator_value":"","parameters":[{"address":null,"highlight":["127.0.0.1"],"key_path":null,"value":null}]}],"span_id": XXX}]},
       _dd.iast.enabled: 1,
       _dd.iast.json:
 {


### PR DESCRIPTION
## Summary of changes

This PR adds the field span_id to the RASP events as it´s defined in the RFC: 
https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit?pli=1

The span_id field, documented in [Nested AppSec Events RFC](https://docs.google.com/document/d/13q9qapKuCJalPStzvIJ-aHRSGwSGW4sVcX-TAG4ub5o/edit#heading=h.rnd972k0hiye), should also be included in events generated through RASP-specific instrumentation. This allows providing the users with more insights regarding where the event occurred, while bypassing the limitation that prevents the use of non-service entry spans to send ASM events and other relevant information.

## Reason for change

It's required for RASP

## Implementation details

It has been included for RASP events, but we could probably consider adding it to other ASM events, as it's defined in this RFC: https://docs.google.com/document/d/13q9qapKuCJalPStzvIJ-aHRSGwSGW4sVcX-TAG4ub5o/edit#heading=h.rnd972k0hiye

## Test coverage

The integration tests have been updated to show this new information

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
