### PR TITLE
Single-step guard rails: telemetry

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -144,6 +144,7 @@ endif()
 # ******************************************************
 add_library("Datadog.Trace.ClrProfiler.Native.static" STATIC
         cor_profiler.cpp
+        process_helper.cpp
         cor_profiler_class_factory.cpp
         dynamic_dispatcher.cpp
         dynamic_instance.cpp

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -145,6 +145,7 @@ endif()
 add_library("Datadog.Trace.ClrProfiler.Native.static" STATIC
         cor_profiler.cpp
         process_helper.cpp
+        single_step_guard_rails.cpp
         cor_profiler_class_factory.cpp
         dynamic_dispatcher.cpp
         dynamic_instance.cpp

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -334,6 +334,7 @@
     <ClInclude Include="process_helper.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="runtimeid_store.h" />
+    <ClInclude Include="single_step_guard_rails.h" />
     <ClInclude Include="util.h" />
   </ItemGroup>
   <ItemGroup>
@@ -355,6 +356,7 @@
     <ClCompile Include="exported_functions.cpp" />
     <ClCompile Include="process_helper.cpp" />
     <ClCompile Include="runtimeid_store.cpp" />
+    <ClCompile Include="single_step_guard_rails.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Datadog.Trace.ClrProfiler.Native.def" />

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Datadog.Trace.ClrProfiler.Native.vcxproj
@@ -331,6 +331,7 @@
     <ClInclude Include="instrumented_assembly_generator\method_signature.h" />
     <ClInclude Include="log.h" />
     <ClInclude Include="exported_functions.h" />
+    <ClInclude Include="process_helper.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="runtimeid_store.h" />
     <ClInclude Include="util.h" />
@@ -352,6 +353,7 @@
     <ClCompile Include="instrumented_assembly_generator\member_signature.cpp" />
     <ClCompile Include="instrumented_assembly_generator\method_signature.cpp" />
     <ClCompile Include="exported_functions.cpp" />
+    <ClCompile Include="process_helper.cpp" />
     <ClCompile Include="runtimeid_store.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
@@ -17,4 +17,5 @@ public:
     // DD_INJECTION_ENABLED is non-empty when SSI is enabled
     inline static const shared::WSTRING SingleStepInstrumentationEnabled = WStr("DD_INJECTION_ENABLED");
     inline static const shared::WSTRING ForceEolInstrumentation = WStr("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES");
+    inline static const shared::WSTRING SingleStepInstrumentationTelemetryForwarderPath = WStr("DD_TELEMETRY_FORWARDER_PATH");
 };

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/EnvironmentVariables.h
@@ -16,6 +16,6 @@ public:
     inline static const shared::WSTRING InternalRuntimeId = WStr("DD_INTERNAL_CIVISIBILITY_RUNTIMEID");
     // DD_INJECTION_ENABLED is non-empty when SSI is enabled
     inline static const shared::WSTRING SingleStepInstrumentationEnabled = WStr("DD_INJECTION_ENABLED");
-    inline static const shared::WSTRING ForceEolInstrumentation = WStr("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES");
+    inline static const shared::WSTRING ForceEolInstrumentation = WStr("DD_INJECT_FORCE");
     inline static const shared::WSTRING SingleStepInstrumentationTelemetryForwarderPath = WStr("DD_TELEMETRY_FORWARDER_PATH");
 };

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -243,6 +243,8 @@ namespace datadog::shared::nativeloader
         if (FAILED(hr))
         {
             Log::Warn("CorProfiler::Initialize: Failed to attach profiler, interface ICorProfilerInfo4 not found.");
+            // we're not recording the exact version here, we just know that at this point it's not enough
+            single_step_guard_rails.RecordBootstrapError(single_step_guard_rails.NetFrameworkRuntime, inferredVersion, "incompatible_runtime");
             return E_FAIL;
         }
         const auto runtimeInformation = GetRuntimeVersion(info4, inferredVersion);
@@ -258,6 +260,7 @@ namespace datadog::shared::nativeloader
         //
         if (m_dispatcher == nullptr)
         {
+            single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
             return E_FAIL;
         }
         IDynamicInstance* cpInstance = m_dispatcher->GetContinuousProfilerInstance();
@@ -321,6 +324,7 @@ namespace datadog::shared::nativeloader
         if (FAILED(hr))
         {
             Log::Warn("CorProfiler::Initialize: Error getting the event mask.");
+            single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
             return E_FAIL;
         }
 
@@ -486,9 +490,11 @@ namespace datadog::shared::nativeloader
         if (FAILED(hr))
         {
             Log::Warn("CorProfiler::Initialize: Error setting the event mask.");
+            single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
             return E_FAIL;
         }               
 
+        single_step_guard_rails.RecordBootstrapSuccess(runtimeInformation);
         return S_OK;
     }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
