### PR TITLE
[Profiler] Improve configuration aroung SSI/non-SSI

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -89,8 +89,9 @@ Configuration::Configuration()
     }
 
     _isEtwEnabled = GetEnvironmentValue(EnvironmentVariables::EtwEnabled, false);
-    ExtractSsiState(_isSsiDeployed, _isSsiActivated);
+    _deploymentMode = GetEnvironmentValue(EnvironmentVariables::SsiDeployed, DeploymentMode::Manual);
     _isEtwLoggingEnabled = GetEnvironmentValue(EnvironmentVariables::EtwLoggingEnabled, false);
+    _enablementStatus = ExtractEnablementStatus();
 }
 
 fs::path Configuration::ExtractLogDirectory()
@@ -397,9 +398,10 @@ std::string const& Configuration::GetGitCommitSha() const
 // - replace shared::TryParse by this implementation
 // - add tests
 
-bool TryParse(shared::WSTRING const& s, int32_t& result)
+static bool TryParse(shared::WSTRING const& s, int32_t& result)
 {
-    if (s.empty())
+    auto r = shared::Trim(s);
+    if (r.empty())
     {
         result = 0;
         return false;
@@ -407,7 +409,7 @@ bool TryParse(shared::WSTRING const& s, int32_t& result)
 
     try
     {
-        result = std::stoi(shared::ToString(s));
+        result = std::stoi(shared::ToString(r));
         return true;
     }
     catch (std::exception const&)
@@ -418,9 +420,11 @@ bool TryParse(shared::WSTRING const& s, int32_t& result)
     return false;
 }
 
-bool TryParse(shared::WSTRING const& s, uint64_t& result)
+static bool TryParse(shared::WSTRING const& s, uint64_t& result)
 {
-    if (s.empty())
+    auto r = shared::Trim(s);
+
+    if (r.empty())
     {
         result = 0;
         return false;
@@ -428,7 +432,7 @@ bool TryParse(shared::WSTRING const& s, uint64_t& result)
 
     try
     {
-        auto str = shared::ToString(s);
+        auto str = shared::ToString(r);
         result = std::stoull(str);
         return true;
     }
@@ -538,16 +542,6 @@ bool Configuration::IsEtwEnabled() const
 #endif
 }
 
-bool Configuration::IsSsiDeployed() const
-{
-    return _isSsiDeployed;
-}
-
-bool Configuration::IsSsiActivated() const
-{
-    return _isSsiActivated;
-}
-
 bool Configuration::IsEtwLoggingEnabled() const
 {
 #ifdef LINUX
@@ -557,36 +551,46 @@ bool Configuration::IsEtwLoggingEnabled() const
 #endif
 }
 
-bool convert_to(shared::WSTRING const& s, bool& result)
+EnablementStatus Configuration::GetEnablementStatus() const
+{
+    return _enablementStatus;
+}
+
+DeploymentMode Configuration::GetDeploymentMode() const
+{
+    return _deploymentMode;
+}
+
+static bool convert_to(shared::WSTRING const& s, bool& result)
 {
     return shared::TryParseBooleanEnvironmentValue(s, result);
 }
 
-bool convert_to(shared::WSTRING const& s, std::string& result)
+static bool convert_to(shared::WSTRING const& s, std::string& result)
 {
-    result = shared::ToString(s);
+    result = shared::ToString(shared::Trim(s));
     return true;
 }
 
-bool convert_to(shared::WSTRING const& s, shared::WSTRING& result)
+static bool convert_to(shared::WSTRING const& s, shared::WSTRING& result)
 {
-    result = s;
+    result = shared::Trim(s);
     return true;
 }
 
-bool convert_to(shared::WSTRING const& s, int32_t& result)
+static bool convert_to(shared::WSTRING const& s, int32_t& result)
 {
     return TryParse(s, result);
 }
 
-bool convert_to(shared::WSTRING const& s, uint64_t& result)
+static bool convert_to(shared::WSTRING const& s, uint64_t& result)
 {
     return TryParse(s, result);
 }
 
-bool convert_to(shared::WSTRING const& s, double& result)
+static bool convert_to(shared::WSTRING const& s, double& result)
 {
-    auto str = shared::ToString(s);
+    auto str = shared::ToString(shared::Trim(s));
 
     char* endPtr = nullptr;
     const char* ptr = str.c_str();
@@ -602,13 +606,21 @@ bool convert_to(shared::WSTRING const& s, double& result)
     return (errno != ERANGE);
 }
 
+static bool convert_to(shared::WSTRING const& s, DeploymentMode& result)
+{
+    // if we reach here it means the env var exists
+    result = DeploymentMode::SingleStepInstrumentation;
+    return true;
+}
+
 template <typename T>
 T Configuration::GetEnvironmentValue(shared::WSTRING const& name, T const& defaultValue)
 {
-    auto r = shared::Trim(shared::GetEnvironmentValue(name));
-    if (r.empty()) return defaultValue;
+    if (!shared::EnvironmentExist(name)) return defaultValue;
+
     T result{};
-    if (!convert_to(r, result)) return std::move(defaultValue);
+    auto r = shared::GetEnvironmentValue(name);
+    if (!convert_to(r, result)) return defaultValue;
     return result;
 }
 
@@ -625,29 +637,36 @@ bool Configuration::IsEnvironmentValueSet(shared::WSTRING const& name, T& value)
     return true;
 }
 
-void Configuration::ExtractSsiState(bool& ssiDeployed, bool& ssiEnabled)
+EnablementStatus Configuration::ExtractEnablementStatus()
 {
-    // if the profiler has been deployed via Single Step Instrumentation,
-    // the DD_INJECTION_ENABLED env var exists.
-    // if the profiler has been activated via Single Step Instrumentation,
-    // the DD_INJECTION_ENABLED env var should contain "profiling" (it is a list of SSI installed products)
-    //
-    if (!shared::EnvironmentExist(EnvironmentVariables::SsiDeployed))
+    auto enabled = shared::GetEnvironmentValue(EnvironmentVariables::ProfilerEnabled);
+
+    auto isEnabled = false;
+    auto parsed = shared::TryParseBooleanEnvironmentValue(enabled, isEnabled);
+    if (enabled.empty() || !parsed)
     {
-        ssiDeployed = false;
-        ssiEnabled = false;
-        return;
+        auto r = shared::GetEnvironmentValue(EnvironmentVariables::SsiDeployed);
+        auto pos = r.find(WStr("profiler"));
+        auto ssiEnabled = (pos != shared::WSTRING::npos);
+
+        if (ssiEnabled)
+        {
+            return EnablementStatus::SsiEnabled;
+        }
+        else
+        {
+            return EnablementStatus::Default;
+        }
     }
-
-    ssiDeployed = true;
-
-    auto r = shared::GetEnvironmentValue(EnvironmentVariables::SsiDeployed);
-    if (r.empty())
+    else
     {
-        ssiEnabled = false;
-        return;
+        if (isEnabled)
+        {
+            return EnablementStatus::ManuallyEnabled;
+        }
+        else
+        {
+            return EnablementStatus::ManuallyDisabled;
+        }
     }
-
-    auto pos = r.find(WStr("profiling"));
-    ssiEnabled = (pos != shared::WSTRING::npos);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.cpp
@@ -655,7 +655,7 @@ EnablementStatus Configuration::ExtractEnablementStatus()
         }
         else
         {
-            return EnablementStatus::Default;
+            return EnablementStatus::NotSet;
         }
     }
     else

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Configuration.h
@@ -6,6 +6,8 @@
 #include <memory>
 #include <string>
 
