### PR TITLE
[TRACER] Ensure synchronization in MethodInfo lazy operations

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -237,7 +237,7 @@ namespace iast
         if (SUCCEEDED(hr))
         {
             MemberRefInfo* targetMemberRefInfo = nullptr;
-            //Look for our method based uppon the signature representation
+            //Look for our method based upon the signature representation
             for (auto candidate : targetMethodRefCandidates)
             {
                 if (auto memberRefInfo = module->GetMemberRefInfo(candidate))

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -32,7 +32,7 @@ namespace iast
     {
         return _id;
     }
-    WSTRING TypeInfo::GetName()
+    WSTRING& TypeInfo::GetName()
     {
         if (_name.size() == 0)
         {
@@ -87,42 +87,33 @@ namespace iast
     {
         return _module;
     }
-    WSTRING MemberRefInfo::GetName()
+    WSTRING& MemberRefInfo::GetName()
     {
         return _name;
     }
-    WSTRING MemberRefInfo::GetMemberName()
-    {
-        if (_memberName.size() == 0)
-        {
-            auto pos = _name.find(WStr("("));
-            if (pos != WSTRING::npos)
-            {
-                _memberName = _name.substr(0, pos);
-            }
-            else
-            {
-                _memberName = _name;
-            }
-        }
-        return _memberName;
-    }
 
-    WSTRING MemberRefInfo::GetFullName()
+    WSTRING& MemberRefInfo::GetFullName()
     {
         if (_fullName.size() == 0)
         {
-            auto fullName = GetTypeName() + WStr("::") + _name;
-            auto signature = GetSignature();
-            if (signature != nullptr)
+            if (_fullNameCounterLock.fetch_add(1, std::memory_order_acquire) == 0) // First thread to calculate full name
             {
-                fullName = signature->CharacterizeMember(fullName, false);
-            }
-            if (_fullNameCounterLock.fetch_add(1, std::memory_order_acquire) == 0)
-            {
+                auto fullName = GetTypeName() + WStr("::") + _name;
+                auto signature = GetSignature();
+                if (signature != nullptr)
+                {
+                    fullName = signature->CharacterizeMember(fullName);
+                }
                 _fullName = fullName;
+                _fullNameCounterLock++;
             }
-            return fullName;
+            else // Second thread. Wait for first thread to finish
+            {
+                while (_fullNameCounterLock < 2)
+                {
+                    Sleep(1);
+                }
+            }
         }
         return _fullName;
     }
@@ -136,7 +127,7 @@ namespace iast
         }
         return res;
     }
-    WSTRING MemberRefInfo::GetTypeName()
+    WSTRING& MemberRefInfo::GetTypeName()
     {
         auto type = GetTypeInfo();
         if (type) { return type->GetName(); }
@@ -245,6 +236,19 @@ namespace iast
             _name = methodName;
         }
         _allowRestoreOnSecondJit = GetRestoreOnSecondJitConfigValue();
+
+        _isExcluded = _module->_dataflow->IsMethodExcluded(GetFullName());
+        if (!_isExcluded && _module->_dataflow->HasMethodAttributeExclusions())
+        {
+            for (auto methodAttribute : GetCustomAttributes())
+            {
+                if (_module->_dataflow->IsMethodAttributeExcluded(methodAttribute))
+                {
+                    _isExcluded = true;
+                    break;
+                }
+            }
+        }
     }
     MethodInfo::~MethodInfo()
     {
@@ -255,10 +259,6 @@ namespace iast
     mdMethodDef MethodInfo::GetMethodDef()
     {
         return _id;
-    }
-    WSTRING MethodInfo::GetMethodName()
-    {
-        return GetMemberName();
     }
 
 
@@ -287,22 +287,6 @@ namespace iast
 
     bool MethodInfo::IsExcluded()
     {
-        if (_isExcluded < 0)
-        {
-            _isExcluded = _module->_dataflow->IsMethodExcluded(GetFullName());
-            if (!_isExcluded && _module->_dataflow->HasMethodAttributeExclusions())
-            {
-                for (auto methodAttribute : GetCustomAttributes())
-                {
-                    if (_module->_dataflow->IsMethodAttributeExcluded(methodAttribute))
-                    {
-                        _isExcluded = true;
-                        break;
-                    }
-                }
-            
-            }
-        }
         return _isExcluded;
     }
     bool MethodInfo::IsProcessed()

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.h
@@ -63,9 +63,6 @@ namespace iast
         ULONG GetParameterCount();
         CorElementType GetReturnCorType();
         virtual std::vector<WSTRING> GetCustomAttributes();
-
-    private:
-        std::atomic<unsigned char> _fullNameCounterLock;
     };
 
     class MethodSpec : public MemberRefInfo

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.h
@@ -25,7 +25,7 @@ namespace iast
         mdTypeDef _id = 0;
     public:
         mdTypeDef GetTypeDef();
-        WSTRING GetName();
+        WSTRING& GetName();
     };
 
     class MemberRefInfo
