### PR TITLE
Normalize the profiler thread names

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/OpSysTools.h
@@ -38,7 +38,7 @@ public:
     static inline bool QueryThreadCycleTime(HANDLE handle, PULONG64 cycleTime);
     static inline HANDLE GetCurrentProcess();
 
-    static bool SetNativeThreadName(std::thread* pNativeThread, const WCHAR* description);
+    static bool SetNativeThreadName(const WCHAR* description);
 #ifdef _WINDOWS
     static shared::WSTRING GetNativeThreadName(HANDLE threadHandle);
     static ScopedHandle GetThreadHandle(DWORD threadId);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.cpp
@@ -33,10 +33,16 @@ void SamplesCollector::RegisterBatchedProvider(IBatchedSamplesProvider* batchedS
 bool SamplesCollector::StartImpl()
 {
     Log::Info("Starting the samples collector");
-    _workerThread = std::thread(&SamplesCollector::SamplesWork, this);
-    OpSysTools::SetNativeThreadName(&_workerThread, WorkerThreadName);
-    _exporterThread = std::thread(&SamplesCollector::ExportWork, this);
-    OpSysTools::SetNativeThreadName(&_exporterThread, ExporterThreadName);
+    _workerThread = std::thread([this]
+        {
+            OpSysTools::SetNativeThreadName(WorkerThreadName);
+            SamplesWork();
+        });
+    _exporterThread = std::thread([this]
+        {
+            OpSysTools::SetNativeThreadName(ExporterThreadName);
+            ExportWork();
+        });
     return true;
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SamplesCollector.h
@@ -43,8 +43,8 @@ private:
     void SendHeartBeatMetric(bool success);
 
     const char* _serviceName = "SamplesCollector";
-    const WCHAR* WorkerThreadName = WStr("DD.Profiler.SamplesCollector.WorkerThread");
-    const WCHAR* ExporterThreadName = WStr("DD.Profiler.SamplesCollector.ExporterThread");
+    const WCHAR* WorkerThreadName = WStr("DD_worker");
+    const WCHAR* ExporterThreadName = WStr("DD_exporter");
 
     inline static constexpr std::chrono::nanoseconds CollectingPeriod = 60ms;
     inline static std::string const SuccessfulExportsMetricName = "datadog.profiling.dotnet.operational.exports";

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -45,27 +45,27 @@ StackSamplerLoop::StackSamplerLoop(
     ICollector<RawCpuSample>* pCpuTimeCollector,
     MetricsRegistry& metricsRegistry)
     :
-    _pCorProfilerInfo{ pCorProfilerInfo },
-    _pStackFramesCollector{ pStackFramesCollector },
-    _pManager{ pManager },
-    _pConfiguration{ pConfiguration },
-    _pThreadsCpuManager{ pThreadsCpuManager },
-    _pManagedThreadList{ pManagedThreadList },
-    _pCodeHotspotsThreadList{ pCodeHotspotThreadList },
-    _pWallTimeCollector{ pWallTimeCollector },
-    _pCpuTimeCollector{ pCpuTimeCollector },
-    _pLoopThread{ nullptr },
-    _loopThreadOsId{ 0 },
+    _pCorProfilerInfo{pCorProfilerInfo},
+    _pStackFramesCollector{pStackFramesCollector},
+    _pManager{pManager},
+    _pConfiguration{pConfiguration},
+    _pThreadsCpuManager{pThreadsCpuManager},
+    _pManagedThreadList{pManagedThreadList},
+    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
+    _pWallTimeCollector{pWallTimeCollector},
+    _pCpuTimeCollector{pCpuTimeCollector},
+    _pLoopThread{nullptr},
+    _loopThreadOsId{0},
     _targetThread(nullptr),
-    _iteratorWallTime{ 0 },
-    _iteratorCpuTime{ 0 },
-    _iteratorCodeHotspot{ 0 },
-    _walltimeThreadsThreshold{ pConfiguration->WalltimeThreadsThreshold() },
-    _cpuThreadsThreshold{ pConfiguration->CpuThreadsThreshold() },
-    _codeHotspotsThreadsThreshold{ pConfiguration->CodeHotspotsThreadsThreshold() },
-    _isWalltimeEnabled{ pConfiguration->IsWallTimeProfilingEnabled() },
-    _isCpuEnabled{ pConfiguration->IsCpuProfilingEnabled() },
-    _areInternalMetricsEnabled{ pConfiguration->IsInternalMetricsEnabled() }
+    _iteratorWallTime{0},
+    _iteratorCpuTime{0},
+    _iteratorCodeHotspot{0},
+    _walltimeThreadsThreshold{pConfiguration->WalltimeThreadsThreshold()},
+    _cpuThreadsThreshold{pConfiguration->CpuThreadsThreshold()},
+    _codeHotspotsThreadsThreshold{pConfiguration->CodeHotspotsThreadsThreshold()},
+    _isWalltimeEnabled{pConfiguration->IsWallTimeProfilingEnabled()},
+    _isCpuEnabled{pConfiguration->IsCpuProfilingEnabled()},
+    _areInternalMetricsEnabled{pConfiguration->IsInternalMetricsEnabled()}
 {
     _nbCores = OsSpecificApi::GetProcessorCount();
     Log::Info("Processor cores = ", _nbCores);
@@ -82,7 +82,7 @@ StackSamplerLoop::StackSamplerLoop(
     _iteratorCpuTime = _pManagedThreadList->CreateIterator();
     _iteratorCodeHotspot = _pCodeHotspotsThreadList->CreateIterator();
 
-    if (_areInternalMetricsEnabled)
+    if(_areInternalMetricsEnabled)
     {
         _walltimeDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_internal_walltime_iterations_duration");
         _cpuDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_internal_cpu_iterations_duration");
@@ -291,14 +291,14 @@ void StackSamplerLoop::CpuProfilingIteration()
             // Note: it is not possible to get this information on Windows 32-bit or in some cases in 64-bit
             //       so isRunning should be true if this thread consumed some CPU since the last iteration
 #if _WINDOWS
-#if BIT64  // Windows 64-bit
+    #if BIT64  // Windows 64-bit
             if (failure)
             {
                 isRunning = (lastConsumption < currentConsumption);
-        }
-#else  // Windows 32-bit
+            }
+    #else  // Windows 32-bit
             isRunning = (lastConsumption < currentConsumption);
-#endif
+    #endif
 #else  // nothing to do for Linux
 #endif
 
@@ -336,8 +336,8 @@ void StackSamplerLoop::CpuProfilingIteration()
                 }
             }
             _targetThread.reset();
+        }
     }
