### PR TITLE
chore(lib-injection): update base image to alpine 3.20

### DIFF
--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -4,7 +4,7 @@ ARG LINUX_PACKAGE
 # The ADD command does more than COPY, so it can directly copy a local directory or it can copy over a `tar.gz` file and automatically extract its contents into the destination
 ADD ${LINUX_PACKAGE} /
 
-FROM alpine:3.18.3
+FROM alpine:3.18.6
 
 ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \

--- a/lib-injection/Dockerfile
+++ b/lib-injection/Dockerfile
@@ -4,7 +4,7 @@ ARG LINUX_PACKAGE
 # The ADD command does more than COPY, so it can directly copy a local directory or it can copy over a `tar.gz` file and automatically extract its contents into the destination
 ADD ${LINUX_PACKAGE} /
 
-FROM alpine:3.18.6
+FROM alpine:3.20
 
 ARG UID=10000
 RUN addgroup -g 10000 -S datadog && \


### PR DESCRIPTION
## Summary of changes

3.18.3 has a known vulnerability, CVE-2023-5363 that can trigger warnings even though this image is not used to run any applications.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
