### PR TITLE
Update workflow file again

### DIFF
--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -11,8 +11,7 @@ jobs:
     # If this is a 2.x release, do the version bump in the release/2.x branch
     # If this is a 3.x.0 release, do the version bump on master
     
-    if: |
-      !endsWith(github.event.release.tag_name, '.0')
+    if: endsWith(github.event.release.tag_name, '.0') || endsWith(github.event.release.tag_name, '.0-prerelease')
     runs-on: windows-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary of changes

Fix GitHub versino-bump action

## Reason for change

I got the condition wrong 🤦‍♂️ Also, it didn't support `-prerelease` releases

## Implementation details

Run the version bump if the release _does_ end with `.0` (or `.0-prerelease`)

## Test coverage

Meh, surely I can't get it wrong twice 😶 

## Other details
I got it wrong here first:
- https://github.com/DataDog/dd-trace-dotnet/pull/5706

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
