### PR TITLE
Remap `http.response.status_code` regardless of type

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -315,8 +315,14 @@ namespace Datadog.Trace.Activity
                 return;
             }
 
-            // remap keys as needed regardless of datatype
-            if (key == "http.response.status_code")
+            // remap the http.response.status_code if it is some int-like type
+            if (key == "http.response.status_code" && (
+                value is short ||
+                value is ushort ||
+                value is int ||
+                value is uint ||
+                value is long ||
+                value is ulong))
             {
                 span.SetTag(Tags.HttpStatusCode, value.ToString());
                 return;

--- a/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
+++ b/tracer/src/Datadog.Trace/Activity/OtlpHelpers.cs
@@ -315,6 +315,13 @@ namespace Datadog.Trace.Activity
                 return;
             }
 
+            // remap keys as needed regardless of datatype
+            if (key == "http.response.status_code")
+            {
+                span.SetTag(Tags.HttpStatusCode, value.ToString());
+                return;
+            }
+
             switch (value)
             {
                 case char c:
@@ -338,17 +345,8 @@ namespace Datadog.Trace.Activity
                 case ushort us:
                     span.SetMetric(key, us);
                     break;
-                case int i: // TODO: Can't get here from OTEL API, test with Activity API
-                    // special case where we need to remap "http.response.status_code"
-                    if (key == "http.response.status_code")
-                    {
-                        span.SetTag(Tags.HttpStatusCode, i.ToString(CultureInfo.InvariantCulture));
-                    }
-                    else
-                    {
-                        span.SetMetric(key, i);
-                    }
-
+                case int i:
+                    span.SetMetric(key, i);
                     break;
                 case uint ui:
                     span.SetMetric(key, ui);


### PR DESCRIPTION
## Summary of changes

Remap `http.response.status_code` regardless of type

## Reason for change

Only remapping if it was an `int` type, but we want to cover more possible data types

## Implementation details

Moved out of `int` type block and just runs on the `object`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
