### PR TITLE
[Dynamic Instrumentation] Aligned the line probe snapshot to fix System Tests failures

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Snapshots/DebuggerSnapshotCreator.cs
@@ -780,7 +780,7 @@ namespace Datadog.Trace.Debugger.Snapshots
 
                 _jsonWriter.WritePropertyName("lines");
                 _jsonWriter.WriteStartArray();
-                _jsonWriter.WriteValue(methodNameOrLineNumber);
+                _jsonWriter.WriteValue(methodNameOrLineNumber.ToString());
                 _jsonWriter.WriteEndArray();
             }
 

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInstanceMethod.verified.txt
@@ -108,7 +108,7 @@
           "location": {
             "file": "AsyncInstanceMethod.cs",
             "lines": [
-              21
+              "21"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInterfaceProperties.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncInterfaceProperties.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
@@ -172,7 +172,7 @@
           "location": {
             "file": "AsyncInterfaceProperties.cs",
             "lines": [
-              34
+              "34"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncLineProbeWithFieldsArgsAndLocalsTest.verified.txt
@@ -643,7 +643,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              23
+              "23"
             ]
           },
           "version": 0
@@ -738,7 +738,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              25
+              "25"
             ]
           },
           "version": 0
@@ -833,7 +833,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              26
+              "26"
             ]
           },
           "version": 0
@@ -929,7 +929,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              27
+              "27"
             ]
           },
           "version": 0
@@ -1084,7 +1084,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              28
+              "28"
             ]
           },
           "version": 0
@@ -1344,7 +1344,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              29
+              "29"
             ]
           },
           "version": 0
@@ -1701,7 +1701,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              45
+              "45"
             ]
           },
           "version": 0
@@ -2058,7 +2058,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              46
+              "46"
             ]
           },
           "version": 0
@@ -2415,7 +2415,7 @@
           "location": {
             "file": "AsyncLineProbeWithFieldsArgsAndLocalsTest.cs",
             "lines": [
-              47
+              "47"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithArgsTest.verified.txt
@@ -150,7 +150,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithArgsTest.cs",
             "lines": [
-              35
+              "35"
             ]
           },
           "version": 0
@@ -320,7 +320,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithArgsTest.cs",
             "lines": [
-              36
+              "36"
             ]
           },
           "version": 0
@@ -490,7 +490,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithArgsTest.cs",
             "lines": [
-              37
+              "37"
             ]
           },
           "version": 0
@@ -654,7 +654,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithArgsTest.cs",
             "lines": [
-              42
+              "42"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncSpanOnMethodWithExceptionProbeTest.verified.txt
@@ -150,7 +150,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithExceptionProbeTest.cs",
             "lines": [
-              35
+              "35"
             ]
           },
           "version": 0
@@ -320,7 +320,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithExceptionProbeTest.cs",
             "lines": [
-              36
+              "36"
             ]
           },
           "version": 0
@@ -490,7 +490,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithExceptionProbeTest.cs",
             "lines": [
-              37
+              "37"
             ]
           },
           "version": 0
@@ -654,7 +654,7 @@
           "location": {
             "file": "AsyncSpanOnMethodWithExceptionProbeTest.cs",
             "lines": [
-              42
+              "42"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncStaticType.verified.txt
@@ -110,7 +110,7 @@
           "location": {
             "file": "AsyncStaticType.cs",
             "lines": [
-              28
+              "28"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ByRefLikeTest.verified.txt
@@ -25,7 +25,7 @@
           "location": {
             "file": "ByRefLikeTest.cs",
             "lines": [
-              10
+              "10"
             ]
           },
           "version": 0
@@ -70,7 +70,7 @@
           "location": {
             "file": "ByRefLikeTest.cs",
             "lines": [
-              11
+              "11"
             ]
           },
           "version": 0
@@ -115,7 +115,7 @@
           "location": {
             "file": "ByRefLikeTest.cs",
             "lines": [
-              12
+              "12"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#1..verified.txt
@@ -156,7 +156,7 @@
           "location": {
             "file": "ConditionAndTemplateChangeTest.cs",
             "lines": [
-              70
+              "70"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ConditionAndTemplateChangeTest_#3..verified.txt
@@ -53,7 +53,7 @@
           "location": {
             "file": "ConditionAndTemplateChangeTest.cs",
             "lines": [
-              70
+              "70"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericByRefLikeTest.verified.txt
@@ -81,7 +81,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              23
+              "23"
             ]
           },
           "version": 0
@@ -182,7 +182,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              24
+              "24"
             ]
           },
           "version": 0
@@ -283,7 +283,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              25
+              "25"
             ]
           },
           "version": 0
@@ -385,7 +385,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              26
+              "26"
             ]
           },
           "version": 0
@@ -546,7 +546,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              27
+              "27"
             ]
           },
           "version": 0
