### PR TITLE
[build] improve isolation and speed in "local build" docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,19 +1,59 @@
-tracer/test/
-tracer/deploy/
-
-.circleci/
-
+.git/
 .github/
+.gitlab/
 **/.vs/
 **/.vscode/
-packages/
+**/.idea/
 **/bin/
 **/obj/
+**/*.user
+.nuke/temp/
+exploration-tests/
+packages/
 
-!tracer/test/test-applications/aspnet/Samples.AspNet472.LoaderOptimizationRegKey/bin/
-!tracer/src/WindowsInstaller/bin/
+# Tracer deployment artifacts
+tracer/deploy/linux/
+tracer/deploy/AzureAppServices/
+tracer/src/Datadog.Trace.Bundle/home
+tracer/build_data/
 
-!tracer/test/Datadog.Trace.TestHelpers/
-!tracer/test/agent/
-!tracer/test/Directory.Build.props
-!tracer/test/GlobalSuppressions.cs
+# native tracer build files
+tracer/src/Datadog.Tracer.Native/build/
+tracer/src/Datadog.Tracer.Native/deps/
+tracer/src/Datadog.Tracer.Native/CMakeFiles/
+tracer/src/Datadog.Tracer.Native/tmp.*
+tracer/src/Datadog.Tracer.Native/Makefile
+tracer/src/Datadog.Tracer.Native/CMakeCache.txt
+tracer/src/Datadog.Tracer.Native/cmake_install.cmake
+
+# shared loader build files
+shared/src/Datadog.Trace.ClrProfiler.Native/build/
+shared/src/Datadog.Trace.ClrProfiler.Native/deps/
+shared/src/Datadog.Trace.ClrProfiler.Native/CMakeFiles/
+shared/src/Datadog.Trace.ClrProfiler.Native/tmp.*
+shared/src/Datadog.Trace.ClrProfiler.Native/Makefile
+shared/src/Datadog.Trace.ClrProfiler.Native/CMakeCache.txt
+shared/src/Datadog.Trace.ClrProfiler.Native/cmake_install.cmake
+shared/src/Datadog.Trace.ClrProfiler.Native/cmake-build-debug/
+cmake-build-debug/*
+
+#profiler build files
+profiler/_build/
+profiler/build_data/
+
+# global build folder
+obj/*
+obj_arm64/*
+obj_x86_64/*
+
+# cmake build files
+.ionide/
+CMakeCache.txt
+Makefile
+_deps/
+CMakeFiles/
+lib/
+libdatadog-*/
+*-prefix/
+cmake-build-debug/
+.cmake/

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -109,12 +109,12 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
     && rm dotnet-install.sh
 
 ##################################################
-# used from "build_in_docker.ps1" for local builds, not in CI
-# keep this stage last to avoid running it on legacy builders which don't skip unreferenced stages
+# Used from "build_in_docker.ps1" for local builds, not in CI.
+# Keep this stage last to avoid running it on legacy builders which don't skip unreferenced stages.
 
 FROM base as local_builder
 
-# Copy the Nuke project and build it
+# Copy the Nuke project and pre-build it for later
 COPY tracer/build/_build/ /project/tracer/build/_build/
 RUN dotnet build /project/tracer/build/_build/
 

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -2,8 +2,9 @@
 FROM mcr.microsoft.com/dotnet/runtime-deps:5.0-buster-slim as base
 ARG DOTNETSDK_VERSION
 
-# Based on https://github.com/dotnet/dotnet-docker/blob/34c81d5f9c8d56b36cc89da61702ccecbf00f249/src/sdk/6.0/bullseye-slim/amd64/Dockerfile
-# and https://github.com/dotnet/dotnet-docker/blob/1eab4cad6e2d42308bd93d3f0cc1f7511ac75882/src/sdk/5.0/buster-slim/amd64/Dockerfile
+# Based on
+# - https://github.com/dotnet/dotnet-docker/blob/34c81d5f9c8d56b36cc89da61702ccecbf00f249/project/sdk/6.0/bullseye-slim/amd64/Dockerfile
+# - https://github.com/dotnet/dotnet-docker/blob/1eab4cad6e2d42308bd93d3f0cc1f7511ac75882/project/sdk/5.0/buster-slim/amd64/Dockerfile
 ENV \
     # Unset ASPNETCORE_URLS from aspnet base image
     ASPNETCORE_URLS= \
@@ -39,7 +40,7 @@ RUN apt-get update \
         liblzma-dev \
         gdb \
         cppcheck \
-		zlib1g-dev \
+        zlib1g-dev \
         \
         # required to install clang
         lsb-release \
@@ -66,7 +67,7 @@ RUN curl -sSL https://dot.net/v1/dotnet-install.sh --output dotnet-install.sh  \
     && ./dotnet-install.sh --version $DOTNETSDK_VERSION --install-dir /usr/share/dotnet \
     && rm ./dotnet-install.sh \
     && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-# Trigger first run experience by running arbitrary cmd
