### PR TITLE
Enforce not referencing Datadog.Trace directly in sample projects

### DIFF
--- a/tracer/test/test-applications/Directory.Build.props
+++ b/tracer/test/test-applications/Directory.Build.props
@@ -50,5 +50,13 @@
     </Otherwise>
   </Choose>
 
+  <!-- Ensure that we don't reference Datadog.Trace directly (unless explicitly handled) -->
+  <!-- Note that you need to ensure the buid logic is updated to exclude the project if you take this approach -->
+  <Target Name="ValidateDisallowedReferences" BeforeTargets="CoreCompile">
+    <Error
+      Condition="'%(ProjectReference.FileName)' == 'Datadog.Trace' AND '$(AllowDatadogTraceReference)' != 'true'"
+      Text="You should not directly reference Datadog.Trace in this project" />
+  </Target>
+
   <Import Project=".\Samples.Shared\Samples.Shared.projitems" Label="Shared" Condition="'$(IncludeSharedSampleHelpers)' != 'false'" />
 </Project>

--- a/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
+++ b/tracer/test/test-applications/Samples.Shared/SampleHelpers.cs
@@ -25,6 +25,7 @@ namespace Samples
         private static readonly Type ProcessHelpersType = Type.GetType("Datadog.Trace.Util.ProcessHelpers, Datadog.Trace");
         private static readonly Type UserDetailsType = Type.GetType("Datadog.Trace.UserDetails, Datadog.Trace");
         private static readonly Type SpanExtensionsType = Type.GetType("Datadog.Trace.SpanExtensions, Datadog.Trace");
+        public static readonly Type IpcClientType = Type.GetType("Datadog.Trace.Ci.Ipc.IpcClient, Datadog.Trace");
         private static readonly PropertyInfo GetTracerManagerProperty = TracerType?.GetProperty("TracerManager", BindingFlags.NonPublic | BindingFlags.Instance);
         private static readonly MethodInfo GetNativeTracerVersionMethod = InstrumentationType?.GetMethod("GetNativeTracerVersion");
         private static readonly MethodInfo GetTracerInstance = TracerType?.GetProperty("Instance", BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)?.GetMethod;
@@ -56,7 +57,6 @@ namespace Samples
         private static readonly MethodInfo SetUserMethod = SpanExtensionsType?.GetMethod("SetUser", BindingFlags.Public | BindingFlags.Static);
 #endif
         private static readonly FieldInfo TracerThreePartVersionField = TracerConstantsType?.GetField("ThreePartVersion");
