### PR TITLE
Fix null ref

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/ActionResponseFilter.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AspNetCore/ActionResponseFilter.cs
@@ -26,7 +26,7 @@ internal class ActionResponseFilter : IActionFilter
         if (security.Enabled
             && context.Result.TryDuckCast<ObjectResult>(out var result)
             && result.Value is not null
-            && Tracer.Instance.ActiveScope.Span is Span currentSpan)
+            && Tracer.Instance.ActiveScope?.Span is Span currentSpan)
         {
             security.CheckBody(context.HttpContext, currentSpan, result.Value, response: true);
         }


### PR DESCRIPTION
## Summary of changes

Fixes a null ref cited in an escalation:

```
System.NullReferenceException:
   at Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.ActionResponseFilter.OnActionExecuted (Datadog.Trace, Version=2.51.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb: c:\mnt\tracer\src\Datadog.Trace\ClrProfiler\AutoInstrumentation\AspNetCore\ActionResponseFilter.cs:26)
   at Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker.Next (Microsoft.AspNetCore.Mvc.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60)
```

## Test coverage

We have been unable to reproduce the conditions where this issue occurs. 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
