### PR TITLE
Config refactor - distinguish between "not present" and "not valid"

### DIFF
--- a/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
+++ b/tracer/src/Datadog.Trace.Trimming/build/Datadog.Trace.Trimming.xml
@@ -568,6 +568,7 @@
       <type fullname="System.Func`4" />
       <type fullname="System.Func`5" />
       <type fullname="System.Func`6" />
+      <type fullname="System.Func`7" />
       <type fullname="System.GC" />
       <type fullname="System.Globalization.CultureInfo" />
       <type fullname="System.Globalization.DateTimeStyles" />

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -218,8 +218,8 @@ namespace Datadog.Trace.Ci.Configuration
         {
             var source = GlobalConfigurationSource.CreateDefaultConfigurationSource();
             var defaultExcludedUrlSubstrings = string.Empty;
-            if (((ITelemeteredConfigurationSource)source).GetString(ConfigurationKeys.HttpClientExcludedUrlSubstrings, NullConfigurationTelemetry.Instance, null, false)?.Result is { } substrings &&
-                !string.IsNullOrWhiteSpace(substrings))
+            var configResult = ((ITelemeteredConfigurationSource)source).GetString(ConfigurationKeys.HttpClientExcludedUrlSubstrings, NullConfigurationTelemetry.Instance, validator: null, recordValue: false);
+            if (configResult is { IsValid: true, Result: { } substrings } && !string.IsNullOrWhiteSpace(substrings))
             {
                 defaultExcludedUrlSubstrings = substrings + ", ";
             }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.SourceGenerators;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/CompositeConfigurationSource.cs
@@ -75,8 +75,10 @@ namespace Datadog.Trace.Configuration
         [PublicApi]
         public string? GetString(string key)
         {
-            return _sources.Select(source => source.GetString(key, NullConfigurationTelemetry.Instance, validator: null, recordValue: true))
-                           .FirstOrDefault(value => value != null)?.Result;
+            var value = _sources
+                  .Select(source => source.GetString(key, NullConfigurationTelemetry.Instance, validator: null, recordValue: true))
+                  .FirstOrDefault(value => value.IsValid, ConfigurationResult<string>.NotFound());
+            return value.IsValid ? value.Result : null;
         }
 
         /// <summary>
@@ -89,8 +91,10 @@ namespace Datadog.Trace.Configuration
         [PublicApi]
         public int? GetInt32(string key)
         {
-            return _sources.Select(source => source.GetInt32(key, NullConfigurationTelemetry.Instance, validator: null))
-                           .FirstOrDefault(value => value != null)?.Result;
+            var value = _sources
+                       .Select(source => source.GetInt32(key, NullConfigurationTelemetry.Instance, validator: null))
+                       .FirstOrDefault(value => value.IsValid, ConfigurationResult<int>.NotFound());
+            return value.IsValid ? value.Result : null;
         }
 
         /// <summary>
@@ -103,8 +107,10 @@ namespace Datadog.Trace.Configuration
         [PublicApi]
         public double? GetDouble(string key)
         {
-            return _sources.Select(source => source.GetDouble(key, NullConfigurationTelemetry.Instance, validator: null))
-                           .FirstOrDefault(value => value != null)?.Result;
+            var value = _sources
+                       .Select(source => source.GetDouble(key, NullConfigurationTelemetry.Instance, validator: null))
+                       .FirstOrDefault(value => value.IsValid, ConfigurationResult<double>.NotFound());
+            return value.IsValid ? value.Result : null;
         }
 
         /// <summary>
@@ -117,8 +123,10 @@ namespace Datadog.Trace.Configuration
         [PublicApi]
         public bool? GetBool(string key)
         {
-            return _sources.Select(source => source.GetBool(key, NullConfigurationTelemetry.Instance, validator: null))
-                           .FirstOrDefault(value => value != null)?.Result;
+            var value = _sources
+                       .Select(source => source.GetBool(key, NullConfigurationTelemetry.Instance, validator: null))
+                       .FirstOrDefault(value => value.IsValid, ConfigurationResult<bool>.NotFound());
+            return value.IsValid ? value.Result : null;
         }
 
         internal void AddInternal(IConfigurationSource source)
@@ -159,16 +167,20 @@ namespace Datadog.Trace.Configuration
         [PublicApi]
         public IDictionary<string, string>? GetDictionary(string key)
         {
-            return _sources.Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null))
-                           .FirstOrDefault(value => value != null)?.Result;
+            var value = _sources
+                       .Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null))
+                       .FirstOrDefault(value => value.IsValid, ConfigurationResult<IDictionary<string, string>>.NotFound());
+            return value.IsValid ? value.Result : null;
         }
 
         /// <inheritdoc />
         [PublicApi]
         public IDictionary<string, string>? GetDictionary(string key, bool allowOptionalMappings)
         {
-            return _sources.Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null, allowOptionalMappings, separator: ':'))
-                           .FirstOrDefault(value => value != null)?.Result;
+            var value = _sources
+                       .Select(source => source.GetDictionary(key, NullConfigurationTelemetry.Instance, validator: null, allowOptionalMappings, separator: ':'))
+                       .FirstOrDefault(value => value.IsValid, ConfigurationResult<IDictionary<string, string>>.NotFound());
+            return value.IsValid ? value.Result : null;
         }
 
         /// <inheritdoc />