@@ -812,7 +812,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              29
+              "29"
             ]
           },
           "version": 0
@@ -1078,7 +1078,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              30
+              "30"
             ]
           },
           "version": 0
@@ -1344,7 +1344,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              31
+              "31"
             ]
           },
           "version": 0
@@ -1610,7 +1610,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              32
+              "32"
             ]
           },
           "version": 0
@@ -1876,7 +1876,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              34
+              "34"
             ]
           },
           "version": 0
@@ -2142,7 +2142,7 @@
           "location": {
             "file": "GenericByRefLikeTest.cs",
             "lines": [
-              35
+              "35"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.GenericMethodWithArguments.verified.txt
@@ -272,7 +272,7 @@
           "location": {
             "file": "GenericMethodWithArgumentsAndLocals.cs",
             "lines": [
-              22
+              "22"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.HasLocalsAndReturnValue.verified.txt
@@ -110,7 +110,7 @@
           "location": {
             "file": "HasLocalsAndReturnValue.cs",
             "lines": [
-              16
+              "16"
             ]
           },
           "version": 0
@@ -161,7 +161,7 @@
           "location": {
             "file": "HasLocalsAndReturnValue.cs",
             "lines": [
-              17
+              "17"
             ]
           },
           "version": 0
@@ -222,7 +222,7 @@
           "location": {
             "file": "HasLocalsAndReturnValue.cs",
             "lines": [
-              25
+              "25"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InstanceMethodWithArguments.verified.txt
@@ -92,7 +92,7 @@
           "location": {
             "file": "InstanceMethodWithArguments.cs",
             "lines": [
-              18
+              "18"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InterfaceProperties.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.InterfaceProperties.verified.txt
@@ -242,7 +242,7 @@
           "location": {
             "file": "InterfaceProperties.cs",
             "lines": [
-              36
+              "36"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LargeSnapshotTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LargeSnapshotTest.verified.txt
@@ -67899,16 +67899,24 @@
                                           "value": "BigObject"
                                         },
                                         {
-                                          "pruned": true
+                                          "notCapturedReason": "depth",
+                                          "type": "BigObject",
+                                          "value": "BigObject"
                                         },
                                         {
-                                          "pruned": true
+                                          "notCapturedReason": "depth",
+                                          "type": "BigObject",
+                                          "value": "BigObject"
                                         },
                                         {
-                                          "pruned": true
+                                          "notCapturedReason": "depth",
+                                          "type": "BigObject",
+                                          "value": "BigObject"
                                         },
                                         {
-                                          "pruned": true
+                                          "notCapturedReason": "depth",
+                                          "type": "BigObject",
+                                          "value": "BigObject"
                                         },
                                         {
                                           "pruned": true
@@ -74623,7 +74631,7 @@
           "location": {
             "file": "LargeSnapshotTest.cs",
             "lines": [
-              20
+              "20"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionFullSnapshot.verified.txt
@@ -41,7 +41,7 @@
           "location": {
             "file": "LineConditionFullSnapshot.cs",
             "lines": [
-              26
+              "26"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionPartialSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineConditionPartialSnapshot.verified.txt
@@ -13,7 +13,7 @@
           "location": {
             "file": "LineConditionPartialSnapshot.cs",
             "lines": [
-              26
+              "26"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#1..verified.txt
@@ -114,7 +114,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              41
+              "41"
             ]
           },
           "version": 0
@@ -177,7 +177,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              55
+              "55"
             ]
           },
           "version": 0
@@ -240,7 +240,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              56
+              "56"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#2..verified.txt
@@ -43,7 +43,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              41
+              "41"
             ]
           },
           "version": 0
@@ -106,7 +106,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              55
+              "55"
             ]
           },
           "version": 0
@@ -169,7 +169,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              56
+              "56"
             ]
           },
           "version": 0
@@ -232,7 +232,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              57
+              "57"
             ]
           },
           "version": 0
@@ -295,7 +295,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              58
+              "58"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#3..verified.txt
@@ -43,7 +43,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              46
+              "46"
             ]
           },
           "version": 0
@@ -106,7 +106,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              46
+              "46"
             ]
           },
           "version": 0
