### PR TITLE
[Tracing] Don't allow enabling UDS on < .NET Core 3.1 and .NET Framework

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -489,6 +489,6 @@ namespace Datadog.Trace.Configuration
         }
 
         private void RecordTraceTransport(string transport, ConfigurationOrigins origin = ConfigurationOrigins.Default)
-            => _telemetry.Record(ConfigTelemetryData.AgentTraceTransport, transport, recordValue: true, ConfigurationOrigins.Default);
+            => _telemetry.Record(ConfigTelemetryData.AgentTraceTransport, transport, recordValue: true, origin);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ExporterSettings.cs
@@ -363,19 +363,30 @@ namespace Datadog.Trace.Configuration
             }
             else if (metricsUnixDomainSocketPath != null)
             {
+#if NETCOREAPP3_1_OR_GREATER
                 SetUds(metricsUnixDomainSocketPath, metricsUnixDomainSocketPath, metricsUnixDomainSocketPath, ConfigurationKeys.MetricsUnixDomainSocketPath);
+#else
+                // .NET Core 2.1 and .NET FX don't support Unix Domain Sockets
+                ValidationWarnings.Add($"Found metrics UDS configuration {metricsUnixDomainSocketPath}, but current runtime doesn't support UDS, so ignoring it.");
+                _telemetry.Record(
+                    ConfigurationKeys.MetricsUnixDomainSocketPath,
+                    metricsUnixDomainSocketPath,
+                    recordValue: true,
+                    ConfigurationOrigins.Default,
+                    TelemetryErrorCode.UdsOnUnsupportedPlatform);
+                SetDefault();
+#endif
             }
+#if NETCOREAPP3_1_OR_GREATER
+            // .NET Core 2.1 and .NET FX don't support Unix Domain Sockets, so we don't care if the file already exists
             else if (_fileExists(DefaultMetricsUnixDomainSocket))
             {
                 SetUds(DefaultMetricsUnixDomainSocket, DefaultMetricsUnixDomainSocket, DefaultMetricsUnixDomainSocket, null);
             }
+#endif
             else
             {
-                SetUdp(
-                    hostname: DefaultDogstatsdHostname,
-                    hostnameSource: null,
-                    port: DefaultDogstatsdPort,
-                    portSource: null);
+                SetDefault();
             }
 
             // set these values if they're not already set just to keep some things happy
@@ -396,6 +407,7 @@ namespace Datadog.Trace.Configuration
                 var origin = ConfigurationOrigins.Default; // only called from the constructor
                 if (uri.OriginalString.StartsWith(UnixDomainSocketPrefix, StringComparison.OrdinalIgnoreCase))
                 {
+#if NETCOREAPP3_1_OR_GREATER
                     var absoluteUri = uri.AbsoluteUri.Replace(UnixDomainSocketPrefix, string.Empty);
                     var probablyValid = SetUds(uri.PathAndQuery, uri.OriginalString, absoluteUri, ConfigurationKeys.AgentUri);
                     _telemetry.Record(
@@ -404,6 +416,18 @@ namespace Datadog.Trace.Configuration
                         recordValue: true,
                         origin,
                         probablyValid ? null : TelemetryErrorCode.PotentiallyInvalidUdsPath);
+#else
+                    // .NET Core 2.1 and .NET FX don't support Unix Domain Sockets, but it's _explicitly_ being
+                    // configured here, so warn the user, and switch to using the default transport instead.
+                    ValidationWarnings.Add($"The provided metrics Uri {uri} represents a Unix Domain Socket (UDS), but the current runtime doesn't support UDS. Falling back to the default UDP transport.");
+                    _telemetry.Record(
+                        ConfigurationKeys.MetricsUnixDomainSocketPath,
+                        metricsUrl,
+                        recordValue: true,
+                        origin,
+                        TelemetryErrorCode.UdsOnUnsupportedPlatform);
+                    SetDefault();
+#endif
                     return true;
                 }
 
