### PR TITLE
[CrashTracking] Fix the heuristic to filter out BlockingMiddleware

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -346,7 +346,7 @@ internal class CreatedumpCommand : Command
 
             if (typeName != null)
             {
-                if (typeName.EndsWith("BlockingMiddleware"))
+                if (typeName.Contains("BlockingMiddleware"))
                 {
                     return false;
                 }


### PR DESCRIPTION
## Summary of changes

Change the heuristic to look for `BlockingMiddleware` anywhere in the type, when deciding if we caused the crash.

## Reason for change

The previous condition failed to filter `Datadog.Trace.ClrProfiler.AutoInstrumentation.AspNetCore.BlockingMiddleware+<Invoke>d__5.MoveNext`.

## Implementation details

s/EndsWith/Contains
