### PR TITLE
Add basic smoke tests for macos

### DIFF
--- a/.azure-pipelines/steps/install-dotnet.yml
+++ b/.azure-pipelines/steps/install-dotnet.yml
@@ -1,43 +1,48 @@
+parameters:
+  - name: packageType
+    type: string
+    default: runtime
+
 steps:
 - task: UseDotNet@2
-  displayName: install dotnet core runtime 2.1
+  displayName: install dotnet core ${{ parameters.packageType }} 2.1
   inputs:
-    packageType: runtime
+    packageType: ${{ parameters.packageType }}
     version: 2.1.x
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
-  displayName: install dotnet core runtime 3.0
+  displayName: install dotnet core ${{ parameters.packageType }} 3.0
   inputs:
-    packageType: runtime
+    packageType: ${{ parameters.packageType }}
     version: 3.0.x
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
-  displayName: install dotnet core runtime 3.1
+  displayName: install dotnet core ${{ parameters.packageType }} 3.1
   inputs:
-    packageType: runtime
+    packageType: ${{ parameters.packageType }}
     version: 3.1.x
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
-  displayName: install dotnet core runtime 5.0
+  displayName: install dotnet core ${{ parameters.packageType }} 5.0
   inputs:
-    packageType: runtime
+    packageType: ${{ parameters.packageType }}
     version: 5.0.x
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
-  displayName: install dotnet core runtime 6.0
+  displayName: install dotnet core ${{ parameters.packageType }} 6.0
   inputs:
-    packageType: runtime
+    packageType: ${{ parameters.packageType }}
     version: 6.0.x
   retryCountOnTaskFailure: 5
 
 - task: UseDotNet@2
-  displayName: install dotnet core runtime 7.0
+  displayName: install dotnet core ${{ parameters.packageType }} 7.0
   inputs:
-    packageType: runtime
+    packageType: ${{ parameters.packageType }}
     version: 7.0.x
   retryCountOnTaskFailure: 5
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5807,6 +5807,146 @@ stages:
     - script: tracer\build.cmd CheckSmokeTestsForErrors
       displayName: CheckSmokeTestsForErrors
 
