### PR TITLE
[SSI] Fix some of the single step injection forwarder code

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -244,7 +244,7 @@ namespace datadog::shared::nativeloader
         {
             Log::Warn("CorProfiler::Initialize: Failed to attach profiler, interface ICorProfilerInfo4 not found.");
             // we're not recording the exact version here, we just know that at this point it's not enough
-            single_step_guard_rails.RecordBootstrapError(single_step_guard_rails.NetFrameworkRuntime, inferredVersion, "incompatible_runtime");
+            single_step_guard_rails.RecordBootstrapError(SingleStepGuardRails::NetFrameworkRuntime, inferredVersion, "incompatible_runtime");
             return E_FAIL;
         }
         const auto runtimeInformation = GetRuntimeVersion(info4, inferredVersion);

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -116,7 +116,7 @@ HRESULT SingleStepGuardRails::HandleUnsupportedNetCoreVersion(const std::string&
         return S_OK;
     }
 
-    SendAbortTelemetry(NetCoreRuntime, runtimeVersion, MinNetCoreVersion, MaxNetCoreVersion);
+    SendAbortTelemetry(NetCoreRuntime, runtimeVersion);
     return E_FAIL;
 }
 
@@ -127,7 +127,7 @@ HRESULT SingleStepGuardRails::HandleUnsupportedNetFrameworkVersion(const std::st
         return S_OK;
     }
 
-    SendAbortTelemetry(NetFrameworkRuntime, runtimeVersion, MinNetFrameworkVersion, MaxNetFrameworkVersion);
+    SendAbortTelemetry(NetFrameworkRuntime, runtimeVersion);
     return E_FAIL;
 }
 
@@ -209,8 +209,7 @@ void SingleStepGuardRails::RecordBootstrapSuccess(const RuntimeInformation& runt
     SendTelemetry(runtimeName, runtimeVersion, points);
 }
 
-void SingleStepGuardRails::SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion,
-                                              const std::string& minVersion, const std::string& maxVersion) const
+void SingleStepGuardRails::SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion) const
 {
     if(!m_isRunningInSingleStep)
     {
@@ -221,9 +220,7 @@ void SingleStepGuardRails::SendAbortTelemetry(const std::string& runtimeName, co
 
     const std::string abort = "{\\\"name\\\": \\\"library_entrypoint.abort\\\", \\\"tags\\\": [\\\"reason:"
                               + reason + "\\\"]}";
-    const std::string abort_runtime =
-        "{\\\"name\\\": \\\"library_entrypoint.abort.runtime\\\", \\\"tags\\\": [\\\"min_supported_version:"
-        + minVersion + "\\\",\\\"max_supported_version:" + maxVersion + "\\\"]}";
+    const std::string abort_runtime = "{\\\"name\\\": \\\"library_entrypoint.abort.runtime\\\"}";
     
     const std::string points = "[" + abort + "," + abort_runtime + "]";
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -273,7 +273,7 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
     const std::vector args = {initialArg, linuxMetadata};
 #endif
 
-    Log::Debug("SingleStepGuardRails::SendTelemetry: Invoking: ", processPath, " with ", args[0]);
+    Log::Debug("SingleStepGuardRails::SendTelemetry: Invoking: ", processPath, " with ", initialArg, "and metadata " , args[1]);
     const auto success = ProcessHelper::RunProcess(processPath, args);
     if(success)
     {

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -259,7 +259,7 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
         + "\\\",\\\"language_name\\\": \\\"dotnet\\\",\\\"language_version\\\": \\\"" + runtimeVersion
         + "\\\",\\\"tracer_version\\\": \\\"" + PROFILER_VERSION
         + "\\\",\\\"pid\\\":" + std::to_string(GetPID())
-        + ",},\\\"points\\\": " + points + "}";
+        + "},\\\"points\\\": " + points + "}";
 
     const auto processPath = ToString(forwarderPath);
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
@@ -11,16 +11,11 @@ private:
     bool m_isRunningInSingleStep;
     bool m_isForcedExecution = false;
 
-    inline static const std::string MinNetFrameworkVersion = "4.6.1";
-    inline static const std::string MaxNetFrameworkVersion = "4.8.1";
-    inline static const std::string MinNetCoreVersion = "3.1.0";
-    inline static const std::string MaxNetCoreVersion = "8.0.0";
-
     bool ShouldForceInstrumentationOverride(const std::string& eolDescription);
     HRESULT HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
     HRESULT HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
 
-    void SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& minVersion, const std::string& maxVersion) const;
+    void SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion) const;
     void SendTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& telemetryPoints) const;
 public:
     inline static const std::string NetFrameworkRuntime = ".NET Framework";

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
@@ -12,10 +12,10 @@ private:
     bool m_isForcedExecution = false;
 
     bool ShouldForceInstrumentationOverride(const std::string& eolDescription);
-    HRESULT HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
-    HRESULT HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion);
+    HRESULT HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion, const bool isEol);
+    HRESULT HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion, const bool isEol);
 
-    void SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion) const;
+    void SendAbortTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const bool isEol) const;
     void SendTelemetry(const std::string& runtimeName, const std::string& runtimeVersion, const std::string& telemetryPoints) const;
 public:
     inline static const std::string NetFrameworkRuntime = ".NET Framework";

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -237,8 +237,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                "name": "library_entrypoint.abort", 
                                "tags": ["reason:eol_runtime"]
                              },{
-                               "name": "library_entrypoint.abort.runtime",
-                               "tags": ["min_supported_version:3.1.0", "max_supported_version:8.0.0"]
+                               "name": "library_entrypoint.abort.runtime"
                              }]
                              """;
             AssertHasExpectedTelemetry(logDir, processResult, pointsJson);


### PR DESCRIPTION
## Summary of changes

- Removes tags that we shouldn't be sending
- Conditionally send `incompatible_runtime` vs `eol_runtime`

## Reason for change

The extra tags mean the metrics are rejected

## Implementation details

`incompatible_runtime` >= .NET 9
`eol_runtime`  <=.NET Core 3.0 

## Test coverage

Covered by existing

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