-}
 }
 
 void StackSamplerLoop::CodeHotspotIteration()
@@ -440,7 +440,7 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             // Notify the loop manager that we are starting a stack collection, and set up a finalizer to notify the manager when we finsih it.
             // This will enable the manager to monitor if this collection freezes due to a deadlock.
 
-            on_leave{ _pManager->NotifyIterationFinished(); };
+            on_leave { _pManager->NotifyIterationFinished(); };
 
             // On Windows, we will now suspend the target thread.
             // On Linux, if we use signals, the suspension may be a no-op since signal handlers do not use explicit suspension.
@@ -467,7 +467,7 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             // Perform the stack walk according to bitness, OS, platform, sync/async stack-walking, etc..:
             {
                 // We rely on RAII to call NotifyCollectionEnd when we get out this scope.
-                on_leave{ _pManager->NotifyCollectionEnd(); };
+                on_leave { _pManager->NotifyCollectionEnd(); };
 
                 _pManager->NotifyCollectionStart();
                 pStackSnapshotResult = _pStackFramesCollector->CollectStackSample(pThreadInfo.get(), &hrCollectStack);
@@ -582,17 +582,17 @@ void StackSamplerLoop::PersistStackSnapshotResults(
         _pWallTimeCollector->Add(std::move(rawSample));
     }
     else
-        if (profilingType == PROFILING_TYPE::CpuTime)
-        {
-            // add the CPU sample to the lipddprof pipeline if needed
-            RawCpuSample rawCpuSample;
-            rawCpuSample.Timestamp = pSnapshotResult->GetUnixTimeUtc();
-            rawCpuSample.LocalRootSpanId = pSnapshotResult->GetLocalRootSpanId();
-            rawCpuSample.SpanId = pSnapshotResult->GetSpanId();
-            rawCpuSample.AppDomainId = pThreadInfo->GetAppDomainId();
-            rawCpuSample.Stack = std::move(callstack);
-            rawCpuSample.ThreadInfo = pThreadInfo;
-            rawCpuSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();
-            _pCpuTimeCollector->Add(std::move(rawCpuSample));
-        }
+    if (profilingType == PROFILING_TYPE::CpuTime)
+    {
+        // add the CPU sample to the lipddprof pipeline if needed
+        RawCpuSample rawCpuSample;
+        rawCpuSample.Timestamp = pSnapshotResult->GetUnixTimeUtc();
+        rawCpuSample.LocalRootSpanId = pSnapshotResult->GetLocalRootSpanId();
+        rawCpuSample.SpanId = pSnapshotResult->GetSpanId();
+        rawCpuSample.AppDomainId = pThreadInfo->GetAppDomainId();
+        rawCpuSample.Stack = std::move(callstack);
+        rawCpuSample.ThreadInfo = pThreadInfo;
+        rawCpuSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();
+        _pCpuTimeCollector->Add(std::move(rawCpuSample));
+    }
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoop.cpp
@@ -31,7 +31,7 @@
 
 // Configuration constants:
 using namespace std::chrono_literals;
-constexpr const WCHAR* ThreadName = WStr("DD.Profiler.StackSamplerLoop.Thread");
+constexpr const WCHAR* ThreadName = WStr("DD_StackSampler");
 
 StackSamplerLoop::StackSamplerLoop(
     ICorProfilerInfo4* pCorProfilerInfo,
@@ -45,27 +45,27 @@ StackSamplerLoop::StackSamplerLoop(
     ICollector<RawCpuSample>* pCpuTimeCollector,
     MetricsRegistry& metricsRegistry)
     :
-    _pCorProfilerInfo{pCorProfilerInfo},
-    _pStackFramesCollector{pStackFramesCollector},
-    _pManager{pManager},
-    _pConfiguration{pConfiguration},
-    _pThreadsCpuManager{pThreadsCpuManager},
-    _pManagedThreadList{pManagedThreadList},
-    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
-    _pWallTimeCollector{pWallTimeCollector},
-    _pCpuTimeCollector{pCpuTimeCollector},
-    _pLoopThread{nullptr},
-    _loopThreadOsId{0},
+    _pCorProfilerInfo{ pCorProfilerInfo },
+    _pStackFramesCollector{ pStackFramesCollector },
+    _pManager{ pManager },
+    _pConfiguration{ pConfiguration },
+    _pThreadsCpuManager{ pThreadsCpuManager },
+    _pManagedThreadList{ pManagedThreadList },
+    _pCodeHotspotsThreadList{ pCodeHotspotThreadList },
+    _pWallTimeCollector{ pWallTimeCollector },
+    _pCpuTimeCollector{ pCpuTimeCollector },
+    _pLoopThread{ nullptr },
+    _loopThreadOsId{ 0 },
     _targetThread(nullptr),
-    _iteratorWallTime{0},
-    _iteratorCpuTime{0},
-    _iteratorCodeHotspot{0},
-    _walltimeThreadsThreshold{pConfiguration->WalltimeThreadsThreshold()},
-    _cpuThreadsThreshold{pConfiguration->CpuThreadsThreshold()},
-    _codeHotspotsThreadsThreshold{pConfiguration->CodeHotspotsThreadsThreshold()},
-    _isWalltimeEnabled{pConfiguration->IsWallTimeProfilingEnabled()},
-    _isCpuEnabled{pConfiguration->IsCpuProfilingEnabled()},
-    _areInternalMetricsEnabled{pConfiguration->IsInternalMetricsEnabled()}
+    _iteratorWallTime{ 0 },
+    _iteratorCpuTime{ 0 },
+    _iteratorCodeHotspot{ 0 },
+    _walltimeThreadsThreshold{ pConfiguration->WalltimeThreadsThreshold() },
+    _cpuThreadsThreshold{ pConfiguration->CpuThreadsThreshold() },
+    _codeHotspotsThreadsThreshold{ pConfiguration->CodeHotspotsThreadsThreshold() },
+    _isWalltimeEnabled{ pConfiguration->IsWallTimeProfilingEnabled() },
+    _isCpuEnabled{ pConfiguration->IsCpuProfilingEnabled() },
+    _areInternalMetricsEnabled{ pConfiguration->IsInternalMetricsEnabled() }
 {
     _nbCores = OsSpecificApi::GetProcessorCount();
     Log::Info("Processor cores = ", _nbCores);
@@ -82,7 +82,7 @@ StackSamplerLoop::StackSamplerLoop(
     _iteratorCpuTime = _pManagedThreadList->CreateIterator();
     _iteratorCodeHotspot = _pCodeHotspotsThreadList->CreateIterator();
 
-    if(_areInternalMetricsEnabled)
+    if (_areInternalMetricsEnabled)
     {
         _walltimeDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_internal_walltime_iterations_duration");
         _cpuDurationMetric = metricsRegistry.GetOrRegister<MeanMaxMetric>("dotnet_internal_cpu_iterations_duration");
@@ -108,8 +108,11 @@ const char* StackSamplerLoop::GetName()
 
 bool StackSamplerLoop::StartImpl()
 {
-    _pLoopThread = std::make_unique<std::thread>(&StackSamplerLoop::MainLoop, this);
-    OpSysTools::SetNativeThreadName(_pLoopThread.get(), ThreadName);
+    _pLoopThread = std::make_unique<std::thread>([this]
+        {
+            OpSysTools::SetNativeThreadName(ThreadName);
+            MainLoop();
+        });
 
     return true;
 }
@@ -288,14 +291,14 @@ void StackSamplerLoop::CpuProfilingIteration()
             // Note: it is not possible to get this information on Windows 32-bit or in some cases in 64-bit
             //       so isRunning should be true if this thread consumed some CPU since the last iteration
 #if _WINDOWS
-    #if BIT64  // Windows 64-bit
+#if BIT64  // Windows 64-bit
             if (failure)
             {
                 isRunning = (lastConsumption < currentConsumption);
-            }
-    #else  // Windows 32-bit
+        }
+#else  // Windows 32-bit
             isRunning = (lastConsumption < currentConsumption);
-    #endif
+#endif
 #else  // nothing to do for Linux
 #endif
 
@@ -333,8 +336,8 @@ void StackSamplerLoop::CpuProfilingIteration()
                 }
             }
             _targetThread.reset();
-        }
     }
