### PR TITLE
[v3] Fix rebasing issue

### DIFF
--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/IntegrationIdExtensions.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/IntegrationIdExtensions.cs
@@ -80,6 +80,8 @@ internal static class IntegrationIdExtensions
             IntegrationId.NHibernate => MetricTags.IntegrationName.NHibernate,
             IntegrationId.DotnetTest => MetricTags.IntegrationName.DotnetTest,
             IntegrationId.Selenium => MetricTags.IntegrationName.Selenium,
+            IntegrationId.DirectoryListingLeak => MetricTags.IntegrationName.DirectoryListingLeak,
+            IntegrationId.SessionTimeout => MetricTags.IntegrationName.SessionTimeout,
             IntegrationId.DatadogTraceManual => MetricTags.IntegrationName.DatadogTraceManual,
             _ => throw new InvalidOperationException($"Unknown IntegrationID {integrationId}"), // dangerous, but we test it will never be called
         };

--- a/tracer/test/snapshots/OpenTracingTests.CustomServiceName.verified.txt
+++ b/tracer/test/snapshots/OpenTracingTests.CustomServiceName.verified.txt
@@ -13,7 +13,6 @@
     },
     Metrics: {
       process_id: 0,
-      _dd.agent_psr: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OpenTracingTests.MinimalSpan.verified.txt
+++ b/tracer/test/snapshots/OpenTracingTests.MinimalSpan.verified.txt
@@ -12,7 +12,6 @@
     },
     Metrics: {
       process_id: 0,
-      _dd.agent_psr: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/OpenTracingTests.Utf8Everywhere.verified.txt
+++ b/tracer/test/snapshots/OpenTracingTests.Utf8Everywhere.verified.txt
@@ -14,7 +14,6 @@
     },
     Metrics: {
       process_id: 0,
-      _dd.agent_psr: 1.0,
       _dd.top_level: 1.0,
       _dd.tracer_kr: 1.0,
       _sampling_priority_v1: 1.0

--- a/tracer/test/snapshots/Security.AspNetCore5.SecurityBlockingTemplatesHtml.__test=server.request.uri.raw_expectedStatusCode=403_url=_health-q=fun.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.SecurityBlockingTemplatesHtml.__test=server.request.uri.raw_expectedStatusCode=403_url=_health-q=fun.verified.txt
@@ -32,7 +32,6 @@
     },
     Metrics: {
       process_id: 0,
-      _dd.agent_psr: 1.0,
       _dd.appsec.enabled: 1.0,
       _dd.appsec.waf.duration: 0.0,
       _dd.appsec.waf.duration_ext: 0.0,

--- a/tracer/test/snapshots/Security.AspNetCore5.SecurityBlockingTemplatesJson.__test=server.request.uri.raw_expectedStatusCode=403_url=_Home_Privacy-q=fun.verified.txt
+++ b/tracer/test/snapshots/Security.AspNetCore5.SecurityBlockingTemplatesJson.__test=server.request.uri.raw_expectedStatusCode=403_url=_Home_Privacy-q=fun.verified.txt
@@ -31,7 +31,6 @@
     },
     Metrics: {
       process_id: 0,
-      _dd.agent_psr: 1.0,
       _dd.appsec.enabled: 1.0,
       _dd.appsec.waf.duration: 0.0,
       _dd.appsec.waf.duration_ext: 0.0,


### PR DESCRIPTION
## Summary of changes

Fix rebasing issues

## Reason for change

#5073 introduced new snapshots (for OpenTracing), but in v2 we no longer add `_dd.agent_psr: 1.0` to _all_ snapshots by default, so the tests were failing.

## Implementation details

Remove `_dd.agent_psr: 1.0` from the open tracing snapshots

## Test coverage

This is the test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
