### PR TITLE
[Profiler] Fix services start/stop

### DIFF
--- a/profiler/.clang-format
+++ b/profiler/.clang-format
@@ -36,11 +36,10 @@ AllowShortLoopsOnASingleLine: true
 PointerAlignment: Left
 AlignConsecutiveAssignments: false
 AlignTrailingComments: true
-SpaceAfterCStyleCast: true
+SpaceAfterCStyleCast: false
 CommentPragmas: '^ NO-FORMAT:'
 IndentCaseLabels: true
 IndentGotoLabels: true
-SpaceAfterCStyleCast: false
 
 # The following doesn't work pre clang-format version 13
 #BreakBeforeConceptDeclarations: true

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsRecorder.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsRecorder.cpp
@@ -114,12 +114,12 @@ const char* AllocationsRecorder::GetName()
     return "AllocationsRecorder";
 }
 
-bool AllocationsRecorder::Start()
+bool AllocationsRecorder::StartImpl()
 {
     return true;
 }
 
-bool AllocationsRecorder::Stop()
+bool AllocationsRecorder::StopImpl()
 {
     return true;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsRecorder.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AllocationsRecorder.h
@@ -33,12 +33,13 @@ public:
 
 public:
     virtual const char* GetName() override;
-    virtual bool Start() override;
-    virtual bool Stop() override;
     virtual void OnObjectAllocated(ObjectID objectId, ClassID classId) override;
     virtual bool Serialize(const std::string& filename) override;
 
 private:
+    bool StartImpl() override;
+    bool StopImpl() override;
+
     ICorProfilerInfo5* _pCorProfilerInfo;
     IFrameStore* _pFrameStore;
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ApplicationStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ApplicationStore.cpp
@@ -58,13 +58,13 @@ const char* ApplicationStore::GetName()
     return _serviceName;
 }
 
-bool ApplicationStore::Start()
+bool ApplicationStore::StartImpl()
 {
     // nothing special to start
     return true;
 }
 
-bool ApplicationStore::Stop()
+bool ApplicationStore::StopImpl()
 {
     // nothing special to stop
     return true;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ApplicationStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ApplicationStore.h
@@ -24,11 +24,12 @@ public:
     void SetGitMetadata(std::string runtimeId, std::string repositoryUrl, std::string commitSha) override;
 
     const char* GetName() override;
-    bool Start() override;
-    bool Stop() override;
 
 private:
     const char* _serviceName = "ApplicationStore";
+
+    bool StartImpl() override;
+    bool StopImpl() override;
 
     IConfiguration* const _pConfiguration;
     std::unordered_map<std::string, ApplicationInfo> _infos;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -619,7 +619,7 @@ bool CorProfilerCallback::StopServices()
         }
         else
         {
-            Log::Error(name, " failed to stop.");
+            Log::Info(name, " failed to stop.");
         }
         result &= success;
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -253,6 +253,7 @@
     <ClInclude Include="MemoryResourceManager.h" />
     <ClInclude Include="RawSamples.hpp" />
     <ClInclude Include="SamplesEnumerator.h" />
+    <ClInclude Include="ServiceBase.h" />
     <ClInclude Include="Success.h" />
     <ClInclude Include="Exception.h" />
     <ClInclude Include="Exporter.h" />
@@ -393,6 +394,7 @@
     <ClCompile Include="FileHelper.cpp" />
     <ClCompile Include="FrameworkThreadInfo.cpp" />
     <ClCompile Include="MemoryResourceManager.cpp" />
+    <ClCompile Include="ServiceBase.cpp" />
     <ClCompile Include="Success.cpp" />
     <ClCompile Include="Exception.cpp" />
     <ClCompile Include="ExceptionsProvider.cpp" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj.filters
@@ -437,11 +437,13 @@
     <ClInclude Include="Callstack.h">
       <Filter>Profiler-Driver</Filter>
     </ClInclude>
-    <ClInclude Include="CallstackPool.h">
-      <Filter>Profiler-Driver</Filter>
-    </ClInclude>
     <ClInclude Include="CrashReporting.h">
       <Filter>libdatadog</Filter>
+    </ClInclude>
+    <ClInclude Include="CallstackProvider.h" />
+    <ClInclude Include="MemoryResourceManager.h" />
+    <ClInclude Include="ServiceBase.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -661,11 +663,17 @@
     <ClCompile Include="Callstack.cpp">
       <Filter>Profiler-Driver</Filter>
     </ClCompile>