+}
 }
 
 void StackSamplerLoop::CodeHotspotIteration()
@@ -437,7 +440,7 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             // Notify the loop manager that we are starting a stack collection, and set up a finalizer to notify the manager when we finsih it.
             // This will enable the manager to monitor if this collection freezes due to a deadlock.
 
-            on_leave { _pManager->NotifyIterationFinished(); };
+            on_leave{ _pManager->NotifyIterationFinished(); };
 
             // On Windows, we will now suspend the target thread.
             // On Linux, if we use signals, the suspension may be a no-op since signal handlers do not use explicit suspension.
@@ -464,7 +467,7 @@ void StackSamplerLoop::CollectOneThreadStackSample(
             // Perform the stack walk according to bitness, OS, platform, sync/async stack-walking, etc..:
             {
                 // We rely on RAII to call NotifyCollectionEnd when we get out this scope.
-                on_leave { _pManager->NotifyCollectionEnd(); };
+                on_leave{ _pManager->NotifyCollectionEnd(); };
 
                 _pManager->NotifyCollectionStart();
                 pStackSnapshotResult = _pStackFramesCollector->CollectStackSample(pThreadInfo.get(), &hrCollectStack);
@@ -579,17 +582,17 @@ void StackSamplerLoop::PersistStackSnapshotResults(
         _pWallTimeCollector->Add(std::move(rawSample));
     }
     else
-    if (profilingType == PROFILING_TYPE::CpuTime)
-    {
-        // add the CPU sample to the lipddprof pipeline if needed
-        RawCpuSample rawCpuSample;
-        rawCpuSample.Timestamp = pSnapshotResult->GetUnixTimeUtc();
-        rawCpuSample.LocalRootSpanId = pSnapshotResult->GetLocalRootSpanId();
-        rawCpuSample.SpanId = pSnapshotResult->GetSpanId();
-        rawCpuSample.AppDomainId = pThreadInfo->GetAppDomainId();
-        rawCpuSample.Stack = std::move(callstack);
-        rawCpuSample.ThreadInfo = pThreadInfo;
-        rawCpuSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();
-        _pCpuTimeCollector->Add(std::move(rawCpuSample));
-    }
+        if (profilingType == PROFILING_TYPE::CpuTime)
+        {
+            // add the CPU sample to the lipddprof pipeline if needed
+            RawCpuSample rawCpuSample;
+            rawCpuSample.Timestamp = pSnapshotResult->GetUnixTimeUtc();
+            rawCpuSample.LocalRootSpanId = pSnapshotResult->GetLocalRootSpanId();
+            rawCpuSample.SpanId = pSnapshotResult->GetSpanId();
+            rawCpuSample.AppDomainId = pThreadInfo->GetAppDomainId();
+            rawCpuSample.Stack = std::move(callstack);
+            rawCpuSample.ThreadInfo = pThreadInfo;
+            rawCpuSample.Duration = pSnapshotResult->GetRepresentedDurationNanoseconds();
+            _pCpuTimeCollector->Add(std::move(rawCpuSample));
+        }
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -36,31 +36,31 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     ICollector<RawCpuSample>* pCpuTimeCollector,
     MetricsRegistry& metricsRegistry,
     CallstackProvider callstackProvider
-) :
-    _pCorProfilerInfo{ pCorProfilerInfo },
-    _pConfiguration{ pConfiguration },
-    _pThreadsCpuManager{ pThreadsCpuManager },
-    _pManagedThreadList{ pManagedThreadList },
-    _pCodeHotspotsThreadList{ pCodeHotspotThreadList },
-    _pWallTimeCollector{ pWallTimeCollector },
-    _pCpuTimeCollector{ pCpuTimeCollector },
-    _pStackFramesCollector{ nullptr },
-    _pStackSamplerLoop{ nullptr },
-    _deadlockInterventionInProgress{ 0 },
-    _pWatcherThread{ nullptr },
-    _isWatcherShutdownRequested{ false },
-    _pTargetThread{ nullptr },
-    _collectionStartNs{ 0 },
-    _isTargetThreadSuspended{ false },
-    _isForceTerminated{ false },
-    _currentPeriod{ 0 },
-    _currentPeriodStartNs{ 0 },
-    _deadlocksInPeriod{ 0 },
-    _totalDeadlockDetectionsCount{ 0 },
-    _metricsSender{ metricsSender },
-    _statisticsReadyToSend{ nullptr },
-    _metricsRegistry{ metricsRegistry },
-    _callstackProvider{ std::move(callstackProvider) }
+    ) :
+    _pCorProfilerInfo{pCorProfilerInfo},
+    _pConfiguration{pConfiguration},
+    _pThreadsCpuManager{pThreadsCpuManager},
+    _pManagedThreadList{pManagedThreadList},
+    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
+    _pWallTimeCollector{pWallTimeCollector},
+    _pCpuTimeCollector{pCpuTimeCollector},
+    _pStackFramesCollector{nullptr},
+    _pStackSamplerLoop{nullptr},
+    _deadlockInterventionInProgress{0},
+    _pWatcherThread{nullptr},
+    _isWatcherShutdownRequested{false},
+    _pTargetThread{nullptr},
+    _collectionStartNs{0},
+    _isTargetThreadSuspended{false},
+    _isForceTerminated{false},
+    _currentPeriod{0},
+    _currentPeriodStartNs{0},
+    _deadlocksInPeriod{0},
+    _totalDeadlockDetectionsCount{0},
+    _metricsSender{metricsSender},
+    _statisticsReadyToSend{nullptr},
+    _metricsRegistry{metricsRegistry},
+    _callstackProvider{std::move(callstackProvider)}
 {
     _pCorProfilerInfo->AddRef();
     _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, pConfiguration, &_callstackProvider);
