### PR TITLE
[ASM] Send duration metrics in nanoseconds

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspTelemetryHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspTelemetryHelper.cs
@@ -23,8 +23,12 @@ internal class RaspTelemetryHelper
 
     public void GenerateRaspSpanMetricTags(ITags tags)
     {
-        tags.SetMetric(Metrics.RaspRuleEval, _raspRuleEval);
-        tags.SetMetric(Metrics.RaspWafDuration, _raspWafDuration);
-        tags.SetMetric(Metrics.RaspWafAndBindingsDuration, _raspWafAndBindingsDuration);
+        // add the metrics only when there are non zero values
+        if (_raspRuleEval > 0)
+        {
+            tags.SetMetric(Metrics.RaspRuleEval, _raspRuleEval);
+            tags.SetMetric(Metrics.RaspWafDuration, _raspWafDuration);
+            tags.SetMetric(Metrics.RaspWafAndBindingsDuration, _raspWafAndBindingsDuration);
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -132,8 +132,8 @@ namespace Datadog.Trace.AppSec.Waf
             }
 
             _stopwatch.Stop();
-            _totalRuntimeOverRuns += retNative.TotalRuntime / 1000;
-            var result = new Result(retNative, code, _totalRuntimeOverRuns, (ulong)(_stopwatch.Elapsed.TotalMilliseconds * 1000), isRasp);
+            _totalRuntimeOverRuns += retNative.TotalRuntime;
+            var result = new Result(retNative, code, _totalRuntimeOverRuns, (ulong)(_stopwatch.Elapsed.TotalMilliseconds * 1000000), isRasp);
             _wafLibraryInvoker.ResultFree(ref retNative);
 
             if (Log.IsEnabled(LogEventLevel.Debug))


### PR DESCRIPTION
## Summary of changes

In RASP and ASM RFCs, it's stated that we should send the duration metrics in nanoseconds. Currently, we are sending them in microseconds instead. This has been fixed.

RFCs:
https://docs.google.com/document/d/1lcCvURsWTS_p01-MvrI6SmDB309L1e8bx9txuUR1zCk/edit#heading=h.rnd972k0hiye
https://docs.google.com/document/d/1vmMqpl8STDk7rJnd3YBsa6O9hCls_XHHdsodD61zr_4/edit?pli=1

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
