### PR TITLE
[Tracer] scrub `_dd.agent_psr` tag from `TraceAnnotationsTests` snapshots only

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.SharedSource/VerifyHelper.cs
@@ -215,16 +215,7 @@ namespace Datadog.Trace.TestHelpers
 
         public static Dictionary<string, double>? ScrubNumericTags(MockSpan span, Dictionary<string, double>? tags)
         {
-            string[] ignoreKeys =
-            [
-                Metrics.SamplingAgentDecision,
-                // more coming soon
-            ];
-
-            return tags
-                 ?.Where(kvp => !ignoreKeys.Contains(kvp.Key))
-                  .OrderBy(x => x.Key)
-                  .ToDictionary(x => x.Key, x => x.Value);
+            return tags; // no-op
         }
 
         public static Dictionary<string, string>? ScrubCIVisibilityTags(MockSpan span, Dictionary<string, string>? tags) => ScrubCIVisibilityTags(tags);


### PR DESCRIPTION
## Summary of changes

In a previous PR, #5562, I scrubbed the `_dd.agent_psr` tag from all snapshots. In this PR, I try scrubbing it only from the tests where is causes flake (because the test intentionally loads older tracer versions). There's no need to scrub it everywhere since the tag should not appear anymore in other tests after #5545.

## Reason for change

Allowing this tag in snapshots would allow us to test this tag in the future if we ever return sampling rates from the mock agent.

## Implementation details

Move the tag-scrubbing code from the global `VerifyHelper` into `TraceAnnotationsTests`.

## Test coverage

the test tests itself

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
