### PR TITLE
Single-step guard rails: Use stdin instead of args to invoke telemetry

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
@@ -45,7 +45,7 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
     SECURITY_ATTRIBUTES sa;
 
     sa.nLength = sizeof(SECURITY_ATTRIBUTES);
-    sa.bInheritHandle = TRUE;
+    sa.bInheritHandle = FALSE;
     sa.lpSecurityDescriptor = NULL;
 
     HANDLE hStdinRead, hStdinWrite;
@@ -58,7 +58,7 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
     }
 
     // Ensure the write handle to the pipe for STDIN is not inherited.
-    if (!SetHandleInformation(hStdinWrite, HANDLE_FLAG_INHERIT, 0)) {
+    if (!SetHandleInformation(hStdinRead, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT)) {
         Log::Warn("ProcessHelper::RunProcess: Failed to set handle information");
         CloseHandle(hStdinRead);
         CloseHandle(hStdinWrite);

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
@@ -100,7 +100,6 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
     int read_fd = pipefd[0];
     int write_fd = pipefd[1];
 
-    bool success = true;
     pid_t processId = fork();
 
     if (processId == 0)
@@ -144,7 +143,7 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
     int status;
     waitpid(processId, &status, 0);
 
-    return success;
+    return true;
 }
 
 #endif

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
@@ -19,16 +19,18 @@ using namespace shared;
 namespace datadog::shared::nativeloader
 {
 /**
- * Start a process, in a "fire and forget" way, sending arguments.
- * No attempt is made to connect to the process, establish a pipe, or anything else.
+ * Start a process, send the input, and wait for it to exit.
  * @param processPath The path of the process to execute
  * @param args The additional arguments (if any) to send
+ * @param The data to send through stdin
  * @return true if the process was invoked successfully, false otherwise
  */
 bool ProcessHelper::RunProcess(const std::string& processPath,
-                               const std::vector<std::string>& args)
+                               const std::vector<std::string>& args,
+                               std::string input)
 {
 #if _WIN32
+    /*
     // For windows we combine the processPath and args into a single, space separated, string
     // and pass null for the application name
     // We assume that all the required escaping has been done etc
@@ -75,6 +77,7 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
         return true;
     }
 
+     */
     // Error starting
     return false;
 }
@@ -87,187 +90,61 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
     }
     argv.push_back(nullptr);
 
-    // Largely blindly copied from the .NET runtime code
-    // and then deleted stuff I didn't _think_ we needed for this basic scenario :blindfold:
-    // https://github.com/dotnet/runtime/blob/f4c9264fe8448fdf1f66eda04a582cbade40cd39/src/native/libs/System.Native/pal_process.c#L212
+    int pipefd[2];
+    if (pipe(pipefd) == -1)
+    {
+        Log::Warn("SingleStepGuardRails::SendTelemetry: Failed to initialize the pipe");
+        return false;
+    }
+
+    int read_fd = pipefd[0];
+    int write_fd = pipefd[1];
 
     bool success = true;
-    int waitForChildToExecPipe[2] = {-1, -1};
-    pid_t processId = -1;
-    sigset_t signal_set;
-    sigset_t old_signal_set;
+    pid_t processId = fork();
 
