### PR TITLE
Set CODEOWNERS of debugger configuration keys to the debugger team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,6 +60,7 @@ tracer/src/Datadog.InstrumentedAssemblyVerification/ @DataDog/debugger-dotnet
 fault_tolerant_*.cpp                       @DataDog/debugger-dotnet
 fault_tolerant_*.h                         @DataDog/debugger-dotnet
 /tracer/src/Datadog.Trace/FaultTolerant/   @DataDog/debugger-dotnet
+/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs   @DataDog/debugger-dotnet
 
 # Serverless
 /tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-aws


### PR DESCRIPTION
## Summary of changes
Set CODEOWNERS of debugger configuration keys to the debugger team

## Reason for change
To not enforce the tracer team to review those PR's that include changes in the debugger configuration keys
