### PR TITLE
[Profiler] Fix crash when different threads are trying to set a class description

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FrameStore.cpp
@@ -394,6 +394,14 @@ bool FrameStore::GetTypeDesc(ClassID classId, TypeDesc*& pTypeDesc)
         {
             std::lock_guard<std::mutex> lock(_typesLock);
 
+            // it is possible that another thread already added the type description while we were building it
+            auto typeEntry = _types.find(classId);
+            if (typeEntry != _types.end())
+            {
+                pTypeDesc = &typeEntry->second;
+                return true;
+            }
+
             pTypeDesc = &(_types[originalClassId] = typeDesc);
         }
         else


### PR DESCRIPTION
## Summary of changes
Check if a type description has been set under the lock

## Reason for change
Crash in exception provider

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
