### PR TITLE
[v3] Small bug fixes 

### DIFF
--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -97,6 +97,7 @@ Also note that the implementation types from all public APIs have changed. For e
 Several settings have changed their default values:
 - `DD_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED` now defaults to `true`. This setting provides a better experience in the majority of cases.
 - `DD_TRACE_WCF_WEB_HTTP_RESOURCE_NAMES_ENABLED` now defaults to `true`. This setting provides a better experience in the majority of cases.
+- `DD_TRACE_SAMPLING_RULES_FORMAT` now defaults to `glob` instead of `regex`. This setting is consistent with other language client libraries. 
 
 #### What action should you take?
 We recommend using the new settings if possible. If this is not possible, you can manually change the value for each setting to it's previous value, for example: `DD_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED=false`

--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -22,7 +22,6 @@ src/Datadog.Trace/ReadOnlySpanContext.cs
 src/Datadog.Trace/Scope.cs
 src/Datadog.Trace/Scope.IScope.cs
 src/Datadog.Trace/Span.cs
-src/Datadog.Trace/Span.ISpan.cs
 src/Datadog.Trace/SpanContext.cs
 src/Datadog.Trace/SpanExtensions.Core.cs
 src/Datadog.Trace/SpanExtensions.cs

--- a/tracer/src/Datadog.Trace.Manual/Stubs/NullSpan.cs
+++ b/tracer/src/Datadog.Trace.Manual/Stubs/NullSpan.cs
@@ -13,19 +13,19 @@ internal class NullSpan : ISpan
     {
     }
 
-    public string OperationName
+    public string? OperationName
     {
         get => string.Empty;
         set { }
     }
 
-    public string ResourceName
+    public string? ResourceName
     {
         get => string.Empty;
         set { }
     }
 
-    public string Type
+    public string? Type
     {
         get => string.Empty;
         set { }
@@ -37,7 +37,7 @@ internal class NullSpan : ISpan
         set { }
     }
 
-    public string ServiceName
+    public string? ServiceName
     {
         get => string.Empty;
         set { }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/GetActiveScopeIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Tracer/GetActiveScopeIntegration.cs
@@ -35,8 +35,6 @@ public class GetActiveScopeIntegration
         var tracer = (Datadog.Trace.Tracer)instance.AutomaticTracer;
         var scope = tracer.ActiveScope;
 
-        // The manual instrumentation returns null by default, so can re-use the return value here
-        // (Not ideal for clarity, but generics prevent returning null directly)
-        return new CallTargetReturn<TReturn>(state.Scope.DuckCast<TReturn>());
+        return new CallTargetReturn<TReturn>(scope.DuckCast<TReturn>());
     }
 }

--- a/tracer/src/Datadog.Trace/ISpan.cs
+++ b/tracer/src/Datadog.Trace/ISpan.cs
@@ -20,19 +20,19 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets or sets operation name
         /// </summary>
-        string OperationName { get; set; }
+        string? OperationName { get; set; }
 
         /// <summary>
         /// Gets or sets the resource name
         /// </summary>
-        string ResourceName { get; set; }
+        string? ResourceName { get; set; }
 
         /// <summary>
         /// Gets or sets the type of request this span represents (ex: web, db).
         /// Not to be confused with span kind.
         /// </summary>
         /// <seealso cref="SpanTypes"/>
