### PR TITLE
Record SSI injection values in configuration

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -22,6 +22,7 @@ using Datadog.Trace.Sampling;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
+using Datadog.Trace.Util;
 
 namespace Datadog.Trace.Configuration
 {
@@ -417,6 +418,10 @@ namespace Datadog.Trace.Configuration
             telemetry.Record(ConfigTelemetryData.NativeTracerVersion, Instrumentation.GetNativeTracerVersion(), recordValue: true, ConfigurationOrigins.Default);
             telemetry.Record(ConfigTelemetryData.FullTrustAppDomain, value: AppDomain.CurrentDomain.IsFullyTrusted, ConfigurationOrigins.Default);
             telemetry.Record(ConfigTelemetryData.ManagedTracerTfm, value: ConfigTelemetryData.ManagedTracerTfmValue, recordValue: true, ConfigurationOrigins.Default);
+
+            // these are SSI variables that would be useful for correlation purposes
+            telemetry.Record(ConfigTelemetryData.SsiInjectionEnabled, value: EnvironmentHelpers.GetEnvironmentVariable("DD_INJECTION_ENABLED"), recordValue: true, ConfigurationOrigins.EnvVars);
+            telemetry.Record(ConfigTelemetryData.SsiAllowUnsupportedRuntimesEnabled, value: EnvironmentHelpers.GetEnvironmentVariable("DD_INJECT_FORCE"), recordValue: true, ConfigurationOrigins.EnvVars);
 
             if (AzureAppServiceMetadata is not null)
             {

--- a/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/DTOs/ConfigTelemetryData.cs
@@ -21,6 +21,9 @@ namespace Datadog.Trace.Telemetry
         public const string ProfilerLoaded = "profiler_loaded";
         public const string CodeHotspotsEnabled = "code_hotspots_enabled";
 
+        public const string SsiInjectionEnabled = "ssi_injection_enabled";
+        public const string SsiAllowUnsupportedRuntimesEnabled = "ssi_forced_injection_enabled";
+
         // We intentionally are using specific values here, not OR_GREATER_THAN
 #if NET6_0
         public const string ManagedTracerTfmValue = "net6.0";

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/ConfigurationTests.cs
@@ -49,7 +49,9 @@ public class ConfigurationTests
         "DD_DOTNET_TRACER_HOME",
         "DD_INSTRUMENTATION_INSTALL_ID",
         "DD_INSTRUMENTATION_INSTALL_TYPE",
-        "DD_INSTRUMENTATION_INSTALL_TIME"
+        "DD_INSTRUMENTATION_INSTALL_TIME",
+        "DD_INJECTION_ENABLED",
+        "DD_INJECT_FORCE",
     };
 
     [Fact]

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -565,5 +565,7 @@
   "trace.sidecar_trace_sender": "trace_sidecar_trace_sender",
   "trace.sampling_rules_format": "trace_sampling_rules_format",
   "DD_TRACE_SAMPLING_RULES_FORMAT": "trace_sampling_rules_format",
-  "trace.agentless": "trace_agentless"
+  "trace.agentless": "trace_agentless",
+  "ssi_injection_enabled": "ssi_injection_enabled",
+  "ssi_forced_injection_enabled": "ssi_forced_injection_enabled"
 }


### PR DESCRIPTION
## Summary of changes

Adds `ssi_injection_enabled` and `ssi_allow_unsupported_runtime_enabled` to configuration telemetry data

## Reason for change

We use these on the native side only, but could be useful to have with everything else in config telemetry

## Implementation details

Read the env vars and add to config. Note that we _only_ read the env vars (we don't use normal config) because only the env vars will have an impact

## Test coverage

Meh

## Other details

I'll do a PR to add these to the intake if consensus is yay

Prerequisite for single-step guard rails work stack
- https://github.com/DataDog/dd-trace-dotnet/pull/5635
- https://github.com/DataDog/dd-trace-dotnet/pull/5636
- https://github.com/DataDog/dd-trace-dotnet/pull/5637
- https://github.com/DataDog/dd-trace-dotnet/pull/5611

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