@@ -1,0 +1,283 @@
+﻿#include "process_helper.h"
+#include "cor_profiler.h"
+#include "log.h"
+#include "util.h"
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+#include <pthread.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#endif
+
+
+using namespace shared;
+
+namespace datadog::shared::nativeloader
+{
+/**
+ * Start a process, in a "fire and forget" way, sending arguments.
+ * No attempt is made to connect to the process, establish a pipe, or anything else.
+ * @param processPath The path of the process to execute
+ * @param args The additional arguments (if any) to send
+ * @param env The environment variables to set for the process
+ * @return true if the process was invoked successfully, false otherwise
+ */
+bool ProcessHelper::RunProcess(const std::string& processPath,
+                               const std::vector<std::string>& args,
+                               const std::vector<std::string>& env)
+{
+#if _WIN32
+    // For windows we combine the processPath and args into a single, space separated, string
+    // and pass null for the application name
+    // We assume that all the required escaping has been done etc
+
+    std::string combined = processPath;
+    for(const auto &arg: args)
+    {
+        combined += " " + arg;
+    }
+
+    auto commandLine = ToWSTRING(combined);
+
+    STARTUPINFO si;
+    SecureZeroMemory(&si, sizeof(STARTUPINFO));
+    si.cb = sizeof(STARTUPINFO);
+
+    // TODO: This currently ignores the passed-in environment variables for simplicity
+    // as it's not REQUIRED right now (the child inherits the caller's env vars),
+    // and the docs show that it's a PITA:
+    //
+    // Each process has an environment block associated with it.
+    // The environment block consists of a null-terminated block of null-terminated strings
+    // (meaning there are two null bytes at the end of the block), where each string is in the form:
+    // name=value
+    // All strings in the environment block must be sorted alphabetically by name.
+    // The sort is case-insensitive, Unicode order, without regard to locale.
+    // Because the equal sign is a separator, it must not be used in the name of an environment variable.
+
+    PROCESS_INFORMATION pi;
+    if (CreateProcess(
+        nullptr,                  // lpApplicationName
+        commandLine.data(),       // lpCommandLine
+        nullptr,                  // lpProcessAttributes
+        nullptr,                  // lpThreadAttributes
+        FALSE,                    // bInheritHandles
+        CREATE_NEW_PROCESS_GROUP, // dwCreationFlags (don't create as a child)
+        nullptr,                  // lpEnvironment
+        nullptr,                  // lpCurrentDirectory
+        &si,                      // lpStartupInfo
+        &pi))                     // lpProcessInformation
+    {
+        // we don't need to wait for it to finish, so just free-up resources 
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+        return true;
+    }
+
+    // Error starting
+    return false;
+}
+#else
+    // The args include the path as the first argument
+    std::vector<const char*> argv = {processPath.c_str()};
+    for (const auto& arg : args)
+    {
+        argv.push_back(arg.c_str());
+    }
+    argv.push_back(nullptr);
+
+    // envp needs to be a null-terminated array of c-style strings
+    std::vector<const char*> envp;
+    for (const auto& envPair : env)
+    {
+        envp.push_back(envPair.c_str());
+    }
+    envp.push_back(nullptr);
+
+    // Largely blindly copied from the .NET runtime code
+    // and then deleted stuff I didn't _think_ we needed for this basic scenario :blindfold:
+    // https://github.com/dotnet/runtime/blob/f4c9264fe8448fdf1f66eda04a582cbade40cd39/src/native/libs/System.Native/pal_process.c#L212
+
+    bool success = true;
+    int waitForChildToExecPipe[2] = {-1, -1};
+    pid_t processId = -1;
+    sigset_t signal_set;
+    sigset_t old_signal_set;
+
+    // The fork child must not be signalled until it calls exec(): our signal handlers do not
+    // handle being raised in the child process correctly
+    sigfillset(&signal_set);
+    pthread_sigmask(SIG_SETMASK, &signal_set, &old_signal_set);
+
+    if ((processId = fork()) == 0) // processId == 0 if this is child process
+    {
+
+        // It turns out that child processes depend on their sigmask being set to something sane rather than mask all.
+        // On the other hand, we have to mask all to avoid our own signal handlers running in the child process, writing
+        // to the pipe, and waking up the handling thread in the parent process. This also avoids third-party code getting
+        // equally confused.
+        // Remove all signals, then restore signal mask.
+        // Since we are in a vfork() child, the only safe signal values are SIG_DFL and SIG_IGN.  See man 3 libthr on BSD.
+        // "The implementation interposes the user-installed signal(3) handlers....to postpone signal delivery to threads
+        // which entered (libthr-internal) critical sections..."  We want to pass SIG_DFL anyway.
+        sigset_t junk_signal_set;
+        struct sigaction sa_default;
+        struct sigaction sa_old;
+        memset(&sa_default, 0, sizeof(sa_default)); // On some architectures, sa_mask is a struct so assigning zero to it doesn't compile
+        sa_default.sa_handler = SIG_DFL;
+        for (int sig = 1; sig < NSIG; ++sig)
+        {
+
+            if (sig == SIGKILL || sig == SIGSTOP)
+            {
+                continue;
+            }
+            if (!sigaction(sig, NULL, &sa_old))
+            {
+                void (*oldhandler)(int) = handler_from_sigaction (&sa_old);
+
+                if (oldhandler != SIG_IGN && oldhandler != SIG_DFL)
+                {
+                    // It has a custom handler, put the default handler back.
+                    // We check first to preserve flags on default handlers.
+                    sigaction(sig, &sa_default, NULL);
+                }
+            }
+        }
+
+        pthread_sigmask(SIG_SETMASK, &old_signal_set, &junk_signal_set); // Not all architectures allow NULL here
+
+        // Finally, execute the new process.  execve will not return if it's successful.
+        execve(processPath.c_str(), const_cast<char* const *>(argv.data()), const_cast<char* const *>(envp.data()));
+        ExitChild(waitForChildToExecPipe[WRITE_END_OF_PIPE], errno); // execve failed
+    }
+
+    // Restore signal mask in the parent process immediately after fork() or vfork() call
+
+    pthread_sigmask(SIG_SETMASK, &old_signal_set, &signal_set);
+
+    if (processId < 0)
+    {
+
+        // failed
+        success = false;
+    }
+
+    // Also close the write end of the exec waiting pipe, and wait for the pipe to be closed
+    // by trying to read from it (the read will wake up when the pipe is closed and broken).
+    // Ignore any errors... this is a best-effort attempt.
+
+    CloseIfOpen(waitForChildToExecPipe[WRITE_END_OF_PIPE]);
+    if (waitForChildToExecPipe[READ_END_OF_PIPE] != -1)
+    {
+
+        int childError;
+        if (success)
+        {
+
+            ssize_t result = ReadSize(waitForChildToExecPipe[READ_END_OF_PIPE], &childError, sizeof(childError));
+            if (result == sizeof(childError))
+            {
+                success = false;
+            }
+        }
+        CloseIfOpen(waitForChildToExecPipe[READ_END_OF_PIPE]);
+    }
+
+    // If we failed, close everything else and give back error values in all out arguments.
+    if (!success)
+    {
+        Log::Warn("SingleStepGuardRails::SendTelemetry: Error calling telemetry forwarder");
+        // Reap child
+        if (processId > 0)
+        {
+            int status;
+            waitpid(processId, &status, 0);
+        }
+    }
+
+    return success;
+}
+
+VoidIntFn ProcessHelper::handler_from_sigaction (struct sigaction *sa)
+{
+    if (((unsigned int)sa->sa_flags) & SA_SIGINFO)
+    {
+        // work around -Wcast-function-type
+        void (*tmp)(void) = (void (*)(void))sa->sa_sigaction;
+        return (void (*)(int))tmp;
+    }
+    else
+    {
+        return sa->sa_handler;
+    }
+}
+
+void ProcessHelper::CloseIfOpen(int fd)
+{
+    if (fd >= 0)
+    {
+        close(fd); // Ignoring errors from close is a deliberate choice
+    }
+}
+
+inline bool ProcessHelper::CheckInterrupted(ssize_t result)
+{
+    return result < 0 && errno == EINTR;
+}
+
+ssize_t ProcessHelper::WriteSize(int fd, const void* buffer, size_t count)
+{
+    ssize_t rv = 0;
+    while (count > 0)
+    {
+        ssize_t result = 0;
+        while (CheckInterrupted(result = write(fd, buffer, count)));
+        if (result > 0)
+        {
+            rv += result;
+            buffer = (const uint8_t*)buffer + result;
+            count -= (size_t)result;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    return rv;
+}
+
+ssize_t ProcessHelper::ReadSize(int fd, void* buffer, size_t count)
+{
+    ssize_t rv = 0;
+    while (count > 0)
+    {
+        ssize_t result = 0;
+        while (CheckInterrupted(result = read(fd, buffer, count)));
+        if (result > 0)
+        {
+            rv += result;
+            buffer = (uint8_t*)buffer + result;
+            count -= (size_t)result;
+        }
+        else
+        {
+            return -1;
+        }
+    }
+    return rv;
+}
+
+void ProcessHelper::ExitChild(int pipeToParent, int error)
+{
+    if (pipeToParent != -1)
+    {
+        WriteSize(pipeToParent, &error, sizeof(error));
+    }
+    _exit(error != 0 ? error : EXIT_FAILURE);
+}
+
+#endif
+}

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.h
@@ -1,0 +1,37 @@
+﻿#pragma once
+
+#include <string>
+#include <vector>
+#ifndef _WIN32
+#include <signal.h>
+#include <sys/types.h>
+#endif
+
+namespace datadog::shared::nativeloader
+{
+#ifndef _WIN32    
+typedef void (*VoidIntFn)(int);
+
+enum
+{
+    READ_END_OF_PIPE = 0,
+    WRITE_END_OF_PIPE = 1,
+};
+#endif
+
+class ProcessHelper
+{
+private:
+#ifndef _WIN32    
+    static VoidIntFn handler_from_sigaction (struct sigaction *sa);
+    static void CloseIfOpen(int fd);
+    static inline bool CheckInterrupted(ssize_t result);
+    static ssize_t WriteSize(int fd, const void* buffer, size_t count);
+    static ssize_t ReadSize(int fd, void* buffer, size_t count);
+    static void ExitChild(int pipeToParent, int error);
+#endif
+public:
+    static bool RunProcess(const std::string& processPath, const std::vector<std::string>& args, const std::vector<std::string>& env);
+};
+
+} // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.h
@@ -31,7 +31,7 @@ private:
     static void ExitChild(int pipeToParent, int error);
 #endif
 public:
-    static bool RunProcess(const std::string& processPath, const std::vector<std::string>& args, const std::vector<std::string>& env);
+    static bool RunProcess(const std::string& processPath, const std::vector<std::string>& args);
 };
 
 } // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -260,7 +260,7 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
         "{\\\"metadata\\\":{\\\"runtime_name\\\": \\\"" + runtimeName
         + "\\\",\\\"runtime_version\\\": \\\"" + runtimeVersion
         + "\\\",\\\"language_name\\\": \\\"dotnet\\\",\\\"language_version\\\": \\\"" + runtimeVersion
