### PR TITLE
[v3] Update native loader to explicitly handle alpine

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -140,9 +140,8 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             var loaderConfigFilePath = Path.GetTempFileName();
             using var sw = new StreamWriter(loaderConfigFilePath);
 
-            // loader conf doesn't support musl, so we have to force IsAlpine to false
-            sw.WriteLine($"PROFILER;{{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}};{GetArchitectureSubfolder(isAlpine: false)};{profilerPath}");
-            sw.WriteLine($"TRACER;{{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5}};{GetArchitectureSubfolder(isAlpine: false)};{tracerPath}");
+            sw.WriteLine($"PROFILER;{{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A}};{GetArchitectureSubfolder(IsAlpine)};{profilerPath}");
+            sw.WriteLine($"TRACER;{{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5}};{GetArchitectureSubfolder(IsAlpine)};{tracerPath}");
             return loaderConfigFilePath;
         }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -4,62 +4,11 @@
 #include <unordered_map>
 
 #include "log.h"
+#include "util.h"
 #include "../../../shared/src/native-src/dd_filesystem.hpp"
 // namespace fs is an alias defined in "dd_filesystem.hpp"
 #include "../../../shared/src/native-src/pal.h"
 #include "../../../shared/src/native-src/util.h"
-
-#if AMD64
-
-#if _WINDOWS
-const std::string currentOsArch = "win-x64";
-#elif LINUX
-const std::string currentOsArch = "linux-x64";
-#elif MACOS
-const std::string currentOsArch = "osx-x64";
-#else
-#error "currentOsArch not defined."
-#endif
-
-#elif X86
-
-#if _WINDOWS
-const std::string currentOsArch = "win-x86";
-#elif LINUX
-const std::string currentOsArch = "linux-x86";
-#elif MACOS
-const std::string currentOsArch = "osx-x86";
-#else
-#error "currentOsArch not defined."
-#endif
-
-#elif ARM64
-
-#if _WINDOWS
-const std::string currentOsArch = "win-arm64";
-#elif LINUX
-const std::string currentOsArch = "linux-arm64";
-#elif MACOS
-const std::string currentOsArch = "osx-arm64";
-#else
-#error "currentOsArch not defined."
-#endif
-
-#elif ARM
-
-#if _WINDOWS
-const std::string currentOsArch = "win-arm";
-#elif LINUX
-const std::string currentOsArch = "linux-arm";
-#elif MACOS
-const std::string currentOsArch = "osx-arm";
-#else
-#error "currentOsArch not defined."
-#endif
-
-#else
-#error "currentOsArch not defined."
-#endif
 
 namespace datadog::shared::nativeloader
 {
@@ -105,11 +54,14 @@ namespace datadog::shared::nativeloader
         // Set the current path to the configuration folder (to allow relative paths)
         fs::current_path(configFolder);
 
-        const std::string allOsArch[12] = {
-            "win-x64", "linux-x64", "osx-x64",
-            "win-x86", "linux-x86", "osx-x86",
-            "win-arm64", "linux-arm64", "osx-arm64",
-            "win-arm", "linux-arm", "osx-arm",
+        const auto isRunningOnAlpine = IsRunningOnAlpine();
+        const auto currentOsArch = GetCurrentOsArch(isRunningOnAlpine);
+
+        const std::string allOsArch[16] = {
+            "win-x64", "linux-x64", "linux-musl-x64", "osx-x64",
+            "win-x86", "linux-x86", "linux-musl-x86", "osx-x86",
+            "win-arm64", "linux-arm64", "linux-musl-arm64", "osx-arm64",
+            "win-arm", "linux-arm", "linux-musl-arm", "osx-arm",
         };
 
         while (t)
@@ -144,7 +96,7 @@ namespace datadog::shared::nativeloader
                         // Convert possible relative paths to absolute paths using the configuration file folder as base
                         // (current_path)
                         std::string absoluteFilepathValue = fs::absolute(filepathValue).string();
-                        Log::Debug("DynamicDispatcherImpl::LoadConfiguration: [", type, "] Loading: ", filepathValue, " [AbsolutePath=", absoluteFilepathValue,"]");
+                        Log::Debug("DynamicDispatcherImpl::LoadConfiguration: [", type, "] Loading: ", filepathValue, " [AbsolutePath=", absoluteFilepathValue,"] (", currentOsArch, ")" );
                         if (fs::exists(absoluteFilepathValue))
                         {
                             Log::Debug("[", type, "] Creating a new DynamicInstance object");

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/loader.conf
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/loader.conf
@@ -2,6 +2,7 @@
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x64;.\Datadog.Profiler.Native.dll
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x86;.\Datadog.Profiler.Native.dll
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-x64;./Datadog.Profiler.Native.so
+PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-musl-x64;./Datadog.Profiler.Native.so
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-arm64;./Datadog.Profiler.Native.so
 
 #Tracer
@@ -9,6 +10,7 @@ TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-arm64;.\Datadog.Tracer.Native.
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-x64;.\Datadog.Tracer.Native.dll
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-x86;.\Datadog.Tracer.Native.dll
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-x64;./Datadog.Tracer.Native.so
+TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-musl-x64;./Datadog.Tracer.Native.so
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-arm64;./Datadog.Tracer.Native.so
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};osx-x64;./Datadog.Tracer.Native.dylib
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};osx-arm64;./Datadog.Tracer.Native.dylib

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -100,3 +100,68 @@ inline bool IsRunningOnIIS()
     const auto& process_name = ::shared::GetCurrentProcessName();
     return process_name == WStr("w3wp.exe") || process_name == WStr("iisexpress.exe");
 }
