### PR TITLE
Fix crash at shutdown in runtime metrics

### DIFF
--- a/Datadog.Trace.sln
+++ b/Datadog.Trace.sln
@@ -572,6 +572,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.CIVisibilityIpc", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Samples.CIVisibilityVersionMismatch", "tracer\test\test-applications\integrations\Samples.CIVisibilityVersionMismatch\Samples.CIVisibilityVersionMismatch.csproj", "{0D996EEE-7C04-4888-AF48-9C1E2F261A00}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RuntimeMetricsShutdown", "tracer\test\test-applications\regression\RuntimeMetricsShutdown\RuntimeMetricsShutdown.csproj", "{C4ABF344-3263-45D5-A074-03FB206FF309}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -1372,6 +1374,10 @@ Global
 		{0D996EEE-7C04-4888-AF48-9C1E2F261A00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0D996EEE-7C04-4888-AF48-9C1E2F261A00}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D996EEE-7C04-4888-AF48-9C1E2F261A00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C4ABF344-3263-45D5-A074-03FB206FF309}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C4ABF344-3263-45D5-A074-03FB206FF309}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C4ABF344-3263-45D5-A074-03FB206FF309}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C4ABF344-3263-45D5-A074-03FB206FF309}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1595,6 +1601,7 @@ Global
 		{32193A01-04DD-463B-A84A-9A93167958A4} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{BA9613FB-8458-4C78-98DE-AA45BBE62F64} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
 		{0D996EEE-7C04-4888-AF48-9C1E2F261A00} = {BAF8F246-3645-42AD-B1D0-0F7EAFBAB34A}
+		{C4ABF344-3263-45D5-A074-03FB206FF309} = {498A300E-D036-49B7-A43D-821D1CAF11A5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}
@@ -1615,6 +1622,7 @@ Global
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{b6a98887-4a47-4c19-9c6f-d833e24f4b1c}*SharedItemsImports = 4
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{bbb60b0f-bf01-4499-936a-4a299a9acfd4}*SharedItemsImports = 4
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{bc44a41f-1bed-4438-9f66-0ea5607906d5}*SharedItemsImports = 5
+		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{c4abf344-3263-45d5-a074-03fb206ff309}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{cb56ac5a-d2c1-40de-99d5-dcf9f44c9482}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{deacde01-95fe-4777-b70a-f20a96aabea7}*SharedItemsImports = 5
 		tracer\test\test-applications\Samples.Shared\Samples.Shared.projitems*{f5582f54-e911-4258-b419-5e894d338c5b}*SharedItemsImports = 4

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -708,8 +708,11 @@ namespace Datadog.Trace
                         await instance.Telemetry.DisposeAsync().ConfigureAwait(false);
                     }
 
+                    // We don't dispose runtime metrics on .NET Core because of https://github.com/dotnet/runtime/issues/103480
+#if NETFRAMEWORK
                     Log.Debug("Disposing Runtime Metrics");
                     instance.RuntimeMetrics?.Dispose();
+#endif
 
                     Log.Debug("Finished waiting for disposals.");
                 }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/RuntimeMetricsShutdownSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/RuntimeMetricsShutdownSmokeTest.cs
@@ -1,0 +1,30 @@
+// <copyright file="RuntimeMetricsShutdownSmokeTest.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#if !NETFRAMEWORK
+
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
+{
+    public class RuntimeMetricsShutdownSmokeTest : SmokeTestBase
+    {
+        public RuntimeMetricsShutdownSmokeTest(ITestOutputHelper output)
+            : base(output, "RuntimeMetricsShutdown")
+        {
+        }
+
+        [SkippableFact]
+        [Trait("Category", "Smoke")]
+        public async Task NoExceptions()
+        {
+            await CheckForSmoke();
+        }
+    }
+}
+
+#endif

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/RuntimeMetricsShutdownSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/RuntimeMetricsShutdownSmokeTest.cs
@@ -16,6 +16,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         public RuntimeMetricsShutdownSmokeTest(ITestOutputHelper output)
             : base(output, "RuntimeMetricsShutdown")
         {
+            SetEnvironmentVariable("DD_RUNTIME_METRICS_ENABLED", "true");
         }
 
         [SkippableFact]

--- a/tracer/test/test-applications/regression/RuntimeMetricsShutdown/Program.cs
+++ b/tracer/test/test-applications/regression/RuntimeMetricsShutdown/Program.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics.Tracing;
+
+namespace DataDogThreadTest
+{
+    public class MyEventListener : EventListener
+    {
+        public MyEventListener()
+        {
+            EventSourceCreated += (_, e) => EnableEventSource(e.EventSource);
+        }
+
+        private void EnableEventSource(EventSource eventSource)
+        {
+            EnableEvents(eventSource, EventLevel.Informational, EventKeywords.All);
+        }
+    }
+
+    class Program
+    {
+        static EventListener _listener;
+
+        static void Main(string[] args)
+        {
+            _listener = new MyEventListener();
+        }
+    }
+}

--- a/tracer/test/test-applications/regression/RuntimeMetricsShutdown/Properties/launchSettings.json
+++ b/tracer/test/test-applications/regression/RuntimeMetricsShutdown/Properties/launchSettings.json
@@ -1,0 +1,21 @@
+{
+  "profiles": {
+    "DataDogThreadTest": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "COR_ENABLE_PROFILING": "1",
+        "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "COR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "CORECLR_ENABLE_PROFILING": "1",
+        "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+        "CORECLR_PROFILER_PATH": "$(SolutionDir)shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+
+        "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
+
+        "DD_LOGS_INJECTION": "true"
+      },
+      "nativeDebugging": true
+    }
+  }
+}

--- a/tracer/test/test-applications/regression/RuntimeMetricsShutdown/RuntimeMetricsShutdown.csproj
+++ b/tracer/test/test-applications/regression/RuntimeMetricsShutdown/RuntimeMetricsShutdown.csproj
@@ -1,0 +1,7 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetLatestRuntimePatch>false</TargetLatestRuntimePatch>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
## Summary of changes

Don't dispose the runtime metrics when shutting down.

## Reason for change

Disposing the underlying EventListener can cause a crash if the customer has another EventListener running: https://github.com/dotnet/runtime/issues/103480

## Implementation details

Removed the explicit `Dispose` call in `TraceManager.RunShutdownTasksAsync`

## Test coverage

Added a smoke test. Confirmed that it crashes without the fix.