### PR TITLE
Fix RCM Capabilities bugs

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -41,11 +41,11 @@ namespace Datadog.Trace.Configuration
             {
                 _subscriptionManager.SubscribeToChanges(_subscription!);
 
-                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingCustomTags, true);
-                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingHttpHeaderTags, true);
-                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingLogsInjection, true);
-                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingSampleRate, true);
-                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingTracingEnabled, true);
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingCustomTags, true);     // 15
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingHttpHeaderTags, true); // 14
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingLogsInjection, true);  // 13
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingSampleRate, true);     // 12
+                _subscriptionManager.SetCapability(RcmCapabilitiesIndices.ApmTracingTracingEnabled, true); // 19
             }
         }
 

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmFile.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/Protocol/RcmFile.cs
@@ -14,6 +14,6 @@ namespace Datadog.Trace.RemoteConfigurationManagement.Protocol
         public string Path { get; set; } = string.Empty;
 
         [JsonProperty("raw")]
-        public byte[] Raw { get; set; } = Array.Empty<byte>();
+        public byte[] Raw { get; set; } = [];
     }
 }

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -7,7 +7,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 using System.Threading;
@@ -15,7 +14,6 @@ using System.Threading.Tasks;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement.Protocol;
 using Datadog.Trace.RemoteConfigurationManagement.Transport;
-using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Serilog.Events;
 
 namespace Datadog.Trace.RemoteConfigurationManagement;
@@ -35,7 +33,7 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
     /// </summary>
     private readonly Dictionary<string, RemoteConfigurationCache> _appliedConfigurations = new();
 
-    private readonly string _id;
+    private readonly string _id = Guid.NewGuid().ToString();
 
     // Ideally this would be an ImmutableArray but that's not available in net461
     private IReadOnlyList<ISubscription> _subscriptions = [];
@@ -44,11 +42,6 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
     private int _targetsVersion;
     private BigInteger _capabilities;
     private string? _lastPollError;
-
-    public RcmSubscriptionManager()
-    {
-        _id = Guid.NewGuid().ToString();
-    }
 
     public bool HasAnySubscription => _subscriptions.Count > 0;
 
@@ -156,7 +149,7 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
     {
         // capabilitiesArray needs to be big endian
 #if NETCOREAPP
-        var capabilitiesArray = _capabilities.ToByteArray(true, true);
+        var capabilitiesArray = _capabilities.ToByteArray(isUnsigned: true, isBigEndian: true);
 #else
         var capabilitiesArray = _capabilities.ToByteArray();
         Array.Reverse(capabilitiesArray);

--- a/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
+++ b/tracer/src/Datadog.Trace/RemoteConfigurationManagement/RcmSubscriptionManager.cs
@@ -153,6 +153,15 @@ internal class RcmSubscriptionManager : IRcmSubscriptionManager
 #else
         var capabilitiesArray = _capabilities.ToByteArray();
         Array.Reverse(capabilitiesArray);
+
+        if (capabilitiesArray.Length > 1 && capabilitiesArray[0] == 0)
+        {
+            // HACK: .NET Framework BigInteger.ToByteArray() can add a 0x00 byte to distinguish
+            // some positive numbers ((2^n)-1) from negative numbers. Remove this byte if present.
+            var unsignedArray = new byte[capabilitiesArray.Length - 1];
+            Array.Copy(capabilitiesArray, 1, unsignedArray, 0, unsignedArray.Length);
+            return unsignedArray;
+        }
 #endif
 
         return capabilitiesArray;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -164,8 +164,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var request = await agent.SetupRcmAndWait(Output, new[] { ((object)new { lib_config = config }, DynamicConfigurationManager.ProductName, fileId) });
 
+            // copy the byte array and reverse the bytes to create a BitArray with the correct order
+            var capabilityBytes = new byte[request.Client.Capabilities.Length];
+            Array.Copy(request.Client.Capabilities, capabilityBytes, request.Client.Capabilities.Length);
+            Array.Reverse(capabilityBytes);
+
             // Validate capabilities
-            var capabilities = new BitArray(request.Client.Capabilities);
+            var capabilities = new BitArray(capabilityBytes);
 
             capabilities[12].Should().BeTrue(); // APM_TRACING_SAMPLE_RATE
             capabilities[13].Should().BeTrue(); // APM_TRACING_LOGS_INJECTION

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -7,13 +7,11 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.RemoteConfigurationManagement;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
@@ -153,7 +151,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 return configurationChanged.Configuration;
             }
 
