### PR TITLE
Fix syntax error in version-bump GitHub Action

### DIFF
--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -11,7 +11,8 @@ jobs:
     # If this is a 2.x release, do the version bump in the release/2.x branch
     # If this is a 3.x.0 release, do the version bump on master
     
-    if: !endsWith(github.event.release.tag_name, '.0')
+    if: |
+      !endsWith(github.event.release.tag_name, '.0')
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary of changes

Fix syntax error

## Reason for change

GitHub complains if it's all on one line it seems, because YAML I guess 🤷‍♂️ 
![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/171952a8-b925-4872-9989-493ccbc63a74)
![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/37616763-5156-4ea1-a18a-08624f40ba0f)

## Implementation details

Pipe your way to glory

## Test coverage

I wish this stuff was more easily testable

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