@@ -199,8 +199,8 @@ void StackSamplerLoopManager::WatcherLoopIteration()
     std::int64_t currentNanosecs = OpSysTools::GetHighPrecisionNanoseconds();
     std::chrono::nanoseconds periodDurationNs =
         (_currentPeriodStartNs == 0)
-        ? 0ns
-        : std::chrono::nanoseconds(currentNanosecs - _currentPeriodStartNs);
+            ? 0ns
+            : std::chrono::nanoseconds(currentNanosecs - _currentPeriodStartNs);
 
     if (_currentPeriodStartNs == 0 || periodDurationNs > StatsAggregationPeriodNs)
     {
@@ -221,7 +221,7 @@ void StackSamplerLoopManager::WatcherLoopIteration()
         {
             _deadlockInterventionInProgress++;
             Log::Info("StackSamplerLoopManager::WatcherLoopIteration - Deadlock intervention still in progress for thread ", _pTargetThread->GetOsThreadId(),
-                std::hex, " (= 0x", _pTargetThread->GetOsThreadId(), ")");
+                       std::hex, " (= 0x", _pTargetThread->GetOsThreadId(), ")");
         }
         return;
     }
@@ -274,9 +274,9 @@ void StackSamplerLoopManager::WatcherLoopIteration()
 bool StackSamplerLoopManager::HasMadeProgress(FILETIME userTime, FILETIME kernelTime)
 {
     return userTime.dwLowDateTime != _userTime.dwLowDateTime ||
-        userTime.dwHighDateTime != _userTime.dwHighDateTime ||
-        kernelTime.dwLowDateTime != _kernelTime.dwLowDateTime ||
-        kernelTime.dwHighDateTime != _kernelTime.dwHighDateTime;
+           userTime.dwHighDateTime != _userTime.dwHighDateTime ||
+           kernelTime.dwLowDateTime != _kernelTime.dwLowDateTime ||
+           kernelTime.dwHighDateTime != _kernelTime.dwHighDateTime;
 }
 
 void StackSamplerLoopManager::PerformDeadlockIntervention(const std::chrono::nanoseconds& ongoingStackSampleCollectionDurationNs)
