### PR TITLE
Fix reading JSON-formatted settings in remote config

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -15,7 +15,6 @@ using Datadog.Trace.Logging;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
-using Datadog.Trace.Util;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -343,16 +343,7 @@ namespace Datadog.Trace.Configuration
 
             try
             {
-                var valueAsString = token switch
-                {
-                    null => null,
-                    _ => token.Type switch
-                    {
-                        JTokenType.Null or JTokenType.None or JTokenType.Undefined => null,
-                        JTokenType.String => token.Value<string>(),
-                        _ => token.ToString(Formatting.None) // serialize back into json
-                    }
-                };
+                var valueAsString = JTokenToString<T>(token);
 
                 if (valueAsString is not null)
                 {
@@ -379,6 +370,20 @@ namespace Datadog.Trace.Configuration
             }
 
             return null;
+        }
+
+        internal static string? JTokenToString(JToken? token)
+        {
+            return token switch
+            {
+                null => null,
+                _ => token.Type switch
+                {
+                    JTokenType.Null or JTokenType.None or JTokenType.Undefined => null, // handle null-like values
+                    JTokenType.String => token.Value<string>(), // return the underlying string value
+                    _ => token.ToString(Formatting.None) // serialize back into json
+                }
+            };
         }
 
         /// <inheritdoc />

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -350,7 +350,7 @@ namespace Datadog.Trace.Configuration
                     {
                         JTokenType.Null or JTokenType.None or JTokenType.Undefined => null,
                         JTokenType.String => token.Value<string>(),
-                        _ => token.ToString()
+                        _ => token.ToString(Formatting.None) // serialize back into json
                     }
                 };
 

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -244,7 +244,7 @@ namespace Datadog.Trace.Configuration
             catch (Exception)
             {
                 telemetry.Record(key, token?.ToString(), recordValue, _origin, TelemetryErrorCode.JsonStringError);
-                throw; // Exising behaviour
+                throw; // Existing behaviour
             }
 
             return null;

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -343,7 +343,17 @@ namespace Datadog.Trace.Configuration
 
             try
             {
-                var valueAsString = token?.Value<string>();
+                var valueAsString = token switch
+                {
+                    null => null,
+                    _ => token.Type switch
+                    {
+                        JTokenType.Null or JTokenType.None or JTokenType.Undefined => null,
+                        JTokenType.String => token.Value<string>(),
+                        _ => token.ToString()
+                    }
+                };
+
                 if (valueAsString is not null)
                 {
                     var value = converter(valueAsString);

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/JsonConfigurationSource.cs
@@ -343,7 +343,7 @@ namespace Datadog.Trace.Configuration
 
             try
             {
-                var valueAsString = JTokenToString<T>(token);
+                var valueAsString = JTokenToString(token);
 
                 if (valueAsString is not null)
                 {

--- a/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
+++ b/tracer/src/Datadog.Trace/Configuration/DynamicConfigurationManager.cs
@@ -77,7 +77,7 @@ namespace Datadog.Trace.Configuration
                 TraceEnabled = settings.WithKeys(ConfigurationKeys.TraceEnabled).AsBool(),
                 // RuntimeMetricsEnabled = settings.WithKeys(ConfigurationKeys.RuntimeMetricsEnabled).AsBool(),
                 // DataStreamsMonitoringEnabled = settings.WithKeys(ConfigurationKeys.DataStreamsMonitoring.Enabled).AsBool(),
-                SamplingRules = settings.WithKeys(ConfigurationKeys.CustomSamplingRules).AsString(),
+                SamplingRules = settings.WithKeys(ConfigurationKeys.CustomSamplingRules).GetAs<string>(null, null, s => s),
                 GlobalSamplingRate = settings.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDouble(),
                 // SpanSamplingRules = settings.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString(),
                 LogsInjectionEnabled = settings.WithKeys(ConfigurationKeys.LogsInjectionEnabled).AsBool(),

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -408,7 +408,7 @@ namespace Datadog.Trace
                     writer.WriteValue(instanceSettings.CustomSamplingRulesInternal);
 
                     writer.WritePropertyName("remote_sampling_rules");
-                    writer.WriteValue(instanceSettings.RemoteSamplingRules);
+                    writer.WriteRawValue(instanceSettings.RemoteSamplingRules);
 
                     writer.WritePropertyName("tags");
                     WriteDictionary(instanceSettings.GlobalTagsInternal);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -255,7 +255,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // (ConfigurationKeys.DebugEnabled, config.DebugLogsEnabled),
                 (ConfigurationKeys.LogsInjectionEnabled, config.LogInjectionEnabled),
                 (ConfigurationKeys.GlobalSamplingRate, config.TraceSampleRate),
-                (ConfigurationKeys.CustomSamplingRules, config.TraceSamplingRules),
+                (ConfigurationKeys.CustomSamplingRules, config.TraceSamplingRules == null ? null : JToken.Parse(config.TraceSamplingRules).ToString()),
                 // (ConfigurationKeys.SpanSamplingRules, config.SpanSamplingRules),
                 // (ConfigurationKeys.DataStreamsMonitoring.Enabled, config.DataStreamsEnabled),
                 (ConfigurationKeys.HeaderTags, config.TraceHeaderTags == null ? null : JToken.Parse(config.TraceHeaderTags).ToString()),
@@ -355,6 +355,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             public double? TraceSampleRate { get; init; }
 
             [JsonProperty("tracing_sampling_rules")]
+            [JsonConverter(typeof(PlainJsonStringConverter))]
             public string TraceSamplingRules { get; init; }
 
             // [JsonProperty("span_sampling_rules")]

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // json["debug"]?.Value<bool>().Should().Be(expectedConfig.DebugLogsEnabled);
                 json["log_injection_enabled"]?.Value<bool>().Should().Be(expectedConfig.LogInjectionEnabled);
                 json["sample_rate"]?.Value<double?>().Should().Be(expectedConfig.TraceSampleRate);
-                json["remote_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.TraceSamplingRules);
+                json["remote_sampling_rules"]?.ToString(Formatting.None).Should().Be(expectedConfig.TraceSamplingRules);
                 // json["span_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SpanSamplingRules);
                 // json["data_streams_enabled"]?.Value<bool>().Should().Be(expectedConfig.DataStreamsEnabled);
                 FlattenJsonArray(json["header_tags"]).Should().Be(expectedConfig.TraceHeaderTags ?? string.Empty);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -209,11 +209,25 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     return string.Empty;
                 }
 
+                static string JTokenToString(JToken token)
+                {
+                    return token switch
+                    {
+                        null => null,
+                        _ => token.Type switch
+                        {
+                            JTokenType.Null or JTokenType.None or JTokenType.Undefined => null,
+                            JTokenType.String => token.Value<string>(),
+                            _ => token.ToString(Formatting.None) // serialize back into json
+                        }
+                    };
+                }
+
                 // json["runtime_metrics_enabled"]?.Value<bool>().Should().Be(expectedConfig.RuntimeMetricsEnabled);
                 // json["debug"]?.Value<bool>().Should().Be(expectedConfig.DebugLogsEnabled);
                 json["log_injection_enabled"]?.Value<bool>().Should().Be(expectedConfig.LogInjectionEnabled);
                 json["sample_rate"]?.Value<double?>().Should().Be(expectedConfig.TraceSampleRate);
-                json["remote_sampling_rules"]?.ToString(Formatting.None).Should().Be(expectedConfig.TraceSamplingRules);
+                JTokenToString(json["remote_sampling_rules"]).Should().Be(expectedConfig.TraceSamplingRules);
                 // json["span_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SpanSamplingRules);
                 // json["data_streams_enabled"]?.Value<bool>().Should().Be(expectedConfig.DataStreamsEnabled);
                 FlattenJsonArray(json["header_tags"]).Should().Be(expectedConfig.TraceHeaderTags ?? string.Empty);
@@ -255,7 +269,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // (ConfigurationKeys.DebugEnabled, config.DebugLogsEnabled),
                 (ConfigurationKeys.LogsInjectionEnabled, config.LogInjectionEnabled),
                 (ConfigurationKeys.GlobalSamplingRate, config.TraceSampleRate),
-                (ConfigurationKeys.CustomSamplingRules, config.TraceSamplingRules == null ? null : JToken.Parse(config.TraceSamplingRules).ToString()),
+                (ConfigurationKeys.CustomSamplingRules, config.TraceSamplingRules == null ? null : JToken.Parse(config.TraceSamplingRules).ToString(Formatting.None)),
                 // (ConfigurationKeys.SpanSamplingRules, config.SpanSamplingRules),
                 // (ConfigurationKeys.DataStreamsMonitoring.Enabled, config.DataStreamsEnabled),
                 (ConfigurationKeys.HeaderTags, config.TraceHeaderTags == null ? null : JToken.Parse(config.TraceHeaderTags).ToString()),

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -209,25 +209,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                     return string.Empty;
                 }
 
-                static string JTokenToString(JToken token)
-                {
-                    return token switch
-                    {
-                        null => null,
-                        _ => token.Type switch
-                        {
-                            JTokenType.Null or JTokenType.None or JTokenType.Undefined => null,
-                            JTokenType.String => token.Value<string>(),
-                            _ => token.ToString(Formatting.None) // serialize back into json
-                        }
-                    };
-                }
-
                 // json["runtime_metrics_enabled"]?.Value<bool>().Should().Be(expectedConfig.RuntimeMetricsEnabled);
                 // json["debug"]?.Value<bool>().Should().Be(expectedConfig.DebugLogsEnabled);
                 json["log_injection_enabled"]?.Value<bool>().Should().Be(expectedConfig.LogInjectionEnabled);
                 json["sample_rate"]?.Value<double?>().Should().Be(expectedConfig.TraceSampleRate);
-                JTokenToString(json["remote_sampling_rules"]).Should().Be(expectedConfig.TraceSamplingRules);
+                JsonConfigurationSource.JTokenToString(json["remote_sampling_rules"]).Should().Be(expectedConfig.TraceSamplingRules);
                 // json["span_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SpanSamplingRules);
                 // json["data_streams_enabled"]?.Value<bool>().Should().Be(expectedConfig.DataStreamsEnabled);
                 FlattenJsonArray(json["header_tags"]).Should().Be(expectedConfig.TraceHeaderTags ?? string.Empty);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;


### PR DESCRIPTION
## Summary of changes

Fix bug when reading JSON-like settings from remote config (RC).

## Reason for change

Remote configuration (RC) sends inline JSON object for `DD_TRACE_SAMPLING_RULES`. We were expecting the setting's value to be an embedded JSON string:
```
{ "CONFIG_NAME": "[]" }
```
instead of an array of JSON objects
```
{ "CONFIG_NAME": [] }
```
This breaks RC when it fails to parse the setting's value.

## Implementation details

Check `JToken.Type,` and convert the token to `string` depending on its type:
- `null` for null-like types
-  `JToken.Value<string>()` for strings to get the underlying value
- `JToken.ToString()` for anything else. This converts arrays or objects back into json, which is what we expect.

## Test coverage

- fixed unit and integration tests in this PR to expect objects from RC (parsed from json) instead of the json string itself
- also tested with [system tests](https://github.com/DataDog/system-tests/blob/9a06a23e4dadd484963c0e77484e5d3521de753e/tests/parametric/test_dynamic_configuration.py#L557), (which revealed the issue in the first place)
```
tests/parametric/test_dynamic_configuration.py::TestDynamicConfigSamplingRules
````

## Other details

In the future, we should consider converting the `JToken` into a collection of sampling rules directly, instead of serializing the token into a json string only to deserialize it again later.

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