-    // The fork child must not be signalled until it calls exec(): our signal handlers do not
-    // handle being raised in the child process correctly
-    sigfillset(&signal_set);
-    pthread_sigmask(SIG_SETMASK, &signal_set, &old_signal_set);
-
-    if ((processId = fork()) == 0) // processId == 0 if this is child process
+    if (processId == 0)
     {
+        // Child process
 
-        // It turns out that child processes depend on their sigmask being set to something sane rather than mask all.
-        // On the other hand, we have to mask all to avoid our own signal handlers running in the child process, writing
-        // to the pipe, and waking up the handling thread in the parent process. This also avoids third-party code getting
-        // equally confused.
-        // Remove all signals, then restore signal mask.
-        // Since we are in a vfork() child, the only safe signal values are SIG_DFL and SIG_IGN.  See man 3 libthr on BSD.
-        // "The implementation interposes the user-installed signal(3) handlers....to postpone signal delivery to threads
-        // which entered (libthr-internal) critical sections..."  We want to pass SIG_DFL anyway.
-        sigset_t junk_signal_set;
-        struct sigaction sa_default;
-        struct sigaction sa_old;
-        memset(&sa_default, 0, sizeof(sa_default)); // On some architectures, sa_mask is a struct so assigning zero to it doesn't compile
-        sa_default.sa_handler = SIG_DFL;
-        for (int sig = 1; sig < NSIG; ++sig)
+        close(write_fd); // The child process doesn't need to write
+
+        // Redirect stdin to the read end of the pipe
+        if (dup2(read_fd, STDIN_FILENO) == -1)
         {
-
-            if (sig == SIGKILL || sig == SIGSTOP)
-            {
-                continue;
-            }
-            if (!sigaction(sig, NULL, &sa_old))
-            {
-                void (*oldhandler)(int) = handler_from_sigaction (&sa_old);
-
-                if (oldhandler != SIG_IGN && oldhandler != SIG_DFL)
-                {
-                    // It has a custom handler, put the default handler back.
-                    // We check first to preserve flags on default handlers.
-                    sigaction(sig, &sa_default, NULL);
-                }
-            }
+            _exit(EXIT_FAILURE);
         }
 
-        pthread_sigmask(SIG_SETMASK, &old_signal_set, &junk_signal_set); // Not all architectures allow NULL here
+        close (read_fd); // Close the original read end of the pipe
 
-        // Finally, execute the new process.  execve will not return if it's successful.
-        execve(processPath.c_str(), const_cast<char* const *>(argv.data()), environ);
-        ExitChild(waitForChildToExecPipe[WRITE_END_OF_PIPE], errno); // execve failed
+        // Spawn the executable
+        int error = execve(processPath.c_str(), const_cast<char* const *>(argv.data()), environ);
+
+        // execve should take over the execution.
+        // If we get here, it means execve failed, so we tear down the process.
+        _exit(error != 0 ? error : EXIT_FAILURE);
     }
 
-    // Restore signal mask in the parent process immediately after fork() or vfork() call
+    // This part is only executed by the parent process
 
-    pthread_sigmask(SIG_SETMASK, &old_signal_set, &signal_set);
-
-    if (processId < 0)
+    if (processId > 0)
     {
+        close(read_fd); // The parent process doesn't need to read
 
-        // failed
-        success = false;
-    }
-
-    // Also close the write end of the exec waiting pipe, and wait for the pipe to be closed
-    // by trying to read from it (the read will wake up when the pipe is closed and broken).
-    // Ignore any errors... this is a best-effort attempt.
-
-    CloseIfOpen(waitForChildToExecPipe[WRITE_END_OF_PIPE]);
-    if (waitForChildToExecPipe[READ_END_OF_PIPE] != -1)
-    {
-
-        int childError;
-        if (success)
-        {
-
-            ssize_t result = ReadSize(waitForChildToExecPipe[READ_END_OF_PIPE], &childError, sizeof(childError));
-            if (result == sizeof(childError))
-            {
-                success = false;
-            }
-        }
-        CloseIfOpen(waitForChildToExecPipe[READ_END_OF_PIPE]);
-    }
-
-    // If we failed, close everything else and give back error values in all out arguments.
-    if (!success)
-    {
-        Log::Warn("SingleStepGuardRails::SendTelemetry: Error calling telemetry forwarder");
-        // Reap child
-        if (processId > 0)
-        {
-            int status;
-            waitpid(processId, &status, 0);
-        }
-    }
-
-    return success;
-}
-
-VoidIntFn ProcessHelper::handler_from_sigaction (struct sigaction *sa)
-{
-    if (((unsigned int)sa->sa_flags) & SA_SIGINFO)
-    {
-        // work around -Wcast-function-type
-        void (*tmp)(void) = (void (*)(void))sa->sa_sigaction;
-        return (void (*)(int))tmp;
+        write(write_fd, input.data(), input.length());
+        close(write_fd);
     }
     else
     {
-        return sa->sa_handler;
+        Log::Warn("SingleStepGuardRails::SendTelemetry: Error calling telemetry forwarder");
     }
-}
 