@@ -176,31 +188,45 @@ namespace Datadog.Trace.Configuration
             => _sources.Select(source => source.IsPresent(key)).FirstOrDefault(value => value);
 
         /// <inheritdoc />
-        ConfigurationResult<string>? ITelemeteredConfigurationSource.GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
-            => _sources.Select(source => source.GetString(key, telemetry, validator, recordValue)).FirstOrDefault(value => value != null);
+        ConfigurationResult<string> ITelemeteredConfigurationSource.GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+            => _sources
+              .Select(source => source.GetString(key, telemetry, validator, recordValue))
+              .FirstOrDefault(value => value.IsValid, ConfigurationResult<string>.NotFound());
 
         /// <inheritdoc />
-        ConfigurationResult<int>? ITelemeteredConfigurationSource.GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
-            => _sources.Select(source => source.GetInt32(key, telemetry, validator)).FirstOrDefault(value => value != null);
+        ConfigurationResult<int> ITelemeteredConfigurationSource.GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+            => _sources
+              .Select(source => source.GetInt32(key, telemetry, validator))
+              .FirstOrDefault(value => value.IsValid, ConfigurationResult<int>.NotFound());
 
         /// <inheritdoc />
-        ConfigurationResult<double>? ITelemeteredConfigurationSource.GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
-            => _sources.Select(source => source.GetDouble(key, telemetry, validator)).FirstOrDefault(value => value != null);
+        ConfigurationResult<double> ITelemeteredConfigurationSource.GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+            => _sources
+              .Select(source => source.GetDouble(key, telemetry, validator))
+              .FirstOrDefault(value => value.IsValid, ConfigurationResult<double>.NotFound());
 
         /// <inheritdoc />
-        ConfigurationResult<bool>? ITelemeteredConfigurationSource.GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
-            => _sources.Select(source => source.GetBool(key, telemetry, validator)).FirstOrDefault(value => value != null);
+        ConfigurationResult<bool> ITelemeteredConfigurationSource.GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+            => _sources
+              .Select(source => source.GetBool(key, telemetry, validator))
+              .FirstOrDefault(value => value.IsValid, ConfigurationResult<bool>.NotFound());
 
         /// <inheritdoc />
-        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
-            => _sources.Select(source => source.GetDictionary(key, telemetry, validator)).FirstOrDefault(value => value != null);
+        ConfigurationResult<IDictionary<string, string>> ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+            => _sources
+              .Select(source => source.GetDictionary(key, telemetry, validator))
+              .FirstOrDefault(value => value.IsValid, ConfigurationResult<IDictionary<string, string>>.NotFound());
 
         /// <inheritdoc />
-        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
-            => _sources.Select(source => source.GetDictionary(key, telemetry, validator, allowOptionalMappings, separator)).FirstOrDefault(value => value != null);
+        ConfigurationResult<IDictionary<string, string>> ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
+            => _sources
+              .Select(source => source.GetDictionary(key, telemetry, validator, allowOptionalMappings, separator))
+              .FirstOrDefault(value => value.IsValid, ConfigurationResult<IDictionary<string, string>>.NotFound());
 
         /// <inheritdoc />
