### PR TITLE
Improve lib-injection tagging script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,11 +86,17 @@ generate-lib-init-tag-values:
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/ci/auto_inject/gitlab:current
   stage: deploy
-  needs: []
+  rules:
+    - if: '$POPULATE_CACHE'
+      when: never
+    # We don't tag prerelease versions
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: always
+    - when: manual
+      allow_failure: true
   variables:
     IMG_DESTINATION_BASE: dd-lib-dotnet-init
     ADDITIONAL_TAG_SUFFIXES: musl # comma separated list of additional tag suffixes
-    CI_COMMIT_TAG: "v1.30.2"
   script:
     - ./.gitlab/build-lib-init.sh
   artifacts:
@@ -100,8 +106,8 @@ generate-lib-init-tag-values:
 deploy-lib-init-trigger:
   stage: deploy
   trigger:
-    project: DataDog/dd-trace-dotnet-gitlab-test # can be used for testing
-#    project: DataDog/public-images
+#    project: DataDog/dd-trace-dotnet-gitlab-test # can be used for testing
+    project: DataDog/public-images
     branch: main
     strategy: depend
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,17 +86,11 @@ generate-lib-init-tag-values:
   tags: ["arch:amd64"]
   image: registry.ddbuild.io/ci/auto_inject/gitlab:current
   stage: deploy
-  rules:
-    - if: '$POPULATE_CACHE'
-      when: never
-    # We don't tag prerelease versions
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: always
-    - when: manual
-      allow_failure: true
+  needs: []
   variables:
     IMG_DESTINATION_BASE: dd-lib-dotnet-init
     ADDITIONAL_TAG_SUFFIXES: musl # comma separated list of additional tag suffixes
+    CI_COMMIT_TAG: "v1.30.2"
   script:
     - ./.gitlab/build-lib-init.sh
   artifacts:
@@ -106,8 +100,8 @@ generate-lib-init-tag-values:
 deploy-lib-init-trigger:
   stage: deploy
   trigger:
-#    project: DataDog/dd-trace-dotnet-gitlab-test # can be used for testing
-    project: DataDog/public-images
+    project: DataDog/dd-trace-dotnet-gitlab-test # can be used for testing
+#    project: DataDog/public-images
     branch: main
     strategy: depend
   variables:

--- a/.gitlab/build-lib-init.sh
+++ b/.gitlab/build-lib-init.sh
@@ -35,8 +35,9 @@ git fetch --tags
 # So we fetch all tags and sort them to find both the latest, and the latest in this major.
 # 'sort' technically gets prerelease versions in the wrong order here, but we explicitly
 # exclude them anyway, as they're ignored for the purposes of determining the 'latest' tags.
-LATEST_TAG="$(git tag | grep -v '-' | sort -V -r | head -n 1)"
-LATEST_MAJOR_TAG="$(git tag -l "$MAJOR_VERSION.*" | grep -v '-' | sort -V -r | head -n 1)"
+LATEST_TAG="$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r | head -n 1)"
+LATEST_MAJOR_TAG="$(git tag -l "$MAJOR_VERSION.*" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V -r | head -n 1)"
+
 echo "This tag: $CI_COMMIT_TAG"
 echo "Latest repository tag: $LATEST_TAG"
 echo "Latest repository tag for this major: $LATEST_MAJOR_TAG"


### PR DESCRIPTION
## Summary of changes

Use a more restrictive regex when searching for tags for lib-injection

## Reason for change

Suggested [here](https://github.com/DataDog/dd-trace-py/pull/9332#discussion_r1608980272) - not _necessary_ for us as we _only_ have `vX.Y.Z-pre` tags, but preferable for other libraries, and we want to keep the scripts in sync if possible

## Implementation details

Replace `grep -v '-'` (i.e. reject any tags with a `-`) with `grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'` (explicit Regex)

## Test coverage

Re-ran all the checks from https://github.com/DataDog/dd-trace-dotnet/pull/5544 and looks good

## Other details
Original implementation in 
- https://github.com/DataDog/dd-trace-dotnet/pull/5544

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
