### PR TITLE
[Tracing] [Samples] Update MicrosoftExtensionsExample.csproj to remove incompatible library

### DIFF
--- a/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Datadog.Trace.Bundle" Version="2.53.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="2.5.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>

--- a/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Program.cs
+++ b/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/Program.cs
@@ -17,24 +17,6 @@ namespace MicrosoftExtensionsExample
         {
             return Host.CreateDefaultBuilder(args)
                 .ConfigureServices(services => services.AddHostedService<Worker>())
-#if NETCOREAPP3_0_OR_GREATER
-                .ConfigureLogging(logging =>
-                {
-                    // The JsonFormatter used by NetEscapades.Extensions.Logging.RollingFile includes all properties
-                    // if scopes are enabled - however, it requires .NET 3.0+
-                    //
-                    // Additions to configuration:
-                    // - used json format
-                    // - enabled scopes
-                    logging.AddFile(opts =>
-                    {
-                        opts.IncludeScopes = true; // must include scopes so that correlation identifiers are added
-                        opts.FileName = "log-MicrosoftExtensions-jsonFile";
-                        opts.Extension = "log";
-                        opts.FormatterName = "json";
-                    });
-                });
-#else
                 .ConfigureLogging(logging =>
                 {
                     // Using Serilog with Microsoft.Extensions.Logging is supported, but uses the Serilog log injection
@@ -45,7 +27,6 @@ namespace MicrosoftExtensionsExample
                         .WriteTo.File(new JsonFormatter(), "Logs/log-Serilog-jsonFile.log")
                         .CreateLogger());
                 });
-#endif
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
Remove NetEscapades.Extensions.Logging.RollingFile because it's incompatible with our updated automatic logs correlation implementation

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