-        + "\\\",\\\"tracer_name\\\": \\\"dotnet\\\",\\\"tracer_version\\\": \\\"" + PROFILER_VERSION
+        + "\\\",\\\"tracer_version\\\": \\\"" + PROFILER_VERSION
         + "\\\",\\\"pid\\\":" + std::to_string(GetPID())
         + ",},\\\"points\\\": " + points + "}";
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -264,10 +264,6 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
         + "\\\",\\\"pid\\\":" + std::to_string(GetPID())
         + ",},\\\"points\\\": " + points + "}";
 
-
-    // We only pass through DD_TRACE_LOG_DIRECTORY for testing purposes, it's not required by the telemetry forwarder
-    const auto logDir = "DD_TRACE_LOG_DIRECTORY=" + ToString(GetEnvironmentValue(WStr("DD_TRACE_LOG_DIRECTORY")));
-    const std::vector env = {logDir};
     const auto processPath = ToString(forwarderPath);
 
 #ifdef _WIN32
@@ -279,7 +275,7 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
 #endif
 
     Log::Debug("SingleStepGuardRails::SendTelemetry: Invoking: ", processPath, " with ", args[0]);
-    const auto success = ProcessHelper::RunProcess(processPath, args, env);
+    const auto success = ProcessHelper::RunProcess(processPath, args);
     if(success)
     {
         Log::Debug("SingleStepGuardRails::SendTelemetry: Telemetry sent to forwarder");

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -266,12 +266,14 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
 
     const auto processPath = ToString(forwarderPath);
 
+    // The telemetry forwarder expects the first argument to be the execution type:
+    const std::string initialArg = "library_entrypoint";
 #ifdef _WIN32
-    const std::vector args = {metadata};
+    const std::vector args = {initialArg, metadata};
 #else
     // linux and mac require different escaping, so just regex remove the \ for now
     const auto linuxMetadata = std::regex_replace(metadata, std::regex("\\\\"), "");
-    const std::vector args = {linuxMetadata};
+    const std::vector args = {initialArg, linuxMetadata};
 #endif
 
     Log::Debug("SingleStepGuardRails::SendTelemetry: Invoking: ", processPath, " with ", args[0]);

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -1,0 +1,166 @@
+﻿#include "cor_profiler.h"
+#include "log.h"
+#include "util.h"
+#include "../../../shared/src/native-src/version.h"
+#include "EnvironmentVariables.h"
+#include "single_step_guard_rails.h"
+
+using namespace shared;
+
+namespace datadog::shared::nativeloader
+{
+SingleStepGuardRails::SingleStepGuardRails()
+{
+    // This variable is non-empty when we're in single step
+    Log::Debug("SingleStepGuardRails::CheckRuntime: Checking for Single step instrumentation environment using ",
+               EnvironmentVariables::SingleStepInstrumentationEnabled);
+    const auto isSingleStepVariable = GetEnvironmentValue(EnvironmentVariables::SingleStepInstrumentationEnabled);
+
+    m_isRunningInSingleStep = !isSingleStepVariable.empty(); 
+}
+
+SingleStepGuardRails::~SingleStepGuardRails()
+{
+}
+
+/**
+ * Check if we're running in Single Step, and if so, whether we should bail out
+ * 
+ * @param runtimeInformation 
+ * @param pICorProfilerInfoUnk 
+ * @return 
+ */
+HRESULT SingleStepGuardRails::CheckRuntime(const RuntimeInformation& runtimeInformation, IUnknown* pICorProfilerInfoUnk)
+{
+    //
+    // Check if we're running in Single Step, and if so, whether we should bail out
+    //
+    if(!m_isRunningInSingleStep)
+    {
+        // not single step, don't do anything else
+        return S_OK;
+    }
+    
+    Log::Debug("SingleStepGuardRails::CheckRuntime: Single step instrumentation detected, checking for EOL environment");
+    // We're doing single-step instrumentation, check if we're in an EOL environment
+    
+    IUnknown* tstVerProfilerInfo;
+    std::string unsupportedRuntimeVersion;
+    std::string unsupportedSummary;
+
+    if (runtimeInformation.is_core())
+    {
+        Log::Debug("SingleStepGuardRails::CheckRuntime: Running in .NET Core - checking available version");
+
+        // For .NET Core, we require .NET Core 3.1 or higher
+        // We could use runtime_information, but I don't know how reliable the values we get from that are?
+        if (S_OK == pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo11), (void**) &tstVerProfilerInfo))
+        {
+            tstVerProfilerInfo->Release();
+
+            // .NET Core 3.1+, but is it _too_ high?
+            if(runtimeInformation.major_version <= 8)
+            {
+                // supported
+                Log::Debug("SingleStepGuardRails::CheckRuntime: Supported .NET runtime version detected, continuing with single step instrumentation");
+                return S_OK;
+            }
+
+            const auto eol = ".NET 9 or higher";
+
+            const auto runtime = std::to_string(runtimeInformation.major_version) + "." +
+                                 std::to_string(runtimeInformation.minor_version) + "." +
+                                 std::to_string(runtimeInformation.build_version);
+            return HandleUnsupportedNetCoreVersion(eol, runtime);
+        }
+
+        // Unsupported EOL version, but _which_ version
+        // unfortunately we can't trust the major_version etc values here
+        const auto eol = ".NET Core 3.0 or lower";
+
+        if (S_OK == pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo10), (void**) &tstVerProfilerInfo))
+        {
+            // we can't get this exact runtime version from cor profiler unfortunately
+            tstVerProfilerInfo->Release();
+            return HandleUnsupportedNetCoreVersion(eol, "3.0.0");
+        }
+
+        if (S_OK == pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo9), (void**) &tstVerProfilerInfo))
+        {
+            // no way of detecting 2.2 from here AFAIK, so we treat 2.1 and 2.2 the same
+            tstVerProfilerInfo->Release();
+            return HandleUnsupportedNetCoreVersion(eol, "2.1.0");
+        }
+
+        // Only remaining EOL version that we can instrument is 2.0.0
+        return HandleUnsupportedNetCoreVersion(eol, "2.0.0");
+    }
+
+    // For .NET Framework, we require .NET Framework 4.6.1 or higher
+    if (S_OK == pICorProfilerInfoUnk->QueryInterface(__uuidof(ICorProfilerInfo7), (void**) &tstVerProfilerInfo))
+    {
+        // supported
+        tstVerProfilerInfo->Release();
+        Log::Debug("SingleStepGuardRails::CheckRuntime: Supported .NET Framework runtime version detected, continuing with single step instrumentation");
+        return S_OK;
+    }
+
+    return HandleUnsupportedNetFrameworkVersion(".NET Framework 4.6.0 or lower", "4.6.0");
+}
+
+HRESULT SingleStepGuardRails::HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion)
+{
+    if(ShouldForceInstrumentationOverride(unsupportedDescription))
+    {
+        return S_OK;
+    }
+
+    Log::Warn(
+        "CorProfiler::Initialize: Single-step instrumentation is not supported in '",
+        unsupportedDescription,
+        "'. Set ",
+        EnvironmentVariables::ForceEolInstrumentation,
+        "=1 to override this check and force instrumentation");
+
+    return E_FAIL;
+}
+
+HRESULT SingleStepGuardRails::HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion)
+{
+    if(ShouldForceInstrumentationOverride(unsupportedDescription))
+    {
+        return S_OK;
+    }
+
+    Log::Warn(
+        "CorProfiler::Initialize: Single-step instrumentation is not supported in '",
+        unsupportedDescription,
+        "'. Set ",
+        EnvironmentVariables::ForceEolInstrumentation,
+        "=1 to override this check and force instrumentation");
+
+    return E_FAIL;
+}
+
+bool SingleStepGuardRails::ShouldForceInstrumentationOverride(const std::string& eolDescription)
+{
+    // Are we supposed to override the EOL check?
+    const auto forceEolInstrumentationVariable = GetEnvironmentValue(EnvironmentVariables::ForceEolInstrumentation);
+
+    bool forceEolInstrumentation;
+    if (!forceEolInstrumentationVariable.empty()
+        && TryParseBooleanEnvironmentValue(forceEolInstrumentationVariable, forceEolInstrumentation)
+        && forceEolInstrumentation)
+    {
+        m_isForcedExecution = true;
+        Log::Info(
+            "CorProfiler::Initialize: Unsupported framework version '",
+            eolDescription,
+            "' detected. Forcing instrumentation with single-step instrumentation due to ",
+            EnvironmentVariables::ForceEolInstrumentation);
+        return true;
+    }
+
+    return false;
+}
+} // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -4,6 +4,7 @@
 #include "../../../shared/src/native-src/version.h"
 #include "EnvironmentVariables.h"
 #include "single_step_guard_rails.h"