@@ -39,7 +39,6 @@ namespace iast
         ModuleInfo* _module = nullptr;
         WSTRING _name = EmptyWStr;
         WSTRING _fullName = EmptyWStr;
-        WSTRING _memberName = EmptyWStr;
 
         mdTypeDef _typeDef = 0;
         TypeInfo* _typeInfo = nullptr;
@@ -56,11 +55,10 @@ namespace iast
         mdTypeDef GetTypeDef();
 
         ModuleInfo* GetModuleInfo();
-        WSTRING GetName();
-        WSTRING GetMemberName();
-        WSTRING GetFullName();
+        WSTRING& GetName();
+        WSTRING& GetFullName();
         WSTRING GetFullNameWithReturnType();
-        WSTRING GetTypeName();
+        WSTRING& GetTypeName();
         virtual SignatureInfo* GetSignature();
         ULONG GetParameterCount();
         CorElementType GetReturnCorType();
@@ -118,7 +116,7 @@ namespace iast
     private:
         DWORD _methodAttributes;
 
-        int _isExcluded = -1;
+        bool _isExcluded = false;
         bool _isProcessed = false;
         bool _allowRestoreOnSecondJit = false;
         bool _disableInlining = false;
@@ -133,13 +131,11 @@ namespace iast
         ILRewriter* _rewriter = nullptr;
         std::string _applyMessage = "";
     private:
-        // LPBYTE AllocBuffer(DWORD size);
         void FreeBuffer();
     public:
         MethodInfo(ModuleInfo* pModuleInfo, mdMethodDef methodDef);
         ~MethodInfo() override;
 
-        WSTRING GetMethodName();
         WSTRING GetKey(FunctionID functionID = 0);
         mdMethodDef GetMethodDef();
 

--- a/tracer/src/Datadog.Tracer.Native/iast/module_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/module_info.h
@@ -58,10 +58,9 @@ namespace iast
         std::unordered_map<mdMethodSpec, MethodSpec*> _specs;
         std::unordered_map<mdSignature, SignatureInfo*> _signatures;
 
-        CS _cs;
-        //std::map<mdMethodDef, std::function<HRESULT(MethodInfo*, Dataflow*)>> _jitHooks;
 
     protected:
+        CS _cs;
         Dataflow* _dataflow = nullptr;
         IMetaDataImport2* _metadataImport = nullptr;
         IMetaDataEmit2* _metadataEmit = nullptr;

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_info.cpp
@@ -46,22 +46,26 @@ namespace iast
             hr = ParseMethodSignature(pSig, nSig, (ULONG*)&_callingConvention, &_returnType, &_params, &_genericParamCount, &cbRead);
         }
 
-        std::basic_stringstream<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR>> buffer;
-        buffer << WStr("(");
         if (_params.size() > 0)
         {
+            std::stringstream buffer;
+            buffer << "(";
             int count = 0;
             for (auto p : _params)
             {
                 if (count++ > 0)
                 {
-                    buffer << WStr(",");
+                    buffer << ",";
                 }
-                buffer << p->GetName();
+                buffer << ToString(p->GetName());
             }
+            buffer << ")";
+            _paramsString = ToWSTRING(buffer.str());
         }