+#include "DeploymentMode.h"
+#include "EnablementStatus.h"
 #include "IConfiguration.h"
 #include "TagsHelper.h"
 #include "shared/src/native-src/string.h"
@@ -67,10 +69,9 @@ public:
     bool IsCIVisibilityEnabled() const override;
     std::uint64_t GetCIVisibilitySpanId() const override;
     bool IsEtwEnabled() const override;
-    bool IsSsiDeployed() const override;
-    bool IsSsiActivated() const override;
     bool IsEtwLoggingEnabled() const override;
-
+    EnablementStatus GetEnablementStatus() const override;
+    DeploymentMode GetDeploymentMode() const override;
 
 private:
     static tags ExtractUserTags();
@@ -92,7 +93,7 @@ private:
     static int32_t ExtractCpuThreadsThreshold();
     static int32_t ExtractCodeHotspotsThreadsThreshold();
     static bool GetContention();
-    static void ExtractSsiState(bool& ssiDeployed, bool& ssiEnabled);
+    EnablementStatus ExtractEnablementStatus();
 
 private:
     static std::string const DefaultProdSite;
@@ -155,7 +156,7 @@ private:
     bool _isCIVisibilityEnabled;
     std::uint64_t _internalCIVisibilitySpanId;
     bool _isEtwEnabled;
