### PR TITLE
[ASM] Fix null exception security coordinator

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -74,6 +74,11 @@ internal readonly partial struct SecurityCoordinator
 
     public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, bool isRasp = false)
     {
+        if (!HasContext())
+        {
+            return null;
+        }
+
         LogAddressIfDebugEnabled(args);
         IResult? result = null;
         try

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -67,6 +67,11 @@ internal readonly partial struct SecurityCoordinator
         return RunWaf(args, lastTime);
     }
 
+    public bool HasContext()
+    {
+        return _httpTransport.Context is not null;
+    }
+
     public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, bool isRasp = false)
     {
         LogAddressIfDebugEnabled(args);

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -83,6 +83,7 @@ internal static class RaspModule
     {
         var securityCoordinator = new SecurityCoordinator(Security.Instance, rootSpan);
 
+        // We need a context for RASP
         if (!securityCoordinator.HasContext())
         {
             return;

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -82,6 +82,12 @@ internal static class RaspModule
     private static void RunWafRasp(Dictionary<string, object> arguments, Span rootSpan, string address)
     {
         var securityCoordinator = new SecurityCoordinator(Security.Instance, rootSpan);
+
+        if (!securityCoordinator.HasContext())
+        {
+            return;
+        }
+
         var result = securityCoordinator.RunWaf(arguments, runWithEphemeral: true, isRasp: true);
 
         if (result is not null)


### PR DESCRIPTION
## Summary of changes


We are receiving the following error message:

```
Error: Call into the security module failed with arguments {Args}
System.NullReferenceException
at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.HttpTransport.GetAdditiveContext()
at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.RunWaf(Dictionary`2 args, Boolean lastWafCall, Boolean runWithEphemeral, Boolean isRasp)
```

This message appeared after refactoring the SecurityCoordinator and enabling RASP by default.

The error occurs in both .NET Core and .NET Framework versions. When examining the .NET Framework code, we observe:

```csharp
internal override IContext? GetAdditiveContext() => Context.Items[WafKey] as IContext;
```

Looking at the property and it's implementation in net framework, we see that Items is a dictionary that cannot ever be null, so the only possibility is that Context is null. In the SecurityCoordinator constructor, we set the Context but do not check if it's null.

Calling RunWaf with a null Context always results in a NullReferenceException, so we have protected this method against a null Context.

Additionally, we have added an early exit statement to RASP for handling null Context appropriately.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