-        ConfigurationResult<T>? ITelemeteredConfigurationSource.GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
-            => _sources.Select(source => source.GetAs<T>(key, telemetry, converter, validator, recordValue)).FirstOrDefault(value => value != null);
+        ConfigurationResult<T> ITelemeteredConfigurationSource.GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+            => _sources
+              .Select(source => source.GetAs<T>(key, telemetry, converter, validator, recordValue))
+              .FirstOrDefault(value => value.IsValid, ConfigurationResult<T>.NotFound());
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/NullConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/NullConfigurationSource.cs
@@ -30,24 +30,24 @@ internal class NullConfigurationSource : IConfigurationSource, ITelemeteredConfi
 
     public IDictionary<string, string>? GetDictionary(string key, bool allowOptionalMappings) => null;
 
-    public ConfigurationResult<string>? GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
-        => null;
+    public ConfigurationResult<string> GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+        => ConfigurationResult<string>.NotFound();
 
-    public ConfigurationResult<int>? GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
-        => null;
+    public ConfigurationResult<int> GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+        => ConfigurationResult<int>.NotFound();
 
-    public ConfigurationResult<double>? GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
-        => null;
+    public ConfigurationResult<double> GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+        => ConfigurationResult<double>.NotFound();
 
-    public ConfigurationResult<bool>? GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
-        => null;
+    public ConfigurationResult<bool> GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+        => ConfigurationResult<bool>.NotFound();
 
-    public ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
-        => null;
+    public ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+        => ConfigurationResult<IDictionary<string, string>>.NotFound();
 
-    public ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
-        => null;
+    public ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
+        => ConfigurationResult<IDictionary<string, string>>.NotFound();
 
-    public ConfigurationResult<T>? GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
-        => null;
+    public ConfigurationResult<T> GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+        => ConfigurationResult<T>.NotFound();
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/StringConfigurationSource.cs
@@ -181,13 +181,13 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
-        ConfigurationResult<string>? ITelemeteredConfigurationSource.GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+        ConfigurationResult<string> ITelemeteredConfigurationSource.GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
         {
             var value = GetString(key);
 
             if (value is null)
             {
-                return null;
+                return ConfigurationResult<string>.NotFound();
             }
 
             if (validator is null || validator(value))
@@ -201,13 +201,13 @@ namespace Datadog.Trace.Configuration
         }
 
         /// <inheritdoc />
-        ConfigurationResult<int>? ITelemeteredConfigurationSource.GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+        ConfigurationResult<int> ITelemeteredConfigurationSource.GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
         {
             var value = GetString(key);
 
             if (value is null)
             {
-                return null;
+                return ConfigurationResult<int>.NotFound();
             }
 
             if (int.TryParse(value, out var result))
@@ -223,17 +223,17 @@ namespace Datadog.Trace.Configuration
             }
 
             telemetry.Record(key, value, recordValue: true, Origin, TelemetryErrorCode.ParsingInt32Error);
-            return null;
+            return ConfigurationResult<int>.ParseFailure();
         }
 
         /// <inheritdoc />
-        ConfigurationResult<double>? ITelemeteredConfigurationSource.GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+        ConfigurationResult<double> ITelemeteredConfigurationSource.GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
         {
             var value = GetString(key);
 
             if (value is null)
             {
-                return null;
+                return ConfigurationResult<double>.NotFound();
             }
 
             if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var result))
@@ -249,17 +249,17 @@ namespace Datadog.Trace.Configuration
             }
 
             telemetry.Record(key, value, recordValue: true, Origin, TelemetryErrorCode.ParsingDoubleError);
-            return null;
+            return ConfigurationResult<double>.ParseFailure();
         }
 
         /// <inheritdoc />
-        ConfigurationResult<bool>? ITelemeteredConfigurationSource.GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+        ConfigurationResult<bool> ITelemeteredConfigurationSource.GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
         {
             var value = GetString(key);
 
             if (value is null)
             {
-                return null;
+                return ConfigurationResult<bool>.NotFound();
             }
 
             var result = value.ToBoolean();
@@ -276,17 +276,17 @@ namespace Datadog.Trace.Configuration
             }
 
             telemetry.Record(key, value, recordValue: true, Origin, TelemetryErrorCode.ParsingBooleanError);
