### PR TITLE
[ASM] RASP: Add stack trace bottom and top filtering

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -67,7 +67,7 @@ internal class AppSecRequestContext
             {
                 _raspStackTraces.Add(ExploitStackKey, new());
             }
-            else if (_raspStackTraces[ExploitStackKey].Count >= maxStackTraces)
+            else if (maxStackTraces > 0 && _raspStackTraces[ExploitStackKey].Count >= maxStackTraces)
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
@@ -6,8 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Serialization;
 
 #nullable enable
 
@@ -17,9 +15,9 @@ internal static class StackReporter
 {
     private const string _language = "dotnet";
 
-    public static Dictionary<string, object>? GetStack(int maxStackTraceDepth, string id)
+    public static Dictionary<string, object>? GetStack(int maxStackTraceDepth, string id, StackFrame[]? stackFrames = null)
     {
-        var frames = GetFrames(maxStackTraceDepth);
+        var frames = GetFrames(maxStackTraceDepth, stackFrames ?? new StackTrace(true).GetFrames());
 
         if (frames is null || frames.Count == 0)
         {
@@ -29,13 +27,13 @@ internal static class StackReporter
         return MetaStructHelper.StackTraceInfoToDictionary(null, _language, id, null, frames);
     }
 
-    private static List<Dictionary<string, object>> GetFrames(int maxStackTraceDepth)
+    private static List<Dictionary<string, object>> GetFrames(int maxStackTraceDepth, StackFrame?[] frames)
     {
-        var stackTrace = new StackTrace(true);
-        var stackFrameList = new List<Dictionary<string, object>>(maxStackTraceDepth);
+        var allValidFrames = new List<Dictionary<string, object>>(frames.Length);
         int counter = 0;
 
-        foreach (var frame in stackTrace.GetFrames())
+        // Collect all valid frames
+        foreach (var frame in frames)
         {
             var declaringType = frame?.GetMethod()?.DeclaringType;
             var assembly = declaringType?.Assembly.GetName().Name;
@@ -43,7 +41,7 @@ internal static class StackReporter
             {
                 var fileName = System.IO.Path.GetFileName(frame?.GetFileName());
                 var fileNameValid = !string.IsNullOrEmpty(fileName);
-                stackFrameList.Add(MetaStructHelper.StackFrameToDictionary(
+                allValidFrames.Add(MetaStructHelper.StackFrameToDictionary(
                     (uint)counter,
                     null,
                     fileName,
@@ -54,14 +52,23 @@ internal static class StackReporter
                     frame?.GetMethod()?.Name));
                 counter++;
             }
-
-            if (maxStackTraceDepth > 0 && counter >= maxStackTraceDepth)
-            {
-                break;
-            }
         }
 
-        return stackFrameList;
+        // Determine if we need to trim the stack
+        if (maxStackTraceDepth > 0 && allValidFrames.Count > maxStackTraceDepth)
+        {
+            int topCount = Math.Max(1, (int)(0.25 * maxStackTraceDepth));
+            int bottomCount = maxStackTraceDepth - topCount;
+            var trimmedStackFrames = new List<Dictionary<string, object>>(maxStackTraceDepth);
+            // Add the top 25% frames
+            trimmedStackFrames.AddRange(allValidFrames.GetRange(0, topCount));
+            // Add the bottom 75% frames
+            trimmedStackFrames.AddRange(allValidFrames.GetRange(allValidFrames.Count - bottomCount, bottomCount));
+
+            return trimmedStackFrames;
+        }
+
+        return allValidFrames;
     }
 
     private static bool AssemblyExcluded(string assembly)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/StackReporterTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/StackReporterTests.cs
@@ -1,0 +1,118 @@
+// <copyright file="StackReporterTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using Datadog.Trace.AppSec.Rasp;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests.RASP;
+
+public class StackReporterTests
+{
+    [Fact]
+    public void GivenMaxDepthMoreThanTotalFrames_WhenGetStackIsCalled_ThenReturnsAllFrames()
+    {
+        int maxStackTraceDepth = 10;
+        var mockFrames = CreateStackForTests(2);
+        var result = StackReporter.GetStack(maxStackTraceDepth, "test", mockFrames);
+
+        Assert.NotNull(result);
+        Assert.True(result.ContainsKey("frames"));
+
+        var frames = result["frames"] as List<Dictionary<string, object>>;
+        Assert.NotNull(frames);
+        Assert.Equal(mockFrames.Length, frames.Count);
+        Assert.Equal("file1.cs", frames[0]["file"]);
+        Assert.Equal("file2.cs", frames[1]["file"]);
+    }
+
+    [Fact]
+    public void GivenMultipleFrames_WhenMaxDepthIsSet_ThenReturnsTop25AndBottom75Percent()
+    {
+        int maxStackTraceDepth = 2;
+        var mockFrames = CreateStackForTests(4);
+        var result = StackReporter.GetStack(maxStackTraceDepth, "test", mockFrames);
+        Assert.NotNull(result);
+        Assert.True(result.ContainsKey("frames"));
+
+        var frames = result["frames"] as List<Dictionary<string, object>>;
+        Assert.NotNull(frames);
+        Assert.Equal(maxStackTraceDepth, frames.Count);
+        Assert.Equal("file1.cs", frames[0]["file"]);
+        Assert.Equal("file4.cs", frames[1]["file"]);
+    }
+
+    [Fact]
+    public void GivenMultipleFrames_WhenMaxDepthIsSetTo4_ThenReturnsTop25AndBottom75Percent()
+    {
+        int maxStackTraceDepth = 4;
+        var mockFrames = CreateStackForTests(40);
+        var result = StackReporter.GetStack(maxStackTraceDepth, "test", mockFrames);
+        Assert.NotNull(result);
+        Assert.True(result.ContainsKey("frames"));
+
+        var frames = result["frames"] as List<Dictionary<string, object>>;
+        Assert.NotNull(frames);
+        Assert.Equal(maxStackTraceDepth, frames.Count);
+        Assert.Equal("file1.cs", frames[0]["file"]);
+        Assert.Equal("file38.cs", frames[1]["file"]);
+        Assert.Equal("file39.cs", frames[2]["file"]);
+        Assert.Equal("file40.cs", frames[3]["file"]);
+    }
+
+    [Fact]
+    public void GivenMultipleFrames_WhenMaxDepthIsSetTo0_ThenAllFramesAreReturned()
+    {
+        var mockFrames = CreateStackForTests(40);
+
+        var result = StackReporter.GetStack(0, "test", mockFrames);
+        Assert.NotNull(result);
+        Assert.True(result.ContainsKey("frames"));
+
+        (result["frames"] as List<Dictionary<string, object>>).Count.Should().Be(40);
+    }
+
+    [Fact]
+    public void GivenNoStackFrames_WhenGetStackIsCalled_ThenReturnsNull()
+    {
+        StackFrame[] mockFrames = [];
+        var result = StackReporter.GetStack(5, "test", mockFrames);
+        Assert.Null(result);
+    }
+
+    private StackFrame[] CreateStackForTests(int numberOfElements)
+    {
+        StackFrame[] mockFrames = new StackFrame[numberOfElements];
+        for (int i = 1; i <= numberOfElements; i++)
+        {
+            mockFrames[i - 1] = StackFrameCreate($"file{i}.cs", i, 1);
+        }
+
+        return mockFrames;
+    }
+
+    private StackFrame StackFrameCreate(string file, int line, int column)
+    {
+        var frame = new StackFrameForTest(file, line, column);
+        return frame;
+    }
+
+    public class StackFrameForTest : StackFrame
+    {
+        public StackFrameForTest(string fileName, int lineNumber, int columnNumber)
+            : base(fileName, lineNumber, columnNumber)
+        {
+        }
+
+        public override MethodBase GetMethod()
+        {
+            return typeof(string).GetMethod("Concat", new Type[] { typeof(string), typeof(string) });
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

This PR filters the RASP stack traces sent by getting 25% from the top and 75% from the bottom when the stack trace has more frames than the maximum number of frames that RASP is allowed to send.

Setting a maximum number of 0 frames will allow also adding a unlimited amount of frames to the returned stack.

## Reason for change

It has been defined in the RASP integration and validation RFC: https://docs.google.com/document/d/1122UKiuvJao6cV5D_NqoExTL5GQjDpbGTJENkBbEgVc/edit

## Implementation details

## Test coverage

Some unit tests have been added.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
