### PR TITLE
[ASM] Capture exception to avoid errors

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Framework.cs
@@ -240,7 +240,15 @@ internal readonly partial struct SecurityCoordinator
             // key could be null, but it's not a valid key in a dictionary
             // Using [] instead of Add to avoid potential duplicate key
             // but it does mean there's a (tiny) chance of overwriting the key
-            formData[key ?? string.Empty] = _httpTransport.Context.Request.Form[key];
+            try
+            {
+                formData[key ?? string.Empty] = _httpTransport.Context.Request.Form[key];
+            }
+            catch (HttpRequestValidationException)
+            {
+                // We cannot retrieve the value of Form[key] because it triggers a validation exception,
+                // which happens when a dangerous value is detected in the request and validation is enabled.
+            }
         }
 
         return formData;


### PR DESCRIPTION
## Summary of changes

This PR fix this error:
System.Web.HttpRequestValidationException
at System.Web.HttpRequest.ValidateString(String value, String collectionKey, RequestValidationSource requestCollection)
at System.Web.HttpValueCollection.EnsureKeyValidated(String key)
at System.Web.HttpValueCollection.GetValues(String name)
at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.GetBasicRequestArgsForWaf()
at Datadog.Trace.AspNet.TracingHttpModule.OnEndRequest(Object sender, EventArgs eventArgs)

This error happens when a dangerous value is retrieved from the request and validation is enabled. The idea is to get some protection from XSS and similar attacks.

We should capture this exception and continue.

## Reason for change

It was throwing an exception that was causing an error.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