-            return null;
+            return ConfigurationResult<bool>.ParseFailure();
         }
 
         /// <inheritdoc />
-        ConfigurationResult<T>? ITelemeteredConfigurationSource.GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+        ConfigurationResult<T> ITelemeteredConfigurationSource.GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
         {
             var value = GetString(key);
 
             if (value is null)
             {
-                return null;
+                return ConfigurationResult<T>.NotFound();
             }
 
             var result = converter(value);
@@ -303,24 +303,24 @@ namespace Datadog.Trace.Configuration
             }
 
             telemetry.Record(key, value, recordValue, Origin, TelemetryErrorCode.ParsingCustomError);
-            return null;
+            return ConfigurationResult<T>.ParseFailure();
         }
 
         /// <inheritdoc />
-        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+        ConfigurationResult<IDictionary<string, string>> ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
             => GetDictionary(key, telemetry, validator, allowOptionalMappings: false, separator: ':');
 
         /// <inheritdoc />
-        ConfigurationResult<IDictionary<string, string>>? ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
+        ConfigurationResult<IDictionary<string, string>> ITelemeteredConfigurationSource.GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
             => GetDictionary(key, telemetry, validator, allowOptionalMappings, separator);
 
-        private ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
+        private ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
         {
             var value = GetString(key);
 
             if (value is null)
             {
-                return null;
+                return ConfigurationResult<IDictionary<string, string>>.NotFound();
             }
 
             // We record the original dictionary value here instead of serializing the _parsed_ value

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationLoadResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationLoadResult.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="ConfigurationLoadResult.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+internal enum ConfigurationLoadResult
+{
+    /// <summary>
+    /// The configuration value was found, parsed, and validated successfully
+    /// </summary>
+    Valid = 0,
+
+    /// <summary>
+    /// The configuration value was not found
+    /// </summary>
+    NotFound = 1,
+
+    /// <summary>
+    /// The configuration value could not be parsed to the required type
+    /// </summary>
+    ParsingError = 2,
+
+    /// <summary>
+    /// The configuration value was found, parsed, but failed validation
+    /// </summary>
+    ValidationFailure = 3,
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
@@ -33,7 +33,7 @@ internal readonly record struct ConfigurationResult<T>
     /// <summary>
     /// Gets a value indicating whether the configuration loader should defer to a fallback key
     /// </summary>
-    public bool ShouldFallBack => LoadResult is not (ConfigurationLoadResult.Valid or ConfigurationLoadResult.ValidationFailure);
+    public bool ShouldFallBack => LoadResult is ConfigurationLoadResult.NotFound or ConfigurationLoadResult.ParsingError;
 
     /// <summary>
     /// Gets a value indicating whether the key was present in the configuration source.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ConfigurationResult.cs
@@ -5,27 +5,52 @@
 
 #nullable enable
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 
 internal readonly record struct ConfigurationResult<T>
 {
-    private ConfigurationResult(T result, bool isValid)
+    private ConfigurationResult(T? result, ConfigurationLoadResult loadResult)
     {
         Result = result;
-        IsValid = isValid;
+        LoadResult = loadResult;
     }
 
     /// <summary>
-    /// Gets the extracted configuration value.
+    /// Gets the extracted configuration value, if it was found
     /// </summary>
-    public T Result { get; }
+    public T? Result { get; }
 
     /// <summary>
     /// Gets a value indicating whether <see cref="Result"/> result passed validation.
+    /// If <c>true</c>, implies that <see cref="Result"/> contains a valid value. If
+    /// <c>false</c>, see <see cref="LoadResult"/> for more information.
     /// </summary>
-    public bool IsValid { get; }
+    [MemberNotNullWhen(true, nameof(Result))]
+    public bool IsValid => LoadResult == ConfigurationLoadResult.Valid;
 
-    public static ConfigurationResult<T> Valid(T result) => new(result, isValid: true);
+    /// <summary>
+    /// Gets a value indicating whether the configuration loader should defer to a fallback key
+    /// </summary>
+    public bool ShouldFallBack => LoadResult is not (ConfigurationLoadResult.Valid or ConfigurationLoadResult.ValidationFailure);
 
-    public static ConfigurationResult<T> Invalid(T result) => new(result, isValid: false);
+    /// <summary>
+    /// Gets a value indicating whether the key was present in the configuration source.
+    /// Note that this does not say anything about whether the key was successfully parsed, validated, or converted.
+    /// </summary>
+    public bool IsPresent => LoadResult != ConfigurationLoadResult.NotFound;
+
+    /// <summary>
+    /// Gets a value indicating the result of trying to load the configuration
+    /// </summary>
+    public ConfigurationLoadResult LoadResult { get; }
+
+    public static ConfigurationResult<T> Valid(T result) => new(result, ConfigurationLoadResult.Valid);
+
+    public static ConfigurationResult<T> Invalid(T result) => new(result, ConfigurationLoadResult.ValidationFailure);
+
+    public static ConfigurationResult<T> NotFound() => new(default, ConfigurationLoadResult.NotFound);
+
+    public static ConfigurationResult<T> ParseFailure() => new(default, ConfigurationLoadResult.ParsingError);
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/CustomTelemeteredConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/CustomTelemeteredConfigurationSource.cs
@@ -35,14 +35,14 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
         return result is not null;
     }
 
-    public ConfigurationResult<string>? GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
+    public ConfigurationResult<string> GetString(string key, IConfigurationTelemetry telemetry, Func<string, bool>? validator, bool recordValue)
     {
 #pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
         var result = Source.GetString(key);
 #pragma warning restore DD0002
         if (result is null)
         {
-            return null;
+            return ConfigurationResult<string>.NotFound();
         }
 
         if (validator is null || validator(result))
@@ -55,14 +55,19 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
         return ConfigurationResult<string>.Invalid(result);
     }
 
-    public ConfigurationResult<int>? GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
+    public ConfigurationResult<int> GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator)
     {
 #pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
         var result = Source.GetInt32(key);
 #pragma warning restore DD0002
         if (result is null)
         {
-            return null;
+            // Because this is an IConfigurationSource _not_ an ITelemeteredConfigurationSource
+            // we can't distinguish between "not found" and "found but failed to parse"
+            // so we just have to accept this for now. Alternatively, we could call `GetString()`
+            // and do the parsing ourselves, but that doesn't necessarily have the same behaviour
+            // (e.g. this would fail with a json-based source)
+            return ConfigurationResult<int>.NotFound();
         }
 
         if (validator is null || validator(result.Value))
@@ -75,14 +80,19 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
         return ConfigurationResult<int>.Invalid(result.Value);
     }
 
-    public ConfigurationResult<double>? GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
+    public ConfigurationResult<double> GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator)
     {
 #pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
         var result = Source.GetDouble(key);
 #pragma warning restore DD0002
         if (result is null)
         {
-            return null;
+            // Because this is an IConfigurationSource _not_ an ITelemeteredConfigurationSource
+            // we can't distinguish between "not found" and "found but failed to parse"
+            // so we just have to accept this for now. Alternatively, we could call `GetString()`
+            // and do the parsing ourselves, but that doesn't necessarily have the same behaviour
+            // (e.g. this would fail with a json-based source)
+            return ConfigurationResult<double>.NotFound();
         }
 
         if (validator is null || validator(result.Value))
@@ -95,14 +105,19 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
         return ConfigurationResult<double>.Invalid(result.Value);
     }
 