@@ -310,24 +310,24 @@ void StackSamplerLoopManager::PerformDeadlockIntervention(const std::chrono::nan
     // resume target thread
     uint32_t hr;
     _pStackFramesCollector->ResumeTargetThreadIfRequired(_pTargetThread.get(),
-        _isTargetThreadSuspended,
-        &hr);
+                                                         _isTargetThreadSuspended,
+                                                         &hr);
 
     // don't forget to resume the target thread if needed (required in 32 bit)
     _pStackFramesCollector->OnDeadlock();
 
     LogDeadlockIntervention(ongoingStackSampleCollectionDurationNs,
-        wasThreadSafeForStackSampleCollection,
-        isThreadSafeForStackSampleCollection,
-        SUCCEEDED(hr));
+                            wasThreadSafeForStackSampleCollection,
+                            isThreadSafeForStackSampleCollection,
+                            SUCCEEDED(hr));
 
     // The sampled thread has been resumed. The lock blocking the stack sampler loop should be released anytime soon.
 }
 
 void StackSamplerLoopManager::LogDeadlockIntervention(const std::chrono::nanoseconds& ongoingStackSampleCollectionDurationNs,
-    bool wasThreadSafeForStackSampleCollection,
-    bool isThreadSafeForStackSampleCollection,
-    bool isThreadResumed)
+                                                      bool wasThreadSafeForStackSampleCollection,
+                                                      bool isThreadSafeForStackSampleCollection,
+                                                      bool isThreadResumed)
 {
     // ** Log a notice of this intervention:
     // (only if we successfully resumed the target thread, as it is not safe otherwise)
@@ -336,41 +336,41 @@ void StackSamplerLoopManager::LogDeadlockIntervention(const std::chrono::nanosec
     std::uint64_t threadDeadlockInAggPeriodCount;
     std::uint64_t threadUsedDeadlocksAggPeriodIndex;
     _pTargetThread->GetDeadlocksCount(&threadDeadlockTotalCount,
-        &threadDeadlockInAggPeriodCount,
-        &threadUsedDeadlocksAggPeriodIndex);
+                                      &threadDeadlockInAggPeriodCount,
+                                      &threadUsedDeadlocksAggPeriodIndex);
 
     Log::Info("StackSamplerLoopManager::PerformDeadlockIntervention(): The ongoing StackSampleCollection duration crossed the threshold."
-        " A deadlock intervention was performed."
-        " Deadlocked target thread=(OsThreadId=", std::dec, _pTargetThread->GetOsThreadId(), ", ",
-        " ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), ");", std::dec,
-        " ongoingStackSampleCollectionDurationNs=", ToMillis(ongoingStackSampleCollectionDurationNs), " millisecs;",
-        " _isTargetThreadResumed=", std::boolalpha, isThreadResumed, ";",
-        " _currentPeriod=", _currentPeriod, ";",
-        " _deadlocksInPeriod=", _deadlocksInPeriod, ";",
-        " _totalDeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ";",
-        " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
-        " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
-        " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
-        " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
-        " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ".");
+              " A deadlock intervention was performed."
+              " Deadlocked target thread=(OsThreadId=", std::dec, _pTargetThread->GetOsThreadId(), ", ",
+              " ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), ");", std::dec,
+              " ongoingStackSampleCollectionDurationNs=", ToMillis(ongoingStackSampleCollectionDurationNs), " millisecs;",
+              " _isTargetThreadResumed=", std::boolalpha, isThreadResumed, ";",
+              " _currentPeriod=", _currentPeriod, ";",
+              " _deadlocksInPeriod=", _deadlocksInPeriod, ";",
+              " _totalDeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ";",
+              " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
+              " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
+              " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
+              " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
+              " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ".");
 
     if (wasThreadSafeForStackSampleCollection != isThreadSafeForStackSampleCollection)
     {
         Log::Info("ShouldCollectThread status changed in PerformDeadlockIntervention"
-            " for thread (OsThreadId=", _pTargetThread->GetOsThreadId(),
-            ", ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), std::dec,
-            ", ThreadName=\"", _pTargetThread->GetThreadName(),
-            " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
-            " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
-            " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
-            " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
-            " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
-            " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
+                  " for thread (OsThreadId=", _pTargetThread->GetOsThreadId(),
+                  ", ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), std::dec,
+                  ", ThreadName=\"", _pTargetThread->GetThreadName(),
+                  " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
+                  " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
+                  " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
+                  " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
+                  " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
+                  " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
     }
 }
 
 void StackSamplerLoopManager::StartNewStatsAggregationPeriod(std::int64_t currentHighPrecisionNanosecs,
-    const std::chrono::nanoseconds& periodDurationNs)
+                                                             const std::chrono::nanoseconds& periodDurationNs)
 {
     // This method must only be called while _watcherActivityLock is held!
 
@@ -384,11 +384,11 @@ void StackSamplerLoopManager::StartNewStatsAggregationPeriod(std::int64_t curren
         if (_deadlocksInPeriod > 0)
         {
             Log::Info("StackSamplerLoopManager: Completing a StatsAggregationPeriod.",
-                " Period-Index=", _currentPeriod, ",",
-                " Targeted-PeriodDuration=", StatsAggregationPeriodMs.count(), " millisec,",
-                " Actual-PeriodDuration=", ToMillis(periodDurationNs), " millisec,",
-                " Period-DeadlockDetectionsCount=", _deadlocksInPeriod, ",",
-                " AppLifetime-DeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ".");
+                      " Period-Index=", _currentPeriod, ",",
+                      " Targeted-PeriodDuration=", StatsAggregationPeriodMs.count(), " millisec,",
+                      " Actual-PeriodDuration=", ToMillis(periodDurationNs), " millisec,",
+                      " Period-DeadlockDetectionsCount=", _deadlocksInPeriod, ",",
+                      " AppLifetime-DeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ".");
         }
     }
 
@@ -415,19 +415,19 @@ bool StackSamplerLoopManager::AllowStackWalk(std::shared_ptr<ManagedThreadInfo> 
         std::uint64_t threadDeadlockInAggPeriodCount;
         std::uint64_t threadUsedDeadlocksAggPeriodIndex;
         pThreadInfo->GetDeadlocksCount(&threadDeadlockTotalCount,
-            &threadDeadlockInAggPeriodCount,
-            &threadUsedDeadlocksAggPeriodIndex);
+                                       &threadDeadlockInAggPeriodCount,
+                                       &threadUsedDeadlocksAggPeriodIndex);
 
         // At that step, the target thread is not suspended so no deadlock risk when logging
         Log::Info("ShouldCollectThread status changed in AllowStackWalk",
-            " for thread (OsThreadId=", pThreadInfo->GetOsThreadId(),
-            ", ClrThreadId=0x", std::hex, pThreadInfo->GetClrThreadId(), std::dec,
-            ", ThreadName=\"", pThreadInfo->GetThreadName(), "\"):",
-            " ShouldCollectThread=", isThreadSafeForStackSampleCollection, ";",
-            " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
-            " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
-            " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
-            " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
+                  " for thread (OsThreadId=", pThreadInfo->GetOsThreadId(),
+                  ", ClrThreadId=0x", std::hex, pThreadInfo->GetClrThreadId(), std::dec,
+                  ", ThreadName=\"", pThreadInfo->GetThreadName(), "\"):",
+                  " ShouldCollectThread=", isThreadSafeForStackSampleCollection, ";",
+                  " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
+                  " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
+                  " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
+                  " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
     }
 
 
@@ -489,8 +489,8 @@ void StackSamplerLoopManager::NotifyCollectionEnd()
     _currentStatistics->AddCollectionTime(collectionDuration);
 
     _collectionStartNs = 0;
-    _kernelTime = { 0 };
-    _userTime = { 0 };
+    _kernelTime = {0};
+    _userTime = {0};
     _deadlockInterventionInProgress = 0;
 }
 
@@ -554,5 +554,5 @@ inline bool StackSamplerLoopManager::ShouldCollectThread(
     std::uint64_t globalAggPeriodDeadlockCount)
 {
     return (threadAggPeriodDeadlockCount <= DeadlocksPerThreadThreshold) &&
-        (globalAggPeriodDeadlockCount <= TotalDeadlocksThreshold);
+           (globalAggPeriodDeadlockCount <= TotalDeadlocksThreshold);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.cpp
@@ -21,7 +21,7 @@ constexpr std::chrono::milliseconds StatsAggregationPeriodMs = 10000ms;
 #endif
 constexpr std::chrono::nanoseconds StatsAggregationPeriodNs = StatsAggregationPeriodMs;
 
-const WCHAR* WatcherThreadName = WStr("DD.Profiler.StackSamplerLoopManager.WatcherThread");
+const WCHAR* WatcherThreadName = WStr("DD_Watcher");
 const std::chrono::nanoseconds StackSamplerLoopManager::StatisticAggregationPeriodNs = 10s;
 
 StackSamplerLoopManager::StackSamplerLoopManager(
@@ -36,31 +36,31 @@ StackSamplerLoopManager::StackSamplerLoopManager(
     ICollector<RawCpuSample>* pCpuTimeCollector,
     MetricsRegistry& metricsRegistry,
     CallstackProvider callstackProvider
-    ) :
-    _pCorProfilerInfo{pCorProfilerInfo},
-    _pConfiguration{pConfiguration},
-    _pThreadsCpuManager{pThreadsCpuManager},
-    _pManagedThreadList{pManagedThreadList},
-    _pCodeHotspotsThreadList{pCodeHotspotThreadList},
-    _pWallTimeCollector{pWallTimeCollector},
-    _pCpuTimeCollector{pCpuTimeCollector},
-    _pStackFramesCollector{nullptr},
-    _pStackSamplerLoop{nullptr},
-    _deadlockInterventionInProgress{0},
-    _pWatcherThread{nullptr},
-    _isWatcherShutdownRequested{false},
-    _pTargetThread{nullptr},
-    _collectionStartNs{0},
-    _isTargetThreadSuspended{false},
-    _isForceTerminated{false},
-    _currentPeriod{0},
-    _currentPeriodStartNs{0},
-    _deadlocksInPeriod{0},
-    _totalDeadlockDetectionsCount{0},
-    _metricsSender{metricsSender},
-    _statisticsReadyToSend{nullptr},
-    _metricsRegistry{metricsRegistry},
-    _callstackProvider{std::move(callstackProvider)}
+) :
+    _pCorProfilerInfo{ pCorProfilerInfo },
+    _pConfiguration{ pConfiguration },
+    _pThreadsCpuManager{ pThreadsCpuManager },
+    _pManagedThreadList{ pManagedThreadList },
+    _pCodeHotspotsThreadList{ pCodeHotspotThreadList },
+    _pWallTimeCollector{ pWallTimeCollector },
+    _pCpuTimeCollector{ pCpuTimeCollector },
+    _pStackFramesCollector{ nullptr },
+    _pStackSamplerLoop{ nullptr },
+    _deadlockInterventionInProgress{ 0 },
+    _pWatcherThread{ nullptr },
+    _isWatcherShutdownRequested{ false },
+    _pTargetThread{ nullptr },
+    _collectionStartNs{ 0 },
+    _isTargetThreadSuspended{ false },
+    _isForceTerminated{ false },
+    _currentPeriod{ 0 },
+    _currentPeriodStartNs{ 0 },
+    _deadlocksInPeriod{ 0 },
+    _totalDeadlockDetectionsCount{ 0 },
+    _metricsSender{ metricsSender },
+    _statisticsReadyToSend{ nullptr },
+    _metricsRegistry{ metricsRegistry },
+    _callstackProvider{ std::move(callstackProvider) }
 {
     _pCorProfilerInfo->AddRef();
     _pStackFramesCollector = OsSpecificApi::CreateNewStackFramesCollectorInstance(_pCorProfilerInfo, pConfiguration, &_callstackProvider);
@@ -125,8 +125,11 @@ void StackSamplerLoopManager::RunStackSampling()
 
 void StackSamplerLoopManager::RunWatcher()
 {
-    _pWatcherThread = std::make_unique<std::thread>(&StackSamplerLoopManager::WatcherLoop, this);
-    OpSysTools::SetNativeThreadName(_pWatcherThread.get(), WatcherThreadName);
+    _pWatcherThread = std::make_unique<std::thread>([this]
+        {
+            OpSysTools::SetNativeThreadName(WatcherThreadName);
+            WatcherLoop();
+        });
 }
 
 void StackSamplerLoopManager::ShutdownWatcher()
@@ -196,8 +199,8 @@ void StackSamplerLoopManager::WatcherLoopIteration()
     std::int64_t currentNanosecs = OpSysTools::GetHighPrecisionNanoseconds();
     std::chrono::nanoseconds periodDurationNs =
         (_currentPeriodStartNs == 0)
-            ? 0ns
-            : std::chrono::nanoseconds(currentNanosecs - _currentPeriodStartNs);
+        ? 0ns
+        : std::chrono::nanoseconds(currentNanosecs - _currentPeriodStartNs);
 
     if (_currentPeriodStartNs == 0 || periodDurationNs > StatsAggregationPeriodNs)
     {
@@ -218,7 +221,7 @@ void StackSamplerLoopManager::WatcherLoopIteration()
         {
             _deadlockInterventionInProgress++;
             Log::Info("StackSamplerLoopManager::WatcherLoopIteration - Deadlock intervention still in progress for thread ", _pTargetThread->GetOsThreadId(),
-                       std::hex, " (= 0x", _pTargetThread->GetOsThreadId(), ")");
+                std::hex, " (= 0x", _pTargetThread->GetOsThreadId(), ")");
         }
         return;
     }
@@ -271,9 +274,9 @@ void StackSamplerLoopManager::WatcherLoopIteration()
 bool StackSamplerLoopManager::HasMadeProgress(FILETIME userTime, FILETIME kernelTime)
 {
     return userTime.dwLowDateTime != _userTime.dwLowDateTime ||
-           userTime.dwHighDateTime != _userTime.dwHighDateTime ||
-           kernelTime.dwLowDateTime != _kernelTime.dwLowDateTime ||
-           kernelTime.dwHighDateTime != _kernelTime.dwHighDateTime;
+        userTime.dwHighDateTime != _userTime.dwHighDateTime ||
+        kernelTime.dwLowDateTime != _kernelTime.dwLowDateTime ||
+        kernelTime.dwHighDateTime != _kernelTime.dwHighDateTime;
 }
 
 void StackSamplerLoopManager::PerformDeadlockIntervention(const std::chrono::nanoseconds& ongoingStackSampleCollectionDurationNs)
@@ -307,24 +310,24 @@ void StackSamplerLoopManager::PerformDeadlockIntervention(const std::chrono::nan
     // resume target thread
     uint32_t hr;
     _pStackFramesCollector->ResumeTargetThreadIfRequired(_pTargetThread.get(),
-                                                         _isTargetThreadSuspended,
-                                                         &hr);
+        _isTargetThreadSuspended,
+        &hr);
 
     // don't forget to resume the target thread if needed (required in 32 bit)
     _pStackFramesCollector->OnDeadlock();
 
     LogDeadlockIntervention(ongoingStackSampleCollectionDurationNs,
-                            wasThreadSafeForStackSampleCollection,
-                            isThreadSafeForStackSampleCollection,
-                            SUCCEEDED(hr));
+        wasThreadSafeForStackSampleCollection,
+        isThreadSafeForStackSampleCollection,
+        SUCCEEDED(hr));
 
     // The sampled thread has been resumed. The lock blocking the stack sampler loop should be released anytime soon.
 }
 
 void StackSamplerLoopManager::LogDeadlockIntervention(const std::chrono::nanoseconds& ongoingStackSampleCollectionDurationNs,
-                                                      bool wasThreadSafeForStackSampleCollection,
-                                                      bool isThreadSafeForStackSampleCollection,
-                                                      bool isThreadResumed)
+    bool wasThreadSafeForStackSampleCollection,
+    bool isThreadSafeForStackSampleCollection,
+    bool isThreadResumed)
 {
     // ** Log a notice of this intervention:
     // (only if we successfully resumed the target thread, as it is not safe otherwise)
@@ -333,41 +336,41 @@ void StackSamplerLoopManager::LogDeadlockIntervention(const std::chrono::nanosec
     std::uint64_t threadDeadlockInAggPeriodCount;
     std::uint64_t threadUsedDeadlocksAggPeriodIndex;
     _pTargetThread->GetDeadlocksCount(&threadDeadlockTotalCount,
-                                      &threadDeadlockInAggPeriodCount,
-                                      &threadUsedDeadlocksAggPeriodIndex);
+        &threadDeadlockInAggPeriodCount,
+        &threadUsedDeadlocksAggPeriodIndex);
 
     Log::Info("StackSamplerLoopManager::PerformDeadlockIntervention(): The ongoing StackSampleCollection duration crossed the threshold."
-              " A deadlock intervention was performed."
-              " Deadlocked target thread=(OsThreadId=", std::dec, _pTargetThread->GetOsThreadId(), ", ",
-              " ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), ");", std::dec,
-              " ongoingStackSampleCollectionDurationNs=", ToMillis(ongoingStackSampleCollectionDurationNs), " millisecs;",
-              " _isTargetThreadResumed=", std::boolalpha, isThreadResumed, ";",
-              " _currentPeriod=", _currentPeriod, ";",
-              " _deadlocksInPeriod=", _deadlocksInPeriod, ";",
-              " _totalDeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ";",
-              " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
-              " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
-              " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
-              " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
-              " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ".");
+        " A deadlock intervention was performed."
+        " Deadlocked target thread=(OsThreadId=", std::dec, _pTargetThread->GetOsThreadId(), ", ",
+        " ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), ");", std::dec,
+        " ongoingStackSampleCollectionDurationNs=", ToMillis(ongoingStackSampleCollectionDurationNs), " millisecs;",
+        " _isTargetThreadResumed=", std::boolalpha, isThreadResumed, ";",
+        " _currentPeriod=", _currentPeriod, ";",
+        " _deadlocksInPeriod=", _deadlocksInPeriod, ";",
+        " _totalDeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ";",
+        " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
+        " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
+        " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
+        " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
+        " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ".");
 
     if (wasThreadSafeForStackSampleCollection != isThreadSafeForStackSampleCollection)
     {
         Log::Info("ShouldCollectThread status changed in PerformDeadlockIntervention"
-                  " for thread (OsThreadId=", _pTargetThread->GetOsThreadId(),
-                  ", ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), std::dec,
-                  ", ThreadName=\"", _pTargetThread->GetThreadName(),
-                  " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
-                  " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
-                  " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
-                  " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
-                  " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
-                  " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
+            " for thread (OsThreadId=", _pTargetThread->GetOsThreadId(),
+            ", ClrThreadId=0x", std::hex, _pTargetThread->GetClrThreadId(), std::dec,
+            ", ThreadName=\"", _pTargetThread->GetThreadName(),
+            " wasThreadSafeForStackSampleCollection=", std::boolalpha, wasThreadSafeForStackSampleCollection, ";",
+            " isThreadSafeForStackSampleCollection=", isThreadSafeForStackSampleCollection, ";", std::noboolalpha,
+            " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
+            " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
+            " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
+            " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
     }
 }
 
 void StackSamplerLoopManager::StartNewStatsAggregationPeriod(std::int64_t currentHighPrecisionNanosecs,
-                                                             const std::chrono::nanoseconds& periodDurationNs)
+    const std::chrono::nanoseconds& periodDurationNs)
 {
     // This method must only be called while _watcherActivityLock is held!
 
@@ -381,11 +384,11 @@ void StackSamplerLoopManager::StartNewStatsAggregationPeriod(std::int64_t curren
         if (_deadlocksInPeriod > 0)
         {
             Log::Info("StackSamplerLoopManager: Completing a StatsAggregationPeriod.",
-                      " Period-Index=", _currentPeriod, ",",
-                      " Targeted-PeriodDuration=", StatsAggregationPeriodMs.count(), " millisec,",
-                      " Actual-PeriodDuration=", ToMillis(periodDurationNs), " millisec,",
-                      " Period-DeadlockDetectionsCount=", _deadlocksInPeriod, ",",
-                      " AppLifetime-DeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ".");
+                " Period-Index=", _currentPeriod, ",",
+                " Targeted-PeriodDuration=", StatsAggregationPeriodMs.count(), " millisec,",
+                " Actual-PeriodDuration=", ToMillis(periodDurationNs), " millisec,",
+                " Period-DeadlockDetectionsCount=", _deadlocksInPeriod, ",",
+                " AppLifetime-DeadlockDetectionsCount=", _totalDeadlockDetectionsCount, ".");
         }
     }
 
@@ -412,19 +415,19 @@ bool StackSamplerLoopManager::AllowStackWalk(std::shared_ptr<ManagedThreadInfo> 
         std::uint64_t threadDeadlockInAggPeriodCount;
         std::uint64_t threadUsedDeadlocksAggPeriodIndex;
         pThreadInfo->GetDeadlocksCount(&threadDeadlockTotalCount,
-                                       &threadDeadlockInAggPeriodCount,
-                                       &threadUsedDeadlocksAggPeriodIndex);
+            &threadDeadlockInAggPeriodCount,
+            &threadUsedDeadlocksAggPeriodIndex);
 
         // At that step, the target thread is not suspended so no deadlock risk when logging
         Log::Info("ShouldCollectThread status changed in AllowStackWalk",
-                  " for thread (OsThreadId=", pThreadInfo->GetOsThreadId(),
-                  ", ClrThreadId=0x", std::hex, pThreadInfo->GetClrThreadId(), std::dec,
-                  ", ThreadName=\"", pThreadInfo->GetThreadName(), "\"):",
-                  " ShouldCollectThread=", isThreadSafeForStackSampleCollection, ";",
-                  " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
-                  " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
-                  " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
-                  " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
+            " for thread (OsThreadId=", pThreadInfo->GetOsThreadId(),
+            ", ClrThreadId=0x", std::hex, pThreadInfo->GetClrThreadId(), std::dec,
+            ", ThreadName=\"", pThreadInfo->GetThreadName(), "\"):",
+            " ShouldCollectThread=", isThreadSafeForStackSampleCollection, ";",
+            " threadDeadlockTotalCount=", threadDeadlockTotalCount, ";",
+            " threadDeadlockInAggPeriodCount=", threadDeadlockInAggPeriodCount, ";",
+            " threadUsedDeadlocksAggPeriodIndex=", threadUsedDeadlocksAggPeriodIndex, ";",
+            " _deadlocksInPeriod=", _deadlocksInPeriod, ".");
     }
 
 