-
 
         static SampleHelpers()
         {

--- a/tracer/test/test-applications/aspnet/Directory.Build.props
+++ b/tracer/test/test-applications/aspnet/Directory.Build.props
@@ -10,4 +10,13 @@
   </PropertyGroup>
 
   <Import Project="..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
+
+  <!-- Ensure that we don't reference Datadog.Trace directly (unless explicitly handled) -->
+  <!-- Note that you need to ensure the buid logic is updated to exclude the project if you take this approach -->
+  <Target Name="ValidateDisallowedReferences" BeforeTargets="CoreCompile">
+    <Error
+      Condition="'%(ProjectReference.FileName)' == 'Datadog.Trace' AND '$(AllowDatadogTraceReference)' != 'true'"
+      Text="You should not directly reference Datadog.Trace in this project" />
+  </Target>
+
 </Project>

--- a/tracer/test/test-applications/azure-functions/Directory.Build.props
+++ b/tracer/test/test-applications/azure-functions/Directory.Build.props
@@ -11,4 +11,12 @@
   </PropertyGroup>
 
   <Import Project="..\Samples.Shared\Samples.Shared.projitems" Label="Shared" />
+
+  <!-- Ensure that we don't reference Datadog.Trace directly (unless explicitly handled) -->
+  <!-- Note that you need to ensure the buid logic is updated to exclude the project if you take this approach -->
+  <Target Name="ValidateDisallowedReferences" BeforeTargets="CoreCompile">
+    <Error
+      Condition="'%(ProjectReference.FileName)' == 'Datadog.Trace' AND '$(AllowDatadogTraceReference)' != 'true'"
+      Text="You should not directly reference Datadog.Trace in this project" />
+  </Target>
 </Project>

--- a/tracer/test/test-applications/debugger/Directory.Build.props
+++ b/tracer/test/test-applications/debugger/Directory.Build.props
@@ -18,4 +18,13 @@
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp3.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
+
+  <!-- Ensure that we don't reference Datadog.Trace directly (unless explicitly handled) -->
+  <!-- Note that you need to ensure the buid logic is updated to exclude the project if you take this approach -->
+  <Target Name="ValidateDisallowedReferences" BeforeTargets="CoreCompile">
+    <Error
+      Condition="'%(ProjectReference.FileName)' == 'Datadog.Trace' AND '$(AllowDatadogTraceReference)' != 'true'"
+      Text="You should not directly reference Datadog.Trace in this project" />
+  </Target>
+
 </Project>

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.5" />
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>
 

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/CallTargetNativeTest.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)..\..\..\..\..\Datadog.Trace.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AllowDatadogTraceReference>true</AllowDatadogTraceReference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructFourParametersVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructFourParametersVoidIntegration.cs
@@ -16,7 +16,7 @@ public static class RefStructFourParametersVoidIntegration
         ref var readOnlySpanValue = ref arg02.DangerousGetReadOnlySpan<char>(out success);
         if (success)
         {
-            readOnlySpanValue = "World";
+            readOnlySpanValue = "World".AsSpan();
         }
 
         ref var spanValue = ref arg03.DangerousGetSpan<char>(out success);

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructOneParametersVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructOneParametersVoidIntegration.cs
@@ -16,7 +16,7 @@ public static class RefStructOneParametersVoidIntegration
             ref var readOnlySpanValue = ref callTargetRefStruct.DangerousGetReadOnlySpan<char>(out success);
             if (success)
             {
-                readOnlySpanValue = "Hello World";
+                readOnlySpanValue = "Hello World".AsSpan();
                 return returnValue;
             }
             

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructTwoParametersVoidIntegration.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/NoOp/RefStructTwoParametersVoidIntegration.cs
@@ -16,7 +16,7 @@ public static class RefStructTwoParametersVoidIntegration
             ref var readOnlySpanValue = ref callTargetRefStruct.DangerousGetReadOnlySpan<char>(out success);
             if (success)
             {
-                readOnlySpanValue = "Hello";
+                readOnlySpanValue = "Hello".AsSpan();
                 goto secondArgument;
             }
             
@@ -41,7 +41,7 @@ public static class RefStructTwoParametersVoidIntegration
             ref var readOnlySpanValue = ref callTargetRefStruct2.DangerousGetReadOnlySpan<char>(out success);
             if (success)
             {
-                readOnlySpanValue = "World";
+                readOnlySpanValue = "World".AsSpan();
                 goto returnValue;
             }
             

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefStructArguments.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefStructArguments.cs
@@ -9,12 +9,12 @@ partial class Program
         var wRefStructArg = new WithRefStructArguments();
 
         Console.WriteLine($"{typeof(WithRefArguments).FullName} | ReadOnlySpan<char> methods");
-        RunMethod(() => wRefStructArg.VoidReadOnlySpanMethod("BadParam"));
+        RunMethod(() => wRefStructArg.VoidReadOnlySpanMethod("BadParam".AsSpan()));
         RunMethod(() =>
         {
             var arg1 = "BadParam".AsSpan();
             wRefStructArg.VoidReadOnlySpanMethod(ref arg1);
-            if (arg1 != "Hello World") throw new Exception("Error modifying arg1 value.");
+            if (!arg1.SequenceEqual("Hello World".AsSpan())) throw new Exception("Error modifying arg1 value.");
         });
         RunMethod(() =>
         {
@@ -27,15 +27,18 @@ partial class Program
             var arg1 = "BadParam".AsSpan();
             var arg2 = "BadParam".AsSpan();
             wRefStructArg.Void2ReadOnlySpanMethod(ref arg1, ref arg2);
-            if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-            if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+            if (!arg1.SequenceEqual("Hello".AsSpan())) throw new Exception("Error modifying arg1 value.");
+            if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
         });
         RunMethod(() =>
         {
             var arg1 = "BadParam".AsSpan();
             var arg2 = "BadParam".AsSpan();
             wRefStructArg.Void2ReadOnlySpanMethod(arg1, ref arg2);
-            if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+            if (!arg2.SequenceEqual("World".AsSpan()))
+            {
+                throw new Exception("Error modifying arg2 value.");
+            }
         });
         
         Console.WriteLine($"{typeof(WithRefArguments).FullName} | Span<char> methods");