-    public ConfigurationResult<bool>? GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
+    public ConfigurationResult<bool> GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator)
     {
 #pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
         var result = Source.GetBool(key);
 #pragma warning restore DD0002
         if (result is null)
         {
-            return null;
+            // Because this is an IConfigurationSource _not_ an ITelemeteredConfigurationSource
+            // we can't distinguish between "not found" and "found but failed to parse"
+            // so we just have to accept this for now. Alternatively, we could call `GetString()`
+            // and do the parsing ourselves, but that doesn't necessarily have the same behaviour
+            // (e.g. this would fail with a json-based source)
+            return ConfigurationResult<bool>.NotFound();
         }
 
         if (validator is null || validator(result.Value))
@@ -115,17 +130,22 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
         return ConfigurationResult<bool>.Invalid(result.Value);
     }
 
-    public ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
+    public ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator)
         => GetDictionary(key, telemetry, validator, allowOptionalMappings: false, separator: ':');
 
-    public ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
+    public ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator)
     {
 #pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
         var result = Source.GetDictionary(key, allowOptionalMappings);
 #pragma warning restore DD0002
         if (result is null)
         {
-            return null;
+            // Because this is an IConfigurationSource _not_ an ITelemeteredConfigurationSource
+            // we can't distinguish between "not found" and "found but failed to parse"
+            // so we just have to accept this for now. Alternatively, we could call `GetString()`
+            // and do the parsing ourselves, but that doesn't necessarily have the same behaviour
+            // (e.g. this would fail with a json-based source)
+            return ConfigurationResult<IDictionary<string, string>>.NotFound();
         }
 
         // This is horrible. We _could_ call Source.GetString(), but as this is a custom implementation,
@@ -158,7 +178,7 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
         return ConfigurationResult<IDictionary<string, string>>.Invalid(result);
     }
 