@@ -486,8 +489,8 @@ void StackSamplerLoopManager::NotifyCollectionEnd()
     _currentStatistics->AddCollectionTime(collectionDuration);
 
     _collectionStartNs = 0;
-    _kernelTime = {0};
-    _userTime = {0};
+    _kernelTime = { 0 };
+    _userTime = { 0 };
     _deadlockInterventionInProgress = 0;
 }
 
@@ -551,5 +554,5 @@ inline bool StackSamplerLoopManager::ShouldCollectThread(
     std::uint64_t globalAggPeriodDeadlockCount)
 {
     return (threadAggPeriodDeadlockCount <= DeadlocksPerThreadThreshold) &&
-           (globalAggPeriodDeadlockCount <= TotalDeadlocksThreshold);
+        (globalAggPeriodDeadlockCount <= TotalDeadlocksThreshold);
 }


### PR DESCRIPTION
## Summary of changes

Prefix all profiler thread names with `DD_`, make sure they're less than 16 characters, and set them on Linux.

## Reason for change

Libunwind struggles to unwind signals on Alpine, which makes our work more difficult to know if our instrumentation caused the crash or not. Normalizing the thread names will allow to use this extra info to figure out if we caused the crash.

## Implementation details

 - The < 16 characters limit comes from [`prctl`](https://man7.org/linux/man-pages/man2/prctl.2.html): 
```
The name can be up to 16 bytes long, including the terminating null byte.
```
 - On Linux only the thread can set its own name, so I changed the code a bit to call `SetNativeThreadName` when starting the thread

## Test coverage

It works on my machine.