-    bool _isSsiDeployed;
-    bool _isSsiActivated;
+    DeploymentMode _deploymentMode;
     bool _isEtwLoggingEnabled;
+    EnablementStatus _enablementStatus;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -64,7 +64,7 @@ class Loader;
 class CorProfilerCallback : public ICorProfilerCallback10
 {
 public:
-    CorProfilerCallback();
+    CorProfilerCallback(IConfiguration* pConfiguration);
     virtual ~CorProfilerCallback();
 
     // use STDMETHODCALLTYPE macro to match the CLR declaration.
@@ -245,7 +245,7 @@ private :
     std::vector<std::unique_ptr<IService>> _services;
 
     std::unique_ptr<IExporter> _pExporter = nullptr;
-    std::unique_ptr<IConfiguration> _pConfiguration = nullptr;
+    IConfiguration* _pConfiguration = nullptr;
     std::unique_ptr<IAppDomainStore> _pAppDomainStore = nullptr;
     std::unique_ptr<IFrameStore> _pFrameStore = nullptr;
     std::unique_ptr<IRuntimeInfo> _pRuntimeInfo = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.cpp
@@ -9,6 +9,12 @@
 std::mutex CorProfilerCallbackFactory::_lock;
 
 
+CorProfilerCallbackFactory::CorProfilerCallbackFactory(Configuration configuration) :
+    _configuration{std::move(configuration)}
+{
+
+}
+
 CorProfilerCallbackFactory::~CorProfilerCallbackFactory()
 {
 }
@@ -86,7 +92,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallbackFactory::CreateInstance(IUnknown* p
         return E_INVALIDARG;
     }
 
-    CorProfilerCallback* profiler = new (std::nothrow) CorProfilerCallback();
+    CorProfilerCallback* profiler = new (std::nothrow) CorProfilerCallback(&_configuration);
     if (profiler == nullptr)
     {
         return E_OUTOFMEMORY;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "Configuration.h"
+
 #include "unknwn.h"
 #include <atomic>
 #include <mutex>
@@ -10,6 +12,7 @@
 class CorProfilerCallbackFactory : public IClassFactory
 {
 public:
+    CorProfilerCallbackFactory(Configuration configuration);
     virtual ~CorProfilerCallbackFactory();
 
     // use STDMETHODCALLTYPE macro to match the CLR declaration.
@@ -23,4 +26,5 @@ public:
 private:
     std::atomic<ULONG> _refCount{0};
     static std::mutex _lock;
+    Configuration _configuration;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Datadog.Profiler.Native.vcxproj
@@ -240,7 +240,9 @@
     <ClInclude Include="CounterMetric.h" />
     <ClInclude Include="CrashReporting.h" />
     <ClInclude Include="DebugInfoStore.h" />
+    <ClInclude Include="DeploymentMode.h" />
     <ClInclude Include="EnabledProfilers.h" />
+    <ClInclude Include="EnablementStatus.h" />
     <ClInclude Include="EncodedProfile.hpp" />
     <ClInclude Include="EnumHelpers.h" />
     <ClInclude Include="COMHelpers.h" />

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DeploymentMode.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DeploymentMode.h
@@ -9,7 +9,7 @@ enum class DeploymentMode
     SingleStepInstrumentation
 };
 
-std::string to_string(DeploymentMode mode)
+inline std::string to_string(DeploymentMode mode)
 {
     switch (mode)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DeploymentMode.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DeploymentMode.h
@@ -1,0 +1,10 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+enum class DeploymentMode
+{
+    Manual,
+    SingleStepInstrumentation
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DeploymentMode.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DeploymentMode.h
@@ -8,3 +8,16 @@ enum class DeploymentMode
     Manual,
     SingleStepInstrumentation
 };
+
+std::string to_string(DeploymentMode mode)
+{
+    switch (mode)
+    {
+        case DeploymentMode::Manual:
+            return "Manual";
+        case DeploymentMode::SingleStepInstrumentation:
+            return "Single Step Instrumentation";
+    }
+
+    return "Unknown Mode";
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnablementStatus.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnablementStatus.h
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#pragma once
+
+enum class EnablementStatus
+{
+    Default,
+    ManuallyEnabled,
+    ManuallyDisabled,
+    SsiEnabled
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnablementStatus.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnablementStatus.h
@@ -5,7 +5,7 @@
 
 enum class EnablementStatus
 {
-    Default,
+    NotSet,
     ManuallyEnabled,
     ManuallyDisabled,
     SsiEnabled

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/EnvironmentVariables.h
@@ -8,7 +8,7 @@
 class EnvironmentVariables final
 {
 public:
-    inline static const shared::WSTRING ProfilingEnabled            = WStr("DD_PROFILING_ENABLED");
+    inline static const shared::WSTRING ProfilerEnabled            = WStr("DD_PROFILING_ENABLED");
     inline static const shared::WSTRING DebugLogEnabled             = WStr("DD_TRACE_DEBUG");
     inline static const shared::WSTRING LogPath                     = WStr("DD_PROFILING_LOG_PATH");
     inline static const shared::WSTRING LogDirectory                = WStr("DD_TRACE_LOG_DIRECTORY");

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IConfiguration.h
@@ -8,6 +8,8 @@
 #include <vector>
 #include <cstdint>
 
+#include "DeploymentMode.h"
+#include "EnablementStatus.h"
 #include "TagsHelper.h"
 
 #include "shared/src/native-src/dd_filesystem.hpp"
@@ -65,7 +67,7 @@ public:
     virtual bool IsCIVisibilityEnabled() const = 0;
     virtual std::uint64_t GetCIVisibilitySpanId() const = 0;
     virtual bool IsEtwEnabled() const = 0;
-    virtual bool IsSsiDeployed() const = 0;
-    virtual bool IsSsiActivated() const = 0;
     virtual bool IsEtwLoggingEnabled() const = 0;
+    virtual EnablementStatus GetEnablementStatus() const = 0;
+    virtual DeploymentMode GetDeploymentMode() const = 0;
 };

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -849,61 +849,102 @@ TEST(ConfigurationTest, CheckEtwIsDisabledIfEnvVarSetToFalse)
 TEST(ConfigurationTest, CheckSsiDeployedByDefault)
 {
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.IsSsiDeployed(), false);
+    ASSERT_THAT(configuration.GetDeploymentMode(), DeploymentMode::Manual);
 }
 
 TEST(ConfigurationTest, CheckSsiIsDeployedIfEnvVarConstainsProfiling)
 {
-    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("tracer,profiling"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("tracer,profiler"));
     auto configuration = Configuration{};
-    auto expectedValue = true;
-    ASSERT_THAT(configuration.IsSsiDeployed(), expectedValue);
+    auto expectedValue = DeploymentMode::SingleStepInstrumentation;
+    ASSERT_THAT(configuration.GetDeploymentMode(), expectedValue);
 }
 
 TEST(ConfigurationTest, CheckSsiIsDeployedIfEnvVarDoesNotContainProfiling)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("tracer"));
     auto configuration = Configuration{};
-    auto expectedValue = true;
-    ASSERT_THAT(configuration.IsSsiDeployed(), expectedValue);
+    auto expectedValue = DeploymentMode::SingleStepInstrumentation;
+    ASSERT_THAT(configuration.GetDeploymentMode(), expectedValue);
 }
 
 TEST(ConfigurationTest, CheckSsiIsDeployedIfEnvVarIsEmpty)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr(""));
     auto configuration = Configuration{};
-    auto expectedValue = true;
-    ASSERT_THAT(configuration.IsSsiDeployed(), expectedValue);
+    auto expectedValue = DeploymentMode::SingleStepInstrumentation;
+    ASSERT_THAT(configuration.GetDeploymentMode(), expectedValue);
 }
 
-TEST(ConfigurationTest, CheckSsiActivatedByDefault)
+TEST(ConfigurationTest, CheckSsiIsDeployedIfProfilerEnabledVarIsSetToTrue)
 {
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("profiler,tracer"));
+    EnvironmentHelper::EnvironmentVariable ar2(EnvironmentVariables::ProfilerEnabled, WStr("1"));
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.IsSsiActivated(), false);
+    auto expectedValue = DeploymentMode::SingleStepInstrumentation;
+    ASSERT_THAT(configuration.GetDeploymentMode(), expectedValue);
 }
 