-    public ConfigurationResult<T>? GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
+    public ConfigurationResult<T> GetAs<T>(string key, IConfigurationTelemetry telemetry, Func<string, ParsingResult<T>> converter, Func<T, bool>? validator, bool recordValue)
     {
 #pragma warning disable DD0002 // This class is intentionally a wrapper around IConfigurationSource
         var value = Source.GetString(key);
@@ -166,7 +186,12 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
 
         if (value is null)
         {
-            return null;
+            // Because this is an IConfigurationSource _not_ an ITelemeteredConfigurationSource
+            // we can't distinguish between "not found" and "found but failed to parse"
+            // so we just have to accept this for now. Alternatively, we could call `GetString()`
+            // and do the parsing ourselves, but that doesn't necessarily have the same behaviour
+            // (e.g. this would fail with a json-based source)
+            return ConfigurationResult<T>.NotFound();
         }
 
         var result = converter(value);
@@ -183,6 +208,6 @@ internal class CustomTelemeteredConfigurationSource : ITelemeteredConfigurationS
         }
 
         telemetry.Record(key, value, recordValue, ConfigurationOrigins.Code, TelemetryErrorCode.ParsingCustomError);
-        return null;
+        return ConfigurationResult<T>.ParseFailure();
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ITelemeteredConfigurationSource.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/ITelemeteredConfigurationSource.cs
@@ -34,7 +34,7 @@ internal interface ITelemeteredConfigurationSource
     /// a successfully extracted value to determine if it should be accepted</param>
     /// <param name="recordValue">If <c>true</c> the value should be recorded in telemetry. If not, the source value should be redacted</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    ConfigurationResult<string>? GetString(
+    ConfigurationResult<string> GetString(
         string key,
         IConfigurationTelemetry telemetry,
         Func<string, bool>? validator,
@@ -49,7 +49,7 @@ internal interface ITelemeteredConfigurationSource
     /// <param name="validator">An optional validation function that must be applied to
     /// a successfully extracted value to determine if it should be accepted</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    ConfigurationResult<int>? GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator);
+    ConfigurationResult<int> GetInt32(string key, IConfigurationTelemetry telemetry, Func<int, bool>? validator);
 
     /// <summary>
     /// Gets the <see cref="double"/> value of
@@ -60,7 +60,7 @@ internal interface ITelemeteredConfigurationSource
     /// <param name="validator">An optional validation function that must be applied to
     /// a successfully extracted value to determine if it should be accepted</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    ConfigurationResult<double>? GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator);
+    ConfigurationResult<double> GetDouble(string key, IConfigurationTelemetry telemetry, Func<double, bool>? validator);
 
     /// <summary>
     /// Gets the <see cref="bool"/> value of
@@ -71,7 +71,7 @@ internal interface ITelemeteredConfigurationSource
     /// <param name="validator">An optional validation function that must be applied to
     /// a successfully extracted value to determine if it should be accepted</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    ConfigurationResult<bool>? GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator);
+    ConfigurationResult<bool> GetBool(string key, IConfigurationTelemetry telemetry, Func<bool, bool>? validator);
 
     /// <summary>
     /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
@@ -82,7 +82,7 @@ internal interface ITelemeteredConfigurationSource
     /// <param name="validator">An optional validation function that must be applied to
     /// a successfully extracted value to determine if it should be accepted</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator);
+    ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator);
 
     /// <summary>
     /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
