### PR TITLE
[Profiler] Fix race condition in SocketTimeout

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
+++ b/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
@@ -23,8 +23,8 @@ namespace Samples.Computer01
 
         public SocketTimeout()
         {
-            _serverThreadTask = Task.Factory.StartNew(StartServerAsync, TaskCreationOptions.LongRunning);
             _serverReadyEvent = new ManualResetEventSlim(false);
+            _serverThreadTask = Task.Factory.StartNew(StartServerAsync, TaskCreationOptions.LongRunning);
         }
 
         private int TimeoutErrorCode { get; } = OperatingSystem.IsWindows() ? 10060 : 110;
@@ -139,7 +139,7 @@ namespace Samples.Computer01
             }
         }
 
-        private async Task StartServerAsync(object obj)
+        private void StartServerAsync(object obj)
         {
             Thread.CurrentThread.Name = "DD Socket Srv";
 
@@ -157,7 +157,7 @@ namespace Samples.Computer01
             {
                 try
                 {
-                    client = await s.AcceptAsync();
+                    client = s.AcceptAsync().GetAwaiter().GetResult();
                 }
                 catch (Exception e)
                 {

--- a/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
+++ b/profiler/src/Demos/Samples.Computer01/SocketTimeout.cs
@@ -24,7 +24,7 @@ namespace Samples.Computer01
         public SocketTimeout()
         {
             _serverReadyEvent = new ManualResetEventSlim(false);
-            _serverThreadTask = Task.Factory.StartNew(StartServerAsync, TaskCreationOptions.LongRunning);
+            _serverThreadTask = Task.Factory.StartNew(StartServer, TaskCreationOptions.LongRunning);
         }
 
         private int TimeoutErrorCode { get; } = OperatingSystem.IsWindows() ? 10060 : 110;
@@ -139,7 +139,7 @@ namespace Samples.Computer01
             }
         }
 
-        private void StartServerAsync(object obj)
+        private void StartServer(object obj)
         {
             Thread.CurrentThread.Name = "DD Socket Srv";
 


### PR DESCRIPTION
## Summary of changes

Fix a race condition in SocketTimeout that was causing the test to randomly hang.

## Reason for change

Flaky test.

## Implementation details

The task was started before `_serverReadyEvent` was assigned, even though `StartServerAsync` reads the `_serverReadyEvent` field. This randomly caused a NullReferenceException.

Also made the method synchronous, otherwise there is no point in changing the thread name.
