### PR TITLE
[Profiler/Tracer] Bump FluentAssertions to 6.12.0

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Datadog.Profiler.IntegrationTests.csproj
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Google.Protobuf" Version="3.20.1" />
     <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.3.6" />
     <PackageReference Include="MessagePack" Version="1.9.11" />

--- a/profiler/test/Datadog.Profiler.IntegrationTests/DebugInfo/LineNumberTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/DebugInfo/LineNumberTest.cs
@@ -75,8 +75,8 @@ namespace Datadog.Profiler.IntegrationTests.DebugInfo
 
                 // "normal" line info
                 second.Filename.Should().EndWith("LineNumber.cs");
-                second.StartLine.Should().Be(42);
-                second.Line.Should().Be(42);
+                second.StartLine.Should().Be(41);
+                second.Line.Should().Be(41);
 
                 // hidden debug info
                 third.Filename.Should().BeEmpty();

--- a/profiler/test/Datadog.Profiler.IntegrationTests/DebugInfo/LineNumberTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/DebugInfo/LineNumberTest.cs
@@ -70,18 +70,18 @@ namespace Datadog.Profiler.IntegrationTests.DebugInfo
 
                 // forced line info
                 first.Filename.Should().EndWith("LineNumber.cs");
-                first.StartLine.Should().Equals(103);
-                first.Line.Should().Equals(103);
+                first.StartLine.Should().Be(103);
+                first.Line.Should().Be(103);
 
                 // "normal" line info
                 second.Filename.Should().EndWith("LineNumber.cs");
-                second.StartLine.Should().Equals(42);
-                second.Line.Should().Equals(42);
+                second.StartLine.Should().Be(42);
+                second.Line.Should().Be(42);
 
                 // hidden debug info
                 third.Filename.Should().BeEmpty();
-                third.StartLine.Should().Equals(0);
-                third.Line.Should().Equals(0);
+                third.StartLine.Should().Be(0);
+                third.Line.Should().Be(0);
             }
         }
 
@@ -103,7 +103,7 @@ namespace Datadog.Profiler.IntegrationTests.DebugInfo
                     for (var i = 0; i < stackTrace.FramesCount; i++)
                     {
                         stackTrace[i].Filename.Should().BeEmpty();
-                        stackTrace[i].StartLine.Should().Equals(0);
+                        stackTrace[i].StartLine.Should().Be(0);
                     }
                 }
             }
@@ -126,7 +126,7 @@ namespace Datadog.Profiler.IntegrationTests.DebugInfo
                     for (var i = 0; i < stackTrace.FramesCount; i++)
                     {
                         stackTrace[i].Filename.Should().BeEmpty();
-                        stackTrace[i].StartLine.Should().Equals(0);
+                        stackTrace[i].StartLine.Should().Be(0);
                     }
                 }
             }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Exceptions/ExceptionsTest.cs
@@ -123,11 +123,11 @@ namespace Datadog.Profiler.IntegrationTests.Exceptions
             // The profiler samples the exception but also upscale the values after.
             // So we just check that we are in the right order of magnitude.
             // Note: with timestamps, upscaling will round down due to the lack of aggregation
-            exceptionCounts.Should().ContainKey("System.Exception").WhichValue.Should().BeCloseTo(4000, 300);
+            exceptionCounts.Should().ContainKey("System.Exception").WhoseValue.Should().BeCloseTo(4000, 300);
 
             // System.InvalidOperationException is seen only once, so it should be sampled
             // despite the sampler being saturated by the 4000 System.Exception
-            exceptionCounts.Should().ContainKey("System.InvalidOperationException").WhichValue.Should().Be(1);
+            exceptionCounts.Should().ContainKey("System.InvalidOperationException").WhoseValue.Should().Be(1);
         }
 
         [TestAppFact("Samples.ExceptionGenerator")]

--- a/tracer/test/Directory.Build.props
+++ b/tracer/test/Directory.Build.props
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="DelegateDecompiler" Version="0.32.0" />
-    <PackageReference Include="FluentAssertions" Version="6.4.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.8.0" />
     <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftTestSDKVersion)" />


### PR DESCRIPTION
## Summary of changes

Bump FluentAssertions package.

## Reason for change

To be able to use new string matchers.

## Implementation details

Update nuget package

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