+    # Trigger first run experience by running arbitrary cmd
     && dotnet help
 
 ENV \

--- a/tracer/build/_build/docker/debian.dockerfile
+++ b/tracer/build/_build/docker/debian.dockerfile
@@ -112,7 +112,7 @@ RUN if [ "$(uname -m)" = "x86_64" ]; \
 # Used from "build_in_docker.ps1" for local builds, not in CI.
 # Keep this stage last to avoid running it on legacy builders which don't skip unreferenced stages.
 
-FROM base as local_builder
+FROM base as local-builder
 
 # Copy the Nuke project and pre-build it for later
 COPY tracer/build/_build/ /project/tracer/build/_build/

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -25,6 +25,7 @@ docker build `
 # Run Nuke with build arguments
 docker run -it --rm `
     --mount "type=bind,source=$OUTPUT_DIR_ABS,target=/project/$OUTPUT_DIR_REL" `
+    --env artifacts=/project/tracer/bin/artifacts `
     --env NUKE_TELEMETRY_OPTOUT=1 `
     $IMAGE_NAME `
     dotnet /project/tracer/build/_build/bin/Debug/_build.dll $BuildArguments

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -1,28 +1,28 @@
+# Run locally to build Linux artifacts from Windows.
+# Find the output in shared/bin/monitoring-home on the Docker host.
 [CmdletBinding()]
 Param(
-    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [Parameter(Position = 0, Mandatory = $false, ValueFromRemainingArguments = $true)]
     [string[]]$BuildArguments
 )
 
 $ErrorActionPreference = "Stop"
 
-$ROOT_DIR="$PSScriptRoot/.."
-$BUILD_DIR="$ROOT_DIR/tracer/build/_build"
-$IMAGE_NAME="dd-trace-dotnet/alpine-base"
+$ROOT_DIR = "$PSScriptRoot/.."
+$BUILD_DIR = "$ROOT_DIR/tracer/build/_build"
+$IMAGE_NAME = "dd-trace-dotnet/debian-local-builder"
+$OUTPUT_DIR_REL = "shared/bin/monitoring-home"
+$OUTPUT_DIR_ABS = "$ROOT_DIR/$OUTPUT_DIR_REL"
 
-&docker build `
-   --build-arg DOTNETSDK_VERSION=8.0.100 `
-   --tag $IMAGE_NAME `
-   --file "$BUILD_DIR/docker/alpine.dockerfile" `
-   "$BUILD_DIR"
+docker build `
+    --build-arg DOTNETSDK_VERSION=8.0.100 `
+    --tag $IMAGE_NAME `
+    --file "$BUILD_DIR/docker/debian.dockerfile" `
+    --target local_builder `
+    "$ROOT_DIR"
 
-&docker run -it --rm `
-    --mount "type=bind,source=$ROOT_DIR,target=/project" `
-    --env NugetPackageDirectory=/project/packages `
-    --env artifacts=/project/tracer/bin/artifacts `
-    --env DD_INSTRUMENTATION_TELEMETRY_ENABLED=0 `
+docker run -it --rm `
+    --mount "type=bind,source=$OUTPUT_DIR_ABS,target=/src/$OUTPUT_DIR_REL" `
     --env NUKE_TELEMETRY_OPTOUT=1 `
-    -p 5003:5003 `
-    -v /ddlogs:/var/log/datadog/dotnet `
     $IMAGE_NAME `
-    dotnet /build/bin/Debug/_build.dll $BuildArguments
+    dotnet /src/tracer/build/_build/bin/Debug/_build.dll $BuildArguments

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -14,6 +14,7 @@ $IMAGE_NAME = "dd-trace-dotnet/debian-local-builder"
 $OUTPUT_DIR_REL = "shared/bin/monitoring-home"
 $OUTPUT_DIR_ABS = "$ROOT_DIR/$OUTPUT_DIR_REL"
 
+# Build the local builder image, and pre-build the Nuke project
 docker build `
     --build-arg DOTNETSDK_VERSION=8.0.100 `
     --tag $IMAGE_NAME `
@@ -21,8 +22,9 @@ docker build `
     --target local_builder `
     "$ROOT_DIR"
 
+# Run Nuke with build arguments
 docker run -it --rm `
-    --mount "type=bind,source=$OUTPUT_DIR_ABS,target=/src/$OUTPUT_DIR_REL" `
+    --mount "type=bind,source=$OUTPUT_DIR_ABS,target=/project/$OUTPUT_DIR_REL" `
     --env NUKE_TELEMETRY_OPTOUT=1 `
     $IMAGE_NAME `
-    dotnet /src/tracer/build/_build/bin/Debug/_build.dll $BuildArguments
+    dotnet /project/tracer/build/_build/bin/Debug/_build.dll $BuildArguments

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -18,7 +18,7 @@ docker build `
     --build-arg DOTNETSDK_VERSION=8.0.100 `
     --tag $IMAGE_NAME `
     --file "$ROOT_DIR/tracer/build/_build/docker/debian.dockerfile" `
