### PR TITLE
Handle `NullReferenceException` in EF6

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -247,7 +247,6 @@ src/Datadog.Trace/Util/ArrayBuilder.cs
 src/Datadog.Trace/Util/ArraySlice.cs
 src/Datadog.Trace/Util/AsyncUtil.cs
 src/Datadog.Trace/Util/Clock.cs
-src/Datadog.Trace/Util/DbCommandCache.cs
 src/Datadog.Trace/Util/DomainMetadata.cs
 src/Datadog.Trace/Util/FnvHash64.cs
 src/Datadog.Trace/Util/IClock.cs
@@ -459,7 +458,6 @@ src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteReaderWit
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarAsyncIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarIntegration.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/CommandExecuteScalarWithBehaviorIntegration.cs
-src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbType.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/IAdoNetClientData.cs
 src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Aerospike/AerospikeCommon.cs

--- a/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -19,12 +21,12 @@ namespace Datadog.Trace.Util
 
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(DbCommandCache));
 
-        private static ConcurrentDictionary<string, TagsCacheItem> _cache = new();
+        private static ConcurrentDictionary<string, TagsCacheItem>? _cache = new();
 
         /// <summary>
         /// Gets or sets the underlying cache, to be used for unit tests
         /// </summary>
-        internal static ConcurrentDictionary<string, TagsCacheItem> Cache
+        internal static ConcurrentDictionary<string, TagsCacheItem>? Cache
         {
             get
             {
@@ -39,7 +41,7 @@ namespace Datadog.Trace.Util
 
         public static TagsCacheItem GetTagsFromDbCommand(IDbCommand command)
         {
-            string connectionString = null;
+            string? connectionString = null;
             try
             {
                 if (command.GetType().FullName == "System.Data.Common.DbDataSource.DbCommandWrapper")
@@ -104,11 +106,11 @@ namespace Datadog.Trace.Util
                 outHost: GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"));
         }
 
-        private static string GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)
+        private static string? GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)
         {
             foreach (string name in names)
             {
-                if (builder.TryGetValue(name, out object valueObj) &&
+                if (builder.TryGetValue(name, out var valueObj) &&
                     valueObj is string value)
                 {
                     return value;
@@ -120,11 +122,11 @@ namespace Datadog.Trace.Util
 
         internal readonly struct TagsCacheItem
         {
-            public readonly string DbName;
-            public readonly string DbUser;
-            public readonly string OutHost;
+            public readonly string? DbName;
+            public readonly string? DbUser;
+            public readonly string? OutHost;
 
-            public TagsCacheItem(string dbName, string dbUser, string outHost)
+            public TagsCacheItem(string? dbName, string? dbUser, string? outHost)
             {
                 DbName = dbName;
                 DbUser = dbUser;


### PR DESCRIPTION
## Summary of changes

- Add some nullability checks
- Try to handle errors from derived `IDbCommand` implementations
- Fix bug in handling EF6 `InterceptableDbCommand`

## Reason for change

Identified errors in telemetry. Eventually isolated to a fix for some very bad behaviour we were doing when used with EF 6. We specifically don't want to create a span for the `InterceptableDbCommand` and `ProfiledDbCommand` types, so we were returning `null` from `DbScopeFactory.TryGetIntegrationDetails()`. 

However:
- The `DbScopeFactory.Cache<T>()`calls `TryGetIntegrationDetails()` in the ctor
- That returns `false`, so we don't cache any values (i.e. `DbType` and `OperationName` are `null`)
- When we call `Cache.CreateDbCommandScope()` the condition `commandType == CommandType` is true, so we still try to use the "cached" values (even though they're `null`)
- Later we try to use `DbTypeName` but it's `null` and 💥 

So we _don't_ create a span for it, but we do that by throwing a `NullReferenceException` 😅

## Implementation details

Because `IDbCommand` can be overridden and implemented by customers, we can't rely on them following nullability expectations properly.

The main possible source of the error is `command.CommandText` which _should_ be none-null, but might not be, so catching that.

This also generally adds `#nullable enable` and splits the try-catch so we can discern differences in errors between creating the span and propagating the dbm.


## Test coverage

Covered by existing tests (thankfully)

## Other details


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
