### PR TITLE
Single-step guard rails: Update `RuntimeInformation` to include "inferred" runtime version

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -31,8 +31,8 @@ namespace datadog::shared::nativeloader
         ICorProfilerInfo4* m_info;
         std::shared_ptr<ICorProfilerInfo12> m_writeToDiskCorProfilerInfo;
 
-        static void InspectRuntimeCompatibility(IUnknown* corProfilerInfoUnk);
-        static RuntimeInformation GetRuntimeVersion(ICorProfilerInfo4* pCorProfilerInfo);
+        static std::string InspectRuntimeCompatibility(IUnknown* corProfilerInfoUnk);
+        static RuntimeInformation GetRuntimeVersion(ICorProfilerInfo4* pCorProfilerInfo, const std::string& inferred_version);
 
     public:
         CorProfiler(IDynamicDispatcher* dispatcher);
@@ -185,6 +185,7 @@ namespace datadog::shared::nativeloader
         USHORT minor_version;
         USHORT build_version;
         USHORT qfe_version;
+        std::string inferred_version = "";
 
         RuntimeInformation() :
             runtime_type((COR_PRF_RUNTIME_TYPE) 0x0), major_version(0), minor_version(0), build_version(0), qfe_version(0)
@@ -192,12 +193,13 @@ namespace datadog::shared::nativeloader
         }
 
         RuntimeInformation(COR_PRF_RUNTIME_TYPE runtime_type, USHORT major_version, USHORT minor_version,
-                           USHORT build_version, USHORT qfe_version) :
+                           USHORT build_version, USHORT qfe_version, const std::string inferred_version) :
             runtime_type(runtime_type),
             major_version(major_version),
             minor_version(minor_version),
             build_version(build_version),
-            qfe_version(qfe_version)
+            qfe_version(qfe_version),
+            inferred_version(inferred_version)
         {
         }
 
@@ -218,6 +220,21 @@ namespace datadog::shared::nativeloader
         bool is_core() const
         {
             return runtime_type == COR_PRF_CORE_CLR;
+        }
+
+        std::string description() const
+        {
+            // on .NET Core, prior to .NET 5, can't trust the versions
+            // Similarly, the inferred version (from ICorProfiler interface) gives more
+            // granularity for us in .NET Framework
+            if((is_core() && major_version >= 5) || inferred_version.empty())
+            {
+                return std::to_string(major_version) + "." +
+                       std::to_string(minor_version) + "." +
+                       std::to_string(build_version);
+            }
+
+            return inferred_version;
         }
     };
 } // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.h
@@ -185,21 +185,21 @@ namespace datadog::shared::nativeloader
         USHORT minor_version;
         USHORT build_version;
         USHORT qfe_version;
-        std::string inferred_version = "";
+        std::string inferred_version;
 
         RuntimeInformation() :
-            runtime_type((COR_PRF_RUNTIME_TYPE) 0x0), major_version(0), minor_version(0), build_version(0), qfe_version(0)
+            runtime_type((COR_PRF_RUNTIME_TYPE) 0x0), major_version(0), minor_version(0), build_version(0), qfe_version(0), inferred_version("")
         {
         }
 
         RuntimeInformation(COR_PRF_RUNTIME_TYPE runtime_type, USHORT major_version, USHORT minor_version,
-                           USHORT build_version, USHORT qfe_version, const std::string inferred_version) :
+                           USHORT build_version, USHORT qfe_version, std::string inferred_version) :
             runtime_type(runtime_type),
             major_version(major_version),
             minor_version(minor_version),
             build_version(build_version),
             qfe_version(qfe_version),
-            inferred_version(inferred_version)
+            inferred_version(std::move(inferred_version))
         {
         }
 


### PR DESCRIPTION
## Summary of changes

Update the `RuntimeInformation` struct` to include the "inferred" version of .NET we're using

## Reason for change

We use the `corProfilerInfoUnk->QueryInterface` APIs to infer which version of .NET we are actually using, because `pCorProfilerInfo->GetRuntimeInformation` doesn't always return reliable information. This PR stores that value as a string that can be used later (by guard rails). 

## Implementation details

- Added a string field to the `RuntimeInformation` struct
- Return the inferred version (if any) when walking through the `QueryInterface()` calls
- Fallback to the inferred version as the "detected" version of .NET for "early" versions of .NET Core/.NET Framework

## Test coverage

The field isn't used anywhere in this PR, so as long as everything still works, it's ok. The behaviour is covered implicitly by subsequent tests later in the PR stack.

## Other details

Prerequisite for single-step guard rails work stack
- https://github.com/DataDog/dd-trace-dotnet/pull/5635
- https://github.com/DataDog/dd-trace-dotnet/pull/5636
- https://github.com/DataDog/dd-trace-dotnet/pull/5637
- https://github.com/DataDog/dd-trace-dotnet/pull/5611


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
