### PR TITLE
[ASM] Add test for null response in aspnet core

### DIFF
--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -62,6 +62,20 @@ namespace Datadog.Trace.Security.IntegrationTests
 #endif
             await TestAppSecRequestWithVerifyAsync(agent, url, null, 5, 1, settings);
         }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task TestNullAction()
+        {
+            await TryStartApp();
+            var agent = Fixture.Agent;
+            var url = "/null-action/test/test";
+            var dateTime = DateTime.UtcNow;
+            await SubmitRequest(url, null, null);
+            var spans = agent.WaitForSpans(1, minDateTime: dateTime);
+            var settings = VerifyHelper.GetSpanVerifierSettings();
+            await VerifyHelper.VerifySpans(spans, settings).UseFileName($"{GetTestName()}.test-null-action");
+        }
     }
 
     public class AspNetCore5TestsSecurityDisabledWithDefaultExternalRulesFile : AspNetCoreSecurityDisabledWithExternalRulesFile

--- a/tracer/test/snapshots/Security.AspNetCore5.SecurityDisabled.test-null-action.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.SecurityDisabled.test-null-action.verified.txt
@@ -1,0 +1,49 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /null-action/{pathparam}/{pathparam2},
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.HomeController.NullAction (Samples.Security.AspNetCore5),
+      aspnet_core.route: null-action/{pathparam}/{pathparam2},
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: null-action/{pathparam}/{pathparam2},
+      http.status_code: 204,
+      http.url: http://localhost:00000/null-action/test/test,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /null-action/{pathparam}/{pathparam2},
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: nullaction,
+      aspnet_core.controller: home,
+      aspnet_core.route: null-action/{pathparam}/{pathparam2},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Security.AspNetCore5.SecurityEnabled.test-null-action.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.SecurityEnabled.test-null-action.verified.txt
@@ -1,0 +1,53 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /null-action/{pathparam}/{pathparam2},
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.HomeController.NullAction (Samples.Security.AspNetCore5),
+      aspnet_core.route: null-action/{pathparam}/{pathparam2},
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: null-action/{pathparam}/{pathparam2},
+      http.status_code: 204,
+      http.url: http://localhost:00000/null-action/test/test,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /null-action/{pathparam}/{pathparam2},
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: nullaction,
+      aspnet_core.controller: home,
+      aspnet_core.route: null-action/{pathparam}/{pathparam2},
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/HomeController.cs
@@ -40,5 +40,12 @@ namespace Samples.Security.AspNetCore5.Controllers
             Response.Headers.Add("content-language", "krypton");
             return Content("Setting content-language");
         }
+        
+        [AcceptVerbs("GET")]
+        [Route("/null-action/{pathparam}/{pathparam2}")]
+        public object NullAction(string pathparam, string pathparam2)
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

This allows testing the ActionFilter which is added by asm to scan the response body.
It allows ruling out any null reference exception when returned body is null

## Reason for change

null ref exception could happen, or risk

## Implementation details

add integration test

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