-        string Type { get; set; }
+        string? Type { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this span represents an error
@@ -42,7 +42,7 @@ namespace Datadog.Trace
         /// <summary>
         /// Gets or sets the service name.
         /// </summary>
-        string ServiceName { get; set; }
+        string? ServiceName { get; set; }
 
         /// <summary>
         /// Gets the lower 64 bits of the trace's unique 128-bit identifier.

--- a/tracer/src/Datadog.Trace/Span.ISpan.cs
+++ b/tracer/src/Datadog.Trace/Span.ISpan.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 
 namespace Datadog.Trace
@@ -16,21 +18,21 @@ namespace Datadog.Trace
     internal partial class Span : ISpan
     {
         /// <inheritdoc />
-        string ISpan.OperationName
+        string? ISpan.OperationName
         {
             get => OperationName;
             set => OperationName = value;
         }
 
         /// <inheritdoc />
-        string ISpan.ResourceName
+        string? ISpan.ResourceName
         {
             get => ResourceName;
             set => ResourceName = value;
         }
 
         /// <inheritdoc />
-        string ISpan.Type
+        string? ISpan.Type
         {
             get => Type;
             set => Type = value;
@@ -44,7 +46,7 @@ namespace Datadog.Trace
         }
 
         /// <inheritdoc />
-        string ISpan.ServiceName
+        string? ISpan.ServiceName
         {
             get => ServiceName;
             set => ServiceName = value;
@@ -61,7 +63,7 @@ namespace Datadog.Trace
         ISpanContext ISpan.Context => Context;
 
         /// <inheritdoc />
-        ISpan ISpan.SetTag(string key, string value) => SetTag(key, value);
+        ISpan ISpan.SetTag(string key, string? value) => SetTag(key, value);
 
         /// <inheritdoc />
         void ISpan.Finish() => Finish();

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/VersionConflict/AspNetVersionConflictTests.cs
@@ -32,7 +32,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.VersionConflict
             _iisFixture.ShutdownPath = "/home/shutdown";
         }
 
-        [SkippableFact(Skip = "FIXME: THIS IS CURRENTLY BROKEN IN THE 3.0 version bump")]
+        [SkippableFact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.Manual.PublicApiHasNotChanged.verified.txt
@@ -324,12 +324,12 @@ namespace Datadog.Trace
     {
         Datadog.Trace.ISpanContext Context { get; }
         bool Error { get; set; }
-        string OperationName { get; set; }
-        string ResourceName { get; set; }
-        string ServiceName { get; set; }
+        string? OperationName { get; set; }
+        string? ResourceName { get; set; }
+        string? ServiceName { get; set; }
         ulong SpanId { get; }
         ulong TraceId { get; }
-        string Type { get; set; }
+        string? Type { get; set; }
         void Finish();
         void Finish(System.DateTimeOffset finishTimestamp);
         string? GetTag(string key);

--- a/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Snapshots/PublicApiTests.Datadog.Trace.PublicApiHasNotChanged.verified.txt
@@ -387,12 +387,12 @@ namespace Datadog.Trace
     {
         Datadog.Trace.ISpanContext Context { get; }
         bool Error { get; set; }
-        string OperationName { get; set; }
-        string ResourceName { get; set; }
-        string ServiceName { get; set; }
+        string? OperationName { get; set; }
+        string? ResourceName { get; set; }
+        string? ServiceName { get; set; }
         ulong SpanId { get; }
         ulong TraceId { get; }
-        string Type { get; set; }
+        string? Type { get; set; }
         void Finish();
         void Finish(System.DateTimeOffset finishTimestamp);
         string? GetTag(string key);

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Controllers/HomeController.cs
@@ -12,7 +12,7 @@ namespace Samples.AspNet.VersionConflict.Controllers
 {
     public class HomeController : Controller
     {
-        private static readonly Version _manualTracingVersion = new Version("2.255.0.0");
+        private static readonly Version _manualTracingVersion = new Version("2.41.0.0");
 
         public ActionResult Index()
         {
@@ -130,7 +130,7 @@ namespace Samples.AspNet.VersionConflict.Controllers
         private static IDisposable StartAutomaticTrace(string operationName)
         {
             // Get the Datadog.Trace.Tracer type from the automatic instrumentation assembly
-            Assembly automaticAssembly = AppDomain.CurrentDomain.GetAssemblies().Single(asm => asm.GetName().Name.Equals("Datadog.Trace") && asm.GetName().Version < _manualTracingVersion);
+            Assembly automaticAssembly = AppDomain.CurrentDomain.GetAssemblies().Single(asm => asm.GetName().Name.Equals("Datadog.Trace") && asm.GetName().Version > _manualTracingVersion);
             Type tracerType = automaticAssembly.GetType("Datadog.Trace.Tracer");
 
             // Invoke 'Tracer.Instance'

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/Samples.AspNet.VersionConflict.csproj
@@ -27,8 +27,8 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Datadog.Trace, Version=2.255.246.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.255.246\lib\net461\Datadog.Trace.dll</HintPath>
+    <Reference Include="Datadog.Trace, Version=2.41.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\..\packages\Datadog.Trace.2.41.0\lib\net461\Datadog.Trace.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\packages\EntityFramework.6.2.0\lib\net45\EntityFramework.dll</HintPath>

--- a/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
+++ b/tracer/test/test-applications/aspnet/Samples.AspNet.VersionConflict/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Datadog.Trace" version="2.255.246" targetFramework="net461" />
+  <package id="Datadog.Trace" version="2.41.0" targetFramework="net461" />
   <package id="EntityFramework" version="6.2.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net45" />


### PR DESCRIPTION
## Summary of changes

Some fixes for issues I noticed when reviewing https://github.com/DataDog/dd-trace-dotnet/pull/5408

## Reason for change

Discovered these issues for things we need to fix

## Implementation details

- Fixes a bug in the `GetActiveScope` instrumentation
- Update migration doc with details of `DD_TRACE_SAMPLING_RULES_FORMAT` breaking change
- Make `OperationName`, `ResourceName`, `ServiceName`, and `Type` nullable on `ISpan`
  - This one is potentially controversial, as they probably _shouldn't_ be nullable, but the reality is they _could_ have `null` set on them/be uninitialized so I think it makes sense?
- Reenable and adapt the `AspNetVersionConflictTests`
  - Previously it was trying to load a tracer version that's _lower_ than the manual (2.x) version as the automatic tracer, but as automatic tracer is 3.x, that doesn't work.
  - Now it knows the automatic version is _higher_ than the manual version, so fetches like that. Otherwise it's the same

## Test coverage

Added tests for the `GetActiveScope` integration bug (and some additional currently-untested paths) and confirmed the test would have caught it

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->