-    <ClCompile Include="CallstackPool.cpp">
-      <Filter>Profiler-Driver</Filter>
-    </ClCompile>
     <ClCompile Include="CrashReporting.cpp">
       <Filter>libdatadog</Filter>
+    </ClCompile>
+    <ClCompile Include="CallstackProvider.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="MemoryResourceManager.cpp">
+      <Filter>Utils</Filter>
+    </ClCompile>
+    <ClCompile Include="ServiceBase.cpp">
+      <Filter>Utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IAllocationsRecorder.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IAllocationsRecorder.h
@@ -8,11 +8,11 @@
 #include "corprof.h"
 // end
 
-#include "IService.h"
+#include "ServiceBase.h"
 
 #include <string>
 
-class IAllocationsRecorder : public IService
+class IAllocationsRecorder : public ServiceBase
 {
 public:
     virtual ~IAllocationsRecorder() = default;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IApplicationStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IApplicationStore.h
@@ -4,11 +4,11 @@
 #pragma once
 
 #include "ApplicationInfo.h"
-#include "IService.h"
+#include "ServiceBase.h"
 
 #include <string>
 
-class IApplicationStore : public IService
+class IApplicationStore : public ServiceBase
 {
 public:
     virtual ApplicationInfo GetApplicationInfo(const std::string& runtimeId) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IManagedThreadList.h
@@ -5,12 +5,12 @@
 #include "cor.h"
 #include "corprof.h"
 
-#include "IService.h"
+#include "ServiceBase.h"
 #include "ManagedThreadInfo.h"
 
 #include <memory>
 
-class IManagedThreadList : public IService
+class IManagedThreadList : public ServiceBase
 {
 public:
     virtual bool RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThreadInfo) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IStackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IStackSamplerLoopManager.h
@@ -2,11 +2,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #pragma once
-#include "IService.h"
 #include "ManagedThreadInfo.h"
+#include "ServiceBase.h"
 
 
-class IStackSamplerLoopManager : public IService
+class IStackSamplerLoopManager : public ServiceBase
 {
 public:
     virtual bool AllowStackWalk(std::shared_ptr<ManagedThreadInfo> pThreadInfo) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IThreadsCpuManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IThreadsCpuManager.h
@@ -2,12 +2,13 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 
 #pragma once
-#include "IService.h"
+#include "ServiceBase.h"
+
 #include <shared/src/native-src/pal.h>    // for DWORD
 #include <shared/src/native-src/string.h> // WCHAR
 
 
-class IThreadsCpuManager : public IService
+class IThreadsCpuManager : public ServiceBase
 {
 public:
     virtual void Map(DWORD threadOSId, const WCHAR* name) = 0;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -233,12 +233,12 @@ void LiveObjectsProvider::CloseWeakHandle(ObjectHandleID handle) const
     _pCorProfilerInfo->DestroyHandle(handle);
 }
 
-bool LiveObjectsProvider::Start()
+bool LiveObjectsProvider::StartImpl()
 {
     return true;
 }
 
-bool LiveObjectsProvider::Stop()
+bool LiveObjectsProvider::StopImpl()
 {
     return true;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -12,9 +12,9 @@
 #include "IBatchedSamplesProvider.h"
 #include "IGarbageCollectionsListener.h"
 #include "ISampledAllocationsListener.h"
-#include "IService.h"
 #include "LiveObjectInfo.h"
 #include "Sample.h"
+#include "ServiceBase.h"
 
 class IManagedThreadList;
 class IFrameStore;
@@ -25,7 +25,7 @@ class IConfiguration;
 class ISampledAllocationsListener;
 class SampleValueTypeProvider;
 
-class LiveObjectsProvider : public IService,
+class LiveObjectsProvider : public ServiceBase,
                             public IBatchedSamplesProvider,
                             public ISampledAllocationsListener,
                             public IGarbageCollectionsListener
@@ -43,9 +43,6 @@ public:
         MetricsRegistry& metricsRegistry);
 
 public:
-    // Inherited via IService
-    bool Start() override;
-    bool Stop() override;
 
     // Inherited via IBatchedSamplesProvider
     std::unique_ptr<SamplesEnumerator> GetSamples() override;
@@ -76,6 +73,10 @@ private:
     ObjectHandleID CreateWeakHandle(uintptr_t address) const;
     void CloseWeakHandle(ObjectHandleID handle) const;
     bool IsAlive(ObjectHandleID handle) const;
+
+    // Inherited via ServiceBase
+    bool StartImpl() override;
+    bool StopImpl() override;
 
 private:
     static std::vector<SampleValueType> SampleTypeDefinitions;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.cpp
@@ -47,13 +47,13 @@ const char* ManagedThreadList::GetName()
     return _serviceName;
 }
 
-bool ManagedThreadList::Start()
+bool ManagedThreadList::StartImpl()
 {
     // nothing special to start
     return true;
 }
 
-bool ManagedThreadList::Stop()
+bool ManagedThreadList::StopImpl()
 {
     // nothing special to stop
     return true;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadList.h
@@ -28,8 +28,6 @@ private:
 
 public:
     const char* GetName() override;
-    bool Start() override;
-    bool Stop() override;
     bool RegisterThread(std::shared_ptr<ManagedThreadInfo>& pThreadInfo) override;
     bool UnregisterThread(ThreadID clrThreadId, std::shared_ptr<ManagedThreadInfo>& ppThreadInfo) override;
     bool SetThreadOsInfo(ThreadID clrThreadId, DWORD osThreadId, HANDLE osThreadHandle) override;
@@ -48,6 +46,9 @@ private:
     static const std::uint32_t DefaultThreadListSize;
 
 private:
+    bool StartImpl() override;
+    bool StopImpl() override;
+
     // We do most operations under this lock.
     // We expect very little contention on this lock:
     // Modifying operations are expected to be rare and, especially in a thread-pooled architecture.

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.cpp
@@ -22,7 +22,7 @@ const char* const RuntimeIdStore::ServiceName = "RuntimeID Store";
 const char* const RuntimeIdStore::ExternalFunctionName = "GetRuntimeId";
 const char* const RuntimeIdStore::NativeLoaderFilename = "Datadog.Trace.ClrProfiler.Native" LIBRARY_FILE_EXTENSION;
 
-bool RuntimeIdStore::Start()
+bool RuntimeIdStore::StartImpl()
 {
     // should be set by native loader
     shared::WSTRING nativeLoaderPath = shared::GetEnvironmentValue(WStr("DD_INTERNAL_NATIVE_LOADER_PATH"));
@@ -67,7 +67,7 @@ bool RuntimeIdStore::Start()
     return _getIdFn != nullptr;
 }
 
-bool RuntimeIdStore::Stop()
+bool RuntimeIdStore::StopImpl()
 {
     if (_instance != nullptr)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RuntimeIdStore.h
@@ -7,16 +7,14 @@
 #include <mutex>
 #include <unordered_map>
 #include "IRuntimeIdStore.h"
-#include "IService.h"
+#include "ServiceBase.h"
 
-class RuntimeIdStore : public IService, public IRuntimeIdStore
+class RuntimeIdStore : public ServiceBase, public IRuntimeIdStore
 {
 public:
     RuntimeIdStore() = default;
 
     const char* GetName() override;
-    bool Start() override;
-    bool Stop() override;
 
     const char* GetId(AppDomainID appDomainId) override;
 
@@ -28,6 +26,9 @@ private:
     static void* LoadDynamicLibrary(std::string filePath);
     static void* GetExternalFunction(void* instance, const char* funcName);
     static bool FreeDynamicLibrary(void* handle);
+
+    bool StartImpl() override;
+    bool StopImpl() override;
 
     void* _instance = nullptr;
     std::function<const char*(AppDomainID)> _getIdFn;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
@@ -4,14 +4,14 @@
 #include "ServiceBase.h"
 
 ServiceBase::ServiceBase() :
-    _currentState{ServiceState::Init}
+    _currentState{State::Init}
 {
 }
 
 bool ServiceBase::Start()
 {
-    auto expected = ServiceState::Init;
-    auto exchange = _currentState.compare_exchange_strong(expected, ServiceState::Starting);
+    auto expected = State::Init;
+    auto exchange = _currentState.compare_exchange_strong(expected, State::Starting);
 
     if (!exchange)
     {
@@ -21,11 +21,11 @@ bool ServiceBase::Start()
     auto result = StartImpl();
     if (result)
     {
-        _currentState = ServiceState::Started;
+        _currentState = State::Started;
     }
     else
     {
-        _currentState = ServiceState::Init;
+        _currentState = State::Init;
     }
 
     return result;
@@ -33,8 +33,8 @@ bool ServiceBase::Start()
 
 bool ServiceBase::Stop()
 {
-    auto expected = ServiceState::Started;
-    auto exchange = _currentState.compare_exchange_strong(expected, ServiceState::Stopping);
+    auto expected = State::Started;
+    auto exchange = _currentState.compare_exchange_strong(expected, State::Stopping);
 
     if (!exchange)
     {
@@ -44,11 +44,11 @@ bool ServiceBase::Stop()
     auto result = StopImpl();
     if (result)
     {
-        _currentState = ServiceState::Stopped;
+        _currentState = State::Stopped;
     }
     else
     {
-        _currentState = ServiceState::Started;
+        _currentState = State::Started;
     }
 
     return result;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "ServiceBase.h"
+
+ServiceBase::ServiceBase() :
+    _currentState{ServiceState::Init}
+{
+}
+
+bool ServiceBase::Start()
+{
+    auto expected = ServiceState::Init;
+    auto exchange = _currentState.compare_exchange_strong(expected, ServiceState::Starting);
+
+    if (!exchange)
+    {
+        return false;
+    }
+
+    auto result = StartImpl();
+    if (result)
+    {
+        _currentState = ServiceState::Started;
+    }
+    else
+    {
+        _currentState = ServiceState::Init;
+    }
+
+    return result;
+}
+
+bool ServiceBase::Stop()
+{
+    auto expected = ServiceState::Started;
+    auto exchange = _currentState.compare_exchange_strong(expected, ServiceState::Stopping);
+
+    if (!exchange)
+    {
+        return false;
+    }
+
+    auto result = StopImpl();
+    if (result)
+    {
+        _currentState = ServiceState::Stopped;
+    }
+    else
+    {
+        _currentState = ServiceState::Started;
+    }
+
+    return result;
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.cpp
@@ -3,6 +3,27 @@
 
 #include "ServiceBase.h"
 
+#include "Log.h"
+
+static std::string to_string(ServiceBase::State state)
+{
+    switch (state)
+    {
+        case ServiceBase::State::Init:
+            return "Init";
+        case ServiceBase::State::Started:
+            return "Started";
+        case ServiceBase::State::Starting:
+            return "Starting";
+        case ServiceBase::State::Stopping:
+            return "Stopping";
+        case ServiceBase::State::Stopped:
+            return "Stopped";
+    }
+
+    return "Unknown state";
+}
+
 ServiceBase::ServiceBase() :
     _currentState{State::Init}
 {
@@ -15,6 +36,7 @@ bool ServiceBase::Start()
 
     if (!exchange)
     {
+        Log::Debug("Unable to start the service. Current state: ", to_string(_currentState.load()));
         return false;
     }
 
@@ -26,6 +48,7 @@ bool ServiceBase::Start()
     else
     {
         _currentState = State::Init;
+        Log::Debug("Unable to start the service. Call to StartImpl failed. Current state: ", to_string(_currentState.load()));
     }
 
     return result;
@@ -38,6 +61,7 @@ bool ServiceBase::Stop()
 
     if (!exchange)
     {
+        Log::Debug("Unable to stop the service. Current state: ", to_string(_currentState.load()));
         return false;
     }
 
@@ -49,6 +73,7 @@ bool ServiceBase::Stop()
     else
     {
         _currentState = State::Started;
+        Log::Debug("Unable to stop the service. Call to StartImpl failed. Current state: ", to_string(_currentState.load()));
     }
 
     return result;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+#pragma once
+
+#include "IService.h"
+
+#include <atomic>
+
+enum class ServiceState
+{
+    Init,
+    Starting,
+    Started,
+    Stopping,
+    Stopped
+};
+
+class ServiceBase : public IService
+{
+public:
+    ServiceBase();
+
+    bool Start() final override;
+    bool Stop() final override;
+
+protected:
+    virtual bool StartImpl() = 0;
+    virtual bool StopImpl() = 0;
+
+private:
+    std::atomic<ServiceState> _currentState;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
@@ -5,6 +5,7 @@
 #include "IService.h"
 
 #include <atomic>
+#include <string>
 
 class ServiceBase : public IService
 {
@@ -28,5 +29,6 @@ private:
         Stopped
     };
 
+    friend std::string to_string(ServiceBase::State);
     std::atomic<State> _currentState;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ServiceBase.h
@@ -6,15 +6,6 @@
 
 #include <atomic>
 
-enum class ServiceState
-{
-    Init,
-    Starting,
-    Started,
-    Stopping,
-    Stopped
-};
-
 class ServiceBase : public IService
 {
 public:
@@ -28,5 +19,14 @@ protected:
     virtual bool StopImpl() = 0;
 
 private:
-    std::atomic<ServiceState> _currentState;
+    enum class State
+    {
+        Init,
+        Starting,
+        Started,
+        Stopping,
+        Stopped
+    };
+
+    std::atomic<State> _currentState;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.h
@@ -18,7 +18,7 @@
 
 #include "ManagedThreadInfo.h"
 #include "ICollector.h"
-#include "IService.h"
+#include "ServiceBase.h"
 #include "RawCpuSample.h"
 #include "RawWallTimeSample.h"
 #include "MetricsRegistry.h"
@@ -40,7 +40,7 @@ typedef enum
     CpuTime
 } PROFILING_TYPE;
 
-class StackSamplerLoop : public IService
+class StackSamplerLoop : public ServiceBase
 {
     friend StackSamplerLoopManager;
 
@@ -63,8 +63,6 @@ public:
 
     // Inherited via IService
     const char* GetName() override;
-    bool Start() override;
-    bool Stop() override;
 
 private:
     ICorProfilerInfo4* _pCorProfilerInfo;
@@ -96,7 +94,6 @@ private:
     bool _areInternalMetricsEnabled;
     std::shared_ptr<MeanMaxMetric> _walltimeDurationMetric;
     std::shared_ptr<MeanMaxMetric> _cpuDurationMetric;
-    bool _isStopped;
 
 private:
     void MainLoop();
@@ -115,4 +112,7 @@ private:
     void PersistStackSnapshotResults(StackSnapshotResultBuffer* pSnapshotResult,
                                      std::shared_ptr<ManagedThreadInfo>& pThreadInfo,
                                      PROFILING_TYPE profilingType);
+
+    bool StartImpl() override;
+    bool StopImpl() override;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -89,7 +89,7 @@ const char* StackSamplerLoopManager::GetName()
     return _serviceName;
 }
 
-bool StackSamplerLoopManager::Start()
+bool StackSamplerLoopManager::StartImpl()
 {
     RunStackSampling();
     RunWatcher();
@@ -97,15 +97,8 @@ bool StackSamplerLoopManager::Start()
     return true;
 }
 
-bool StackSamplerLoopManager::Stop()
+bool StackSamplerLoopManager::StopImpl()
 {
-    // allow multiple calls to Stop()
-    if (_isStopped)
-    {
-        return true;
-    }
-    _isStopped = true;
-
     _pStackSamplerLoop->Stop();
 
     ShutdownWatcher();

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -90,8 +90,6 @@ public:
 
 public:
     const char* GetName() override;
-    bool Start() override;
-    bool Stop() override;
     bool AllowStackWalk(std::shared_ptr<ManagedThreadInfo> pThreadInfo) override;
     void NotifyThreadState(bool isSuspended) override;
     void NotifyCollectionStart() override;
@@ -122,6 +120,9 @@ private:
                                         const std::chrono::nanoseconds& periodDurationNs);
 
     static double ToMillis(const std::chrono::nanoseconds& nanosecs);
+
+    bool StartImpl() override;
+    bool StopImpl() override;
 
 private:
     static const std::chrono::nanoseconds StatisticAggregationPeriodNs;
@@ -237,8 +238,6 @@ private:
     std::unique_ptr<Statistics> _currentStatistics;
     MetricsRegistry& _metricsRegistry;
     std::shared_ptr<CounterMetric> _deadlockCountMetric;
-
-    bool _isStopped = false;
 
     CallstackProvider _callstackProvider;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadsCpuManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadsCpuManager.cpp
@@ -22,13 +22,13 @@ const char* ThreadsCpuManager::GetName()
     return _serviceName;
 }
 
-bool ThreadsCpuManager::Start()
+bool ThreadsCpuManager::StartImpl()
 {
     // nothing special to start
     return true;
 }
 
-bool ThreadsCpuManager::Stop()
+bool ThreadsCpuManager::StopImpl()
 {
     // nothing special to stop
     return true;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadsCpuManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadsCpuManager.h
@@ -21,12 +21,13 @@ public:
 // interfaces implementation
 public:
     const char* GetName() override;
-    bool Start() override;
-    bool Stop() override;
     void Map(DWORD threadOSId, const WCHAR* name) override;
     void LogCpuTimes() override;
 
 private:
+    bool StartImpl() override;
+    bool StopImpl() override;
+
     const char* _serviceName = "ThreadsCpuManager";
 
     // Need to protect access to the map. However, it should not trigger a lot of contention

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj
@@ -80,6 +80,7 @@
     <ClCompile Include="RuntimeInfoHelper.cpp" />
     <ClCompile Include="SamplesCollectorTest.cpp" />
     <ClCompile Include="SampleValueTypeProviderTest.cpp" />
+    <ClCompile Include="ServiceBaseTest.cpp" />
     <ClCompile Include="StackSnapshotResultBufferTest.cpp" />
     <ClCompile Include="TagsTest.cpp" />
     <ClCompile Include="TagsHelperTest.cpp" />

--- a/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
+++ b/profiler/test/Datadog.Profiler.Native.Tests/Datadog.Profiler.Native.Tests.vcxproj.filters
@@ -163,6 +163,9 @@
     <ClCompile Include="CallstackTest.cpp">
       <Filter>Tests</Filter>
     </ClCompile>
+    <ClCompile Include="ServiceBaseTest.cpp">
+      <Filter>Tests</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\src\ProfilerEngine\Datadog.Profiler.Native\HResultConverter.h">

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -137,8 +137,8 @@ public:
     MOCK_METHOD(void, SetApplicationInfo, (const std::string&, const std::string&, const std::string&, const std::string&), (override));
     MOCK_METHOD(void, SetGitMetadata, (std::string, std::string, std::string), (override));
     MOCK_METHOD(const char*, GetName, (), (override));
-    MOCK_METHOD(bool, Start, (), (override));
-    MOCK_METHOD(bool, Stop, (), (override));
+    MOCK_METHOD(bool, StartImpl, (), (override));
+    MOCK_METHOD(bool, StopImpl, (), (override));
 };
 
 class MockRuntimeIdStore : public IRuntimeIdStore

--- a/profiler/test/Datadog.Profiler.Native.Tests/ServiceBaseTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ServiceBaseTest.cpp
@@ -67,7 +67,7 @@ TEST(ServiceBaseTest, CheckStopCannotBeCalledWithoutStart)
     ASSERT_EQ(service._stopCallsCount, 0) << "StopImpl must be called only once";
 }
 
-TEST(ServiceBaseTest, deux)
+TEST(ServiceBaseTest, CheckServiceIsStartedOnceInMultiThreadedEnv)
 {
     auto p = std::promise<void>();
 

--- a/profiler/test/Datadog.Profiler.Native.Tests/ServiceBaseTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ServiceBaseTest.cpp
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ServiceBase.h"
+
+#include <future>
+#include <thread>
+
+class DummyService : public ServiceBase
+{
+public:
+    // Inherited via ServiceBase
+    const char* GetName() override
+    {
+        return "Dummy Service";
+    }
+    bool StartImpl() override
+    {
+        _startCallsCount++;
+        return true;
+    }
+    bool StopImpl() override
+    {
+        _stopCallsCount++;
+        return true;
+    }
+
+    std::atomic<int> _startCallsCount = 0;
+    std::atomic<int> _stopCallsCount = 0;
+};
+
+static void process(std::shared_future<void> startSync, std::promise<void>& ready, DummyService& service)
+{
+    ready.set_value();
+    startSync.wait();
+    service.Start();
+    service.Stop();
+}
+
+template <class... T>
+void WaitAll(T&... args)
+{
+    (args.wait(), ...);
+}
+
+TEST(ServiceBaseTest, CheckThatStartAndStopCanBeCalledOnce)
+{
+    DummyService service;
+    ASSERT_TRUE(service.Start()) << "Unable to start the service";
+    ASSERT_FALSE(service.Start()) << "Service must start only once";
+    ASSERT_TRUE(service.Stop()) << "Unable to stop the service";
+    ASSERT_FALSE(service.Stop()) << "Service must stop only once";
+
+    ASSERT_EQ(service._startCallsCount, 1);
+    ASSERT_EQ(service._stopCallsCount, 1);
+}
+
+TEST(ServiceBaseTest, CheckStopCannotBeCalledWithoutStart)
+{
+    DummyService service;
+    ASSERT_FALSE(service.Stop()) << "Unable to start the service";
+
+    ASSERT_EQ(service._startCallsCount, 0) << "StartImpl must be called only once";
+    ASSERT_EQ(service._stopCallsCount, 0) << "StopImpl must be called only once";
+}
+
+TEST(ServiceBaseTest, deux)
+{
+    auto p = std::promise<void>();
+
+    std::promise<void> ready_promise, t1_ready_promise, t2_ready_promise, t3_ready_promise, t4_ready_promise;
+
+    std::shared_future<void> ready_future(ready_promise.get_future());
+
+    auto fut1 = t1_ready_promise.get_future();
+    auto fut2 = t2_ready_promise.get_future();
+    auto fut3 = t3_ready_promise.get_future();
+    auto fut4 = t4_ready_promise.get_future();
+
+    DummyService service;
+    auto result1 = std::async(std::launch::async, process, ready_future, std::ref(t1_ready_promise), std::ref(service));
+    auto result2 = std::async(std::launch::async, process, ready_future, std::ref(t2_ready_promise), std::ref(service));
+    auto result3 = std::async(std::launch::async, process, ready_future, std::ref(t3_ready_promise), std::ref(service));
+    auto result4 = std::async(std::launch::async, process, ready_future, std::ref(t4_ready_promise), std::ref(service));
+
+    // wait for the threads to become ready
+    WaitAll(fut1, fut2, fut3, fut4);
+
+    // start
+    ready_promise.set_value();
+
+    // wait for the threads to finish
+    WaitAll(result1, result2, result3, result4);
+
+    ASSERT_EQ(service._startCallsCount, 1);
+    ASSERT_EQ(service._stopCallsCount, 1);
+}

--- a/profiler/test/Datadog.Profiler.Native.Tests/ThreadsCpuManagerHelper.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ThreadsCpuManagerHelper.cpp
@@ -8,12 +8,12 @@ const char* ThreadsCpuManagerHelper::GetName()
     return "ThreadsCpuManagerHelper";
 }
 
-bool ThreadsCpuManagerHelper::Start()
+bool ThreadsCpuManagerHelper::StartImpl()
 {
     return true;
 }
 
-bool ThreadsCpuManagerHelper::Stop()
+bool ThreadsCpuManagerHelper::StopImpl()
 {
     return true;
 }

--- a/profiler/test/Datadog.Profiler.Native.Tests/ThreadsCpuManagerHelper.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ThreadsCpuManagerHelper.h
@@ -8,8 +8,8 @@ class ThreadsCpuManagerHelper : public IThreadsCpuManager
 {
     // Inherited via IThreadsCpuManager
     const char* GetName() override;
-    bool Start() override;
-    bool Stop() override;
+    bool StartImpl() override;
+    bool StopImpl() override;
     void Map(DWORD threadOSId, const WCHAR* name) override;
     void LogCpuTimes() override;
 };


### PR DESCRIPTION
## Summary of changes

Fix `IService` start/stop.

## Reason for change

Currently, a service `Start` method can be called multiple times but this can be problematic (crash in the SSI/Telemetry PR). We have classes that try to handle this but this can be done for all the services (in a `ServiceBase` class).

## Implementation details

- Add a `ServiceBase` class which implements `Start/Stop` and make them final to avoid override from children
- In `ServiceBase` declares `StartImpl/StopImpl` as pure virtual method.
- In `ServiceBase::Start/Stop` implements the startup/stop concurrent safe.
- Propagate the change: Replace `IService` inheritance by `ServiceBase` and rename `Start/Stop` implementations by `StartImpl/StopImpl`

## Test coverage
- Add Unit tests: mono-threaded ones and a multithreaded one

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
