### PR TITLE
[ASM] Fix Security module failed error

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Context.cs
@@ -68,7 +68,8 @@ namespace Datadog.Trace.AppSec.Waf
         {
             if (_disposed)
             {
-                ThrowHelper.ThrowException("Can't run WAF when context is disposed");
+                Log.Information("Can't run WAF when context is disposed");
+                return null;
             }
 
             DdwafResultStruct retNative = default;


### PR DESCRIPTION
## Summary of changes

There some [ASM errors](https://app.datadoghq.com/logs/error-tracking/issue/03f80b4c-0ddb-11ef-a1ad-da7ad0900002?query=source%3Adotnet%20%2AAppSec%2A&index=instrumentation-telemetry-data&from_ts=1716822981244&to_ts=1716909381244&live=true):

```
Error : Call into the security module failed with arguments {Args}
System.Exception  
at Datadog.Trace.Util.ThrowHelper.ThrowException(String message)
at Datadog.Trace.AppSec.Waf.Context.RunInternal(IDictionary`2 persistentAddressData, IDictionary`2 ephemeralAddressData, UInt64 timeoutMicroSeconds, Boolean isRasp)
at Datadog.Trace.AppSec.Coordinator.SecurityCoordinator.RunWaf(Dictionary`2 args, Boolean lastWafCall, Boolean runWithEphemeral, Boolean isRasp)
```

There is this  code in the method RunInternal:

```
        private unsafe IResult? RunInternal(IDictionary<string, object>? persistentAddressData, IDictionary<string, object>? ephemeralAddressData, ulong timeoutMicroSeconds, bool isRasp = false)
        {
            if (_disposed)
            {
                ThrowHelper.ThrowException("Can't run WAF when context is disposed");
            }
			
```
This would launch an exception that would be caught in the SecurityCoordinator and logged as an error. Since this is a controlled situation, launching an error message seems too much. This PR writes a Information message and returns null (same as we do if the WAF is disposed, for instance).

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