@@ -169,7 +169,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              46
+              "46"
             ]
           },
           "version": 0
@@ -232,7 +232,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              59
+              "59"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#4..verified.txt
@@ -43,7 +43,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              55
+              "55"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineProbesWithRevertTest_#5..verified.txt
@@ -43,7 +43,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              46
+              "46"
             ]
           },
           "version": 0
@@ -106,7 +106,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              46
+              "46"
             ]
           },
           "version": 0
@@ -169,7 +169,7 @@
           "location": {
             "file": "LineProbesWithRevertTest.cs",
             "lines": [
-              46
+              "46"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplateFullSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplateFullSnapshot.verified.txt
@@ -41,7 +41,7 @@
           "location": {
             "file": "LineTemplateFullSnapshot.cs",
             "lines": [
-              23
+              "23"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplatePartialSnapshot.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.LineTemplatePartialSnapshot.verified.txt
@@ -13,7 +13,7 @@
           "location": {
             "file": "LineTemplatePartialSnapshot.cs",
             "lines": [
-              23
+              "23"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MethodThrowExceptionTest.verified.txt
@@ -153,7 +153,7 @@
           "location": {
             "file": "MethodThrowExceptionTest.cs",
             "lines": [
-              26
+              "26"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ModuleUnloadTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.ModuleUnloadTest.verified.txt
@@ -3,7 +3,6 @@
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
     "ddsource": "dd_debugger",
-    "ddtags": "Unknown",
     "debugger": {
       "snapshot": {
         "captures": {
@@ -36,9 +35,10 @@
           "location": {
             "file": "UnreferencedExternalClass.cs",
             "lines": [
-              11
+              "11"
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"
@@ -58,7 +58,6 @@
     "dd.span_id": "ScrubbedValue",
     "dd.trace_id": "ScrubbedValue",
     "ddsource": "dd_debugger",
-    "ddtags": "Unknown",
     "debugger": {
       "snapshot": {
         "captures": {
@@ -91,9 +90,10 @@
           "location": {
             "file": "UnreferencedExternalClass.cs",
             "lines": [
-              12
+              "12"
             ]
-          }
+          },
+          "version": 0
         },
         "stack": "ScrubbedValue",
         "timestamp": "ScrubbedValue"

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeTest.verified.txt
@@ -122,7 +122,7 @@
           "location": {
             "file": "MultiProbeTest.cs",
             "lines": [
-              39
+              "39"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiProbeWithSpanTest.verified.txt
@@ -144,7 +144,7 @@
           "location": {
             "file": "MultiProbeWithSpanTest.cs",
             "lines": [
-              53
+              "53"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultiScopesWithSameLocalNameTest.verified.txt
@@ -35,7 +35,7 @@
           "location": {
             "file": "MultiScopesWithSameLocalNameTest.cs",
             "lines": [
-              25
+              "25"
             ]
           },
           "version": 0
@@ -90,7 +90,7 @@
           "location": {
             "file": "MultiScopesWithSameLocalNameTest.cs",
             "lines": [
-              25
+              "25"
             ]
           },
           "version": 0
@@ -145,7 +145,7 @@
           "location": {
             "file": "MultiScopesWithSameLocalNameTest.cs",
             "lines": [
-              32
+              "32"
             ]
           },
           "version": 0
@@ -200,7 +200,7 @@
           "location": {
             "file": "MultiScopesWithSameLocalNameTest.cs",
             "lines": [
-              32
+              "32"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.MultipleLineProbes.verified.txt
@@ -86,7 +86,7 @@
           "location": {
             "file": "MultipleLineProbes.cs",
             "lines": [
-              21
+              "21"
             ]
           },
           "version": 0
@@ -135,7 +135,7 @@
           "location": {
             "file": "MultipleLineProbes.cs",
             "lines": [
-              22
+              "22"
             ]
           },
           "version": 0
@@ -184,7 +184,7 @@
           "location": {
             "file": "MultipleLineProbes.cs",
             "lines": [
-              23
+              "23"
             ]
           },
           "version": 0
@@ -233,7 +233,7 @@
           "location": {
             "file": "MultipleLineProbes.cs",
             "lines": [
-              24
+              "24"
             ]
           },
           "version": 0
@@ -282,7 +282,7 @@
           "location": {
             "file": "MultipleLineProbes.cs",
             "lines": [
-              25
+              "25"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.NotSupportedFailureTest.verified.txt
@@ -161,7 +161,7 @@
           "location": {
             "file": "NotSupportedFailureTest.cs",
             "lines": [
-              24
+              "24"
             ]
           },
           "version": 0
@@ -212,7 +212,7 @@
           "location": {
             "file": "NotSupportedFailureTest.cs",
             "lines": [
-              25
+              "25"
             ]
           },
           "version": 0
@@ -263,7 +263,7 @@
           "location": {
             "file": "NotSupportedFailureTest.cs",
             "lines": [
-              26
+              "26"
             ]
           },
           "version": 0
@@ -314,7 +314,7 @@
           "location": {
             "file": "NotSupportedFailureTest.cs",
             "lines": [
-              27
+              "27"
             ]
           },
           "version": 0
@@ -365,7 +365,7 @@
           "location": {
             "file": "NotSupportedFailureTest.cs",
             "lines": [
-              28
+              "28"
             ]
           },
           "version": 0
@@ -414,7 +414,7 @@
           "location": {
             "file": "NotSupportedFailureTest.cs",
             "lines": [
-              51
+              "51"
             ]
           },
           "version": 0
@@ -469,7 +469,7 @@
           "location": {
             "file": "NotSupportedFailureTest.cs",
             "lines": [
-              64
+              "64"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithArgsTest.verified.txt
@@ -253,7 +253,7 @@
           "location": {
             "file": "SpanOnMethodWithArgsTest.cs",
             "lines": [
-              32
+              "32"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.SpanOnMethodWithExceptionProbeTest.verified.txt
@@ -253,7 +253,7 @@
           "location": {
             "file": "SpanOnMethodWithExceptionProbeTest.cs",
             "lines": [
-              33
+              "33"
             ]
           },
           "version": 0
@@ -417,7 +417,7 @@
           "location": {
             "file": "SpanOnMethodWithExceptionProbeTest.cs",
             "lines": [
-              38
+              "38"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticMethodWithArguments.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticMethodWithArguments.verified.txt
@@ -80,7 +80,7 @@
           "location": {
             "file": "StaticMethodWithArguments.cs",
             "lines": [
-              18
+              "18"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticType.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.StaticType.verified.txt
@@ -110,7 +110,7 @@
           "location": {
             "file": "StaticType.cs",
             "lines": [
-              23
+              "23"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UnboundProbeBecomesBoundTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.UnboundProbeBecomesBoundTest.verified.txt
@@ -35,7 +35,7 @@
           "location": {
             "file": "UnreferencedExternalClass.cs",
             "lines": [
-              11
+              "11"
             ]
           },
           "version": 0
@@ -90,7 +90,7 @@
           "location": {
             "file": "UnreferencedExternalClass.cs",
             "lines": [
-              12
+              "12"
             ]
           },
           "version": 0

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LargeSnapshotTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.LargeSnapshotTest.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     "ddsource": "dd_debugger",
     "debugger": {
@@ -7,10 +7,10 @@
         "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
         "probeVersion": 0,
         "runtimeId": "scrubbed",
-        "status": "INSTALLED"
+        "status": "EMITTING"
       }
     },
-    "message": "Installed probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
     "service": "probes"
   }
 ]


### PR DESCRIPTION
## Summary of changes
There was a check that was added into the System Test that make sure each field in the snapshot is correctly typed. There was a small gap between .NET and Java snapshots where the line field in Java is a string, and in .NET is an int.

This difference is from earlier design decision that was made, to allow a line probe to be applied to multiple lines (hence be presented as `X - Y`). This decision was discarded by then, but for backward compatibility reasons with previous library versioning the `string` is kept.

The changes in this PR aligns with this requirement.

## Reason for change
Fix System Tests breakage on improper data type.