### PR TITLE
Add `RawContentType` and `HasMimeType()` methods to `IApiResponse` abstraction

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
@@ -25,6 +25,8 @@ namespace Datadog.Trace.Agent.Transports
 
         public long ContentLength => _response.ContentLength;
 
+        public string RawContentType => _response.ContentType;
+
         public Encoding ContentEncoding { get; }
 
         public string GetHeader(string headerName) => _response.Headers[headerName];
@@ -38,5 +40,7 @@ namespace Datadog.Trace.Agent.Transports
         {
             _response?.Dispose();
         }
+
+        public bool HasMimeType(string mimeType) => ApiResponseExtensions.HasMimeType(RawContentType, mimeType);
     }
 }

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #if NETCOREAPP
+using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -27,6 +28,8 @@ namespace Datadog.Trace.Agent.Transports
         public int StatusCode => (int)_response.StatusCode;
 
         public long ContentLength => _response.Content.Headers.ContentLength ?? -1;
+
+        public string RawContentType => _response.Content.Headers.ContentType?.ToString();
 
         public Encoding ContentEncoding { get; }
 
@@ -59,6 +62,9 @@ namespace Datadog.Trace.Agent.Transports
         {
             return _response.Content.ReadAsStreamAsync();
         }
+
+        public bool HasMimeType(string mimeType)
+            => string.Equals(_response.Content.Headers.ContentType?.MediaType, mimeType, StringComparison.OrdinalIgnoreCase);
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
@@ -29,6 +29,8 @@ namespace Datadog.Trace.Agent.Transports
 
         public Encoding ContentEncoding { get; }
 
+        public string RawContentType => _headers.GetValue("Content-Type");
+
         public Stream ResponseStream { get; }
 
         public void Dispose()
@@ -41,5 +43,7 @@ namespace Datadog.Trace.Agent.Transports
         {
             return Task.FromResult(ResponseStream);
         }
+
+        public bool HasMimeType(string mimeType) => ApiResponseExtensions.HasMimeType(RawContentType, mimeType);
     }
 }

--- a/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiResponse.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/TransportHelpers/TestApiResponse.cs
@@ -19,10 +19,10 @@ internal class TestApiResponse : IApiResponse
     {
         StatusCode = statusCode;
         _body = body;
-        ContentType = contentType;
+        RawContentType = contentType;
     }
 
-    public string ContentType { get; }
+    public string RawContentType { get; }
 
     public int StatusCode { get; }
 
@@ -40,6 +40,8 @@ internal class TestApiResponse : IApiResponse
     {
         return Task.FromResult((Stream)new MemoryStream(ContentEncoding.GetBytes(_body)));
     }
+
+    public bool HasMimeType(string mimeType) => ApiResponseExtensions.HasMimeType(RawContentType, mimeType);
 
     public Task<string> ReadAsStringAsync() => Task.FromResult(_body);
 }

--- a/tracer/test/Datadog.Trace.Tests/Agent/ApiResponseExtensionsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/ApiResponseExtensionsTests.cs
@@ -1,0 +1,55 @@
+﻿// <copyright file="ApiResponseExtensionsTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using Datadog.Trace.Agent;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Agent;
+
+public class ApiResponseExtensionsTests
+{
+    public static TheoryData<string, string, bool> Data => new()
+    {
+        { "text/plain", "text/plain", true },
+        { " text/plain  ", "text/plain", true },
+        { " text/plain;", "text/plain", true },
+        { " text/plain ;", "text/plain", true },
+        { "text/plain ;", "text/plain", true },
+        { "text/plain;", "text/plain", true },
+        { "text/plain; charset=utf8", "text/plain", true },
+        { "text/plain; charset=utf8;boundary=fdsygyh", "text/plain", true },
+        { "text/plain ; charset=utf8; boundary=fdsygyh", "text/plain", true },
+        { " text/plain ; charset=utf8; boundary=fdsygyh", "text/plain", true },
+        { "application/json", "application/json", true },
+        { "text/html", "text/html", true },
+        { "text/htmlx", "text/html", false },
+        { "text/htmlx;", "text/html", false },
+        { "pretext/html;", "text/html", false },
+        { "pretext/html", "text/html", false },
+        { "pre text/html", "text/html", false },
+        { "text/ html", "text/html", false },
+        { string.Empty, "text/plain", false },
+        { null, "text/plain", false },
+    };
+
+    [Theory]
+    [MemberData(nameof(Data))]
+    public void HasMimeType_ReturnsExpectedValues(string rawContentType, string mimeType, bool expectedValue)
+    {
+        ApiResponseExtensions.HasMimeType(rawContentType, mimeType).Should().Be(expectedValue);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void HasMimeType_ThrowsForNullMimeType(string mimeType)
+    {
+        FluentActions.Invoking(() => ApiResponseExtensions.HasMimeType("application/json", mimeType))
+                     .Should()
+                     .ThrowExactly<ArgumentNullException>();
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Logging/DirectSubmission/Sink/LogsApiTests.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Tests.Logging.DirectSubmission.Sink
             {
                 request.Responses.Should()
                        .ContainSingle()
-                       .And.OnlyContain(x => x.ContentType == "application/json");
+                       .And.OnlyContain(x => x.HasMimeType("application/json"));
             }
         }
 

--- a/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
+++ b/tracer/test/benchmarks/Benchmarks.Trace/AgentWriterBenchmark.cs
@@ -149,12 +149,16 @@ namespace Benchmarks.Trace
 
             public Encoding ContentEncoding => Encoding.UTF8;
 
+            public string RawContentType => "application/json";
+
             public string GetHeader(string headerName) => string.Empty;
 
             public Task<Stream> GetStreamAsync()
             {
                 throw new NotImplementedException();
             }
+
+            public bool HasMimeType(string mimeType) => ApiResponseExtensions.HasMimeType(RawContentType, mimeType);
 
             public Task<string> ReadAsStringAsync()
             {


### PR DESCRIPTION
## Summary of changes

Adds a helper for checking if the response has a given `content-type`

## Reason for change

In some code paths (e.g. https://github.com/DataDog/dd-trace-dotnet/pull/5652) we need to know the content-type of the response. Unfortunately, there's _currently_ no way to do this across all our abstractions.

This is because some implementations (e.g. `HttpClient`) don't add "well-known" headers (like `Content-Type`) to the headers collection. Instead, you have to access them directly from the property.

We also need to account for the fact that [the `Content-Type` header can contain multiple parts](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type) (e.g. `text/html; charset=utf-8`) when checking the mime-type of a response.

## Implementation details

Added `RawContentType` and `HasMime()` to `IApiResponse`. I called it "raw" to make it clear that it contains the full content-type header with charset etc, so you shouldn't "naively" use it for comparisons.

Added a basic helper method for extracting the mime-type from a content-type header, and used it in most implementations. For `HttpClient`, the content-type header is already explicitly parsed, so we can just return the value directly.

## Test coverage

Added a bunch of unit tests for the extension. Haven't tested their usage in the implementations in this PR, but they're implicitly tested in https://github.com/DataDog/dd-trace-dotnet/pull/5652 so I think that's fine

## Other details

Dependency for:
- https://github.com/DataDog/dd-trace-dotnet/pull/5652

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
