### PR TITLE
[ASM][IAST] Add `_dd.iast.json.tag.size.exceeded` telemetry metric

### DIFF
--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Iast
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
         private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
+        // IastJsonTagSizeExceededBytes = MessagePack.Serialize("_dd.iast.json.tag.size.exceeded");
+        private static ReadOnlySpan<byte> IastJsonTagSizeExceededBytes => new byte[] { 191, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110, 46, 116, 97, 103, 46, 115, 105, 122, 101, 46, 101, 120, 99, 101, 101, 100, 101, 100 };
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
         private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
 
@@ -24,6 +26,7 @@ namespace Datadog.Trace.Iast
             return key switch
             {
                 "_dd.iast.json" => IastJson,
+                "_dd.iast.json.tag.size.exceeded" => IastJsonTagSizeExceeded,
                 "_dd.iast.enabled" => IastEnabled,
                 _ => base.GetTag(key),
             };
@@ -35,6 +38,9 @@ namespace Datadog.Trace.Iast
             {
                 case "_dd.iast.json": 
                     IastJson = value;
+                    break;
+                case "_dd.iast.json.tag.size.exceeded": 
+                    IastJsonTagSizeExceeded = value;
                     break;
                 case "_dd.iast.enabled": 
                     IastEnabled = value;
@@ -52,6 +58,11 @@ namespace Datadog.Trace.Iast
                 processor.Process(new TagItem<string>("_dd.iast.json", IastJson, IastJsonBytes));
             }
 
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.iast.json.tag.size.exceeded", IastJsonTagSizeExceeded, IastJsonTagSizeExceededBytes));
+            }
+
             if (IastEnabled is not null)
             {
                 processor.Process(new TagItem<string>("_dd.iast.enabled", IastEnabled, IastEnabledBytes));
@@ -66,6 +77,13 @@ namespace Datadog.Trace.Iast
             {
                 sb.Append("_dd.iast.json (tag):")
                   .Append(IastJson)
+                  .Append(',');
+            }
+
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                sb.Append("_dd.iast.json.tag.size.exceeded (tag):")
+                  .Append(IastJsonTagSizeExceeded)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Iast
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
         private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
+        // IastJsonTagSizeExceededBytes = MessagePack.Serialize("_dd.iast.json.tag.size.exceeded");
+        private static ReadOnlySpan<byte> IastJsonTagSizeExceededBytes => new byte[] { 191, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110, 46, 116, 97, 103, 46, 115, 105, 122, 101, 46, 101, 120, 99, 101, 101, 100, 101, 100 };
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
         private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
 
@@ -24,6 +26,7 @@ namespace Datadog.Trace.Iast
             return key switch
             {
                 "_dd.iast.json" => IastJson,
+                "_dd.iast.json.tag.size.exceeded" => IastJsonTagSizeExceeded,
                 "_dd.iast.enabled" => IastEnabled,
                 _ => base.GetTag(key),
             };
@@ -35,6 +38,9 @@ namespace Datadog.Trace.Iast
             {
                 case "_dd.iast.json": 
                     IastJson = value;
+                    break;
+                case "_dd.iast.json.tag.size.exceeded": 
+                    IastJsonTagSizeExceeded = value;
                     break;
                 case "_dd.iast.enabled": 
                     IastEnabled = value;
@@ -52,6 +58,11 @@ namespace Datadog.Trace.Iast
                 processor.Process(new TagItem<string>("_dd.iast.json", IastJson, IastJsonBytes));
             }
 
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.iast.json.tag.size.exceeded", IastJsonTagSizeExceeded, IastJsonTagSizeExceededBytes));
+            }
+
             if (IastEnabled is not null)
             {
                 processor.Process(new TagItem<string>("_dd.iast.enabled", IastEnabled, IastEnabledBytes));
@@ -66,6 +77,13 @@ namespace Datadog.Trace.Iast
             {
                 sb.Append("_dd.iast.json (tag):")
                   .Append(IastJson)
+                  .Append(',');
+            }
+
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                sb.Append("_dd.iast.json.tag.size.exceeded (tag):")
+                  .Append(IastJsonTagSizeExceeded)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Iast
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
         private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
+        // IastJsonTagSizeExceededBytes = MessagePack.Serialize("_dd.iast.json.tag.size.exceeded");
+        private static ReadOnlySpan<byte> IastJsonTagSizeExceededBytes => new byte[] { 191, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110, 46, 116, 97, 103, 46, 115, 105, 122, 101, 46, 101, 120, 99, 101, 101, 100, 101, 100 };
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
         private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
 
@@ -24,6 +26,7 @@ namespace Datadog.Trace.Iast
             return key switch
             {
                 "_dd.iast.json" => IastJson,
+                "_dd.iast.json.tag.size.exceeded" => IastJsonTagSizeExceeded,
                 "_dd.iast.enabled" => IastEnabled,
                 _ => base.GetTag(key),
             };
@@ -35,6 +38,9 @@ namespace Datadog.Trace.Iast
             {
                 case "_dd.iast.json": 
                     IastJson = value;
+                    break;
+                case "_dd.iast.json.tag.size.exceeded": 
+                    IastJsonTagSizeExceeded = value;
                     break;
                 case "_dd.iast.enabled": 
                     IastEnabled = value;
@@ -52,6 +58,11 @@ namespace Datadog.Trace.Iast
                 processor.Process(new TagItem<string>("_dd.iast.json", IastJson, IastJsonBytes));
             }
 
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.iast.json.tag.size.exceeded", IastJsonTagSizeExceeded, IastJsonTagSizeExceededBytes));
+            }
+
             if (IastEnabled is not null)
             {
                 processor.Process(new TagItem<string>("_dd.iast.enabled", IastEnabled, IastEnabledBytes));
@@ -66,6 +77,13 @@ namespace Datadog.Trace.Iast
             {
                 sb.Append("_dd.iast.json (tag):")
                   .Append(IastJson)
+                  .Append(',');
+            }
+
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                sb.Append("_dd.iast.json.tag.size.exceeded (tag):")
+                  .Append(IastJsonTagSizeExceeded)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TagListGenerator/IastTags.g.cs
@@ -16,6 +16,8 @@ namespace Datadog.Trace.Iast
     {
         // IastJsonBytes = MessagePack.Serialize("_dd.iast.json");
         private static ReadOnlySpan<byte> IastJsonBytes => new byte[] { 173, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110 };
+        // IastJsonTagSizeExceededBytes = MessagePack.Serialize("_dd.iast.json.tag.size.exceeded");
+        private static ReadOnlySpan<byte> IastJsonTagSizeExceededBytes => new byte[] { 191, 95, 100, 100, 46, 105, 97, 115, 116, 46, 106, 115, 111, 110, 46, 116, 97, 103, 46, 115, 105, 122, 101, 46, 101, 120, 99, 101, 101, 100, 101, 100 };
         // IastEnabledBytes = MessagePack.Serialize("_dd.iast.enabled");
         private static ReadOnlySpan<byte> IastEnabledBytes => new byte[] { 176, 95, 100, 100, 46, 105, 97, 115, 116, 46, 101, 110, 97, 98, 108, 101, 100 };
 
@@ -24,6 +26,7 @@ namespace Datadog.Trace.Iast
             return key switch
             {
                 "_dd.iast.json" => IastJson,
+                "_dd.iast.json.tag.size.exceeded" => IastJsonTagSizeExceeded,
                 "_dd.iast.enabled" => IastEnabled,
                 _ => base.GetTag(key),
             };
@@ -35,6 +38,9 @@ namespace Datadog.Trace.Iast
             {
                 case "_dd.iast.json": 
                     IastJson = value;
+                    break;
+                case "_dd.iast.json.tag.size.exceeded": 
+                    IastJsonTagSizeExceeded = value;
                     break;
                 case "_dd.iast.enabled": 
                     IastEnabled = value;
@@ -52,6 +58,11 @@ namespace Datadog.Trace.Iast
                 processor.Process(new TagItem<string>("_dd.iast.json", IastJson, IastJsonBytes));
             }
 
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                processor.Process(new TagItem<string>("_dd.iast.json.tag.size.exceeded", IastJsonTagSizeExceeded, IastJsonTagSizeExceededBytes));
+            }
+
             if (IastEnabled is not null)
             {
                 processor.Process(new TagItem<string>("_dd.iast.enabled", IastEnabled, IastEnabledBytes));
@@ -66,6 +77,13 @@ namespace Datadog.Trace.Iast
             {
                 sb.Append("_dd.iast.json (tag):")
                   .Append(IastJson)
+                  .Append(',');
+            }
+
+            if (IastJsonTagSizeExceeded is not null)
+            {
+                sb.Append("_dd.iast.json.tag.size.exceeded (tag):")
+                  .Append(IastJsonTagSizeExceeded)
                   .Append(',');
             }
 

--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -47,7 +47,7 @@ internal class IastRequestContext
             {
                 span.Tags.SetTag(Tags.IastJson, _vulnerabilityBatch.ToString());
 
-                if (_vulnerabilityBatch.IsTruncated)
+                if (_vulnerabilityBatch.IsTruncated())
                 {
                     span.Tags.SetTag(Tags.IastJsonTagSizeExceeded, "1");
                 }

--- a/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastRequestContext.cs
@@ -46,6 +46,11 @@ internal class IastRequestContext
             if (_vulnerabilityBatch != null)
             {
                 span.Tags.SetTag(Tags.IastJson, _vulnerabilityBatch.ToString());
+
+                if (_vulnerabilityBatch.IsTruncated)
+                {
+                    span.Tags.SetTag(Tags.IastJsonTagSizeExceeded, "1");
+                }
             }
 
             if (_executedTelemetryHelper != null)

--- a/tracer/src/Datadog.Trace/Iast/IastTags.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastTags.cs
@@ -16,6 +16,9 @@ internal partial class IastTags : CommonTags
     [Tag(Tags.IastJson)]
     public string? IastJson { get; set; }
 
+    [Tag(Tags.IastJsonTagSizeExceeded)]
+    public string? IastJsonTagSizeExceeded { get; set; }
+
     [Tag(Tags.IastEnabled)]
     public string? IastEnabled { get; set; }
 }

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
@@ -52,6 +52,8 @@ internal class VulnerabilityBatch
 
     public List<Source>? Sources { get; private set; } = null;
 
+    public bool IsTruncated { get; private set; } = false;
+
     internal static JsonSerializerSettings CreateSerializerSettings(int truncationMaxValueLength, bool redacted)
     {
         List<JsonConverter> converters = [new SourceConverter(truncationMaxValueLength), new EvidenceConverter(truncationMaxValueLength, redacted)];
@@ -131,6 +133,7 @@ internal class VulnerabilityBatch
                 if (System.Text.ASCIIEncoding.Unicode.GetByteCount(_vulnerabilitiesJson) > MaxSpanTagSize)
                 {
                     _vulnerabilitiesJson = ToTruncatedJson();
+                    IsTruncated = true;
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
+++ b/tracer/src/Datadog.Trace/Iast/VulnerabilityBatch.cs
@@ -32,6 +32,7 @@ internal class VulnerabilityBatch
     private EvidenceRedactor? _evidenceRedactor;
     private JsonSerializerSettings _serializerSettings;
     private string? _vulnerabilitiesJson;
+    private bool _isTruncated;
 
     public VulnerabilityBatch(int truncationMaxValueLength = IastSettings.TruncationMaxValueLengthDefault, EvidenceRedactor? evidenceRedactor = null)
     {
@@ -52,7 +53,7 @@ internal class VulnerabilityBatch
 
     public List<Source>? Sources { get; private set; } = null;
 
-    public bool IsTruncated { get; private set; } = false;
+    public bool IsTruncated() => _isTruncated;
 
     internal static JsonSerializerSettings CreateSerializerSettings(int truncationMaxValueLength, bool redacted)
     {
@@ -133,7 +134,7 @@ internal class VulnerabilityBatch
                 if (System.Text.ASCIIEncoding.Unicode.GetByteCount(_vulnerabilitiesJson) > MaxSpanTagSize)
                 {
                     _vulnerabilitiesJson = ToTruncatedJson();
-                    IsTruncated = true;
+                    _isTruncated = true;
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -604,6 +604,11 @@ namespace Datadog.Trace
         internal const string IastJson = "_dd.iast.json";
 
         /// <summary>
+        /// Indicates if the vulnerability json has been truncated because it exceeds the maximum tag size
+        /// </summary>
+        internal const string IastJsonTagSizeExceeded = "_dd.iast.json.tag.size.exceeded";
+
+        /// <summary>
         /// Indicates at the end of a request if IAST analisys has been performned
         /// </summary>
         internal const string IastEnabled = "_dd.iast.enabled";

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -198,8 +198,8 @@ internal enum Count
     /// </summary>
     [TelemetryMetric<RaspRuleType>("rasp.timeout", isCommon: true, NS.ASM)] RaspTimeout,
 
-    #endregion
-    #region Iast Namespace
+#endregion
+#region Iast Namespace
 
     /// <summary>
     /// Counts the number of source methods that have been called

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/AspNetCore5IastTests.cs
@@ -123,6 +123,25 @@ public class AspNetCore5IastTestsSpanTelemetryIastEnabled : AspNetCore5IastTests
                           .UseFileName(filename)
                           .DisableRequireUniquePrefix();
     }
+
+    [SkippableFact]
+    [Trait("RunOnWindows", "True")]
+    public async Task TestIastJsonTagSizeExceeded()
+    {
+        var filename = "Iast.JsonTagSizeExceeded.AspNetCore5.TelemetryEnabled";
+        var url = "/Iast/TestJsonTagSizeExceeded?tainted=taint";
+        IncludeAllHttpSpans = true;
+        await TryStartApp();
+        var agent = Fixture.Agent;
+        var spans = await SendRequestsAsync(agent, new string[] { url });
+        var spansFiltered = spans.Where(x => x.Type == SpanTypes.Web).ToList();
+
+        var settings = VerifyHelper.GetSpanVerifierSettings();
+        settings.AddIastScrubbing();
+        await VerifyHelper.VerifySpans(spansFiltered, settings)
+                          .UseFileName(filename)
+                          .DisableRequireUniquePrefix();
+    }
 }
 
 public class AspNetCore5IastTestsOneVulnerabilityPerRequestIastEnabled : AspNetCore5IastTestsVariableVulnerabilityPerRequestIastEnabled

--- a/tracer/test/snapshots/Iast.JsonTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.JsonTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
@@ -1,0 +1,433 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /iast/testjsontagsizeexceeded,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_3,
+    Tags: {
+      aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.TestJsonTagSizeExceeded (Samples.Security.AspNetCore5),
+      aspnet_core.route: iast/testjsontagsizeexceeded,
+      component: aspnet_core,
+      env: integration_tests,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.route: iast/testjsontagsizeexceeded,
+      http.status_code: 200,
+      http.url: http://localhost:00000/Iast/TestJsonTagSizeExceeded?tainted=taint,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.iast.enabled: 1,
+      _dd.iast.json:
+{
+  "vulnerabilities": [
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    },
+    {
+      "type": "COMMAND_INJECTION",
+      "evidence": {
+        "value": "MAX SIZE EXCEEDED"
+      },
+      "hash": -430498668,
+      "location": {
+        "spanId": XXX,
+        "path": "Samples.Security.AspNetCore5.Controllers.IastController",
+        "method": "ExecuteCommandInternal"
+      }
+    }
+  ]
+},
+      _dd.iast.json.tag.size.exceeded: 1
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.iast.telemetry.executed.propagation: 360.0,
+      _dd.iast.telemetry.executed.sink.command_injection: 30.0,
+      _dd.iast.telemetry.executed.sink.header_injection: 1.0,
+      _dd.iast.telemetry.executed.sink.hsts_header_missing: 1.0,
+      _dd.iast.telemetry.executed.sink.unvalidated_redirect: 1.0,
+      _dd.iast.telemetry.executed.sink.xcontenttype_header_missing: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_cookie_name: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_cookie_value: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_header: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_header_name: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_parameter: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_parameter_name: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_path: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_path_parameter: 1.0,
+      _dd.iast.telemetry.executed.source.http_request_query: 1.0,
+      _dd.iast.telemetry.request.tainted:,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: aspnet_core_mvc.request,
+    Resource: GET /iast/testjsontagsizeexceeded,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    ParentId: Id_2,
+    Tags: {
+      aspnet_core.action: testjsontagsizeexceeded,
+      aspnet_core.controller: iast,
+      aspnet_core.route: iast/testjsontagsizeexceeded,
+      component: aspnet_core,
+      env: integration_tests,
+      language: dotnet,
+      span.kind: server
+    }
+  }
+]

--- a/tracer/test/snapshots/Iast.JsonTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.JsonTagSizeExceeded.AspNetCore5.TelemetryEnabled.verified.txt
@@ -6,7 +6,6 @@
     Resource: GET /iast/testjsontagsizeexceeded,
     Service: Samples.Security.AspNetCore5,
     Type: web,
-    ParentId: Id_3,
     Tags: {
       aspnet_core.endpoint: Samples.Security.AspNetCore5.Controllers.IastController.TestJsonTagSizeExceeded (Samples.Security.AspNetCore5),
       aspnet_core.route: iast/testjsontagsizeexceeded,
@@ -414,7 +413,7 @@
   },
   {
     TraceId: Id_1,
-    SpanId: Id_4,
+    SpanId: Id_3,
     Name: aspnet_core_mvc.request,
     Resource: GET /iast/testjsontagsizeexceeded,
     Service: Samples.Security.AspNetCore5,

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Controllers/IastController.cs
@@ -960,6 +960,19 @@ namespace Samples.Security.AspNetCore5.Controllers
             ViewData["XSS"] = escapedText;
             return View("ReflectedXss");
         }
+        
+        [HttpGet("TestJsonTagSizeExceeded")]
+        [Route("TestJsonTagSizeExceeded")]
+        public IActionResult TestJsonTagSizeExceeded(string tainted)
+        {
+            // Generate manually a lot of different vulnerabilities
+            for (var i = 0; i < 30; i++)
+            {
+                ExecuteCommandInternal(i.ToString() + "-" + tainted, i.ToString() + "-" + tainted);
+            }
+            
+            return Content("TestJsonTagSizeExceeded");
+        }
 
         static string CopyStringAvoidTainting(string original)
         {


### PR DESCRIPTION
## Summary of changes

Add a new telemetry metric (`_dd.iast.json.tag.size.exceeded`) to measure how many times `_dd.iast.json` tag exceeds the max tag size.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
