### PR TITLE
Fallback to `OperationName` instead of `string.Empty` for ElasticSearch `ResourceName`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/ElasticsearchNetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Elasticsearch/ElasticsearchNetCommon.cs
@@ -63,7 +63,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Elasticsearch
             {
                 scope = tracer.StartActiveInternal(operationName, serviceName: serviceName, tags: tags);
                 var span = scope.Span;
-                span.ResourceName = requestName ?? string.Empty;
+                span.ResourceName = requestName ?? operationName;
                 span.Type = DatabaseType;
                 tags.Action = requestName;
                 tags.Method = method;


### PR DESCRIPTION
## Summary of changes

Instead of using `string.Empty` for the `Span.ResourceName` fallback to the `OperationName` (which would be `elasticsearch.query`) when the `object? requestParameters` are `null`

## Reason for change

In some logs I saw that the trace agent was needing to fix many ElasticSearch spans where the `Span.Resource` was empty - it would populate it with the operation name `elasticsearch.query`.

It seems like we could just do that in the Tracer instead.

I'm unsure exactly how the ElasticSearch `object? requestParameters` are `null` here to cause this issue though.

```
.... | TRACE | DEBUG | (pkg/trace/agent/normalizer.go:109 in normalize) | Fixing malformed trace. Resource is empty (reason:resource_empty), setting span.resource=elasticsearch.query: service:"....."  name:"elasticsearch.query"
```

## Implementation details

Swap `string.Empty` for `operationName`

## Test coverage

I am actually not entirely sure how this happens and it doesn't seem that we have any test coverage for this case 😬 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
