### PR TITLE
[Crashtracking] Mark DD_* threads as suspicious

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.h
@@ -26,12 +26,13 @@ public:
     int32_t Initialize() override;
 
 private:
-    std::vector<int32_t> GetThreads() override;
+    std::vector<std::pair<int32_t, std::string>> GetThreads() override;
     std::vector<StackFrame> GetThreadFrames(int32_t tid, ResolveManagedCallstack resolveManagedCallstack, void* context) override;
     std::pair<std::string, uintptr_t> FindModule(uintptr_t ip);
     std::vector<ModuleInfo> GetModules();
     std::string GetSignalInfo(int32_t signal) override;
     std::vector<StackFrame> MergeFrames(const std::vector<StackFrame>& nativeFrames, const std::vector<StackFrame>& managedFrames);
+    std::string GetThreadName(int32_t tid);
 
     unw_addr_space_t _addressSpace;
     std::vector<ModuleInfo> _modules;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
@@ -155,9 +155,9 @@ int32_t CrashReporting::ResolveStacks(int32_t crashingThreadId, ResolveManagedCa
 
     *isSuspicious = false;
 
-    for (auto threadId : threads)
+    for (auto thread : threads)
     {
-        auto frames = GetThreadFrames(threadId, resolveCallback, context);
+        auto frames = GetThreadFrames(thread.first, resolveCallback, context);
 
         ddog_prof_Slice_StackFrame stackTrace;
 
@@ -175,9 +175,14 @@ int32_t CrashReporting::ResolveStacks(int32_t crashingThreadId, ResolveManagedCa
         {
             auto frame = frames.at(i);
 
-            if (threadId == crashingThreadId && frame.isSuspicious)
+            if (thread.first == crashingThreadId)
             {
-                *isSuspicious = true;
+                // Mark the callstack as suspicious if one of the frames is suspicious
+                // or the thread name begins with DD_
+                if (frame.isSuspicious || thread.second.rfind("DD_", 0) == 0)
+                {
+                    *isSuspicious = true;
+                }
             }
 
             strings[i] = frame.method;
@@ -206,7 +211,7 @@ int32_t CrashReporting::ResolveStacks(int32_t crashingThreadId, ResolveManagedCa
             };
         }
 
-        auto threadIdStr = std::to_string(threadId);
+        auto threadIdStr = std::to_string(thread.first);
 
         auto result = ddog_crashinfo_set_stacktrace(&_crashInfo, { threadIdStr.c_str(), threadIdStr.length() }, stackTrace);
 
@@ -218,7 +223,7 @@ int32_t CrashReporting::ResolveStacks(int32_t crashingThreadId, ResolveManagedCa
 
         successfulThreads++;
 
-        if (threadId == crashingThreadId)
+        if (thread.first == crashingThreadId)
         {
             // Setting the default stacktrace
             result = ddog_crashinfo_set_stacktrace(&_crashInfo, { nullptr, 0 }, stackTrace);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.h
@@ -98,7 +98,7 @@ protected:
     std::optional<ddog_Error> _error;
     ddog_prof_CrashInfo _crashInfo;
     void SetLastError(ddog_Error error);
-    virtual std::vector<int32_t> GetThreads() = 0;
+    virtual std::vector<std::pair<int32_t, std::string>> GetThreads() = 0;
     virtual std::vector<StackFrame> GetThreadFrames(int32_t tid, ResolveManagedCallstack resolveManagedCallstack, void* context) = 0;
     virtual std::string GetSignalInfo(int32_t signal) = 0;
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -289,6 +289,31 @@ public class CreatedumpTests : ConsoleTestHelper
     }
 
     [SkippableFact]
+    public async Task CheckThreadName()
+    {
+        // Test that threads prefixed with DD_ are marked as suspicious even if they have nothing of Datadog in the stacktrace
+
+        SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
+        using var reportFile = new TemporaryFile();
+
+        using var helper = await StartConsoleWithArgs(
+                               "crash-thread",
+                               true,
+                               [LdPreloadConfig, CrashReportConfig(reportFile)]);
+
+        await helper.Task;
+
+        using var assertionScope = new AssertionScope();
+        assertionScope.AddReportable("stdout", helper.StandardOutput);
+        assertionScope.AddReportable("stderr", helper.ErrorOutput);
+
+        helper.StandardOutput.Should().Contain(CrashReportExpectedOutput);
+
+        File.Exists(reportFile.Path).Should().BeTrue();
+    }
+
+    [SkippableFact]
     public async Task IgnoreNonDatadogCrashes()
     {
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);

--- a/tracer/test/test-applications/integrations/Samples.Console/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Console/Program.cs
@@ -26,9 +26,29 @@ namespace Samples.Console_
                 var exception = args[0] == "crash-datadog" ? (Exception)new BadImageFormatException("Expected") : new InvalidOperationException("Expected");
 
                 // Add an indirection to have a BCL type on the callstack, to properly test obfuscation
-                SynchronizationContext.SetSynchronizationContext(new DummySynchronizationContext());
-                IProgress<Exception> progress = new Progress<Exception>(DumpCallstackAndThrow);
-                progress.Report(exception);
+                void DoCrash()
+                {
+                    SynchronizationContext.SetSynchronizationContext(new DummySynchronizationContext());
+                    IProgress<Exception> progress = new Progress<Exception>(DumpCallstackAndThrow);
+                    progress.Report(exception);
+                }
+
+                if (args[0] == "crash-thread")
+                {
+                    var thread = new Thread(
+                        () =>
+                        {
+                            Thread.CurrentThread.Name = "DD_thread";
+                            DoCrash();
+                        });
+
+                    thread.Start();
+                    thread.Join();
+                }
+                else
+                {
+                    DoCrash();
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary of changes

Whenever the name of a thread starts with `DD_`, assume that we caused the crash.

## Reason for change

Stack unwinding is dodgy on Alpine, so one extra heuristic can't hurt.

## Implementation details

Reading the thread name from `/proc/<pid>/task/<tid>/comm`

## Test coverage

Added a test case to the crashtracking artifact tests.