### PR TITLE
[CrashTracking] Add more exception types 

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -514,7 +514,16 @@ internal class CreatedumpCommand : Command
             // The stacks aren't suspicious, but maybe the exception is
             var exceptionType = exception.Type.Name ?? string.Empty;
 
-            var suspiciousExceptionTypes = new[] { "System.InvalidProgramException", "System.Security.VerificationException", "System.MissingMethodException", "System.BadImageFormatException" };
+            var suspiciousExceptionTypes = new[]
+            {
+                "System.InvalidProgramException",
+                "System.Security.VerificationException",
+                "System.MissingMethodException",
+                "System.MissingFieldException",
+                "System.MissingMemberException",
+                "System.BadImageFormatException",
+                "System.TypeLoadException"
+            };
 
             if (exceptionType.StartsWith("Datadog", StringComparison.OrdinalIgnoreCase) || suspiciousExceptionTypes.Contains(exceptionType))
             {
@@ -666,7 +675,7 @@ internal class CreatedumpCommand : Command
 
         if (exception != null)
         {
-            tags = [..tags, ("exception", exception.ToString())];
+            tags = [.. tags, ("exception", exception.ToString())];
         }
 
         var bag = new List<IntPtr>();


### PR DESCRIPTION
## Summary of changes

Add `System.MissingFieldException`, `System.MissingMemberException`, and `System.TypeLoadException` to the list of suspicious exceptions.

## Reason for change

Those are other exception types that can be thrown by faulty instrumentation.