-    --target local_builder `
+    --target local-builder `
     "$ROOT_DIR"
 
 # Run Nuke with build arguments

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -9,9 +9,9 @@ Param(
 $ErrorActionPreference = "Stop"
 
 $ROOT_DIR = "$PSScriptRoot/.."
+$MONITORING_HOME_DIR = "shared/bin/monitoring-home"
+$ARTIFACTS_DIR = "bin/artifacts"
 $IMAGE_NAME = "dd-trace-dotnet/debian-local-builder"
-$OUTPUT_DIR_REL = "shared/bin/monitoring-home"
-$OUTPUT_DIR_ABS = "$ROOT_DIR/$OUTPUT_DIR_REL"
 
 # Build the local builder image, and pre-build the Nuke project
 docker build `
@@ -23,8 +23,8 @@ docker build `
 
 # Run Nuke with build arguments
 docker run -it --rm `
-    --mount "type=bind,source=$OUTPUT_DIR_ABS,target=/project/$OUTPUT_DIR_REL" `
-    --env artifacts=/project/tracer/bin/artifacts `
+    --mount "type=bind,source=$ROOT_DIR/$MONITORING_HOME_DIR,target=/project/$MONITORING_HOME_DIR" `
+    --mount "type=bind,source=$ROOT_DIR/$ARTIFACTS_DIR,target=/project/$ARTIFACTS_DIR" `
     --env NUKE_TELEMETRY_OPTOUT=1 `
     $IMAGE_NAME `
     dotnet /project/tracer/build/_build/bin/Debug/_build.dll $BuildArguments

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -9,7 +9,6 @@ Param(
 $ErrorActionPreference = "Stop"
 
 $ROOT_DIR = "$PSScriptRoot/.."
-$BUILD_DIR = "$ROOT_DIR/tracer/build/_build"
 $IMAGE_NAME = "dd-trace-dotnet/debian-local-builder"
 $OUTPUT_DIR_REL = "shared/bin/monitoring-home"
 $OUTPUT_DIR_ABS = "$ROOT_DIR/$OUTPUT_DIR_REL"
@@ -18,7 +17,7 @@ $OUTPUT_DIR_ABS = "$ROOT_DIR/$OUTPUT_DIR_REL"
 docker build `
     --build-arg DOTNETSDK_VERSION=8.0.100 `
     --tag $IMAGE_NAME `
-    --file "$BUILD_DIR/docker/debian.dockerfile" `
+    --file "$ROOT_DIR/tracer/build/_build/docker/debian.dockerfile" `
     --target local_builder `
     "$ROOT_DIR"
 

--- a/tracer/build_in_docker.ps1
+++ b/tracer/build_in_docker.ps1
@@ -10,7 +10,7 @@ $ErrorActionPreference = "Stop"
 
 $ROOT_DIR = "$PSScriptRoot/.."
 $MONITORING_HOME_DIR = "shared/bin/monitoring-home"
-$ARTIFACTS_DIR = "bin/artifacts"
+$ARTIFACTS_DIR = "tracer/bin/artifacts"
 $IMAGE_NAME = "dd-trace-dotnet/debian-local-builder"
 
 # Build the local builder image, and pre-build the Nuke project

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -10,7 +10,7 @@ OUTPUT_DIR_ABS="$ROOT_DIR/$OUTPUT_DIR_REL"
 docker build \
    --build-arg DOTNETSDK_VERSION=8.0.100 \
    --tag $IMAGE_NAME \
-   --file "$BUILD_DIR/tracer/build/_build/docker/debian.dockerfile" \
+   --file "$ROOT_DIR/tracer/build/_build/docker/debian.dockerfile" \
    --target local_builder \
    "$ROOT_DIR"
 

--- a/tracer/build_in_docker.sh
+++ b/tracer/build_in_docker.sh
@@ -11,7 +11,7 @@ docker build \
    --build-arg DOTNETSDK_VERSION=8.0.100 \
    --tag $IMAGE_NAME \
    --file "$ROOT_DIR/tracer/build/_build/docker/debian.dockerfile" \
-   --target local_builder \
+   --target local-builder \
    "$ROOT_DIR"
 
 docker run -it --rm \


### PR DESCRIPTION
## Summary of changes

Improve building Linux versions of the library on Docker.
- Faster builds on Windows (especially when the git clone is on the Windows file system instead of inside WSL) and maybe on Macs
- Isolated the local file system from the container's file system. This allows building both in the host and in docker using the same git clone.

## Reason for change

Frustration. Constant waiting and failures.

## Implementation details

- stop mounting the entire repository into the docker image
- only mount `shared/bin/monitoring-home` for the final artifacts
- instead of using a mount, change the build context path so that all the repository files are included in the build context
- fix `.dockerignore` (only the one at the build root is used)
- switch `build_in_docker.ps1` and `build_in_docker.sh` to use Debian images instead of Alpine, since that is usually what we need when building locally (e.g. to run system tests or build AWS Lambda layers).

## Test coverage

Tried it manually.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
