### PR TITLE
[Profiler] Capture dump on timeout in wrapper tests

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/TestApplicationRunner.cs
@@ -70,6 +70,19 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
             PrintTestInfo();
         }
 
+        public bool WaitForExitOrCaptureDump(Process process, int milliseconds)
+        {
+            var success = process.WaitForExit(milliseconds);
+
+            if (!success)
+            {
+                process.GetAllThreadsStack(_testBaseOutputDir, _output);
+                process.TakeMemoryDump(_testBaseOutputDir, _output);
+            }
+
+            return success;
+        }
+
         public ProcessHelper LaunchProcess(MockDatadogAgent agent = null)
         {
             var (executor, arguments) = BuildTestCommandLine();

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -87,12 +87,12 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
 
             runner.Environment.SetVariable("COMPlus_DbgMiniDumpType", string.Empty);
-            
+
             RegisterCrashHandler(runner);
 
             using var processHelper = runner.LaunchProcess();
 
-            processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
+            runner.WaitForExitOrCaptureDump(processHelper.Process, milliseconds: 30_000).Should().BeTrue();
             processHelper.Drain();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
             processHelper.StandardOutput.Should().MatchRegex(@"createdump [\w\.\/]+createdump \d+")
@@ -111,7 +111,7 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
 
             using var processHelper = runner.LaunchProcess();
 
-            processHelper.Process.WaitForExit(milliseconds: 30_000).Should().BeTrue();
+            runner.WaitForExitOrCaptureDump(processHelper.Process, milliseconds: 30_000).Should().BeTrue();
             processHelper.Drain();
             processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
             processHelper.StandardOutput.Should().NotMatchRegex(@"createdump [\w\.\/]+createdump \d+")


### PR DESCRIPTION
## Summary of changes

In wrapper tests, capture a dump and display the callstacks when the process doesn't exit in time.

## Reason for change

The WaitForExit timeouts for unknown reasons.

## Implementation details

Just reusing the helpers that were lying around.