@@ -424,6 +448,7 @@ namespace Datadog.Trace.Configuration
                 return false;
             }
 
+#if NETCOREAPP3_1_OR_GREATER
             [MemberNotNull(nameof(MetricsHostname))]
             bool SetUds(string unixSocket, string original, string absoluteUri, string? source)
             {
@@ -448,7 +473,7 @@ namespace Datadog.Trace.Configuration
 
                 return probablyValid;
             }
-
+#endif
             [MemberNotNull(nameof(MetricsHostname))]
             bool SetUdp(string hostname, string? hostnameSource, int port, string? portSource)
             {
@@ -486,6 +511,12 @@ namespace Datadog.Trace.Configuration
                 // TODO: use this to mark config as errors
                 return probablyValid;
             }
+
+            void SetDefault() => SetUdp(
+                hostname: DefaultDogstatsdHostname,
+                hostnameSource: null,
+                port: DefaultDogstatsdPort,
+                portSource: null);
         }
 
         private void RecordTraceTransport(string transport, ConfigurationOrigins origin = ConfigurationOrigins.Default)

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class TelemetryErrorCodeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 17;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.TelemetryErrorCode"/> value.
@@ -46,6 +46,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError => "Error configuring Continuous Profiler",
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError => "Error configuring Dynamic Instrumentation",
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath => "Potentially invalid UDS path",
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform => "Attempting to use UDS on unsupported runtime",
             _ => value.ToString(),
         };
 
@@ -75,6 +76,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath,
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform,
         };
 
     /// <summary>
@@ -104,6 +106,7 @@ internal static partial class TelemetryErrorCodeExtensions
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath),
+            nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform),
         };
 
     /// <summary>
@@ -133,5 +136,6 @@ internal static partial class TelemetryErrorCodeExtensions
             "Error configuring Continuous Profiler",
             "Error configuring Dynamic Instrumentation",
             "Potentially invalid UDS path",
+            "Attempting to use UDS on unsupported runtime",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class TelemetryErrorCodeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 17;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.TelemetryErrorCode"/> value.
@@ -46,6 +46,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError => "Error configuring Continuous Profiler",
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError => "Error configuring Dynamic Instrumentation",
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath => "Potentially invalid UDS path",
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform => "Attempting to use UDS on unsupported runtime",
             _ => value.ToString(),
         };
 
@@ -75,6 +76,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath,
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform,
         };
 
     /// <summary>
@@ -104,6 +106,7 @@ internal static partial class TelemetryErrorCodeExtensions
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath),
+            nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform),
         };
 
     /// <summary>
@@ -133,5 +136,6 @@ internal static partial class TelemetryErrorCodeExtensions
             "Error configuring Continuous Profiler",
             "Error configuring Dynamic Instrumentation",
             "Potentially invalid UDS path",
+            "Attempting to use UDS on unsupported runtime",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class TelemetryErrorCodeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 17;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.TelemetryErrorCode"/> value.
@@ -46,6 +46,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError => "Error configuring Continuous Profiler",
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError => "Error configuring Dynamic Instrumentation",
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath => "Potentially invalid UDS path",
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform => "Attempting to use UDS on unsupported runtime",
             _ => value.ToString(),
         };
 
@@ -75,6 +76,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath,
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform,
         };
 
     /// <summary>
@@ -104,6 +106,7 @@ internal static partial class TelemetryErrorCodeExtensions
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath),
+            nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform),
         };
 
     /// <summary>
@@ -133,5 +136,6 @@ internal static partial class TelemetryErrorCodeExtensions
             "Error configuring Continuous Profiler",
             "Error configuring Dynamic Instrumentation",
             "Potentially invalid UDS path",
