### PR TITLE
[Profiler] Investigate and fix profiler benchmarks failures

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -118,7 +118,7 @@ bool CorProfilerCallback::InitializeServices()
     if (_pConfiguration->IsSystemCallsShieldEnabled())
     {
         // This service must be started before StackSamplerLoop-based profilers to help with non-restartable system calls (ex: socket operations)
-        _systemCallsShield = RegisterService<SystemCallsShield>(_pConfiguration);
+        _systemCallsShield = RegisterService<SystemCallsShield>(_pConfiguration.get());
     }
 #endif
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.h
@@ -64,7 +64,7 @@ class Loader;
 class CorProfilerCallback : public ICorProfilerCallback10
 {
 public:
-    CorProfilerCallback(IConfiguration* pConfiguration);
+    CorProfilerCallback(std::shared_ptr<IConfiguration> pConfiguration);
     virtual ~CorProfilerCallback();
 
     // use STDMETHODCALLTYPE macro to match the CLR declaration.
@@ -245,7 +245,7 @@ private :
     std::vector<std::unique_ptr<IService>> _services;
 
     std::unique_ptr<IExporter> _pExporter = nullptr;
-    IConfiguration* _pConfiguration = nullptr;
+    std::shared_ptr<IConfiguration> _pConfiguration = nullptr;
     std::unique_ptr<IAppDomainStore> _pAppDomainStore = nullptr;
     std::unique_ptr<IFrameStore> _pFrameStore = nullptr;
     std::unique_ptr<IRuntimeInfo> _pRuntimeInfo = nullptr;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.cpp
@@ -6,10 +6,12 @@
 #include "CorProfilerCallbackFactory.h"
 #include "CorProfilerCallback.h"
 
+#include "IConfiguration.h"
+
 std::mutex CorProfilerCallbackFactory::_lock;
 
 
-CorProfilerCallbackFactory::CorProfilerCallbackFactory(Configuration configuration) :
+CorProfilerCallbackFactory::CorProfilerCallbackFactory(std::shared_ptr<IConfiguration> configuration) :
     _configuration{std::move(configuration)}
 {
 
@@ -92,7 +94,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallbackFactory::CreateInstance(IUnknown* p
         return E_INVALIDARG;
     }
 
-    CorProfilerCallback* profiler = new (std::nothrow) CorProfilerCallback(&_configuration);
+    CorProfilerCallback* profiler = new (std::nothrow) CorProfilerCallback(_configuration);
     if (profiler == nullptr)
     {
         return E_OUTOFMEMORY;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.h
@@ -3,16 +3,16 @@
 
 #pragma once
 
-#include "Configuration.h"
-
 #include "unknwn.h"
 #include <atomic>
 #include <mutex>
 
+class IConfiguration;
+
 class CorProfilerCallbackFactory : public IClassFactory
 {
 public:
-    CorProfilerCallbackFactory(Configuration configuration);
+    CorProfilerCallbackFactory(std::shared_ptr<IConfiguration> configuration);
     virtual ~CorProfilerCallbackFactory();
 
     // use STDMETHODCALLTYPE macro to match the CLR declaration.
@@ -26,5 +26,5 @@ public:
 private:
     std::atomic<ULONG> _refCount{0};
     static std::mutex _lock;
-    Configuration _configuration;
+    std::shared_ptr<IConfiguration> _configuration;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallbackFactory.h
@@ -5,6 +5,7 @@
 
 #include "unknwn.h"
 #include <atomic>
+#include <memory>
 #include <mutex>
 
 class IConfiguration;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/DllMain.cpp
@@ -108,9 +108,9 @@ extern "C" HRESULT STDMETHODCALLTYPE DllGetClassObject(REFCLSID rclsid, REFIID r
         return CLASS_E_CLASSNOTAVAILABLE;
     }
 
-    Configuration configuration;
+    auto configuration = std::make_shared<Configuration>();
 
-    if (!IsProfilingEnabled(configuration))
+    if (!IsProfilingEnabled(*configuration))
     {
         Log::Info("DllGetClassObject(): Profiling is not enabled.");
 


### PR DESCRIPTION
## Summary of changes

Fix bug introduced in another PR and crashes only benchmark tests

## Reason for change
In a previous PR, we create a `Configuration` object and give the ownership to `CorProfilerCallbackFactory` instance. This class was responsible to give a reference to it when creating `CorProfilerCallback` instance. But in Benchmark tests, the `CorProfilerCallbackFactory` instance is deleted, so the `Configuration` instance it was holding is deleted. Then, the `CorProfilerCallbackInstance` uses the pointer to that object and 💥 

## Implementation details

Create a `std::shared_ptr<Configuration>`  and pass it around

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
