### PR TITLE
Don't allocate very large buffers when deserializing responses

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/IApiResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiResponse.cs
@@ -26,6 +26,8 @@ namespace Datadog.Trace.Agent
 
     internal static class ApiResponseExtensions
     {
+        private const int DefaultBufferSize = 1024;
+
         public static async Task<string> ReadAsStringAsync(this IApiResponse apiResponse)
         {
             using var reader = await GetStreamReader(apiResponse).ConfigureAwait(false);
@@ -44,7 +46,7 @@ namespace Datadog.Trace.Agent
             var stream = await apiResponse.GetStreamAsync().ConfigureAwait(false);
             // Server may not send the content length, in that case we use a default value.
             // https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/IO/StreamReader.cs,25
-            var length = apiResponse.ContentLength > 0 ? (int)apiResponse.ContentLength : 1024;
+            var length = apiResponse.ContentLength is > 0 and < DefaultBufferSize ? (int)apiResponse.ContentLength : DefaultBufferSize;
             return new StreamReader(stream, apiResponse.ContentEncoding, detectEncodingFromByteOrderMarks: false, length, leaveOpen: true);
         }
 


### PR DESCRIPTION
## Summary of changes

Limit the buffer size we allocate when deserializing requests

## Reason for change

Currently we're creating a buffer the same size as the whole request, which defeats the purpose of using a `StreamReader` and `JsonTextReader`.

## Implementation details

If the content-length > 1024, use 1024

## Test coverage

As long as the tests all still pass, I'm happy

## Other details

Will do more of a follow up to allow peaking the buffer later

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