@@ -118,7 +121,7 @@ partial class Program
             var arg4 = new ReadOnlyRefStruct("BadParam");
             wRefStructArg.VoidMixedMethod(ref arg1, ref arg2, ref arg3, ref arg4);
             if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-            if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+            if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
             if (arg3.ToString() != "Hello") throw new Exception("Error modifying arg3 value.");
             if (arg4.Value != "World") throw new Exception("Error modifying arg4 value.");
         });
@@ -129,7 +132,7 @@ partial class Program
             var arg3 = new Span<char>(['B', 'a', 'd', 'P', 'a', 'r', 'a', 'm']);
             var arg4 = new ReadOnlyRefStruct("BadParam");
             wRefStructArg.VoidMixedMethod(arg1, ref arg2, arg3, ref arg4);
-            if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+            if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
             if (arg4.Value != "World") throw new Exception("Error modifying arg4 value.");
         });
     }
@@ -141,30 +144,30 @@ internal class WithRefStructArguments
     
     public void VoidReadOnlySpanMethod(ReadOnlySpan<char> arg1)
     {
-        if (arg1 != "Hello World") throw new Exception("Error modifying arg1 value.");
+        if (!arg1.SequenceEqual("Hello World".AsSpan())) throw new Exception("Error modifying arg1 value.");
     }
 
     public void VoidReadOnlySpanMethod(ref ReadOnlySpan<char> arg1)
     {
-        if (arg1 != "Hello World") throw new Exception("Error modifying arg1 value.");
+        if (!arg1.SequenceEqual("Hello World".AsSpan())) throw new Exception("Error modifying arg1 value.");
     }
 
     public void Void2ReadOnlySpanMethod(ReadOnlySpan<char> arg1, ReadOnlySpan<char> arg2)
     {
-        if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-        if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+        if (!arg1.SequenceEqual("Hello".AsSpan())) throw new Exception("Error modifying arg1 value.");
+        if (arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
     }
 
     public void Void2ReadOnlySpanMethod(ref ReadOnlySpan<char> arg1, ref ReadOnlySpan<char> arg2)
     {
-        if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-        if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+        if (!arg1.SequenceEqual("Hello".AsSpan())) throw new Exception("Error modifying arg1 value.");
+        if (arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
     }
 
     public void Void2ReadOnlySpanMethod(ReadOnlySpan<char> arg1, ref ReadOnlySpan<char> arg2)
     {
-        if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-        if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+        if (!arg1.SequenceEqual("Hello".AsSpan())) throw new Exception("Error modifying arg1 value.");
+        if (arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
     }
     
     // *** Span<char> arguments ***
@@ -232,7 +235,7 @@ internal class WithRefStructArguments
     public void VoidMixedMethod(string arg1, ReadOnlySpan<char> arg2, Span<char> arg3, ReadOnlyRefStruct arg4)
     {
         if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-        if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+        if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
         if (arg3.ToString() != "Hello") throw new Exception("Error modifying arg3 value.");
         if (arg4.Value != "World") throw new Exception("Error modifying arg4 value.");
     }
@@ -240,7 +243,7 @@ internal class WithRefStructArguments
     public void VoidMixedMethod(ref string arg1, ref ReadOnlySpan<char> arg2, ref Span<char> arg3, ref ReadOnlyRefStruct arg4)
     {
         if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-        if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+        if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
         if (arg3.ToString() != "Hello") throw new Exception("Error modifying arg3 value.");
         if (arg4.Value != "World") throw new Exception("Error modifying arg4 value.");
     }
@@ -248,7 +251,7 @@ internal class WithRefStructArguments
     public void VoidMixedMethod(string arg1, ref ReadOnlySpan<char> arg2, Span<char> arg3, ref ReadOnlyRefStruct arg4)
     {
         if (arg1 != "Hello") throw new Exception("Error modifying arg1 value.");
-        if (arg2 != "World") throw new Exception("Error modifying arg2 value.");
+        if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
         if (arg3.ToString() != "Hello") throw new Exception("Error modifying arg3 value.");
         if (arg4.Value != "World") throw new Exception("Error modifying arg4 value.");
     }

--- a/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefStructArguments.cs
+++ b/tracer/test/test-applications/instrumentation/CallTargetNativeTest/WithRefStructArguments.cs
@@ -155,19 +155,19 @@ internal class WithRefStructArguments
     public void Void2ReadOnlySpanMethod(ReadOnlySpan<char> arg1, ReadOnlySpan<char> arg2)
     {
         if (!arg1.SequenceEqual("Hello".AsSpan())) throw new Exception("Error modifying arg1 value.");
-        if (arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
+        if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
     }
 
     public void Void2ReadOnlySpanMethod(ref ReadOnlySpan<char> arg1, ref ReadOnlySpan<char> arg2)
     {
         if (!arg1.SequenceEqual("Hello".AsSpan())) throw new Exception("Error modifying arg1 value.");
-        if (arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
+        if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
     }
 
     public void Void2ReadOnlySpanMethod(ReadOnlySpan<char> arg1, ref ReadOnlySpan<char> arg2)
     {
         if (!arg1.SequenceEqual("Hello".AsSpan())) throw new Exception("Error modifying arg1 value.");
-        if (arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
+        if (!arg2.SequenceEqual("World".AsSpan())) throw new Exception("Error modifying arg2 value.");
     }
     
     // *** Span<char> arguments ***

--- a/tracer/test/test-applications/instrumentation/Datadog.Tracer.Native.Checks/Datadog.Tracer.Native.Checks.csproj
+++ b/tracer/test/test-applications/instrumentation/Datadog.Tracer.Native.Checks/Datadog.Tracer.Native.Checks.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
+    <AllowDatadogTraceReference>true</AllowDatadogTraceReference>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tracer/test/test-applications/integrations/Samples.CIVisibilityIpc/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.CIVisibilityIpc/Program.cs
@@ -12,7 +12,7 @@ class Program
 
         Console.WriteLine(@"Using SessionId: " + sessionId);
 
-        var ipcClientType = typeof(Datadog.Trace.Tracer).Assembly.GetType("Datadog.Trace.Ci.Ipc.IpcClient")!;
+        var ipcClientType = Samples.SampleHelpers.IpcClientType!;
         var setMessageReceivedCallbackMethod = ipcClientType.GetMethod("SetMessageReceivedCallback");
         var trySendMessageMethod = ipcClientType.GetMethod("TrySendMessage");
         using var ipcClient = (IDisposable)Activator.CreateInstance(ipcClientType, sessionId)!;

--- a/tracer/test/test-applications/integrations/Samples.CIVisibilityIpc/Samples.CIVisibilityIpc.csproj
+++ b/tracer/test/test-applications/integrations/Samples.CIVisibilityIpc/Samples.CIVisibilityIpc.csproj
@@ -8,8 +8,4 @@
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
+++ b/tracer/test/test-applications/integrations/Samples.ManualInstrumentation/Samples.ManualInstrumentation.csproj
@@ -1,4 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Just temporary, until v3 -->
+    <AllowDatadogTraceReference>true</AllowDatadogTraceReference>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\src\Datadog.Trace\Datadog.Trace.csproj" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of changes

- Enforces not directly referencing Datadog.Trace in the sample projects
- Removes a direct reference in `Samples.CIVisibilityIpc`
- Fixes the build of CallTargetNativeTest on Windows

## Reason for change

- We have an informal "policy" that we shouldn't be directly referencing Datadog.Trace in the samples. 
  - Originally this was because it interfered with code coverage concerns, but at this point it's _mostly_ because we have abstractions in place to use instead, which allow us to switch things out.
- It simplifies some things around the build we're hoping to do later
  - If we can treat the samples as "independent" of code changes in the tracer, then we can do things like build them in parallel, cache them aggressively. 
  - We're not blocking referencing Datadog.Trace.Manual here, partly because we likely _want_ to reference that to test it properly, but also because it's much more lightweight (therefore quick and easy to rebuild), and changes comparatively rarely
  - Note we also allow references to Datadog.Trace _package_ references (e.g. for version conflict test scenarios)

## Implementation details

- Add a target to Directory.Build.props that checks for a project reference to Datadog.Trace. 
- Add override using `AllowDatadogTraceReference` in projects we _expect_ to reference Datadog.Trace
- Remove references where we _shouldn't_ have them
- Fix the build of `CallTargetNativeTest` on Windows (.NET FX requires System.Memory, and doesn't have the same implicit conversions between `ReadOnlySpan<char>` and `string` as .NET Core)

## Test coverage

Should all be covered by existing tests

## Other details

This is prerequisite work for some work to speed up/improve CI

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
