### PR TITLE
[ASM] Fix Null reference exception error

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
+++ b/tracer/src/Datadog.Trace/AppSec/ObjectExtractor.cs
@@ -9,6 +9,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Reflection.Emit;
 using Datadog.Trace.AppSec.Waf;
@@ -56,12 +57,21 @@ namespace Datadog.Trace.AppSec
 
         private static IReadOnlyDictionary<string, object?> ExtractProperties(object body, int depth, HashSet<object> visited)
         {
-            if (visited.Contains(body))
+            try
             {
+                if (visited.Contains(body))
+                {
+                    return EmptyDictionary;
+                }
+
+                visited.Add(body);
+            }
+            catch
+            {
+                // Contains and Add call GetHashCode which can throw an exception if has a custom implementation
+                // If visited is empty, we could potentially get the exception only when calling Add
                 return EmptyDictionary;
             }
-
-            visited.Add(body);
 
             if (Log.IsEnabled(LogEventLevel.Debug))
             {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ObjectExtractorTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ObjectExtractorTests.cs
@@ -391,6 +391,15 @@ namespace Datadog.Trace.Security.Unit.Tests
             Assert.Empty(result);
         }
 
+        [Fact]
+        public void TestNullValues()
+        {
+            TestObject testObject = new TestObject();
+            testObject.Test = new();
+            var result = ObjectExtractor.Extract(testObject);
+            result.Should().NotBeNull();
+        }
+
         private static void PopulateNestedTarget(TestNestedPropertiesPoco target, int count)
         {
             var current = target;
@@ -533,5 +542,17 @@ namespace Datadog.Trace.Security.Unit.Tests
     public class TestNestedDictionaryPoco
     {
         public Dictionary<string, TestNestedDictionaryPoco> TestDictionary { get; set; } = new Dictionary<string, TestNestedDictionaryPoco>();
+    }
+
+    public class TestObject
+    {
+        public TestObject Test { get; set; }
+
+        public object Prop { get; set; }
+
+        public override int GetHashCode()
+        {
+            return Test.GetHashCode() + Prop.GetHashCode();
+        }
     }
 }


### PR DESCRIPTION
## Summary of changes

This PR fixes some NullReferenceException Error seen in production.

These are two different stacks that had the error:

System.NullReferenceException
at REDACTED
at System.Collections.Generic.ObjectEqualityComparer`1.GetHashCode(T obj)
at System.Collections.Generic.HashSet`1.InternalGetHashCode(T item)
at System.Collections.Generic.HashSet`1.AddIfNotPresent(T value)
at Datadog.Trace.AppSec.ObjectExtractor.ExtractProperties(Object body, Int32 depth, HashSet`1 visited)
at Datadog.Trace.AppSec.ObjectExtractor.ExtractListOrArray(Object value, Int32 depth, HashSet`1 visited)
at Datadog.Trace.AppSec.ObjectExtractor.ExtractDictionary(Object value, Type dictType, Int32 depth, HashSet`1 visited)
at Datadog.Trace.AppSec.ControllerContextExtensions.MonitorBodyAndPathParams(IControllerContext controllerContext, IDictionary`2 parameters, String peekScopeKey)

System.NullReferenceException
at REDACTED
at System.Collections.Generic.ObjectEqualityComparer`1.GetHashCode(T obj)
at System.Collections.Generic.HashSet`1.InternalGetHashCode(T item)
at System.Collections.Generic.HashSet`1.Contains(T item)
at Datadog.Trace.AppSec.ObjectExtractor.ExtractProperties(Object body, Int32 depth, HashSet`1 visited)
at Datadog.Trace.AppSec.ObjectExtractor.ExtractType(Type itemType, Object value, Int32 depth, HashSet`1 visited)

If we take a look at the library code, we can see this:

ObjectEqualityComparer`1.GetHashCode has this code:
    public override int GetHashCode(T obj)
    {
        return obj?.GetHashCode() ?? 0;
    }

Sending null values as a body in the method ExtractProperties does not launch any exception. 

While we cannot see it because the stack is redacted, it looks like the exception is thrown in a custom implementation of GetHashCode(). The error is pretty persistent and have seen several times, so it makes sense to protect the method ExtractProperties against this particular case.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