-TEST(ConfigurationTest, CheckSsiIsActivatedIfEnvVarConstainsProfiling)
+TEST(ConfigurationTest, CheckSsiIsDeployedIfProfilerEnabledVarIsEmpty)
 {
-    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("tracer,profiling"));
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("profiler,tracer"));
+    EnvironmentHelper::EnvironmentVariable ar2(EnvironmentVariables::ProfilerEnabled, WStr(""));
     auto configuration = Configuration{};
-    auto expectedValue = true;
-    ASSERT_THAT(configuration.IsSsiActivated(), expectedValue);
+    auto expectedValue = DeploymentMode::SingleStepInstrumentation;
+    ASSERT_THAT(configuration.GetDeploymentMode(), expectedValue);
 }
 
-TEST(ConfigurationTest, CheckSsiIsNotActivatedIfEnvVarDoesNotContainProfiling)
+TEST(ConfigurationTest, CheckSsiIsDeployedIfProfilerEnabledVarIsSetToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("profiler,tracer"));
+    EnvironmentHelper::EnvironmentVariable ar2(EnvironmentVariables::ProfilerEnabled, WStr("0"));
+    auto configuration = Configuration{};
+    auto expectedValue = DeploymentMode::SingleStepInstrumentation;
+    ASSERT_THAT(configuration.GetDeploymentMode(), expectedValue);
+}
+
+TEST(ConfigurationTest, CheckSsiIsActivatedIfEnvVarConstainsProfiler)
+{
+    EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("tracer,profiler"));
+    auto configuration = Configuration{};
+    auto expectedValue = EnablementStatus::SsiEnabled;
+    ASSERT_THAT(configuration.GetEnablementStatus(), expectedValue);
+}
+
+TEST(ConfigurationTest, CheckSsiIsNotActivatedIfEnvVarDoesNotContainProfiler)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("tracer"));
     auto configuration = Configuration{};