+#include "process_helper.h"
 
 using namespace shared;
 
@@ -122,6 +123,7 @@ HRESULT SingleStepGuardRails::HandleUnsupportedNetCoreVersion(const std::string&
         EnvironmentVariables::ForceEolInstrumentation,
         "=1 to override this check and force instrumentation");
 
+    SendAbortTelemetry(NetCoreRuntime, runtimeVersion, MinNetCoreVersion, MaxNetCoreVersion);
     return E_FAIL;
 }
 
@@ -139,6 +141,7 @@ HRESULT SingleStepGuardRails::HandleUnsupportedNetFrameworkVersion(const std::st
         EnvironmentVariables::ForceEolInstrumentation,
         "=1 to override this check and force instrumentation");
 
+    SendAbortTelemetry(NetFrameworkRuntime, runtimeVersion, MinNetFrameworkVersion, MaxNetFrameworkVersion);
     return E_FAIL;
 }
 
@@ -162,5 +165,133 @@ bool SingleStepGuardRails::ShouldForceInstrumentationOverride(const std::string&
     }
 
     return false;
+}
+
+void SingleStepGuardRails::RecordBootstrapError(const RuntimeInformation& runtimeInformation,
+    const std::string& errorType) const
+{
+    if(!m_isRunningInSingleStep)
+    {
+        return;
+    }
+
+    const auto runtimeName = runtimeInformation.is_core() ? NetCoreRuntime : NetFrameworkRuntime;
+    const auto runtimeVersion = runtimeInformation.description();
+
+    RecordBootstrapError(runtimeName, runtimeVersion, errorType);
+}
+
+void SingleStepGuardRails::RecordBootstrapError(const std::string& runtimeName, const std::string& runtimeVersion,
+                                                const std::string& errorType) const
+{
+    if(!m_isRunningInSingleStep)
+    {
+        return;
+    }
+
+    const std::string points = "[{\\\"name\\\": \\\"library_entrypoint.error\\\", \\\"tags\\\": [\\\"error_type:"
+                              + errorType + "\\\"]}]";
+    SendTelemetry(runtimeName, runtimeVersion, points);
+}
+
+void SingleStepGuardRails::RecordBootstrapSuccess(const RuntimeInformation& runtimeInformation) const
+{
+    Log::Debug("SingleStepGuardRails::RecordBootstrapSuccess");
+    if(!m_isRunningInSingleStep)
+    {
+        Log::Debug("SingleStepGuardRails::RecordBootstrapSuccess Not running in Single Step mode");
+        return;
+    }
+
+    Log::Debug("SingleStepGuardRails::RecordBootstrapSuccess Generating telemetry");
+    const auto runtimeName = runtimeInformation.is_core() ? NetCoreRuntime : NetFrameworkRuntime;
+    const auto runtimeVersion = runtimeInformation.description();
+
+    const std::string isForced = m_isForcedExecution ? "true" : "false";
+    const std::string points = "[{\\\"name\\\": \\\"library_entrypoint.complete\\\", \\\"tags\\\": [\\\"injection_forced:"
+                              + isForced + "\\\"]}]";
+
+    SendTelemetry(runtimeName, runtimeVersion, points);
+}
+
+void SingleStepGuardRails::SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion,
+                                              const std::string& minVersion, const std::string& maxVersion) const
+{
+    if(!m_isRunningInSingleStep)
+    {
+        return;
+    }
+
+    const std::string reason = "eol_runtime";  // possible reasons [”eol_runtime”,””incompatible_runtime”, ”integration”, ”package_manager”]
+
+    const std::string abort = "{\\\"name\\\": \\\"library_entrypoint.abort\\\", \\\"tags\\\": [\\\"reason:"
+                              + reason + "\\\"]}";
+    const std::string abort_runtime =
+        "{\\\"name\\\": \\\"library_entrypoint.abort.runtime\\\", \\\"tags\\\": [\\\"min_supported_version:"
+        + minVersion + "\\\",\\\"max_supported_version:" + maxVersion + "\\\"]}";
+    
+    const std::string points = "[" + abort + "," + abort_runtime + "]";
+
+    SendTelemetry(runtimeName, runtimeVersion, points);
+}
+
+void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const std::string& runtimeVersion,
+                                         const std::string& points) const
+{
+    if(!m_isRunningInSingleStep)
+    {
+        Log::Debug("SingleStepGuardRails::SendTelemetry Not running in single step mode");
+        return;
+    }
+
+    auto forwarderPath = GetEnvironmentValue(EnvironmentVariables::SingleStepInstrumentationTelemetryForwarderPath);
+    if (forwarderPath.empty())
+    {
+        Log::Info("SingleStepGuardRails::SendTelemetry: Unable to send telemetry, ",
+                  EnvironmentVariables::SingleStepInstrumentationTelemetryForwarderPath, " is not set");
+        return;
+    }
+
+    std::error_code ec; // fs::exists might throw if no error_code parameter is provided
+    if (!fs::exists(forwarderPath, ec))
+    {
+        Log::Info("SingleStepGuardRails::SendTelemetry: Unable to send telemetry, ",
+                  EnvironmentVariables::SingleStepInstrumentationTelemetryForwarderPath, " path does not exist:",
+                  forwarderPath);
+        return;
+    }
+
+    const std::string metadata =
+        "{\\\"metadata\\\":{\\\"runtime_name\\\": \\\"" + runtimeName
+        + "\\\",\\\"runtime_version\\\": \\\"" + runtimeVersion
+        + "\\\",\\\"language_name\\\": \\\"dotnet\\\",\\\"language_version\\\": \\\"" + runtimeVersion
+        + "\\\",\\\"tracer_name\\\": \\\"dotnet\\\",\\\"tracer_version\\\": \\\"" + PROFILER_VERSION
+        + "\\\",\\\"pid\\\":" + std::to_string(GetPID())
+        + ",},\\\"points\\\": " + points + "}";
+
+
+    // We only pass through DD_TRACE_LOG_DIRECTORY for testing purposes, it's not required by the telemetry forwarder
+    const auto logDir = "DD_TRACE_LOG_DIRECTORY=" + ToString(GetEnvironmentValue(WStr("DD_TRACE_LOG_DIRECTORY")));
+    const std::vector env = {logDir};
+    const auto processPath = ToString(forwarderPath);
+
+#ifdef _WIN32
+    const std::vector args = {metadata};
+#else
+    // linux and mac require different escaping, so just regex remove the \ for now
+    const auto linuxMetadata = std::regex_replace(metadata, std::regex("\\\\"), "");
+    const std::vector args = {linuxMetadata};
+#endif
+
+    Log::Debug("SingleStepGuardRails::SendTelemetry: Invoking: ", processPath, " with ", args[0]);
+    const auto success = ProcessHelper::RunProcess(processPath, args, env);
+    if(success)
+    {
+        Log::Debug("SingleStepGuardRails::SendTelemetry: Telemetry sent to forwarder");
+    }
+    else
+    {
+        Log::Warn("SingleStepGuardRails::SendTelemetry: Error calling telemetry forwarder");
+    }
 }
 } // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
