### PR TITLE
Add a space before |fg: in case of an unknown type

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -197,7 +197,7 @@ FrameInfoView FrameStore::GetManagedFrame(FunctionID functionId)
             std::lock_guard<std::mutex> lock(_methodsLock);
             auto& value = _methods[functionId];
             std::stringstream builder;
-            builder << UnknownManagedType << " |fn:" << std::move(methodName) << "|fg:" << std::move(methodGenericParameters) << " |sg:" << std::move(signature);
+            builder << UnknownManagedType << " |fn:" << std::move(methodName) << " |fg:" << std::move(methodGenericParameters) << " |sg:" << std::move(signature);
             value = {UnknownManagedAssembly, builder.str(), "", 0};
             return value;
         }


### PR DESCRIPTION
## Summary of changes
Add a missing space before |fg: when the CLR fails to return a type for a given ClassID

## Reason for change
Break backend parsing code

## Implementation details

## Test coverage
Not possible to generate invalid type to be tested

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
