### PR TITLE
[Profiler] Add heap size metrics (gen2, loh and poh)

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -161,6 +161,28 @@ struct GCHeapStatsV1Payload
     uint16_t ClrInstanceID;
 };
 
+struct GCHeapStatsV2Payload
+{
+    uint64_t GenerationSize0;
+    uint64_t TotalPromotedSize0;
+    uint64_t GenerationSize1;
+    uint64_t TotalPromotedSize1;
+    uint64_t GenerationSize2;
+    uint64_t TotalPromotedSize2;
+    uint64_t GenerationSize3;
+    uint64_t TotalPromotedSize3;
+    uint64_t FinalizationPromotedSize;
+    uint64_t FinalizationPromotedCount;
+    uint32_t PinnedObjectCount;
+    uint32_t SinkBlockCount;
+    uint32_t GCHandleCount;
+    uint16_t ClrInstanceID;
+
+    // for POH
+    uint64_t GenerationSize4;
+    uint64_t TotalPromotedSize4;
+};
+
 struct GCGlobalHeapPayload
 {
     uint64_t FinalYoungestDesired;
@@ -185,8 +207,12 @@ struct GCDetails
     uint64_t PauseDuration;
     uint64_t StartTimestamp;
 
+    uint64_t gen2Size;
+    uint64_t lohSize;
+    uint64_t pohSize;
+
     // GlobalHeapHistory and HeapStats events are not received in the same order
-    // between Framewrok and CoreCLR. So we need to keep track of what has been received
+    // between Framework and CoreCLR. So we need to keep track of what has been received
     bool HasGlobalHeapHistoryBeenReceived;
     bool HasHeapStatsBeenReceived;
 };
@@ -233,7 +259,7 @@ private:
     void OnGCEnd(GCEndPayload& payload);
     void OnGCSuspendEEBegin(uint64_t timestamp);
     void OnGCRestartEEEnd(uint64_t timestamp);
-    void OnGCHeapStats(uint64_t timestamp);
+    void OnGCHeapStats(uint64_t timestamp, uint64_t gen2Size, uint64_t lohSize, uint64_t pohSize);
     void OnGCGlobalHeapHistory(uint64_t timestamp, GCGlobalHeapPayload& payload);
     void NotifySuspension(uint64_t timestamp, uint32_t number, uint32_t generation, uint64_t duration);
     void NotifyGarbageCollectionStarted(uint64_t timestamp, int32_t number, uint32_t generation, GCReason reason, GCType type);
@@ -246,7 +272,10 @@ private:
         bool isCompacting,
         uint64_t pauseDuration,
         uint64_t totalDuration,
-        uint64_t endTimestamp
+        uint64_t endTimestamp,
+        uint64_t gen2Size,
+        uint64_t lohSize,
+        uint64_t pohSize
         );
     GCDetails& GetCurrentGC();
     void InitializeGC(uint64_t timestamp, GCDetails& gc, GCStartPayload& payload);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/GarbageCollectionProvider.h
@@ -10,6 +10,7 @@
 #include "MetricsRegistry.h"
 #include "CounterMetric.h"
 #include "MeanMaxMetric.h"
+#include "ProxyMetric.h"
 
 #include "shared/src/native-src/dd_memory_resource.hpp"
 
@@ -47,8 +48,10 @@ public:
         bool isCompacting,
         uint64_t pauseDuration,
         uint64_t totalDuration, // from start to end (includes pauses)
-        uint64_t endTimestamp   // end of GC
-        ) override;
+        uint64_t endTimestamp,   // end of GC
+        uint64_t gen2Size,
+        uint64_t lohSize,
+        uint64_t pohSize) override;
 
 private:
     std::shared_ptr<CounterMetric> _gen0CountMetric;
@@ -58,4 +61,12 @@ private:
     std::shared_ptr<CounterMetric> _inducedCountMetric;
     std::shared_ptr<CounterMetric> _compactingGen2CountMetric;
     std::shared_ptr<CounterMetric> _memoryPressureCountMetric;
+    std::shared_ptr<ProxyMetric> _gen2SizeMetric;
+    std::shared_ptr<ProxyMetric> _lohSizeMetric;
+    std::shared_ptr<ProxyMetric> _pohSizeMetric;
+
+    uint64_t _gen2Size;
+    uint64_t _lohSize;
+    uint64_t _pohSize;
+
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IGarbageCollectionsListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IGarbageCollectionsListener.h
@@ -26,8 +26,10 @@ public:
         bool isCompacting,
         uint64_t pauseDuration,
         uint64_t totalDuration, // from start to end (includes pauses)
-        uint64_t endTimestamp   // end of GC
-        ) = 0;
+        uint64_t endTimestamp,  // end of GC
+        uint64_t gen2Size,
+        uint64_t lohSize,
+        uint64_t pohSize) = 0;
 
     virtual ~IGarbageCollectionsListener() = default;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.cpp
@@ -80,7 +80,10 @@ void LiveObjectsProvider::OnGarbageCollectionEnd(
     bool isCompacting,
     uint64_t pauseDuration,
     uint64_t totalDuration,
-    uint64_t endTimestamp)
+    uint64_t endTimestamp,
+    uint64_t gen2Size,
+    uint64_t lohSize,
+    uint64_t pohSize)
 {
     std::lock_guard<std::mutex> lock(_liveObjectsLock);
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/LiveObjectsProvider.h
@@ -67,7 +67,10 @@ public:
         bool isCompacting,
         uint64_t pauseDuration,
         uint64_t totalDuration,
-        uint64_t endTimestamp) override;
+        uint64_t endTimestamp,
+        uint64_t gen2Size,
+        uint64_t lohSize,
+        uint64_t pohSize) override;
 
 private:
     ObjectHandleID CreateWeakHandle(uintptr_t address) const;


### PR DESCRIPTION
## Summary of changes
Add heap size metrics for gen2, loh and poh

## Reason for change
This will help to diagnoze memory leaks

## Implementation details
Extract these details from the GCHeapStats event

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