+            "Attempting to use UDS on unsupported runtime",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/TelemetryErrorCodeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class TelemetryErrorCodeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 16;
+    public const int Length = 17;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.TelemetryErrorCode"/> value.
@@ -46,6 +46,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError => "Error configuring Continuous Profiler",
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError => "Error configuring Dynamic Instrumentation",
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath => "Potentially invalid UDS path",
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform => "Attempting to use UDS on unsupported runtime",
             _ => value.ToString(),
         };
 
@@ -75,6 +76,7 @@ internal static partial class TelemetryErrorCodeExtensions
             Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError,
             Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath,
+            Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform,
         };
 
     /// <summary>
@@ -104,6 +106,7 @@ internal static partial class TelemetryErrorCodeExtensions
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.ContinuousProfilerConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.DynamicInstrumentationConfigurationError),
             nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.PotentiallyInvalidUdsPath),
+            nameof(Datadog.Trace.Telemetry.TelemetryErrorCode.UdsOnUnsupportedPlatform),
         };
 
     /// <summary>
@@ -133,5 +136,6 @@ internal static partial class TelemetryErrorCodeExtensions
             "Error configuring Continuous Profiler",
             "Error configuring Dynamic Instrumentation",
             "Potentially invalid UDS path",
+            "Attempting to use UDS on unsupported runtime",
         };
 }

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryErrorCode.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryErrorCode.cs
@@ -61,4 +61,7 @@ internal enum TelemetryErrorCode
 
     [Description("Potentially invalid UDS path")]
     PotentiallyInvalidUdsPath = 15,
+
+    [Description("Attempting to use UDS on unsupported runtime")]
+    UdsOnUnsupportedPlatform = 16,
 }


### PR DESCRIPTION
## Summary of changes

Updates exporter settings to ensure we don't set the agent URL to UDS on runtimes where it's not supported.

## Reason for change

We don't support UDS on < .NET Core 3.1 or .NET Framework. If the exporter settings _are_ set to UDS, we currently happily accept it in `ExporterSettings`, but then switch to `ApiWebRequestFactory` in the transport factories. Unfortunately, all the configuration (e.g. URLs) is configured for UDS, so we get a bunch of errors, and no transports work:

```
[ERR] Using Unix Domain Sockets for telemetry transport is only supported on .NET Core 3.1 and greater. Falling back to default transport.
[ERR] An error occurred while generating http request to send data to the agent at unix:/opt/datadog/apm/inject/run/apm.socket/v0.4/traces System.NotSupportedException: The URI prefix is not recognized.
   at System.Net.WebRequest.CreateHttp(Uri requestUri)
   at Datadog.Trace.Agent.Transports.ApiWebRequestFactory.Create(Uri endpoint) in /project/tracer/src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs:line 39
   at Datadog.Trace.Agent.Api.SendWithRetry[T](Uri endpoint, SendCallback`1 callback, T state) in /project/tracer/src/Datadog.Trace/Agent/Api.cs:line 132}
```

## Implementation details

Block setting UDS unless we're in .NET Core 3.1+ in `ExporterSettings`, that means:

- Ignore the "ambient" UDS configuration values that are set by the agent (`DD_APM_RECEIVER_SOCKET` and `DD_DOGSTATSD_SOCKET`)
- Don't try to find the "well known" socket paths (`/var/run/datadog/apm.socket` and `/var/run/datadog/dsd.socket`)
- If the customer explicitly sets a unix path (or we set one via SSI for example) then log a validation warning (in the startup logs), and switch to the _default_ TCP/UDP transport.

## Test coverage

Updated `ExporterSettings` tests to check the new behaviour on unsupported runtimes

## Other details

Note that we always switch to the _default_ TCP/UDP in the fallback case, we _don't_ try and use any `DD_AGENT_HOST` values or anything to find a "better" TCP endpoint. This is primarily because the complexity in `ExporterSettings` is already so high and various configuration values can conflict with each other. IMO if customers are setting UDS values on unsupported runtimes, then we're in an unsupported scenario, and using the fixed default for simplicity is the best.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