+- stage: dotnet_tool_nuget_smoke_tests_macos
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [macos]
+
+    - job: macos
+      timeoutInMinutes: 45 # should take ~5 mins
+      strategy:
+        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.dotnet_tool_nuget_installer_macos_smoke_tests_matrix'] ]
+      variables:
+        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+        snapshotSrcDir: "$(System.DefaultWorkingDirectory)/tracer/build/smoke_test_snapshots"
+        snapshotOutputDir: "$(System.DefaultWorkingDirectory)/tracer/build_data/snapshots"
+      pool:
+        vmImage: $(vmImage)
+      
+      steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
+        - template: steps/install-dotnet.yml
+          parameters:
+            packageType: sdk # have to install the SDK (instead of runtime) so we get the aspnetcore runtime
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download tool runner-dotnet-tool
+          inputs:
+            artifact: runner-dotnet-tool
+            path: $(smokeTestAppDir)/artifacts
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'specific'
+            pipelineId: 159827
+
+
+        - script: |
+            mkdir -p tracer/build_data/snapshots
+            mkdir -p tracer/build_data/logs
+            mkdir $(smokeTestAppDir)/publish
+          displayName: create test data directories
+
+        - script: |
+            python --version
+            pip install ddapm-test-agent
+
+            # copied from run-snapshot-test
+            echo "##vso[task.setvariable variable=TOKEN]$(System.JobId)"
+            echo "##vso[task.setvariable variable=START_ENDPOINT]/test/session/start?test_session_token=$(System.JobId)"
+            echo "##vso[task.setvariable variable=TRACE_DUMP_ENDPOINT]/test/session/traces?test_session_token=$(System.JobId)"
+            echo "##vso[task.setvariable variable=STATS_DUMP_ENDPOINT]/test/session/stats?test_session_token=$(System.JobId)"
+            echo "##vso[task.setvariable variable=REQUESTS_DUMP_ENDPOINT]/test/session/requests?test_session_token=$(System.JobId)"
+            snapshotfile="smoke_test_snapshots"
+            echo "##vso[task.setvariable variable=VERIFY_ENDPOINT]/test/session/snapshot?test_session_token=$(System.JobId)&file=$(snapshotSrcDir)/$snapshotfile"
+            echo "##vso[task.setvariable variable=CURL_COMMAND]/usr/bin/curl"
+          displayName: install test agent and set variables
+
+        - script: |
+            cd $(smokeTestAppDir)
+            dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $(publishFramework) -o $(smokeTestAppDir)/publish
+          displayName: Build app
+          failOnStderr: true
+
+        - script: |
+            dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --add-source $(smokeTestAppDir)/artifacts/.
+          displayName: Install tracer
+
+        - script: |
+            ddapm-test-agent --port=8126 &
+            agent_pid=$(echo $!)
+            echo "##vso[task.setvariable variable=AGENT_PID]$agent_pid"
+            echo "Agent PID: $agent_pid, waiting for startup"
+
+            while ! nc -z localhost 8126; do   
+              sleep 0.1 # wait for 1/10 of the second before check again
+            done
+
+            echo "Sending initialisation request"
+            $(CURL_COMMAND) --fail "http://localhost:8126$(START_ENDPOINT)"
+          displayName: run test agent
+          env:
+            ENABLED_CHECKS: trace_count_header,meta_tracer_version_header,trace_content_length
+            SNAPSHOT_DIR: $(System.DefaultWorkingDirectory)/tracer/build/smoke_test_snapshots
+            SNAPSHOT_CI: 1
+            # ignoring 'http.client_ip' and 'network.client.ip' because it's set to '::1' here instead of expected '127.0.0.1'
+            SNAPSHOT_IGNORED_ATTRS: span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.git.commit.sha,meta._dd.git.repository_url,meta.http.client_ip,meta.network.client.ip
+
+        - script: |
+            # Based on variables set in smoke.dotnet-tool.nuget.dockerfile
+            DD_PROFILING_ENABLED=1 \
+            DD_APPSEC_ENABLED=1 \
+            DD_TRACE_DEBUG=1 \
+            ASPNETCORE_URLS=http://localhost:5000 \
+            SUPER_SECRET_CANARY=MySuperSecretCanary \
+            DD_INTERNAL_WORKAROUND_77973_ENABLED=1 \
+            COMPlus_DbgEnableMiniDump=1 \
+            COMPlus_DbgMiniDumpType=4 \
+            DOTNET_DbgMiniDumpName=$(System.DefaultWorkingDirectory)/tracer/build_data/dumps/coredump.%t.%p \
+            DD_INJECTION_ENABLED=tracer \
+            DD_INJECT_FORCE=1 \
+            DD_TELEMETRY_FORWARDER_PATH=/usr/bin/true \
+            DD_TRACE_LOG_DIRECTORY=$(System.DefaultWorkingDirectory)/tracer/build_data/logs \
+            $(smokeTestAppDir)/publish/dd-trace dotnet $(smokeTestAppDir)/publish/AspNetCoreSmokeTest.dll
+          displayName: Run the app
+
+        - script: |
+            echo "Dumping traces"
+            $(CURL_COMMAND) -o $(snapshotOutputDir)/smoke_test_traces.json "http://localhost:8126$(TRACE_DUMP_ENDPOINT)"
+            
+            echo "Dumping stats"
+            $(CURL_COMMAND) -o $(snapshotOutputDir)/smoke_test_stats.json "http://localhost:8126$(STATS_DUMP_ENDPOINT)"
+            
+            echo "Dumping all requests"
+            $(CURL_COMMAND) -o $(snapshotOutputDir)/smoke_test_requests.json "http://localhost:8126$(REQUESTS_DUMP_ENDPOINT)"
+
+            echo "Verifying snapshot session (fail on mis-match)"
+            $(CURL_COMMAND) --fail-with-body "http://localhost:8126$(VERIFY_ENDPOINT)"
+          displayName: check snapshots
+
+        - publish: tracer/build_data
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+          condition: succeededOrFailed()
+          continueOnError: true
+
+        - script: ./tracer/build.sh CheckSmokeTestsForErrors
+          displayName: CheckSmokeTestsForErrors
+
+        - script: kill -15 $(AGENT_PID)
+          displayName: Close test agent
+          condition: succeededOrFailed()
+          continueOnError: true
+
 - stage: dd_dotnet_installer_failure_tests_linux
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
   dependsOn: [generate_variables, merge_commit_id]
@@ -6005,6 +6145,7 @@ stages:
     - nuget_installer_smoke_tests_arm64
     - nuget_installer_smoke_tests_windows
     - dotnet_tool_nuget_smoke_tests_linux