-void ProcessHelper::CloseIfOpen(int fd)
-{
-    if (fd >= 0)
-    {
-        close(fd); // Ignoring errors from close is a deliberate choice
-    }
-}
+    // .NET sets a handler for the SIGCHLD signal and ignores the processes it didn't start,
+    // so we have to call waitpid to avoid creating a zombie process
+    int status;
+    waitpid(processId, &status, 0);
 
-inline bool ProcessHelper::CheckInterrupted(ssize_t result)
-{
-    return result < 0 && errno == EINTR;
-}
-
-ssize_t ProcessHelper::WriteSize(int fd, const void* buffer, size_t count)
-{
-    ssize_t rv = 0;
-    while (count > 0)
-    {
-        ssize_t result = 0;
-        while (CheckInterrupted(result = write(fd, buffer, count)));
-        if (result > 0)
-        {
-            rv += result;
-            buffer = (const uint8_t*)buffer + result;
-            count -= (size_t)result;
-        }
-        else
-        {
-            return -1;
-        }
-    }
-    return rv;
-}
-
-ssize_t ProcessHelper::ReadSize(int fd, void* buffer, size_t count)
-{
-    ssize_t rv = 0;
-    while (count > 0)
-    {
-        ssize_t result = 0;
-        while (CheckInterrupted(result = read(fd, buffer, count)));
-        if (result > 0)
-        {
-            rv += result;
-            buffer = (uint8_t*)buffer + result;
-            count -= (size_t)result;
-        }
-        else
-        {
-            return -1;
-        }
-    }
-    return rv;
-}
-
-void ProcessHelper::ExitChild(int pipeToParent, int error)
-{
-    if (pipeToParent != -1)
-    {
-        WriteSize(pipeToParent, &error, sizeof(error));
-    }
-    _exit(error != 0 ? error : EXIT_FAILURE);
+    return success;
 }
 
 #endif

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
@@ -93,7 +93,7 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
     int pipefd[2];
     if (pipe(pipefd) == -1)
     {
-        Log::Warn("SingleStepGuardRails::SendTelemetry: Failed to initialize the pipe");
+        Log::Warn("ProcessHelper::RunProcess: Failed to initialize the pipe");
         return false;
     }
 
@@ -135,7 +135,8 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
     }
     else
     {
-        Log::Warn("SingleStepGuardRails::SendTelemetry: Error calling telemetry forwarder");
+        Log::Warn("ProcessHelper::RunProcess: Error starting ", processPath);
+        return false;
     }
 
     // .NET sets a handler for the SIGCHLD signal and ignores the processes it didn't start,

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.cpp
@@ -104,15 +104,13 @@ bool ProcessHelper::RunProcess(const std::string& processPath,
         return false;
     }    
 
-    // we don't need to wait for it to finish, so just free-up resources 
-    CloseHandle(pi.hProcess);
-    CloseHandle(pi.hThread);
-
     DWORD written;
     WriteFile(hStdinWrite, input.c_str(), input.length(), &written, nullptr);
 
     CloseHandle(hStdinRead);
     CloseHandle(hStdinWrite);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
 
     return true;
 }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/process_helper.h
@@ -31,7 +31,7 @@ private:
     static void ExitChild(int pipeToParent, int error);
 #endif
 public:
-    static bool RunProcess(const std::string& processPath, const std::vector<std::string>& args);
+    static bool RunProcess(const std::string& processPath, const std::vector<std::string>& args, std::string input);
 };
 
 } // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -268,15 +268,19 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
     const std::vector args = {initialArg};
 
     Log::Debug("SingleStepGuardRails::SendTelemetry: Invoking: ", processPath, " with ", initialArg, "and metadata " , metadata);
-    const auto success = ProcessHelper::RunProcess(processPath, args, metadata);
 
