### PR TITLE
Exclude vsdbg from tracing

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/util.h
@@ -27,6 +27,8 @@ const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace.exe"),
     WStr("aspnet_state.exe"),
     WStr("sqlservr.exe"),
+    WStr("vsdbg"),
+    WStr("vsdbg.exe"),
 };
 
 inline static const ::shared::WSTRING datadog_logs_folder_path = WStr(R"(Datadog .NET Tracer\logs)");

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -69,6 +69,8 @@ const shared::WSTRING default_exclude_assemblies[]{
     WStr("dd-trace.exe"),
     WStr("aspnet_state.exe"),
     WStr("sqlservr.exe"),
+    WStr("vsdbg"),
+    WStr("vsdbg.exe"),
 };
 
 const shared::WSTRING skip_traceattribute_assembly_prefixes[]{


### PR DESCRIPTION
## Summary of changes

Add `vsdbg` to the profiling exclude list

## Reason for change

`vsdbg` is a .NET process used by Visual Studio for debugging purposes. In a container you have:

```
    transport
VS  ---------> vsdbg -> app
```

If a customer enables the .NET client library in their dockerfile ([as in this sample repo](https://github.com/cshaw-dmg/DatadogTraceBug)), then we add tracing both to their app _and_ vsdbg. This causes `vsdbg` to fail to initialize with an error: `Failed to initialize dispatcher with error 80131534`. 

It's not useful for customers to instrument the `vsdbg` process anyway, so adding it to the exclude list is the best solution here.

## Implementation details

Added to the exclude list

## Test coverage

Manually tested that setting `DD_PROFILER_EXCLUDE_PROCESSES=vsdbg` in the dockerfile resolves the issue

## Other details
Fixes #5655

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