+    - dotnet_tool_nuget_smoke_tests_macos
     - dotnet_tool_smoke_tests_linux
     - dotnet_tool_self_instrument_smoke_tests_linux
     - dotnet_tool_smoke_tests_arm64

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2485,7 +2485,7 @@ partial class Build
         var hasRequiredFiles = !allFilesMustExist
                             || (managedFiles.Count > 0
                              && nativeTracerFiles.Count > 0
-                             && nativeProfilerFiles.Count > 0
+                             && (nativeProfilerFiles.Count > 0 || IsOsx) // profiler doesn't support mac 
                              && nativeLoaderFiles.Count > 0);
 
         if (hasRequiredFiles

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -391,6 +391,9 @@ partial class Build : NukeBuild
 
                 // tracer home smoke tests
                 GenerateWindowsTracerHomeSmokeTestsMatrix();
+                
+                // macos smoke tests
+                GenerateMacosDotnetToolNugetSmokeTestsMatrix();
 
                 void GenerateLinuxInstallerSmokeTestsMatrix()
                 {
@@ -1153,6 +1156,31 @@ partial class Build : NukeBuild
                     Logger.Information($"Installer smoke tests dotnet-tool matrix Windows");
                     Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetOutputVariable("dotnet_tool_installer_windows_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
+                }
+
+                void GenerateMacosDotnetToolNugetSmokeTestsMatrix()
+                {
+                    var matrix = new Dictionary<string, object>
+                    {
+                        { "macos-11_netcoreapp3.1", new { vmImage = "macos-11", publishFramework = "netcoreapp3.1" } },
+                        { "macos-11_net6.0", new { vmImage = "macos-11", publishFramework = "net6.0" } },
+                        { "macos-11_net8.0", new { vmImage = "macos-11", publishFramework = "net8.0" } },
+                        { "macos-12_netcoreapp3.1", new { vmImage = "macos-12", publishFramework = "netcoreapp3.1" } },
+                        { "macos-12_net6.0", new { vmImage = "macos-12", publishFramework = "net6.0" } },
+                        { "macos-12_net8.0", new { vmImage = "macos-12", publishFramework = "net8.0" } },
+                        { "macos-13_netcoreapp3.1", new { vmImage = "macos-13", publishFramework = "netcoreapp3.1" } },
+                        { "macos-13_net5.0", new { vmImage = "macos-13", publishFramework = "net5.0" } },
+                        { "macos-13_net6.0", new { vmImage = "macos-13", publishFramework = "net6.0" } },
+                        { "macos-13_net7.0", new { vmImage = "macos-13", publishFramework = "net7.0" } },
+                        { "macos-13_net8.0", new { vmImage = "macos-13", publishFramework = "net8.0" } },
+                        { "macos-14_netcoreapp3.1", new { vmImage = "macos-14", publishFramework = "netcoreapp3.1" } },
+                        { "macos-14_net6.0", new { vmImage = "macos-14", publishFramework = "net6.0" } },
+                        { "macos-14_net8.0", new { vmImage = "macos-14", publishFramework = "net8.0" } },
+                    };
+
+                    Logger.Information($"Installer smoke tests dotnet-tool NuGet matrix MacOs");
+                    Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
+                    AzurePipelines.Instance.SetOutputVariable("dotnet_tool_nuget_installer_macos_smoke_tests_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
                 }
 
                 static string GetInstallerChannel(string publishFramework) =>


### PR DESCRIPTION
## Summary of changes

- Adds smoke tests for all available hosted macos runners

## Reason for change

macos-11 is being removed, so in https://github.com/DataDog/dd-trace-dotnet/pull/5707 we're replacing with macos-12. We have very few macos-11 users, but still we want to make sure that we don't unexpectedly break them.

## Implementation details

Annoying we can't use docker in the macos stages, so we have to basically replicate everything from the dockerimages and the run-snapshot-test.yml template to run "directly" on the machine. Because of that, only testing a single scenario, the `dd-trace` NuGet install (which is the only currently supported scenario anyway for macOS, and that is only for CI visibility).

The extra commits are just to workaround some annoying peculiarities.

## Test coverage

These macos smoke tests only run on master, or where you set `run_all_installer_tests=true`, so manually did a full test run [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=159845&view=results)

## Other details
Will rebase and test https://github.com/DataDog/dd-trace-dotnet/pull/5707 after this is merged

Also, rebase and squash hides all sins 🙈 

![image](https://github.com/DataDog/dd-trace-dotnet/assets/18755388/d9837af4-f861-4091-b464-e73928c7b80e)


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
