### PR TITLE
Add crash test to linux smoke tests

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -148,7 +148,7 @@ steps:
       dockerTag: $(dockerTag)
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
     displayName: Check logs for evidence of crash output
-    condition: eq($(runCrashTest), 'true')
+    condition: eq(variables['runCrashTest'], 'true')
 
 - ${{ if eq(parameters.isLinux, true) }}:
     - script: |

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -129,6 +129,26 @@ steps:
   condition: succeededOrFailed()
   continueOnError: true
 
+# Run crash tests
+- ${{ if eq(parameters.isLinux, true) }}:
+  - bash: |
+      LOGS=$(docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
+      echo $LOGS
+
+      # check logs for evidence of crash detection in the output
+      expected="The crash may have been caused by automatic instrumentation"
+      if [[ $LOGS == *"$expected"* ]]; then
+        echo "Correctly found evidence of crash detection"
+      else
+        echo "Did not find required evidence of crash detection running"
+        exit 1;
+      fi
+
+    env:
+      dockerTag: $(dockerTag)
+      DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
+    displayName: Check logs for evidence of crash output
+
 - ${{ if eq(parameters.isLinux, true) }}:
     - script: |
         sudo chmod -R 644 tracer/build_data/dumps/* || true

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -148,6 +148,7 @@ steps:
       dockerTag: $(dockerTag)
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
     displayName: Check logs for evidence of crash output
+    condition: eq($(runCrashTest), 'true')
 
 - ${{ if eq(parameters.isLinux, true) }}:
     - script: |

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2436,6 +2436,9 @@ partial class Build
            // There's a race in the profiler where unwinding when the thread is running
            knownPatterns.Add(new(@".*Failed to walk \d+ stacks for sampled exception:\s+CORPROF_E_STACKSNAPSHOT_UNSAFE", RegexOptions.Compiled));
 
+           // This one is caused by the intentional crash in the crash tracking smoke test
+           knownPatterns.Add(new("Application threw an unhandled exception: System.BadImageFormatException: Expected", RegexOptions.Compiled));
+           
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });
 

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -579,6 +579,7 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            // https://github.com/dotnet/runtime/issues/66707
                             new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
                             new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
@@ -597,6 +598,7 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            // https://github.com/dotnet/runtime/issues/66707
                             new (publishFramework: TargetFramework.NET5_0, "35-5.0", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm*-1.aarch64.rpm",
@@ -615,6 +617,7 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            // https://github.com/dotnet/runtime/issues/66707
                             new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb", // we advise customers to install the .deb in this case

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -399,20 +399,20 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-buster-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bionic"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-bionic"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-buster-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bionic"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-bionic"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
                         },
                         installer: "datadog-dotnet-apm*_amd64.deb",
                         installCmd: "dpkg -i ./datadog-dotnet-apm*_amd64.deb",
@@ -424,18 +424,18 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "35-5.0"),
-                            (publishFramework: TargetFramework.NET5_0, "34-5.0"),
-                            (publishFramework: TargetFramework.NET5_0, "33-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "34-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "33-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "29-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "35-5.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "34-5.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "34-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "33-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "29-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -447,18 +447,18 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.13"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.13"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.13"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.13"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         installer: "datadog-dotnet-apm*-musl.tar.gz",
                         installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*-musl.tar.gz",
@@ -470,13 +470,13 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "centos",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "7-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "7-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "7-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "7-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "7-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -488,12 +488,12 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "rhel",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "8-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "8-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "8-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "8-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "8-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "8-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -505,13 +505,13 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "centos-stream",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
                             // (publishFramework: TargetFramework.NET7_0, "9-7.0"), Not updated from RC1 yet
-                            (publishFramework: TargetFramework.NET6_0, "9-6.0"),
-                            (publishFramework: TargetFramework.NET6_0, "8-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "8-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
+                            new (publishFramework: TargetFramework.NET6_0, "9-6.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "8-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "8-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "8-3.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -523,13 +523,13 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "opensuse",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "15-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "15-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "15-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
                         },
                         installer: "datadog-dotnet-apm*-1.x86_64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.x86_64.rpm",
@@ -550,10 +550,10 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
                         },
                         installer: null,
                         installCmd: null,
@@ -574,14 +574,14 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb",
                         installCmd: "dpkg -i ./datadog-dotnet-apm_*_arm64.deb",
@@ -593,11 +593,11 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "35-5.0"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "35-5.0"),
                         },
                         installer: "datadog-dotnet-apm*-1.aarch64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.aarch64.rpm",
@@ -610,12 +610,12 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian_tar",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb", // we advise customers to install the .deb in this case
                         installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*.arm64.tar.gz",
@@ -636,10 +636,10 @@ partial class Build : NukeBuild
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"),
                         },
                         installer: null,
                         installCmd: null,
@@ -656,7 +656,7 @@ partial class Build : NukeBuild
                 void AddToLinuxSmokeTestsMatrix(
                     Dictionary<string, object> matrix,
                     string shortName,
-                    (string publishFramework, string runtimeTag)[] images,
+                    SmokeTestImage[] images,
                     string installer,
                     string installCmd,
                     string linuxArtifacts,
@@ -666,7 +666,7 @@ partial class Build : NukeBuild
                 {
                     foreach (var image in images)
                     {
-                        var dockerTag = $"{shortName}_{image.runtimeTag.Replace('.', '_')}";
+                        var dockerTag = $"{shortName}_{image.RuntimeTag.Replace('.', '_')}";
                         matrix.Add(
                             dockerTag,
                             new
@@ -675,9 +675,9 @@ partial class Build : NukeBuild
                                 expectedPath = runtimeId,
                                 installCmd = installCmd,
                                 dockerTag = dockerTag,
-                                publishFramework = image.publishFramework,
+                                publishFramework = image.PublishFramework,
                                 linuxArtifacts = linuxArtifacts,
-                                runtimeImage = $"{dockerName}:{image.runtimeTag}"
+                                runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
                 }
@@ -689,17 +689,17 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -709,13 +709,13 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "33-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -725,15 +725,15 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         relativeProfilerPath: "datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-musl-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -743,13 +743,13 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "centos",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "7-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "7-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "7-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "7-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "7-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -759,13 +759,13 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "opensuse",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "15-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "15-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "15-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
                         },
                         relativeProfilerPath: "datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-x64/Datadog.Linux.ApiWrapper.x64.so",
@@ -784,17 +784,17 @@ partial class Build : NukeBuild
                     AddToNuGetSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
                         },
                         relativeProfilerPath: "datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-arm64/Datadog.Linux.ApiWrapper.x64.so",
@@ -809,7 +809,7 @@ partial class Build : NukeBuild
                 void AddToNuGetSmokeTestsMatrix(
                     Dictionary<string, object> matrix,
                     string shortName,
-                    (string publishFramework, string runtimeTag)[] images,
+                    SmokeTestImage[] images,
                     string relativeProfilerPath,
                     string relativeApiWrapperPath,
                     string dockerName
@@ -817,16 +817,16 @@ partial class Build : NukeBuild
                 {
                     foreach (var image in images)
                     {
-                        var dockerTag = $"{shortName}_{image.runtimeTag.Replace('.', '_')}";
+                        var dockerTag = $"{shortName}_{image.RuntimeTag.Replace('.', '_')}";
                         matrix.Add(
                             dockerTag,
                             new
                             {
                                 dockerTag = dockerTag,
-                                publishFramework = image.publishFramework,
+                                publishFramework = image.PublishFramework,
                                 relativeProfilerPath = relativeProfilerPath,
                                 relativeApiWrapperPath = relativeApiWrapperPath,
-                                runtimeImage = $"{dockerName}:{image.runtimeTag}"
+                                runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
                 }
@@ -838,17 +838,17 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-stretch-slim"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
@@ -857,13 +857,13 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "fedora",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "35-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "33-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "33-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "35-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "29-2.1"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "andrewlock/dotnet-fedora"
@@ -872,15 +872,15 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"), 
-                            (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"), 
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18-composite"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "2.1-alpine3.12"),
                         },
                         platformSuffix: "linux-musl-x64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
@@ -889,13 +889,13 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "centos",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "7-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "7-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "7-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "7-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "7-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "7-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "7-2.1"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "andrewlock/dotnet-centos"
@@ -904,13 +904,13 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "opensuse",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "15-7.0"),
-                            (publishFramework: TargetFramework.NET6_0, "15-6.0"),
-                            (publishFramework: TargetFramework.NET5_0, "15-5.0"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
-                            (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
+                            new (publishFramework: TargetFramework.NET7_0, "15-7.0"),
+                            new (publishFramework: TargetFramework.NET6_0, "15-6.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "15-5.0"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "15-3.1"),
+                            new (publishFramework: TargetFramework.NETCOREAPP2_1, "15-2.1"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "andrewlock/dotnet-opensuse"
@@ -928,17 +928,17 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
                         },
                         platformSuffix: "linux-arm64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
@@ -956,15 +956,15 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "debian",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
-                            (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-jammy"),
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
-                            (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye"),
                         },
                         platformSuffix: "linux-x64",
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
@@ -973,11 +973,11 @@ partial class Build : NukeBuild
                     AddToDotNetToolSmokeTestsMatrix(
                         matrix,
                         "alpine",
-                        new (string publishFramework, string runtimeTag)[]
+                        new SmokeTestImage[]
                         {
-                            (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
-                            (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.15"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.15"),
                         },
                         platformSuffix: "linux-musl-x64",
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
@@ -991,22 +991,22 @@ partial class Build : NukeBuild
                 void AddToDotNetToolSmokeTestsMatrix(
                     Dictionary<string, object> matrix,
                     string shortName,
-                    (string publishFramework, string runtimeTag)[] images,
+                    SmokeTestImage[] images,
                     string platformSuffix,
                     string dockerName
                 )
                 {
                     foreach (var image in images)
                     {
-                        var dockerTag = $"{shortName}_{image.runtimeTag.Replace('.', '_')}";
+                        var dockerTag = $"{shortName}_{image.RuntimeTag.Replace('.', '_')}";
                         matrix.Add(
                             dockerTag,
                             new
                             {
                                 dockerTag = dockerTag,
-                                publishFramework = image.publishFramework,
+                                publishFramework = image.PublishFramework,
                                 platformSuffix = platformSuffix,
-                                runtimeImage = $"{dockerName}:{image.runtimeTag}"
+                                runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
                 }
@@ -1020,25 +1020,25 @@ partial class Build : NukeBuild
                         (MSBuildTargetPlatform.x64, true),
                         (MSBuildTargetPlatform.x86, true)
                     };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform.platform}_{image.runtimeTag.Replace('.', '_')}_{(platform.enable32Bit ? "32bit" : "64bit")}"
+                                     let dockerTag = $"{platform.platform}_{image.RuntimeTag.Replace('.', '_')}_{(platform.enable32Bit ? "32bit" : "64bit")}"
                                      let channel32Bit = platform.enable32Bit
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform.platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1053,26 +1053,26 @@ partial class Build : NukeBuild
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";
 
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
                                      let channel32Bit = platform == MSBuildTargetPlatform.x86
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          relativeProfilerPath = $"win-{platform}/Datadog.Trace.ClrProfiler.Native.dll",
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1087,26 +1087,26 @@ partial class Build : NukeBuild
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";
 
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
                                      let channel32Bit = platform == MSBuildTargetPlatform.x86
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          relativeProfilerPath = $"datadog/win-{platform}/Datadog.Trace.ClrProfiler.Native.dll",
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1121,25 +1121,25 @@ partial class Build : NukeBuild
                     var dockerName = "mcr.microsoft.com/dotnet/aspnet";
 
                     var platforms = new[] { MSBuildTargetPlatform.x64, MSBuildTargetPlatform.x86, };
-                    var runtimeImages = new (string publishFramework, string runtimeTag)[]
+                    var runtimeImages = new SmokeTestImage[]
                     {
-                        (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
-                        (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET8_0, "8.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET7_0, "7.0-windowsservercore-ltsc2022"),
+                        new (publishFramework: TargetFramework.NET6_0, "6.0-windowsservercore-ltsc2022"),
                     };
 
                     var matrix = (
                                      from platform in platforms
                                      from image in runtimeImages
-                                     let dockerTag = $"{platform}_{image.runtimeTag.Replace('.', '_')}"
+                                     let dockerTag = $"{platform}_{image.RuntimeTag.Replace('.', '_')}"
                                      let channel32Bit = platform == MSBuildTargetPlatform.x86
-                                                                       ? GetInstallerChannel(image.publishFramework)
+                                                                       ? GetInstallerChannel(image.PublishFramework)
                                                                        : string.Empty
                                      select new
                                      {
                                          dockerTag = dockerTag,
-                                         publishFramework = image.publishFramework,
-                                         runtimeImage = $"{dockerName}:{image.runtimeTag}",
+                                         publishFramework = image.PublishFramework,
+                                         runtimeImage = $"{dockerName}:{image.RuntimeTag}",
                                          targetPlatform = platform,
                                          channel32Bit = channel32Bit,
                                      }).ToDictionary(x=>x.dockerTag, x => x);
@@ -1304,5 +1304,17 @@ partial class Build : NukeBuild
               .Git($"diff --name-only \"{baseCommit}\"")
               .Select(output => output.Text)
               .ToArray();
+    }
+
+    class SmokeTestImage
+    {
+        public SmokeTestImage(string publishFramework, string runtimeTag)
+        {
+            PublishFramework = publishFramework;
+            RuntimeTag = runtimeTag;
+        }
+
+        public string PublishFramework { get; init; }
+        public string RuntimeTag { get; init; }
     }
 }

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -579,9 +579,9 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb",
                         installCmd: "dpkg -i ./datadog-dotnet-apm_*_arm64.deb",
@@ -597,7 +597,7 @@ partial class Build : NukeBuild
                         {
                             new (publishFramework: TargetFramework.NET7_0, "35-7.0"),
                             new (publishFramework: TargetFramework.NET6_0, "34-6.0"),
-                            new (publishFramework: TargetFramework.NET5_0, "35-5.0"),
+                            new (publishFramework: TargetFramework.NET5_0, "35-5.0", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm*-1.aarch64.rpm",
                         installCmd: "rpm -Uvh ./datadog-dotnet-apm*-1.aarch64.rpm",
@@ -615,7 +615,7 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET8_0, "8.0-bookworm-slim"),
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
                         },
                         installer: "datadog-dotnet-apm_*_arm64.deb", // we advise customers to install the .deb in this case
                         installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*.arm64.tar.gz",
@@ -677,6 +677,7 @@ partial class Build : NukeBuild
                                 dockerTag = dockerTag,
                                 publishFramework = image.PublishFramework,
                                 linuxArtifacts = linuxArtifacts,
+                                runCrashTest = image.RunCrashTest ? "true" : "false",
                                 runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
@@ -792,9 +793,9 @@ partial class Build : NukeBuild
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
                         relativeProfilerPath: "datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so",
                         relativeApiWrapperPath: "datadog/linux-arm64/Datadog.Linux.ApiWrapper.x64.so",
@@ -826,6 +827,7 @@ partial class Build : NukeBuild
                                 publishFramework = image.PublishFramework,
                                 relativeProfilerPath = relativeProfilerPath,
                                 relativeApiWrapperPath = relativeApiWrapperPath,
+                                runCrashTest = image.RunCrashTest ? "true" : "false",
                                 runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
@@ -936,9 +938,9 @@ partial class Build : NukeBuild
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim"),
-                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-bullseye-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-buster-slim", runCrashTest: false),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-focal", runCrashTest: false),
                         },
                         platformSuffix: "linux-arm64",
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
@@ -1006,6 +1008,7 @@ partial class Build : NukeBuild
                                 dockerTag = dockerTag,
                                 publishFramework = image.PublishFramework,
                                 platformSuffix = platformSuffix,
+                                runCrashTest = image.RunCrashTest ? "true" : "false",
                                 runtimeImage = $"{dockerName}:{image.RuntimeTag}"
                             });
                     }
@@ -1308,13 +1311,15 @@ partial class Build : NukeBuild
 
     class SmokeTestImage
     {
-        public SmokeTestImage(string publishFramework, string runtimeTag)
+        public SmokeTestImage(string publishFramework, string runtimeTag, bool runCrashTest = true)
         {
             PublishFramework = publishFramework;
             RuntimeTag = runtimeTag;
+            RunCrashTest = runCrashTest;
         }
 
         public string PublishFramework { get; init; }
         public string RuntimeTag { get; init; }
+        public bool RunCrashTest { get; init; }
     }
 }

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -20,6 +20,11 @@ namespace AspNetCoreSmokeTest
                 Console.WriteLine("Error: Profiler is required and is not loaded.");
                 return 1;
             }
+
+            if(Environment.GetEnvironmentVariable("CRASH_APP_ON_STARTUP") == "1")
+            {
+                throw new BadImageFormatException("Expected");
+            }
             
             Console.WriteLine("Process details: ");
             Console.WriteLine($"Framework: {RuntimeInformation.FrameworkDescription}");
@@ -38,7 +43,7 @@ namespace AspNetCoreSmokeTest
                 .ConfigureServices(ConfigureServices)
                 .ConfigureWebHostDefaults(webBuilder => webBuilder.Configure(Configure));
 
-        private static void ConfigureServices(IServiceCollection services)
+        private static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
         {
             services.AddControllers()
                     .AddApplicationPart(typeof(ValuesController).Assembly);


### PR DESCRIPTION
## Summary of changes

Add crash test detection smoke tests

## Reason for change

We want to test a range of TFMs and platforms

## Implementation details

Add an option to the smoke test app to crash in a way that is suspected as an instrumentation failure

## Test coverage

Run on all linux smoke tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