+
+inline std::string GetCurrentOsArch(bool isRunningOnAlpine)
+{
+#if AMD64
+
+#if _WINDOWS
+    return "win-x64";
+#elif LINUX
+    return isRunningOnAlpine ? "linux-musl-x64" : "linux-x64";
+#elif MACOS
+    return "osx-x64";
+#else
+#error "currentOsArch not defined."
+#endif
+
+#elif X86
+
+#if _WINDOWS
+    return "win-x86";
+#elif LINUX
+    return isRunningOnAlpine ? "linux-musl-x86" : "linux-x86";
+#elif MACOS
+    return "osx-x86";
+#else
+#error "currentOsArch not defined."
+#endif
+
+#elif ARM64
+
+#if _WINDOWS
+    return "win-arm64";
+#elif LINUX
+    return isRunningOnAlpine ? "linux-musl-arm64" : "linux-arm64";
+#elif MACOS
+    return "osx-arm64";
+#else
+#error "currentOsArch not defined."
+#endif
+
+#elif ARM
+
+#if _WINDOWS
+    return "win-arm";
+#elif LINUX
+    return isRunningOnAlpine ? "linux-musl-arm" : "linux-arm";
+#elif MACOS
+    return "osx-arm";
+#else
+#error "currentOsArch not defined."
+#endif
+
+#else
+#error "currentOsArch not defined."
+#endif
+}
+
+inline bool IsRunningOnAlpine()
+{
+#if LINUX
+    std::error_code ec; // fs::exists might throw if no error_code parameter is provided
+    return fs::exists("/etc/alpine-release", ec);
+#else
+    return false;
+#endif
+}

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -888,7 +888,7 @@ partial class Build
             loaderConfContents = Regex.Replace(
                 input: loaderConfContents,
                 pattern: @";(linux-.*?);\.\/Datadog\.",
-                replacement: $@";$1;./{arch}/Datadog.");
+                replacement: $@";$1;./$1/Datadog.");
             File.WriteAllText(assetsDirectory / FileNames.LoaderConf, contents: loaderConfContents);
 
             // Copy createLogPath.sh script and set the permissions


### PR DESCRIPTION
## Summary of changes

Added code to the native loader to specifically check if we're running on alpine, and choose a different entry in to the loader.conf

## Reason for change

Previously, the native loader didn't "care" if it was running on alpine. Instead, we shipped a loader.conf that points to a different location for `linux-x64`, e.g. `linux-x64;./linux-musl-x64/Datadog.Profiler.Native.so` in the musl packages.

With the universal binary changes (and more importantly packaging both glibc and musl together) we will have the same loader.conf for _both_ glibc and musl, so we can no longer use the same trick. 

Instead, we add explicit `-musl` entries in the loader.conf, and the native loader determines whether it needs `linux-x64` or `linux-musl-x64` at runtime.

## Implementation details

- Added IsRunningOnAlpine() helper method
  - This check is the same one implemented [in the ld_preload binary](https://github.com/DataDog/dd-trace-dotnet/pull/5582/files) and in [the auto-injector](https://github.com/DataDog/auto_inject/blob/a9b6e50494e23dc08691067636e6a1c28e11b080/preload_go/docker/configurators.go#L161) library.
- Moved `GetAllOsArch()` and `GetCurrentOsArch()` to helper methods in util, and added alternative paths when running on alpine
- Added linux-musl-x64 entry to the loader.conf
- Update the linux packaging step to preserve the `linux-x64` paths instead of replacing them with `linux-x64-musl` on alpine

## Test coverage

This is (theoretically) a non-breaking change, so all the existing smoke tests should work as expected.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