@@ -1,0 +1,30 @@
+﻿#pragma once
+#include "../../../shared/src/native-src/com_ptr.h"
+#include <string>
+#include "cor_profiler.h"
+
+namespace datadog::shared::nativeloader
+{
+class SingleStepGuardRails
+{
+private:
+    bool m_isRunningInSingleStep;
+    bool m_isForcedExecution = false;
+
+    inline static const std::string MinNetFrameworkVersion = "4.6.1";
+    inline static const std::string MaxNetFrameworkVersion = "4.8.1";
+    inline static const std::string MinNetCoreVersion = "3.1.0";
+    inline static const std::string MaxNetCoreVersion = "8.0.0";
+
+    bool ShouldForceInstrumentationOverride(const std::string& eolDescription);
+    HRESULT HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
+    HRESULT HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
+public:
+    inline static const std::string NetFrameworkRuntime = ".NET Framework";
+    inline static const std::string NetCoreRuntime = ".NET Core";
+
+    SingleStepGuardRails();
+    ~SingleStepGuardRails();
+    HRESULT CheckRuntime(const RuntimeInformation& runtimeInformation, IUnknown* pICorProfilerInfoUnk);
+};
+} // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
@@ -19,6 +19,9 @@ private:
     bool ShouldForceInstrumentationOverride(const std::string& eolDescription);
     HRESULT HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
     HRESULT HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
