### PR TITLE
Make _dd.parent_id a const in Trace Tags

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
+++ b/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs
@@ -64,7 +64,7 @@ namespace Datadog.Trace.Agent.MessagePack
         private readonly byte[] _versionNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Version);
 
         private readonly byte[] _originNameBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.Origin);
-        private readonly byte[] _lastParentIdBytes = StringEncoding.UTF8.GetBytes("_dd.parent_id");
+        private readonly byte[] _lastParentIdBytes = StringEncoding.UTF8.GetBytes(Trace.Tags.LastParentId);
 
         // numeric tags
         private readonly byte[] _metricsBytes = StringEncoding.UTF8.GetBytes("metrics");

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -679,6 +679,12 @@ namespace Datadog.Trace
         /// </summary>
         internal const string BaseService = "_dd.base_service";
 
+        /// <summary>
+        /// Holds the last seen Datadog span ID to be used by the backend for span reparenting
+        /// for distributed traces.
+        /// </summary>
+        internal const string LastParentId = "_dd.parent_id";
+
         internal static class User
         {
             internal const string Email = "usr.email";


### PR DESCRIPTION
## Summary of changes

Adds `LastParentId` to `Trace.Tags` to hold the value of `"_dd.parent_id"`.

## Reason for change

I didn't do this initially.

## Implementation details

- Add `LastParentId` to `Trace.Tags`
- Set it's value to `"_dd.parent_id"`

## Test coverage

Covered by existing tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
