### PR TITLE
Minor fixes for hotfix workflows

### DIFF
--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -6,16 +6,12 @@ on:
 
 jobs:
   bump_version:
+    # If this is a hotfix release, _don't_ do a version bump
     # If this is a 1.x release, do the version bump in the release/1.x branch
     # If this is a 2.x release, do the version bump in the release/2.x branch
     # If this is a 3.x.0 release, do the version bump on master
-    # If this is a 3.x.x hotfix release, _don't_ do a version bump
-    if: |
-      startsWith(github.event.release.tag_name, 'v1.')
-      || startsWith(github.event.release.tag_name, 'v2.')
-      || (startsWith(github.event.release.tag_name, 'v3.')
-        && endsWith(github.event.release.tag_name, '.0'))
-
+    
+    if: !endsWith(github.event.release.tag_name, '.0')
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -36,12 +36,15 @@ jobs:
           dotnet-version: '8.0.100'
 
       - name: "Bump Version"
-        id: versions
-        run: .\tracer\build.ps1 UpdateVersion OutputCurrentVersionToGitHub
+        run: .\tracer\build.ps1 UpdateVersion
 
       - name: "Verify Changes"
         id: changes
         run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump -ExpectChangelogUpdate false
+
+      - name: "Output Version"
+        id: versions
+        run: .\tracer\build.ps1 OutputCurrentVersionToGitHub
 
       - name: "Push hotfix branch"
         run: |

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -31,12 +31,15 @@ jobs:
           dotnet-version: '8.0.100'
 
       - name: "Bump Version"
-        id: versions
-        run: .\tracer\build.ps1 UpdateVersion OutputCurrentVersionToGitHub
+        run: .\tracer\build.ps1 UpdateVersion
 
       - name: "Verify Changes"
         id: changes
         run: .\tracer\build.ps1 VerifyChangedFilesFromVersionBump -ExpectChangelogUpdate false
+
+      - name: "Output Version"
+        id: versions
+        run: .\tracer\build.ps1 OutputCurrentVersionToGitHub
 
       - name: Create Pull Request
         id: pr


### PR DESCRIPTION
## Summary of changes

- Don't create version bump PR for hotfix releases
- Fix name of auto-created hotfix branches

## Reason for change

Fixes a couple of bugs:
- We never want to do a version bump PR for a hotfix release
- When we were creating the hotfix branch originally, it was created with the wrong name (and the commit was incorrect)

## Implementation details

The latter bug was because we weren't recompiling the nuke project between updating the version an emitting it. Fixed by splitting them to separate invocations.

## Test coverage

Meh



<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