+
+    void SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& minVersion, const std::string& maxVersion) const;
+    void SendTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& telemetryPoints) const;
 public:
     inline static const std::string NetFrameworkRuntime = ".NET Framework";
     inline static const std::string NetCoreRuntime = ".NET Core";
@@ -26,5 +29,9 @@ public:
     SingleStepGuardRails();
     ~SingleStepGuardRails();
     HRESULT CheckRuntime(const RuntimeInformation& runtimeInformation, IUnknown* pICorProfilerInfoUnk);
+    void RecordBootstrapError(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& errorType) const;
+    void RecordBootstrapError(const RuntimeInformation& runtimeInformation, const std::string& errorType) const;
+    void RecordBootstrapSuccess(const RuntimeInformation& runtimeInformation) const;
+    
 };
 } // namespace datadog::shared::nativeloader

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -407,7 +407,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                           "points": {{pointsJson}}
                                       }
                                       """;
-            echoLogContent.Should().BeJsonEquivalentTo(expectedTelemetry);
+
+            var argTypePrefix = "library_entrypoint ";
+            echoLogContent.Should().StartWith(argTypePrefix);
+            var telemetryArgument = echoLogContent.Substring(argTypePrefix.Length);
+            telemetryArgument.Should().BeJsonEquivalentTo(expectedTelemetry);
         }
 
         private void AddFilesAsReportable(string logDir, AssertionScope scope, string[] allFiles)

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -4,11 +4,15 @@
 // </copyright>
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
+using Datadog.Trace.TestHelpers.FluentAssertionsExtensions.Json;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Xunit;
@@ -16,11 +20,14 @@ using Xunit.Abstractions;
 
 namespace Datadog.Trace.ClrProfiler.IntegrationTests
 {
-    public class InstrumentationTests : TestHelper
+    public class InstrumentationTests : TestHelper, IClassFixture<InstrumentationTests.TelemetryReporterFixture>
     {
-        public InstrumentationTests(ITestOutputHelper output)
+        private readonly TelemetryReporterFixture _fixture;
+
+        public InstrumentationTests(ITestOutputHelper output, TelemetryReporterFixture fixture)
             : base("Console", output)
         {
+            _fixture = fixture;
             SetServiceVersion("1.0.0");
         }
 
@@ -127,9 +134,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [Trait("RunOnWindows", "True")]
         public async Task InstrumentRunsOnEolFramework()
         {
-            var logDir = Path.Combine(LogDirectory, nameof(InstrumentRunsOnEolFramework));
-            Directory.CreateDirectory(logDir);
-            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+            var logDir = SetLogDirectory();
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
@@ -149,10 +154,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             // indicate we're running in auto-instrumentation, this just needs to be non-null
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
-
-            var logDir = Path.Combine(LogDirectory, nameof(DoesNotInstrumentRunsOnEolFrameworkWithSSI));
-            Directory.CreateDirectory(logDir);
-            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+            var logDir = SetLogDirectory();
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
@@ -167,10 +169,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
             // set the "run me anyway, dammit" flag
             SetEnvironmentVariable("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES", "true");
-
-            var logDir = Path.Combine(LogDirectory, nameof(InstrumentRunsOnEolFrameworkInSSIWithOverride));
-            Directory.CreateDirectory(logDir);
-            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+            var logDir = SetLogDirectory();
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
             using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
@@ -184,7 +183,140 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             allFiles.Should().Contain(filename => Path.GetFileName(filename).StartsWith("dotnet-tracer-managed-dotnet-"));
         }
 
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task OnEolFrameworkInSsi_WhenForwarderPathIsNotSet_DoesNotFailAndLogs()
+        {
+            // indicate we're running in auto-instrumentation, this just needs to be non-null
+            SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
+            // DD_TELEMETRY_FORWARDER_PATH is not set
+
+            var logDir = SetLogDirectory();
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
+            AssertNotInstrumented(agent, logDir);
+            AssertNativeLoaderLogContainsString(logDir, "SingleStepGuardRails::SendTelemetry: Unable to send telemetry, DD_TELEMETRY_FORWARDER_PATH is not set");
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task OnEolFrameworkInSsi_WhenForwarderPathDoesNotExist_DoesNotFailAndLogs()
+        {
+            // indicate we're running in auto-instrumentation, this just needs to be non-null
+            SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
+            SetEnvironmentVariable("DD_TELEMETRY_FORWARDER_PATH", "does_not_exist");
+
+            var logDir = SetLogDirectory();
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
+            AssertNotInstrumented(agent, logDir);
+            AssertNativeLoaderLogContainsString(logDir, "SingleStepGuardRails::SendTelemetry: Unable to send telemetry, DD_TELEMETRY_FORWARDER_PATH path does not exist");
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task OnEolFrameworkInSsi_WhenForwarderPathExists_CallsForwarderWithExpectedTelemetry()
+        {
+            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper);
+            Output.WriteLine("Setting forwarder to " + echoApp);
+
+            // indicate we're running in auto-instrumentation, this just needs to be non-null
+            SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
+            SetEnvironmentVariable("DD_TELEMETRY_FORWARDER_PATH", echoApp);
+
+            var logDir = SetLogDirectory();
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
+            AssertNotInstrumented(agent, logDir);
+
+            var pointsJson = """
+                             [{
+                               "name": "library_entrypoint.abort", 
+                               "tags": ["reason:eol_runtime"]
+                             },{
+                               "name": "library_entrypoint.abort.runtime",
+                               "tags": ["min_supported_version:3.1.0", "max_supported_version:8.0.0"]
+                             }]
+                             """;
+            AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
+        }
+
+        [SkippableFact]
+        [Trait("RunOnWindows", "True")]
+        public async Task OnEolFrameworkInSsi_WhenOverriden_CallsForwarderWithExpectedTelemetry()
+        {
+            var echoFilename = "received_logs.txt";
+            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper);
+            Output.WriteLine("Setting forwarder to " + echoApp);
+
+            // indicate we're running in auto-instrumentation, this just needs to be non-null
+            SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
+            SetEnvironmentVariable("DD_TELEMETRY_FORWARDER_PATH", echoApp);
+            SetEnvironmentVariable("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES", "true");
+
+            var logDir = SetLogDirectory();
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
+            agent.Spans.Should().NotBeEmpty();
+            agent.Telemetry.Should().NotBeEmpty();
+
+            var pointsJson = """
+                             [{
+                               "name": "library_entrypoint.complete", 
+                               "tags": ["injection_forced:true"]
+                             }]
+                             """;
+            AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
+        }
+
 #endif
+#if NETCOREAPP3_1_OR_GREATER
+        [SkippableTheory]
+        [Trait("RunOnWindows", "True")]
+        [InlineData("1")]
+        [InlineData("0")]
+        public async Task OnSupportedFrameworkInSsi_CallsForwarderWithExpectedTelemetry(string isOverriden)
+        {
+            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper);
+            Output.WriteLine("Setting forwarder to " + echoApp);
+
+            // indicate we're running in auto-instrumentation, this just needs to be non-null
+            SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
+            SetEnvironmentVariable("DD_TELEMETRY_FORWARDER_PATH", echoApp);
+            // this value doesn't matter, should have same result, and _shouldn't_ change the metrics
+            SetEnvironmentVariable("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES", isOverriden);
+
+            var logDir = SetLogDirectory($"_{isOverriden}");
+
+            using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
+            using var processResult = await RunSampleAndWaitForExit(agent, arguments: "traces 1");
+            agent.Spans.Should().NotBeEmpty();
+            agent.Telemetry.Should().NotBeEmpty();
+
+            var pointsJson = """
+                             [{
+                               "name": "library_entrypoint.complete", 
+                               "tags": ["injection_forced:false"]
+                             }]
+                             """;
+            AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
+        }
+#endif
+
+        /// <summary>
+        /// Should only be called _directly_ by running test, so that the testName is populated correctly
+        /// </summary>
+        private string SetLogDirectory(string suffix = "", [CallerMemberName] string testName = null)
+        {
+            var logDir = Path.Combine(LogDirectory, $"{testName}{suffix}");
+            Directory.CreateDirectory(logDir);
+            SetEnvironmentVariable(ConfigurationKeys.LogDirectory, logDir);
+            return logDir;
+        }
 
         private async Task<string> RunDotnetCommand(string workingDirectory, MockTracerAgent mockTracerAgent, string arguments)
         {
@@ -223,6 +355,62 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             mockTracerAgent.Telemetry.Should().BeEmpty();
         }
 
+        private void AssertNativeLoaderLogContainsString(string logDir, string requiredLog)
+        {
+            using var scope = new AssertionScope();
+            var allFiles = Directory.GetFiles(logDir);
+            AddFilesAsReportable(logDir, scope, allFiles);
+
+            var nativeLoaderLogFilenames = allFiles
+                                  .Where(filename => Path.GetFileName(filename).StartsWith("dotnet-native-loader-dotnet-"))
+                                  .ToList();
+            nativeLoaderLogFilenames.Should().NotBeEmpty();
+            var nativeLoaderLogFiles = nativeLoaderLogFilenames.Select(File.ReadAllText).ToList();
+            nativeLoaderLogFiles.Should().Contain(log => log.Contains(requiredLog));
+        }
+
+        private void AssertHasExpectedTelemetry(string logDir, ProcessResult processResult, string pointsJson)
+        {
+            var echoLogFileName = Path.Combine(logDir, TelemetryReporterFixture.LogFileName);
+            using var s = new AssertionScope();
+            File.Exists(echoLogFileName).Should().BeTrue();
+            var echoLogContent = File.ReadAllText(echoLogFileName);
+            s.AddReportable(echoLogFileName, echoLogContent);
+
+#if NETFRAMEWORK
+            var runtimeVersion = "4.7.2"; // best we get on the native side
+            var runtimeName = ".NET Framework";
+#else
+            var runtimeName = ".NET Core";
+#if NET5_0_OR_GREATER
+            var runtimeVersion = $"{Environment.Version.Major}.{Environment.Version.Minor}.{Environment.Version.Build}";
+#elif NETCOREAPP3_1
+            var runtimeVersion = $"3.1.0";
+#elif NETCOREAPP3_0
+            var runtimeVersion = "3.0.0";
+#elif NETCOREAPP2_1_OR_GREATER
+            var runtimeVersion = "2.1.0";
+#else
+            var runtimeVersion = "2.0.0";
+#endif
+#endif
+            var expectedTelemetry = $$"""
+                                      {
+                                          "metadata": {
+                                            "runtime_name": "{{runtimeName}}",
+                                            "runtime_version": "{{runtimeVersion}}",
+                                            "language_name": "dotnet",
+                                            "language_version": "{{runtimeVersion}}",
+                                            "tracer_name": "dotnet",
+                                            "tracer_version": "{{TracerConstants.ThreePartVersion}}",
+                                            "pid": {{processResult.Process.Id}}
+                                          },
+                                          "points": {{pointsJson}}
+                                      }
+                                      """;
+            echoLogContent.Should().BeJsonEquivalentTo(expectedTelemetry);
+        }
+
         private void AddFilesAsReportable(string logDir, AssertionScope scope, string[] allFiles)
         {
             scope.AddReportable(
@@ -239,6 +427,111 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
                     return sb.ToString();
                 });
+        }
+
+        public class TelemetryReporterFixture : IDisposable
+        {
+            public const string LogFileName = "received_logs.txt";
+            private readonly string _workingDir = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
+            private string _appPath;
+
+            public string GetAppPath(ITestOutputHelper output, EnvironmentHelper environment)
+            {
+                if (!string.IsNullOrEmpty(_appPath))
+                {
+                    return _appPath;
+                }
+
+                var publishDir = Path.Combine(_workingDir, "publish");
+                Directory.CreateDirectory(publishDir);
+                output.WriteLine("Using forwarder directory " + _workingDir);
+
+                // Create project directory, yeah this should _probably_ just be a sample, but meh
+                var program = $"""
+                               using System;
+                               using System.IO;
+                               using System.Reflection;
+
+                               var logsFolder = Environment.GetEnvironmentVariable("{ConfigurationKeys.LogDirectory}");
+                               var cmdLine = string.Join(" ", args);
+                               var path = Path.Combine(logsFolder, "{LogFileName}");
+
+                               Console.WriteLine(cmdLine);
+                               File.WriteAllText(path, cmdLine);
+                               """;
+                File.WriteAllText(Path.Combine(_workingDir, "Program.cs"), program);
+
+                var project = """
+                              <Project Sdk="Microsoft.NET.Sdk">
+                                  <PropertyGroup>
+                                      <OutputType>Exe</OutputType>
+                                      <TargetFramework>net8.0</TargetFramework>
+                                  </PropertyGroup>
+                              </Project>
+                              """;
+                File.WriteAllText(Path.Combine(_workingDir, "telemetry_echo.csproj"), project);
+
+                // publish the echo app as self contained (for "simplicity")
+                var rid = (EnvironmentTools.GetOS(), EnvironmentTools.GetPlatform(), EnvironmentHelper.IsAlpine()) switch
+                {
+                    ("win", _, _) => "win-x64",
+                    ("linux", "Arm64", _) => "linux-arm64",
+                    ("linux", "X64", false) => "linux-x64",
+                    ("linux", "X64", true) => "linux-musl-x64",
+                    ("osx", "X64", _) => "osx-x64",
+                    ("osx", "Arm64", _) => "osx-arm64",
+                    var unsupportedTarget => throw new PlatformNotSupportedException(unsupportedTarget.ToString())
+                };
+
+                var startInfo = new ProcessStartInfo(environment.GetDotnetExe(), $"publish -c Release -r {rid} --self-contained -o {publishDir}")
+                {
+                    WorkingDirectory = _workingDir,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                };
+                using var process = new ProcessHelper(Process.Start(startInfo), x => output.WriteLine(x), x => output.WriteLine(x));
+                process.Process.WaitForExit(30_000);
+                process.Drain(15_000);
+
+                var extension = EnvironmentTools.IsWindows() ? ".exe" : string.Empty;
+                _appPath = Path.Combine(publishDir, $"telemetry_echo{extension}");
+                output.WriteLine("Created forwarder at: " + _appPath);
+                File.Exists(_appPath).Should().BeTrue();
+
+                // need to chmod +x it on linux
+                if (!EnvironmentTools.IsWindows())
+                {
+                    output.WriteLine("Running chmod +x " + _appPath);
+
+                    var chmodStart = new ProcessStartInfo("chmod", $"+x {_appPath}")
+                    {
+                        WorkingDirectory = Path.GetDirectoryName(_appPath)!,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                    };
+                    using var chmodProcess = new ProcessHelper(Process.Start(chmodStart), x => output.WriteLine(x), x => output.WriteLine(x));
+                    process.Process.WaitForExit(30_000);
+                    process.Drain(15_000);
+                }
+
+                return _appPath;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    Directory.Delete(_workingDir, recursive: true);
+                }
+                catch (Exception)
+                {
+                    // swallow
+                }
+            }
         }
     }
 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -401,7 +401,6 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                             "runtime_version": "{{runtimeVersion}}",
                                             "language_name": "dotnet",
                                             "language_version": "{{runtimeVersion}}",
-                                            "tracer_name": "dotnet",
                                             "tracer_version": "{{TracerConstants.ThreePartVersion}}",
                                             "pid": {{processResult.Process.Id}}
                                           },

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -168,7 +168,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // indicate we're running in auto-instrumentation, this just needs to be non-null
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
             // set the "run me anyway, dammit" flag
-            SetEnvironmentVariable("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES", "true");
+            SetEnvironmentVariable("DD_INJECT_FORCE", "true");
             var logDir = SetLogDirectory();
 
             using var agent = EnvironmentHelper.GetMockAgent(useTelemetry: true);
@@ -255,7 +255,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             // indicate we're running in auto-instrumentation, this just needs to be non-null
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
             SetEnvironmentVariable("DD_TELEMETRY_FORWARDER_PATH", echoApp);
-            SetEnvironmentVariable("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES", "true");
+            SetEnvironmentVariable("DD_INJECT_FORCE", "true");
 
             var logDir = SetLogDirectory();
 
@@ -288,7 +288,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
             SetEnvironmentVariable("DD_TELEMETRY_FORWARDER_PATH", echoApp);
             // this value doesn't matter, should have same result, and _shouldn't_ change the metrics
-            SetEnvironmentVariable("DD_TRACE_ALLOW_UNSUPPORTED_SSI_RUNTIMES", isOverriden);
+            SetEnvironmentVariable("DD_INJECT_FORCE", isOverriden);
 
             var logDir = SetLogDirectory($"_{isOverriden}");
 


### PR DESCRIPTION
## Summary of changes

- Record the outcome of instrumentation in SSI using an available third-party process
- Add integration tests
- Update env vars in line with updated spec

## Reason for change

The SSI guard-rails spec requires sending telemetry by invoking an (injected) process and passing the JSON telemetry as command line arguments.

> The original spec changed so that we would need to send it via `stdin`, which is a bit of a pain, so going with command line. Need to add safeguards to ensure it's not too large, but will handle that in a separate PR.

This PR also refactors slightly to pull the single step work out into its own class

## Implementation details

- Create a "process helper" for starting the sub process
  - _Very_ stripped down, not intended to be "general" because that's beyond me in C++ frankly
  - Significantly different implementations for Win32 vs Linux
  - The Linux version is heavily based on [the underlying .NET implementation](https://github.com/dotnet/runtime/blob/23e15a51b8c45df8c5efbd5b80d577eaef981edb/src/native/libs/System.Native/pal_process.c#L69) for Linux, with a bunch of the signaling and pipe handling ripped out
  - This is the part I'm most unsure about and has taken the most work, so please 👀 
- Extract the SSI checks to a separate class
- The path to the telemetry executable is injected as an env var
- Added a whole bunch of integration tests for the telemetry
  - Create a self-contained "telemetry_echo" app in the integration tests, which writes whatever it receives to a file, which the tests then inspect
  - Tests the "unsupported" path, the "override" path, and the "supported" path
  - Checks we handle missing env vars etc

## Test coverage

Integration tests for the overall single step flow

## Other details

There are still some outstanding parts, which will be addressed in subsequent PRs
- [ ] Check `getconf ARG_MAX` to make sure the command line arguments support what we're trying to send

Prerequisite for single-step guard rails work stack
- https://github.com/DataDog/dd-trace-dotnet/pull/5635
- https://github.com/DataDog/dd-trace-dotnet/pull/5636
- https://github.com/DataDog/dd-trace-dotnet/pull/5637
- https://github.com/DataDog/dd-trace-dotnet/pull/5611


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