-            return Enumerable.Empty<ConfigurationKeyValue>();
+            return [];
         }
 
         private async Task UpdateAndValidateConfig(MockTracerAgent agent, LogEntryWatcher logEntryWatcher, Config config, Config expectedConfig = null)
@@ -315,7 +313,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             latestConfig.Should().HaveCount(expectedCount);
         }
 
-        internal class PlainJsonStringConverter : JsonConverter
+        private class PlainJsonStringConverter : JsonConverter
         {
             public override bool CanConvert(Type objectType)
             {
@@ -333,7 +331,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             }
         }
 
-        internal record Config
+        private record Config
         {
             [JsonProperty("tracing_enabled")]
             public bool TraceEnabled { get; init; }

--- a/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
@@ -1,0 +1,44 @@
+// <copyright file="RcmSubscriptionManagerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections;
+using Datadog.Trace.RemoteConfigurationManagement;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.RemoteConfigurationManagement;
+
+public class RcmSubscriptionManagerTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    // ...
+    [InlineData(6)]
+    // [InlineData(7)] FAILS
+    [InlineData(8)]
+    // ...
+    [InlineData(9)]
+    // [InlineData(15)] FAILS
+    [InlineData(16)]
+    // ...
+    [InlineData(17)]
+    // [InlineData(23)] FAILS
+    [InlineData(24)]
+    public void GetCapabilityBytes(int capabilityIndex)
+    {
+        var subscriptionManager = new RcmSubscriptionManager();
+        subscriptionManager.SetCapability(1 << capabilityIndex, true);
+
+        var byteCount = (capabilityIndex / 8) + 1;
+        var bytes = new byte[byteCount];
+        var bits = new BitArray(bytes) { [capabilityIndex] = true };
+        bits.CopyTo(bytes, 0);
+        Array.Reverse(bytes);
+
+        subscriptionManager.GetCapabilities().Should().BeEquivalentTo(bytes);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
@@ -18,27 +18,26 @@ public class RcmSubscriptionManagerTests
     [InlineData(1)]
     // ...
     [InlineData(6)]
-    // [InlineData(7)] FAILS
+    [InlineData(7)]
     [InlineData(8)]
     // ...
     [InlineData(9)]
-    // [InlineData(15)] FAILS
+    [InlineData(15)]
     [InlineData(16)]
     // ...
     [InlineData(17)]
-    // [InlineData(23)] FAILS
+    [InlineData(23)]
     [InlineData(24)]
-    public void GetCapabilityBytes(int capabilityIndex)
+    public void GetCapabilities(int capabilityIndex)
     {
+        var byteCount = (capabilityIndex / 8) + 1;
+        var expectedBytes = new byte[byteCount];
+        var bits = new BitArray(expectedBytes) { [capabilityIndex] = true };
+        bits.CopyTo(expectedBytes, 0);
+        Array.Reverse(expectedBytes);
+
         var subscriptionManager = new RcmSubscriptionManager();
         subscriptionManager.SetCapability(1 << capabilityIndex, true);
-
-        var byteCount = (capabilityIndex / 8) + 1;
-        var bytes = new byte[byteCount];
-        var bits = new BitArray(bytes) { [capabilityIndex] = true };
-        bits.CopyTo(bytes, 0);
-        Array.Reverse(bytes);
-
-        subscriptionManager.GetCapabilities().Should().BeEquivalentTo(bytes);
+        subscriptionManager.GetCapabilities().Should().BeEquivalentTo(expectedBytes);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
@@ -30,6 +30,10 @@ public class RcmSubscriptionManagerTests
     [InlineData(22)]
     [InlineData(23)] // 23 is the last index of the third byte
     [InlineData(24)]
+    // ...
+    [InlineData(30)]
+    [InlineData(31)] // 31 is the last index of the fourth byte
+    [InlineData(32)]
     public void GetCapabilities(int capabilityIndex)
     {
         var byteCount = (capabilityIndex / 8) + 1;

--- a/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
@@ -43,7 +43,7 @@ public class RcmSubscriptionManagerTests
         Array.Reverse(expectedBytes);
 
         var subscriptionManager = new RcmSubscriptionManager();
-        subscriptionManager.SetCapability(1 << capabilityIndex, true);
+        subscriptionManager.SetCapability(1UL << capabilityIndex, true);
         subscriptionManager.GetCapabilities().Should().BeEquivalentTo(expectedBytes);
     }
 }

--- a/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
@@ -23,11 +23,11 @@ public class RcmSubscriptionManagerTests
     [InlineData(7)] // 7 is the last index of the first byte
     [InlineData(8)]
     // ...
-    [InlineData(9)]
+    [InlineData(14)]
     [InlineData(15)] // 15 is the last index of the second byte
     [InlineData(16)]
     // ...
-    [InlineData(17)]
+    [InlineData(22)]
     [InlineData(23)] // 23 is the last index of the third byte
     [InlineData(24)]
     public void GetCapabilities(int capabilityIndex)

--- a/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/RemoteConfigurationManagement/RcmSubscriptionManagerTests.cs
@@ -13,20 +13,22 @@ namespace Datadog.Trace.Tests.RemoteConfigurationManagement;
 
 public class RcmSubscriptionManagerTests
 {
+    // some values (noted below) can trigger BigInteger.ToByteArray() to an an extra 0x00 byte,
+    // so we're testing a few values to make sure the conversion is correct
     [Theory]
     [InlineData(0)]
     [InlineData(1)]
     // ...
     [InlineData(6)]
-    [InlineData(7)]
+    [InlineData(7)] // 7 is the last index of the first byte
     [InlineData(8)]
     // ...
     [InlineData(9)]
-    [InlineData(15)]
+    [InlineData(15)] // 15 is the last index of the second byte
     [InlineData(16)]
     // ...
     [InlineData(17)]
-    [InlineData(23)]
+    [InlineData(23)] // 23 is the last index of the third byte
     [InlineData(24)]
     public void GetCapabilities(int capabilityIndex)
     {


### PR DESCRIPTION
## Summary of changes

1. Add a workaround for `BigInteger.ToByteArray()` in .NET Framework. This method adds an additional `0x00` byte to the array when the number's highest bit is set (otherwise it would look like a negative number). We already avoid this issue in .NET Core by using the overload with a `isUnsigned: true` parameter which doesn't need to distinguish between positive and negative values.
2. Fix a bug in test `DynamicConfigurationTests` that was not reversing the bytes from `request.Client.Capabilities` after deserializing the RC json string. We had not hit this issue until we tried to add a capability at index 29, which extends the array from 3 to 4 bytes.

## Reason for change

1. We haven't hit the `BigInteger.ToByteArray()` issue yet, but it's only a matter of time.

2. `DynamicConfigurationTests` is already failing in #5453 when adding capability at index 29.

## Implementation details

1. In `RcmSubscriptionManager.GetCapabilities()`, if running on .NET Framework and the zero byte is present, remove it by creating a new array and copying every other byte over except the zero byte. This is a quick workaround until we refactor `RcmCapabilitiesIndices` and `IRcmSubscriptionManager` to move away from using `BigInteger`.
2. In `DynamicConfigurationTests`, reverse the byte array.
3. Required miscellaneous code cleanup.

## Test coverage

1. For `RcmSubscriptionManager.GetCapabilities()`, added a test that failed until the workaround was added.
2. `DynamicConfigurationTests` is a test, but I confirmed is used to break when adding capability `29` before the fix, and no longer breaks after the fix.

## Other details
N/A
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