-    auto expectedValue = false;
-    ASSERT_THAT(configuration.IsSsiActivated(), expectedValue);
+    auto expectedValue = EnablementStatus::Default;
+    ASSERT_THAT(configuration.GetEnablementStatus(), expectedValue);
 }
 
 TEST(ConfigurationTest, CheckSsiIsNotActivatedIfEnvVarIsEmpty)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr(""));
     auto configuration = Configuration{};
-    auto expectedValue = false;
-    ASSERT_THAT(configuration.IsSsiActivated(), expectedValue);
+    auto expectedValue = EnablementStatus::Default;
+    ASSERT_THAT(configuration.GetEnablementStatus(), expectedValue);
+}
+
+TEST(ConfigurationTest, CheckProfilerEnablementIfEnvVarIsNotSet)
+{
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetEnablementStatus(), EnablementStatus::Default) << "Env var is not set. Profiler enablement should be the default one.";
+}
+
+TEST(ConfigurationTest, CheckProfilerEnablementIfEnvVarIsToTrue)
+{
+    EnvironmentHelper::EnvironmentVariable ar2(EnvironmentVariables::ProfilerEnabled, WStr("1 ")); // add a space on purpose to ensure that it's correctly parsed
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetEnablementStatus(), EnablementStatus::ManuallyEnabled) << "Env var is to 1. Profiler must be enabled.";
+}
+
+TEST(ConfigurationTest, CheckProfilerEnablementIfEnvVarIsToFalse)
+{
+    EnvironmentHelper::EnvironmentVariable ar2(EnvironmentVariables::ProfilerEnabled, WStr("  0 ")); // add a space on purpose to ensure that it's correctly parsed
+    auto configuration = Configuration{};
+    ASSERT_THAT(configuration.GetEnablementStatus(), EnablementStatus::ManuallyDisabled) << "Env var is to 0. Profiler must be disabled.";
 }
 
 TEST(ConfigurationTest, CheckEtwLoggingIsDisabledByDefault)