-    if(success)
+    std::thread([processPath, args, metadata]()
     {
-        Log::Debug("SingleStepGuardRails::SendTelemetry: Telemetry sent to forwarder");
-    }
-    else
-    {
-        Log::Warn("SingleStepGuardRails::SendTelemetry: Error calling telemetry forwarder");
-    }
+        const auto success = ProcessHelper::RunProcess(processPath, args, metadata);
+
+        if (success)
+        {
+            Log::Debug("SingleStepGuardRails::SendTelemetry: Telemetry sent to forwarder");
+        }
+        else
+        {
+            Log::Warn("SingleStepGuardRails::SendTelemetry: Error calling telemetry forwarder");
+        }
+    }).detach();
 }
 } // namespace datadog::shared::nativeloader

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InstrumentationTests.cs" company="Datadog">
+// <copyright file="InstrumentationTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -240,7 +240,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                "name": "library_entrypoint.abort.runtime"
                              }]
                              """;
-            AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
+            await AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
         }
 
         [SkippableFact]
@@ -268,7 +268,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                "tags": ["injection_forced:true"]
                              }]
                              """;
-            AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
+            await AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
         }
 
 #endif
@@ -301,7 +301,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                "tags": ["injection_forced:false"]
                              }]
                              """;
-            AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
+            await AssertHasExpectedTelemetry(logDir, processResult, pointsJson);
         }
 #endif
 
@@ -367,10 +367,18 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             nativeLoaderLogFiles.Should().Contain(log => log.Contains(requiredLog));
         }
 
-        private void AssertHasExpectedTelemetry(string logDir, ProcessResult processResult, string pointsJson)
+        private async Task AssertHasExpectedTelemetry(string logDir, ProcessResult processResult, string pointsJson)
         {
             var echoLogFileName = Path.Combine(logDir, TelemetryReporterFixture.LogFileName);
             using var s = new AssertionScope();
+
+            var start = DateTime.UtcNow;
+
+            while (!File.Exists(echoLogFileName) && (DateTime.UtcNow - start) < TimeSpan.FromMinutes(1))
+            {
+                await Task.Delay(500);
+            }
+
             File.Exists(echoLogFileName).Should().BeTrue();
             var echoLogContent = File.ReadAllText(echoLogFileName);
             s.AddReportable(echoLogFileName, echoLogContent);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -451,14 +451,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var program = $"""
                                using System;
                                using System.IO;
+                               using System.Text;
                                using System.Reflection;
 
                                var logsFolder = Environment.GetEnvironmentVariable("{ConfigurationKeys.LogDirectory}");
-                               var cmdLine = string.Join(" ", args);
+
+                               var sb = new StringBuilder();
+                               sb.Append(string.Join(" ", args));
+                               sb.Append(" ");
+
+                               string line;
+                               while ((line = Console.In.ReadLine()) != null)
+                                   sb.AppendLine(line);
+
+                               var data = sb.ToString();
+
                                var path = Path.Combine(logsFolder, "{LogFileName}");
 
-                               Console.WriteLine(cmdLine);
-                               File.WriteAllText(path, cmdLine);
+                               Console.WriteLine(data);
+                               File.WriteAllText(path, data);
                                """;
                 File.WriteAllText(Path.Combine(_workingDir, "Program.cs"), program);
 

--- a/tracer/test/test-applications/integrations/Samples.Console/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.Console/Program.cs
@@ -54,6 +54,19 @@ namespace Samples.Console_
             {
                 AsyncMain(args).GetAwaiter().GetResult();
             }
+
+            var fileToWatch = Environment.GetEnvironmentVariable("DD_INTERNAL_TEST_FILE_TO_WATCH");
+
+            if (fileToWatch != null)
+            {
+                // Wait for up to 1 minute for the file to be created
+                var start = DateTime.UtcNow;
+
+                while (!File.Exists(fileToWatch) && (DateTime.UtcNow - start) < TimeSpan.FromMinutes(1))
+                {
+                    Thread.Sleep(500);
+                }
+            }
         }
 
         // Can't use a "real" async Main because it messes up the callstack for the crash-report tests


### PR DESCRIPTION
## Summary of changes

Use stdin instead of command-line args to invoke the telemetry process.
Also, simplify the Linux implementation.

## Reason for change

Using arguments to pass arbitrary data is scary.

## Implementation details

Greatly simplified the Linux implementation after investigating what is actually needed when forking a process.
Because Linux requires to call `waitpid` (otherwise the zombie process is not freed), I moved the code to a background thread.

## Test coverage

Updated the existing tests.