-        buffer << WStr(")");
-        _paramsString = buffer.str();
+        else
+        {
+            _paramsString = WStr("()");
+        }
 
         if (_returnType)
         {

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_info.cpp
@@ -45,6 +45,28 @@ namespace iast
         {
             hr = ParseMethodSignature(pSig, nSig, (ULONG*)&_callingConvention, &_returnType, &_params, &_genericParamCount, &cbRead);
         }
+
+        std::basic_stringstream<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR>> buffer;
+        buffer << WStr("(");
+        if (_params.size() > 0)
+        {
+            int count = 0;
+            for (auto p : _params)
+            {
+                if (count++ > 0)
+                {
+                    buffer << WStr(",");
+                }
+                buffer << p->GetName();
+            }
+        }
+        buffer << WStr(")");
+        _paramsString = buffer.str();
+
+        if (_returnType)
+        {
+            _returnTypeString = _returnType->GetName();
+        }
     }
 
     SignatureInfo::~SignatureInfo()
@@ -56,28 +78,13 @@ namespace iast
         }
         _params.clear();
     }
-    WSTRING SignatureInfo::GetReturnTypeString()
+    WSTRING& SignatureInfo::GetReturnTypeString()
     {
-        if (_returnType && _returnTypeString.length() == 0)
-        {
-            _returnTypeString = _returnType->GetName();
-        }
         return _returnTypeString;
     }
-    WSTRING SignatureInfo::GetParamsRepresentation()
+    WSTRING& SignatureInfo::GetParamsRepresentation()
     {
-        if (_params.size() > 0 && _paramsString.length() == 0)
-        {
-            int count = 0;
-            std::stringstream buffer;
-            for (auto p : _params)
-            {
-                if (count++ > 0) { buffer << ","; }
-                buffer << ToString(p->GetName());
-            }
-            _paramsString = ToWSTRING(buffer.str());
-        }
-        return WStr("(") + _paramsString + WStr(")");
+        return _paramsString;
     }
 
 
@@ -634,25 +641,12 @@ namespace iast
         return (int)res;
     }
 
-    WSTRING SignatureInfo::CharacterizeMember(WSTRING memberName, bool addReturyType)
+    WSTRING SignatureInfo::CharacterizeMember(WSTRING memberName)
     {
         if (_signatureType == SignatureTypes::Method)
         {
             auto paramsStr = GetParamsRepresentation();
-            if (addReturyType)
-            {
-                auto returnTypeStr = GetReturnTypeString();
-                //return Format("%s %s%s"_W, returnTypeStr.c_str(), memberName.c_str(), paramsStr.c_str());
-                return returnTypeStr + WStr(" ") + memberName +  paramsStr;
-            }
-            //return Format("%s%s"_W, memberName.c_str(), paramsStr.c_str());
             return memberName.c_str() + paramsStr;
-        }
-        else if (_signatureType == SignatureTypes::Field && addReturyType)
-        {
-            auto returnTypeStr = GetReturnTypeString();
-            //return Format("%s %s"_W, returnTypeStr.c_str(), memberName.c_str());
-            return returnTypeStr + WStr(" ") + memberName;
         }
         return memberName;
     }

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_info.h
@@ -24,8 +24,8 @@ namespace iast
         SignatureInfo(ModuleInfo* moduleInfo, PCCOR_SIGNATURE pSig, DWORD nSig);
         virtual ~SignatureInfo();
 
-        WSTRING GetReturnTypeString();
-        WSTRING GetParamsRepresentation();
+        WSTRING& GetReturnTypeString();
+        WSTRING& GetParamsRepresentation();
     protected:
         ModuleInfo* _module = nullptr;
 
@@ -58,7 +58,7 @@ namespace iast
         PCCOR_SIGNATURE GetSignature(DWORD* sigSize = nullptr);
         bool HasThis();
         int GetEffectiveParamCount();
-        WSTRING CharacterizeMember(WSTRING memberName, bool addReturyType);
+        WSTRING CharacterizeMember(WSTRING memberName);
 
     public:
         // Inherited via ISignatureBuilder


### PR DESCRIPTION
## Summary of changes
Aded better synchronization in `MethodInfo `lazy initialization

## Reason for change
Some crashes in `GetFullName() `and `IsExcluded()` have been reported

## Implementation details
`IsExcluded()` init moved to `ctor`. `GetFullName()` synched with parent's module mutex.