@@ -95,7 +95,7 @@ internal interface ITelemeteredConfigurationSource
     /// <param name="allowOptionalMappings">Determines whether to create dictionary entries when the input has no value mapping</param>
     /// <param name="separator">Sets the character that separates keys and values in the input</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    ConfigurationResult<IDictionary<string, string>>? GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator);
+    ConfigurationResult<IDictionary<string, string>> GetDictionary(string key, IConfigurationTelemetry telemetry, Func<IDictionary<string, string>, bool>? validator, bool allowOptionalMappings, char separator);
 
     /// <summary>
     /// Gets the <see cref="IDictionary{TKey, TValue}"/> value of
@@ -108,7 +108,7 @@ internal interface ITelemeteredConfigurationSource
     /// a successfully extracted value to determine if it should be accepted</param>
     /// <param name="recordValue">If <c>true</c> the value should be recorded in telemetry. If not, the source value should be redacted</param>
     /// <returns>The value of the setting, or <c>null</c> if not found.</returns>
-    ConfigurationResult<T>? GetAs<T>(
+    ConfigurationResult<T> GetAs<T>(
         string key,
         IConfigurationTelemetry telemetry,
         Func<string, ParsingResult<T>> converter,

--- a/tracer/src/Datadog.Trace/ExtensionMethods/EnumerableExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/EnumerableExtensions.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Datadog.Trace.Util;
+namespace Datadog.Trace.ExtensionMethods;
 
 internal static class EnumerableExtensions
 {

--- a/tracer/src/Datadog.Trace/Util/EnumerableExtensions.cs
+++ b/tracer/src/Datadog.Trace/Util/EnumerableExtensions.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="EnumerableExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace Datadog.Trace.Util;
+
+internal static class EnumerableExtensions
+{
+#if !NET6_0_OR_GREATER
+    // Polyfill for FirstOrDefault overload that takes a default value
+    // https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Linq/src/System/Linq/First.cs#L60C13-L61C50
+    public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate, TSource defaultValue)
+    {
+        if (source == null)
+        {
+            ThrowHelper.ThrowArgumentNullException(nameof(source));
+        }
+
+        if (predicate == null)
+        {
+            ThrowHelper.ThrowArgumentNullException(nameof(predicate));
+        }
+
+        foreach (var element in source)
+        {
+            if (predicate(element))
+            {
+                return element;
+            }
+        }
+
+        return defaultValue;
+    }
+#endif
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/CompositeConfigurationSourceTests.cs
@@ -125,7 +125,7 @@ public class CompositeConfigurationSourceTests
     public void GetsTheExpectedStringInAllCases(string key, string expected)
     {
         var actual = ((ITelemeteredConfigurationSource)_source).GetString(key, _telemetry, validator: null, recordValue: true);
-        actual?.Result.Should().Be(expected);
+        actual.Result.Should().Be(expected);
     }
 
     [Theory]
@@ -137,7 +137,7 @@ public class CompositeConfigurationSourceTests
     {
         var expected = ((IConfigurationSource)_source).GetString(key);
         var actual = ((ITelemeteredConfigurationSource)_source).GetString(key, _telemetry, validator: null, recordValue: true);
-        actual?.Result.Should().Be(expected);
+        actual.Result.Should().Be(expected);
     }
 
     [Theory]
@@ -160,7 +160,7 @@ public class CompositeConfigurationSourceTests
     public void GetsTheExpectedIntInAllCases(string key, int expected)
     {
         var actual = ((ITelemeteredConfigurationSource)_source).GetInt32(key, _telemetry, validator: null);
-        actual?.Result.Should().Be(expected);
+        actual.Result.Should().Be(expected);
     }
 
     [Theory]
@@ -172,7 +172,7 @@ public class CompositeConfigurationSourceTests
     {
         var expected = ((IConfigurationSource)_source).GetInt32(key);
         var actual = ((ITelemeteredConfigurationSource)_source).GetInt32(key, _telemetry, validator: null);
-        actual?.Result.Should().Be(expected);
+        actual.Result.Should().Be(expected);
     }
 
     [Theory]
@@ -195,7 +195,7 @@ public class CompositeConfigurationSourceTests
     public void GetsTheExpectedDoubleInAllCases(string key, double expected)
     {
         var actual = ((ITelemeteredConfigurationSource)_source).GetDouble(key, _telemetry, validator: null);
-        actual?.Result.Should().Be(expected);
+        actual.Result.Should().Be(expected);
     }
 
     [Theory]
@@ -207,7 +207,7 @@ public class CompositeConfigurationSourceTests
     {
         var expected = ((IConfigurationSource)_source).GetDouble(key);
         var actual = ((ITelemeteredConfigurationSource)_source).GetDouble(key, _telemetry, validator: null);
-        actual?.Result.Should().Be(expected);
+        actual.Result.Should().Be(expected);
     }
 
     [Theory]
@@ -230,7 +230,7 @@ public class CompositeConfigurationSourceTests
     public void GetsTheExpectedBoolInAllCases(string key, bool expected)
     {
         var actual = ((ITelemeteredConfigurationSource)_source).GetBool(key, _telemetry, validator: null);
-        actual?.Result.Should().Be(expected);
+        actual.Result.Should().Be(expected);
     }
 
     [Theory]
@@ -242,7 +242,7 @@ public class CompositeConfigurationSourceTests
     {
         var expected = ((IConfigurationSource)_source).GetBool(key);
         var actual = ((ITelemeteredConfigurationSource)_source).GetBool(key, _telemetry, validator: null);
-        ((bool?)actual?.Result).Should().Be(expected);
+        ((bool?)actual.Result).Should().Be(expected);
     }
 
     [Theory]
@@ -265,7 +265,7 @@ public class CompositeConfigurationSourceTests
     public void GetsTheExpectedDictionaryInAllCases(string key, params string[] expectedKeys)
     {
         var actual = ((ITelemeteredConfigurationSource)_source).GetDictionary(key, _telemetry, validator: null);
-        actual?.Result.Should().ContainKeys(expectedKeys);
+        actual.Result.Should().ContainKeys(expectedKeys);
     }
 
     [Theory]
@@ -277,7 +277,7 @@ public class CompositeConfigurationSourceTests
     {
         var expected = ((IConfigurationSource)_source).GetDictionary(key);
         var actual = ((ITelemeteredConfigurationSource)_source).GetDictionary(key, _telemetry, validator: null);
-        actual?.Result.Should().Equal(expected);
+        actual.Result.Should().Equal(expected);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary of changes

- Changes `ITelemetredConfigurationSource` methods to return `ConfigurationResult<T>` instead of `ConfigurationResult<T>?`
- Add additional properties to `ConfigurationResult<>` to distinguish between "key not found" and "value not parsable"

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/5661, we added support for mapping standard OTel configuration to DD equivalents. Unfortunately, doing this correctly required distinguishing between "key not found" and "value not parsable". As a workaround, an addition method `IsPresent(key)` was added, but this essentially duplicates a lot of the work we're already doing when loading keys "normally". 

The changes in this PR are a first step to simplifying and unifying the support for Otel

## Implementation details

- Change all `ITelemeteredConfigurationSource.Get*` methods to return `ConfigurationResult` instead of a potentially null value. Update all sources as appropriate.
- Update `ConfigurationResult`
  - Add `bool IsPresent()`
  - Add `LoadResult` enum which can be one of `Valid`, `NotFound`, `ParsingError`, or `ValidationFailure `. Previously we effectively had a bool of just `Valid` or `ValidationFailure`, and "is null" meant `NotFound` _or_ `ParsingError`
  - Add helper method `ShouldFallBack`
- Refactor `ConfigurationBuilder`
  - Extract common "cascading fallbacks" code to private `GetResult` methods. By extracting static lambdas we can reuse a lot of the logic for multiple types
  - Refactor code to use the new properties where possible. 
  - `ITelemeteredConfigurationSource.IsPresent` is still used in Otel paths currently - removed in a subsequent PR

## Test coverage

This is just a refactor, so all covered by existing tests

## Other details

This is part of a big stack of config refactoring PRs:

- https://github.com/DataDog/dd-trace-dotnet/pull/5713 (this PR)
- https://github.com/DataDog/dd-trace-dotnet/pull/5714
- https://github.com/DataDog/dd-trace-dotnet/pull/5715
- https://github.com/DataDog/dd-trace-dotnet/pull/5716
- https://github.com/DataDog/dd-trace-dotnet/pull/5717

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
