### PR TITLE
Build against `macos-12` instead of `macos-11`

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -684,7 +684,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-11
+      vmImage: macos-12
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -704,7 +704,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-11
+      vmImage: macos-12
     steps:
     - template: steps/clone-repo.yml
       parameters:
@@ -729,7 +729,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [native_tracer, native_loader_and_managed ]
     pool:
-      vmImage: macos-11
+      vmImage: macos-12
     steps:
     - checkout: none
 
@@ -1029,7 +1029,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-11
+      vmImage: macos-12
     steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1096,7 +1096,7 @@ stages:
   - job: managed
     timeoutInMinutes: 90
     pool:
-      vmImage: macos-11
+      vmImage: macos-12
     steps:
       - template: steps/clone-repo.yml
         parameters:
@@ -1593,7 +1593,7 @@ stages:
     timeoutInMinutes: 60 #default value
     dependsOn: [ ]
     pool:
-      vmImage: macos-11
+      vmImage: macos-12
     steps:
     - template: steps/clone-repo.yml
       parameters:


### PR DESCRIPTION
## Summary of changes

Change the build agent to use `macos-11` instead of `macos-12`

## Reason for change

[Microsoft have announced](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml#recent-updates):

> The macOS-11 Big Sur image is deprecated and will be retired June 28, 2024

And they've started implementing brown-outs, so we need to get off that image ASAP

## Implementation details

`macos-11` -> `macos-12`

## Test coverage

@tonyredondo was going to fire up a macos-11 VM to confirm everything still works when built with the later OS, but he couldn't actually get that to run IIRC - best we can tell it's ok.

## Other details
A backport of:
- https://github.com/DataDog/dd-trace-dotnet/pull/5395

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