--- a/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ConfigurationTest.cpp
@@ -915,7 +915,7 @@ TEST(ConfigurationTest, CheckSsiIsNotActivatedIfEnvVarDoesNotContainProfiler)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr("tracer"));
     auto configuration = Configuration{};
-    auto expectedValue = EnablementStatus::Default;
+    auto expectedValue = EnablementStatus::NotSet;
     ASSERT_THAT(configuration.GetEnablementStatus(), expectedValue);
 }
 
@@ -923,14 +923,14 @@ TEST(ConfigurationTest, CheckSsiIsNotActivatedIfEnvVarIsEmpty)
 {
     EnvironmentHelper::EnvironmentVariable ar(EnvironmentVariables::SsiDeployed, WStr(""));
     auto configuration = Configuration{};
-    auto expectedValue = EnablementStatus::Default;
+    auto expectedValue = EnablementStatus::NotSet;
     ASSERT_THAT(configuration.GetEnablementStatus(), expectedValue);
 }
 
 TEST(ConfigurationTest, CheckProfilerEnablementIfEnvVarIsNotSet)
 {
     auto configuration = Configuration{};
-    ASSERT_THAT(configuration.GetEnablementStatus(), EnablementStatus::Default) << "Env var is not set. Profiler enablement should be the default one.";
+    ASSERT_THAT(configuration.GetEnablementStatus(), EnablementStatus::NotSet) << "Env var is not set. Profiler enablement should be the default one.";
 }
 
 TEST(ConfigurationTest, CheckProfilerEnablementIfEnvVarIsToTrue)

--- a/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
+++ b/profiler/test/Datadog.Profiler.Native.Tests/ProfilerMockedInterface.h
@@ -70,8 +70,8 @@ public:
     MOCK_METHOD(bool, IsCIVisibilityEnabled, (), (const override));
     MOCK_METHOD(std::uint64_t, GetCIVisibilitySpanId, (), (const override));
     MOCK_METHOD(bool, IsEtwEnabled, (), (const override));
-    MOCK_METHOD(bool, IsSsiDeployed, (), (const override));
-    MOCK_METHOD(bool, IsSsiActivated, (), (const override));
+    MOCK_METHOD(EnablementStatus, GetEnablementStatus, (), (const override));
+    MOCK_METHOD(DeploymentMode, GetDeploymentMode, (), (const override));
     MOCK_METHOD(bool, IsEtwLoggingEnabled, (), (const override));
 };
 


### PR DESCRIPTION
## Summary of changes

Improve profiler configuration.

## Reason for change

We need to separate profiler deployment and profiler enablement. This makes it easier to reason on the profiler behavior when it comes to SSI/non-SSI.

## Implementation details

- Add `EnablementStatus` & `DeploymentMode` to express those concepts
- Create the configuration from the `DllMain` and pass it to `CorprofilerCallback` instance, in order to reuse the deployment logic.

## Test coverage

- Add unit tests.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
