### PR TITLE
Try to fix the build by changing BuildId

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -105,25 +105,15 @@ steps:
     env:
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
 
-- task: DockerCompose@0
+- script: docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) logs $(TEST_AGENT_TARGET)
   displayName: dump docker-compose logs for $(TEST_AGENT_TARGET)
-  inputs:
-    containerregistrytype: Container Registry
-    dockerComposeCommand: logs $(TEST_AGENT_TARGET)
-    projectName: ddtrace_$(Build.BuildNumber)
-    dockerComposeFile: $(COMPOSE_PATH)
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
   condition: succeededOrFailed()
   continueOnError: true
 
-- task: DockerCompose@0
+- script: docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) down
   displayName: docker-compose stop services
-  inputs:
-    containerregistrytype: Container Registry
-    dockerComposeCommand: down
-    projectName: ddtrace_$(Build.BuildNumber)
-    dockerComposeFile: $(COMPOSE_PATH)
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
   condition: succeededOrFailed()

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1,3 +1,6 @@
+# Change the default BuildId to not include a '.' in the name (use '_' instead)
+name: $(Date:yyyyMMdd)_$(Rev:rr)
+
 trigger:
   branches:
     include:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1864,19 +1864,15 @@ stages:
         artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
-    - task: DockerCompose@0
-      displayName: docker-compose run --no-deps IntegrationTests
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeFileArgs: |
-          baseImage=$(baseImage)
-          framework=$(publishTargetFramework)
-          runCodeCoverage=$(runCodeCoverage)
-          Filter=$(IntegrationTestFilter)
-          SampleName=$(IntegrationTestSampleName)
-          DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) -e IncludeTestsRequiringDocker=false  -e Filter=$(IntegrationTestFilter) -e SampleName=$(IntegrationTestSampleName) IntegrationTests
-        projectName: ddtrace_$(Build.BuildNumber)
+    - script: |
+        docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+          run --no-deps --rm -e baseImage=$(baseImage) \
+          -e framework=$(publishTargetFramework) \
+          -e runCodeCoverage=$(runCodeCoverage) \
+          -e IncludeTestsRequiringDocker=false  \
+          -e Filter=$(IntegrationTestFilter) \
+          -e SampleName=$(IntegrationTestSampleName) \
+          IntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -1958,28 +1954,21 @@ stages:
       displayName: docker-compose build IntegrationTests and run StartDependencies
       retryCountOnTaskFailure: 5
 
-    - task: DockerCompose@0
+    - script: |
+        docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+          run --rm -e baseImage=$(baseImage) \
+          -e framework=$(publishTargetFramework) \
+          -e runCodeCoverage=$(runCodeCoverage) \
+          -e IncludeTestsRequiringDocker=true \
+          -e Filter=$(IntegrationTestFilter) \
+          -e SampleName=$(IntegrationTestSampleName) \
+          IntegrationTests
       displayName: docker-compose run IntegrationTests
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeFileArgs: |
-          baseImage=$(baseImage)
-          runCodeCoverage=$(runCodeCoverage)
-          framework=$(publishTargetFramework)
-          Filter=$(IntegrationTestFilter)
-          SampleName=$(IntegrationTestSampleName)
-          DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) -e IncludeTestsRequiringDocker=true -e Filter=$(IntegrationTestFilter) -e SampleName=$(IntegrationTestSampleName) IntegrationTests
-        projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-    - task: DockerCompose@0
+    - script: docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) down
       displayName: docker-compose stop services
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeCommand: down
-        projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
       condition: succeededOrFailed()
@@ -2097,20 +2086,15 @@ stages:
       displayName: docker-compose build IntegrationTests.Serverless and run StartDependencies.Serverless
       retryCountOnTaskFailure: 5
 
-    - task: DockerCompose@0
+    - script: |
+        docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+          run --rm \ 
+          -e baseImage=$(baseImage) \ 
+          -e framework=$(publishTargetFramework) \ 
+          -e lambdaBaseImage=$(lambdaBaseImage) \
+          -e runCodeCoverage=$(runCodeCoverage) \
+          IntegrationTests.Serverless
       displayName: docker-compose run IntegrationTests.Serverless
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeFileArgs: |
-          baseImage=$(baseImage)
-          framework=$(publishTargetFramework)
-          lambdaBaseImage=$(lambdaBaseImage)
-          runCodeCoverage=$(runCodeCoverage)
-          DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) IntegrationTests.Serverless
-        additionalDockerComposeFiles: |
-          docker-compose.serverless.yml
-        projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -2162,14 +2146,8 @@ stages:
       condition: succeededOrFailed()
       retryCountOnTaskFailure: 5
 
-    - task: DockerCompose@0
+    - script: docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) down
       displayName: docker-compose stop services
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeCommand: down
-        projectName: ddtrace_$(Build.BuildNumber)
-        additionalDockerComposeFiles: |
-          docker-compose.serverless.yml
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
       condition: succeededOrFailed()
@@ -2257,17 +2235,14 @@ stages:
         artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
-    - task: DockerCompose@0
+    - script: |
+        docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+          run --no-deps --rm \ 
+          -e baseImage=$(baseImage) \ 
+          -e framework=$(publishTargetFramework) \ 
+          -e runCodeCoverage=$(runCodeCoverage) \
+          IntegrationTests.Debugger
       displayName: docker-compose run --no-deps IntegrationTests.Debugger
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeFileArgs: |
-          baseImage=$(baseImage)
-          framework=$(publishTargetFramework)
-          runCodeCoverage=$(runCodeCoverage)
-          DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) IntegrationTests.Debugger
-        projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -2454,15 +2429,12 @@ stages:
         extraArgs: "--cpus 0.5 --env CONTAINER_CPUS=0.5"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
-    - task: DockerCompose@0
+    - script: |
+        docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+          run --rm \
+          -e baseImage=$(baseImage) \
+          ProfilerIntegrationTests
       displayName: docker-compose run --no-deps ProfilerIntegrationTests
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeFileArgs: |
-          baseImage=$(baseImage)
-          DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-        dockerComposeCommand: run --rm -e baseImage=$(baseImage) ProfilerIntegrationTests
-        projectName: ddtrace_$(Build.BuildNumber)
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -2680,19 +2652,17 @@ stages:
             artifact: linux-monitoring-home-linux-arm64
             path: $(monitoringHome)
 
-        - task: DockerCompose@0
+        - script: |
+            docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+              run --no-deps --rm \ 
+              -e baseImage=$(baseImage) \ 
+              -e framework=$(publishTargetFramework) \ 
+              -e runCodeCoverage=$(runCodeCoverage) \ 
+              -e IncludeTestsRequiringDocker=false \ 
+              -e Filter=$(IntegrationTestFilter) \ 
+              -e SampleName=$(IntegrationTestSampleName) \ 
+              IntegrationTests.ARM64
           displayName: docker-compose run --no-deps IntegrationTests
-          inputs:
-            containerregistrytype: Container Registry
-            dockerComposeFileArgs: |
-              baseImage=$(baseImage)
-              framework=$(publishTargetFramework)
-              Filter=$(IntegrationTestFilter)
-              SampleName=$(IntegrationTestSampleName)
-              runCodeCoverage=$(runCodeCoverage)
-              DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-            dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) -e IncludeTestsRequiringDocker=false -e Filter=$(IntegrationTestFilter) -e SampleName=$(IntegrationTestSampleName) IntegrationTests.ARM64
-            projectName: ddtrace_$(Build.BuildNumber)
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -2770,28 +2740,23 @@ stages:
           displayName: docker-compose build IntegrationTests and run StartDependencies
           retryCountOnTaskFailure: 5
 
-        - task: DockerCompose@0
+        - script: |
+            docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+              run --rm \
+              -e baseImage=$(baseImage) \
+              -e framework=$(publishTargetFramework) \
+              -e runCodeCoverage=$(runCodeCoverage) \
+              -e IncludeTestsRequiringDocker=true \
+              -e Filter=$(IntegrationTestFilter) \
+              -e SampleName=$(IntegrationTestSampleName) \
+              IntegrationTests.ARM64 \
+              projectName: ddtrace_$(Build.BuildNumber)
           displayName: docker-compose run IntegrationTests
-          inputs:
-            containerregistrytype: Container Registry
-            dockerComposeFileArgs: |
-              baseImage=$(baseImage)
-              framework=$(publishTargetFramework)
-              Filter=$(IntegrationTestFilter)
-              SampleName=$(IntegrationTestSampleName)
-              runCodeCoverage=$(runCodeCoverage)
-              DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-            dockerComposeCommand: run --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) -e IncludeTestsRequiringDocker=true -e Filter=$(IntegrationTestFilter) -e SampleName=$(IntegrationTestSampleName) IntegrationTests.ARM64
-            projectName: ddtrace_$(Build.BuildNumber)
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-        - task: DockerCompose@0
+        - script: docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) down
           displayName: docker-compose stop services
-          inputs:
-            containerregistrytype: Container Registry
-            dockerComposeCommand: down
-            projectName: ddtrace_$(Build.BuildNumber)
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
           condition: succeededOrFailed()
@@ -2871,17 +2836,14 @@ stages:
             artifact: linux-monitoring-home-linux-arm64
             path: $(monitoringHome)
 
-        - task: DockerCompose@0
+        - script: |
+            docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+              run --no-deps --rm \
+              -e baseImage=$(baseImage) \
+              -e framework=$(publishTargetFramework) \
+              -e runCodeCoverage=$(runCodeCoverage) \
+              IntegrationTests.ARM64.Debugger
           displayName: docker-compose run --no-deps IntegrationTests.ARM64.Debugger
-          inputs:
-            containerregistrytype: Container Registry
-            dockerComposeFileArgs: |
-              baseImage=$(baseImage)
-              framework=$(publishTargetFramework)
-              runCodeCoverage=$(runCodeCoverage)
-              DD_LOGGER_DD_API_KEY=$(DD_LOGGER_DD_API_KEY)
-            dockerComposeCommand: run --no-deps --rm -e baseImage=$(baseImage) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) IntegrationTests.ARM64.Debugger
-            projectName: ddtrace_$(Build.BuildNumber)
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -3026,39 +2988,38 @@ stages:
         command: "SetupExplorationTests -ExplorationTestUseCase $(explorationTestUseCase) --explorationTestName $(explorationTestName) --framework $(publishTargetFramework)"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
-    - task: DockerCompose@0
+    - script: |
+          docker-compose -f $(COMPOSE_PATH) -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
+          build \
+          --build-arg baseImage=$(baseImage) \ 
+          --build-arg explorationTestUseCase=$(explorationTestUseCase) \ 
+          --build-arg explorationTestName=$(explorationTestName) \ 
+          --build-arg framework=$(publishTargetFramework) \
+          --build-arg runCodeCoverage=$(runCodeCoverage) \
+          ExplorationTests
       displayName: docker-compose build ExplorationTests
       env:
         baseImage: $(baseImage)
         azdo_network: $(agent.containernetwork)
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-      inputs:
-        containerregistrytype: Container Registry
-        additionalDockerComposeFiles: docker-compose.ci.azdo.yml
-        dockerComposeCommand: build --build-arg baseImage=$(baseImage) --build-arg explorationTestUseCase=$(explorationTestUseCase) --build-arg explorationTestName=$(explorationTestName) --build-arg framework=$(publishTargetFramework) --build-arg runCodeCoverage=$(runCodeCoverage) ExplorationTests
 
-    - task: DockerCompose@0
+    - script: |
+        docker-compose -f $(COMPOSE_PATH) -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
+          run --rm \
+          -e DD_AGENT_HOST=dd_agent \
+          -e baseImage=$(baseImage) \
+          -e explorationTestUseCase=$(explorationTestUseCase) \
+          -e explorationTestName=$(explorationTestName) \
+          -e framework=$(publishTargetFramework) \
+          -e runCodeCoverage=$(runCodeCoverage) \
+          ExplorationTests
       displayName: docker-compose run ExplorationTests
       env:
         azdo_network: $(agent.containernetwork)
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
-      inputs:
-        containerregistrytype: Container Registry
-        additionalDockerComposeFiles: docker-compose.ci.azdo.yml
-        dockerComposeFileArgs: |
-          baseImage=$(baseImage)
-          framework=$(publishTargetFramework)
-          runCodeCoverage=$(runCodeCoverage)
-          explorationTestUseCase=$(explorationTestUseCase)
-          explorationTestName=$(explorationTestName)
-        dockerComposeCommand: run --rm -e DD_AGENT_HOST=dd_agent -e baseImage=$(baseImage) -e explorationTestUseCase=$(explorationTestUseCase) -e explorationTestName=$(explorationTestName) -e framework=$(publishTargetFramework) -e runCodeCoverage=$(runCodeCoverage) ExplorationTests
 
-    - task: DockerCompose@0
+    - script: docker-compose -f $(COMPOSE_PATH) -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) down
       displayName: docker-compose stop services
-      inputs:
-        containerregistrytype: Container Registry
-        dockerComposeCommand: down
-        projectName: ddtrace_$(Build.BuildNumber)
       condition: succeededOrFailed()
       continueOnError: true
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2655,13 +2655,13 @@ stages:
 
         - script: |
             docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
-              run --no-deps --rm \ 
-              -e baseImage=$(baseImage) \ 
-              -e framework=$(publishTargetFramework) \ 
-              -e runCodeCoverage=$(runCodeCoverage) \ 
-              -e IncludeTestsRequiringDocker=false \ 
-              -e Filter=$(IntegrationTestFilter) \ 
-              -e SampleName=$(IntegrationTestSampleName) \ 
+              run --no-deps --rm \
+              -e baseImage=$(baseImage) \
+              -e framework=$(publishTargetFramework) \
+              -e runCodeCoverage=$(runCodeCoverage) \
+              -e IncludeTestsRequiringDocker=false \
+              -e Filter=$(IntegrationTestFilter) \
+              -e SampleName=$(IntegrationTestSampleName) \
               IntegrationTests.ARM64
           displayName: docker-compose run --no-deps IntegrationTests
           env:

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -135,6 +135,7 @@ variables:
   IncludeAllTestFrameworks: $[or(eq(variables['run_all_test_frameworks'], 'true'), and(or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), startsWith(variables['Build.SourceBranch'], 'refs/heads/hostfix/')), not(eq(variables['Build.Reason'], 'Schedule'))))]
   IntegrationTestSampleName:  $(TEST_SAMPLE_NAME)
   IntegrationTestFilter:  $(TEST_FILTER)
+  DockerComposeProjectName: ddtrace_$(Build.BuildNumber)
   # Logger variables
   DD_LOGGER_DD_API_KEY: $(DD_API_KEY)
   DD_LOGGER_DD_SERVICE: dd-trace-dotnet
@@ -1865,7 +1866,7 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --no-deps --rm -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
           -e runCodeCoverage=$(runCodeCoverage) \
@@ -1943,8 +1944,8 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg runCodeCoverage=$(runCodeCoverage) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
-        docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies
+        docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg runCodeCoverage=$(runCodeCoverage) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
+        docker-compose -p $(DockerComposeProjectName) run --rm StartDependencies
       env:
         baseImage: $(baseImage)
         framework: $(publishTargetFramework)
@@ -1955,7 +1956,7 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
-        docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --rm -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
           -e runCodeCoverage=$(runCodeCoverage) \
@@ -1967,7 +1968,7 @@ stages:
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-    - script: docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) down
+    - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) down
       displayName: docker-compose stop services
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2058,7 +2059,7 @@ stages:
         
     - script: |
         # Include the serverless dockerfile
-        docker-compose -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -p $(DockerComposeProjectName) \
           -f $(System.DefaultWorkingDirectory)/docker-compose.yml \
           -f docker-compose.serverless.yml \
           build \
@@ -2067,14 +2068,14 @@ stages:
           --build-arg runCodeCoverage=$(runCodeCoverage) \
           IntegrationTests.Serverless
 
-        docker-compose -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -p $(DockerComposeProjectName) \
           -f $(System.DefaultWorkingDirectory)/docker-compose.yml \
           -f docker-compose.serverless.yml \
           --build-arg runCodeCoverage=$(runCodeCoverage) \
           --build-arg framework=$(publishTargetFramework) \
           pull --include-deps StartDependencies.Serverless
 
-        docker-compose -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -p $(DockerComposeProjectName) \
           -f $(System.DefaultWorkingDirectory)/docker-compose.yml \
           -f docker-compose.serverless.yml \
           run --rm StartDependencies.Serverless
@@ -2087,7 +2088,7 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
-        docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
           run --rm \ 
           -e baseImage=$(baseImage) \ 
           -e framework=$(publishTargetFramework) \ 
@@ -2101,7 +2102,7 @@ stages:
     - script: |
         mkdir -p tracer/build_data/docker
 
-        docker-compose -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -p $(DockerComposeProjectName) \
           -f $(System.DefaultWorkingDirectory)/docker-compose.yml \
           -f docker-compose.serverless.yml \
           logs \
@@ -2146,7 +2147,7 @@ stages:
       condition: succeededOrFailed()
       retryCountOnTaskFailure: 5
 
-    - script: docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) down
+    - script: docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) down
       displayName: docker-compose stop services
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2236,7 +2237,7 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
           run --no-deps --rm \ 
           -e baseImage=$(baseImage) \ 
           -e framework=$(publishTargetFramework) \ 
@@ -2430,7 +2431,7 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - script: |
-        docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e baseImage=$(baseImage) \
           ProfilerIntegrationTests
@@ -2653,7 +2654,7 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+            docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
               run --no-deps --rm \ 
               -e baseImage=$(baseImage) \ 
               -e framework=$(publishTargetFramework) \ 
@@ -2729,8 +2730,8 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg runCodeCoverage=$(runCodeCoverage) IntegrationTests.ARM64
-            docker-compose -p ddtrace_$(Build.BuildNumber) run --rm StartDependencies.ARM64
+            docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg runCodeCoverage=$(runCodeCoverage) IntegrationTests.ARM64
+            docker-compose -p $(DockerComposeProjectName) run --rm StartDependencies.ARM64
           env:
             baseImage: $(baseImage)
             framework: $(publishTargetFramework)
@@ -2741,7 +2742,7 @@ stages:
           retryCountOnTaskFailure: 5
 
         - script: |
-            docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
+            docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
               run --rm \
               -e baseImage=$(baseImage) \
               -e framework=$(publishTargetFramework) \
@@ -2750,12 +2751,12 @@ stages:
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
               IntegrationTests.ARM64 \
-              projectName: ddtrace_$(Build.BuildNumber)
+              projectName: $(DockerComposeProjectName)
           displayName: docker-compose run IntegrationTests
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-        - script: docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) down
+        - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) down
           displayName: docker-compose stop services
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2837,7 +2838,7 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
+            docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
               -e framework=$(publishTargetFramework) \
@@ -2989,7 +2990,7 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - script: |
-          docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
+          docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) \
           build \
           --build-arg baseImage=$(baseImage) \ 
           --build-arg explorationTestUseCase=$(explorationTestUseCase) \ 
@@ -3004,7 +3005,7 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
     - script: |
-        docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e DD_AGENT_HOST=dd_agent \
           -e baseImage=$(baseImage) \
@@ -3018,7 +3019,7 @@ stages:
         azdo_network: $(agent.containernetwork)
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-    - script: docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) down
+    - script: docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) down
       displayName: docker-compose stop services
       condition: succeededOrFailed()
       continueOnError: true
@@ -4679,7 +4680,7 @@ stages:
 
     # Run the "normal" installer smoke tests
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -4698,7 +4699,7 @@ stages:
 
     # Run the "dd-dotnet" installer smoke tests
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -4759,7 +4760,7 @@ stages:
 
         # Run the "normal" installer smoke tests
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+            docker-compose -p $(DockerComposeProjectName) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -4777,7 +4778,7 @@ stages:
         
         # Run the "dd-dotnet" installer smoke tests
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+            docker-compose -p $(DockerComposeProjectName) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -4843,7 +4844,7 @@ stages:
       displayName: create test data directories
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -4861,7 +4862,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -4927,7 +4928,7 @@ stages:
       displayName: create test data directories
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -4995,7 +4996,7 @@ stages:
       displayName: create test data directories and extract tool
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5072,7 +5073,7 @@ stages:
       displayName: create test data directories and extract tool
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5138,7 +5139,7 @@ stages:
 
         # Run the "normal" installer smoke tests 
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+            docker-compose -p $(DockerComposeProjectName) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5156,7 +5157,7 @@ stages:
 
         # Run the "dd-dotnet" installer smoke tests
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+            docker-compose -p $(DockerComposeProjectName) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5217,7 +5218,7 @@ stages:
 
         # Run the "normal" installer smoke tests 
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+            docker-compose -p $(DockerComposeProjectName) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5235,7 +5236,7 @@ stages:
         
         # Run the "dd-dotnet" installer smoke tests
         - script: |
-            docker-compose -p ddtrace_$(Build.BuildNumber) build \
+            docker-compose -p $(DockerComposeProjectName) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5301,7 +5302,7 @@ stages:
       displayName: create test data directories
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5319,7 +5320,7 @@ stages:
         snapshotPrefix: "smoke_test"
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5384,7 +5385,7 @@ stages:
       displayName: create test data directories and extract tool
 
     - script: |
-        docker-compose -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5454,7 +5455,7 @@ stages:
       displayName: create test data directories
 
     - bash: |
-        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5473,7 +5474,7 @@ stages:
         isLinux: false
 
     - bash: |
-        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5541,7 +5542,7 @@ stages:
       displayName: Create test data directories
 
     - bash: |
-        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5608,7 +5609,7 @@ stages:
       displayName: Create test data directories
 
     - bash: |
-        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5679,7 +5680,7 @@ stages:
           displayName: Create test data directories
 
         - bash: |
-            docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+            docker-compose -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
               --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
@@ -5744,7 +5745,7 @@ stages:
         path: $(smokeTestAppDir)/artifacts
 
     - bash: |
-        docker-compose -f docker-compose.windows.yml -p ddtrace_$(Build.BuildNumber) build \
+        docker-compose -f docker-compose.windows.yml -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1866,14 +1866,17 @@ stages:
         path: $(monitoringHome)
 
     - script: |
+        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
-          run --no-deps --rm -e baseImage=$(baseImage) \
+          run --no-deps --rm \
+          -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
           -e runCodeCoverage=$(runCodeCoverage) \
           -e IncludeTestsRequiringDocker=false  \
           -e Filter=$(IntegrationTestFilter) \
           -e SampleName=$(IntegrationTestSampleName) \
           IntegrationTests
+      displayName: docker-compose run IntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
@@ -1956,8 +1959,10 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
+        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
-          run --rm -e baseImage=$(baseImage) \
+          run --rm \
+          -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
           -e runCodeCoverage=$(runCodeCoverage) \
           -e IncludeTestsRequiringDocker=true \
@@ -2088,10 +2093,11 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
+        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
-          run --rm \ 
-          -e baseImage=$(baseImage) \ 
-          -e framework=$(publishTargetFramework) \ 
+          run --rm \
+          -e baseImage=$(baseImage) \
+          -e framework=$(publishTargetFramework) \
           -e lambdaBaseImage=$(lambdaBaseImage) \
           -e runCodeCoverage=$(runCodeCoverage) \
           IntegrationTests.Serverless
@@ -2237,10 +2243,11 @@ stages:
         path: $(monitoringHome)
 
     - script: |
+        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
-          run --no-deps --rm \ 
-          -e baseImage=$(baseImage) \ 
-          -e framework=$(publishTargetFramework) \ 
+          run --no-deps --rm \
+          -e baseImage=$(baseImage) \
+          -e framework=$(publishTargetFramework) \
           -e runCodeCoverage=$(runCodeCoverage) \
           IntegrationTests.Debugger
       displayName: docker-compose run --no-deps IntegrationTests.Debugger
@@ -2654,6 +2661,7 @@ stages:
             path: $(monitoringHome)
 
         - script: |
+            baseImage=$(baseImage) # for interpolation in the docker-compose file
             docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
@@ -2742,6 +2750,7 @@ stages:
           retryCountOnTaskFailure: 5
 
         - script: |
+            baseImage=$(baseImage) # for interpolation in the docker-compose file
             docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
               run --rm \
               -e baseImage=$(baseImage) \
@@ -2751,7 +2760,6 @@ stages:
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
               IntegrationTests.ARM64 \
-              projectName: $(DockerComposeProjectName)
           displayName: docker-compose run IntegrationTests
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2838,6 +2846,7 @@ stages:
             path: $(monitoringHome)
 
         - script: |
+            baseImage=$(baseImage) # for interpolation in the docker-compose file
             docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
@@ -2990,11 +2999,12 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - script: |
-          docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) \
+        baseImage=$(baseImage) # for interpolation in the docker-compose file
+        docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) \
           build \
-          --build-arg baseImage=$(baseImage) \ 
-          --build-arg explorationTestUseCase=$(explorationTestUseCase) \ 
-          --build-arg explorationTestName=$(explorationTestName) \ 
+          --build-arg baseImage=$(baseImage) \
+          --build-arg explorationTestUseCase=$(explorationTestUseCase) \
+          --build-arg explorationTestName=$(explorationTestName) \
           --build-arg framework=$(publishTargetFramework) \
           --build-arg runCodeCoverage=$(runCodeCoverage) \
           ExplorationTests
@@ -3005,6 +3015,7 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
     - script: |
+        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e DD_AGENT_HOST=dd_agent \

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1866,7 +1866,6 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --no-deps --rm \
           -e baseImage=$(baseImage) \
@@ -1879,6 +1878,7 @@ stages:
       displayName: docker-compose run IntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
 
     - script: |
         sudo chmod -R 644 tracer/build_data/dumps/* || true
@@ -1959,7 +1959,6 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
-        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e baseImage=$(baseImage) \
@@ -1972,6 +1971,7 @@ stages:
       displayName: docker-compose run IntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
 
     - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) down
       displayName: docker-compose stop services
@@ -2093,7 +2093,6 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
-        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e baseImage=$(baseImage) \
@@ -2104,6 +2103,7 @@ stages:
       displayName: docker-compose run IntegrationTests.Serverless
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
 
     - script: |
         mkdir -p tracer/build_data/docker
@@ -2243,7 +2243,6 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
           run --no-deps --rm \
           -e baseImage=$(baseImage) \
@@ -2253,6 +2252,7 @@ stages:
       displayName: docker-compose run --no-deps IntegrationTests.Debugger
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
 
     - script: |
         sudo chmod -R 644 tracer/build_data/dumps/* || true
@@ -2661,7 +2661,6 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            baseImage=$(baseImage) # for interpolation in the docker-compose file
             docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p $(DockerComposeProjectName) \
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
@@ -2674,6 +2673,7 @@ stages:
           displayName: docker-compose run --no-deps IntegrationTests
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
+            baseImage: $(baseImage) # for interpolation in the docker-compose file
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -2750,7 +2750,6 @@ stages:
           retryCountOnTaskFailure: 5
 
         - script: |
-            baseImage=$(baseImage) # for interpolation in the docker-compose file
             docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
               run --rm \
               -e baseImage=$(baseImage) \
@@ -2763,6 +2762,7 @@ stages:
           displayName: docker-compose run IntegrationTests
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
+            baseImage: $(baseImage) # for interpolation in the docker-compose file
 
         - script: docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) down
           displayName: docker-compose stop services
@@ -2846,7 +2846,6 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            baseImage=$(baseImage) # for interpolation in the docker-compose file
             docker-compose -f docker-compose.yml -p $(DockerComposeProjectName) \
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
@@ -2856,6 +2855,7 @@ stages:
           displayName: docker-compose run --no-deps IntegrationTests.ARM64.Debugger
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
+            baseImage: $(baseImage) # for interpolation in the docker-compose file
 
         - publish: tracer/build_data
           artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -2999,7 +2999,6 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - script: |
-        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) \
           build \
           --build-arg baseImage=$(baseImage) \
@@ -3010,12 +3009,11 @@ stages:
           ExplorationTests
       displayName: docker-compose build ExplorationTests
       env:
-        baseImage: $(baseImage)
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
         azdo_network: $(agent.containernetwork)
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
     - script: |
-        baseImage=$(baseImage) # for interpolation in the docker-compose file
         docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) \
           run --rm \
           -e DD_AGENT_HOST=dd_agent \
@@ -3027,6 +3025,7 @@ stages:
           ExplorationTests
       displayName: docker-compose run ExplorationTests
       env:
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
         azdo_network: $(agent.containernetwork)
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -1865,7 +1865,7 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
           run --no-deps --rm -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
           -e runCodeCoverage=$(runCodeCoverage) \
@@ -1955,7 +1955,7 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
-        docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
           run --rm -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
           -e runCodeCoverage=$(runCodeCoverage) \
@@ -1967,7 +1967,7 @@ stages:
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-    - script: docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) down
+    - script: docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) down
       displayName: docker-compose stop services
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2087,7 +2087,7 @@ stages:
       retryCountOnTaskFailure: 5
 
     - script: |
-        docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
           run --rm \ 
           -e baseImage=$(baseImage) \ 
           -e framework=$(publishTargetFramework) \ 
@@ -2146,7 +2146,7 @@ stages:
       condition: succeededOrFailed()
       retryCountOnTaskFailure: 5
 
-    - script: docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) down
+    - script: docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) down
       displayName: docker-compose stop services
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2236,7 +2236,7 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
           run --no-deps --rm \ 
           -e baseImage=$(baseImage) \ 
           -e framework=$(publishTargetFramework) \ 
@@ -2430,7 +2430,7 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - script: |
-        docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
           run --rm \
           -e baseImage=$(baseImage) \
           ProfilerIntegrationTests
@@ -2653,7 +2653,7 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            docker-compose -f $(COMPOSE_PATH) -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
+            docker-compose -f docker-compose.yml -f docker-compose.serverless.yml -p ddtrace_$(Build.BuildNumber) \
               run --no-deps --rm \ 
               -e baseImage=$(baseImage) \ 
               -e framework=$(publishTargetFramework) \ 
@@ -2741,7 +2741,7 @@ stages:
           retryCountOnTaskFailure: 5
 
         - script: |
-            docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+            docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
               run --rm \
               -e baseImage=$(baseImage) \
               -e framework=$(publishTargetFramework) \
@@ -2755,7 +2755,7 @@ stages:
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-        - script: docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) down
+        - script: docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) down
           displayName: docker-compose stop services
           env:
             DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -2837,7 +2837,7 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) \
+            docker-compose -f docker-compose.yml -p ddtrace_$(Build.BuildNumber) \
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
               -e framework=$(publishTargetFramework) \
@@ -2989,7 +2989,7 @@ stages:
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - script: |
-          docker-compose -f $(COMPOSE_PATH) -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
+          docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
           build \
           --build-arg baseImage=$(baseImage) \ 
           --build-arg explorationTestUseCase=$(explorationTestUseCase) \ 
@@ -3004,7 +3004,7 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
     - script: |
-        docker-compose -f $(COMPOSE_PATH) -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
+        docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) \
           run --rm \
           -e DD_AGENT_HOST=dd_agent \
           -e baseImage=$(baseImage) \
@@ -3018,7 +3018,7 @@ stages:
         azdo_network: $(agent.containernetwork)
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-    - script: docker-compose -f $(COMPOSE_PATH) -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) down
+    - script: docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p ddtrace_$(Build.BuildNumber) down
       displayName: docker-compose stop services
       condition: succeededOrFailed()
       continueOnError: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -427,7 +427,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-8.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-8.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-netcoreapp3.1} --filter ${Filter:- } --SampleName ${SampleName:- } --code-coverage ${runCodeCoverage:-true}
+    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests
     volumes:
       - ./:/project
     cap_add:
@@ -439,7 +439,7 @@ services:
       - Filter=${Filter:- } #optional
       - SampleName=${SampleName:- } #optional
       - baseImage=${baseImage:-default}
-      - runCodeCoverage=${runCodeCoverage:-true}
+      - CodeCoverage=${runCodeCoverage:-true}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
@@ -520,7 +520,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-8.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-8.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests --framework ${framework:-netcoreapp3.1} --code-coverage ${runCodeCoverage:-true} --targetplatform x64
+    command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project
     cap_add:
@@ -530,7 +530,8 @@ services:
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-default}
-      - runCodeCoverage=${runCodeCoverage:-true}
+      - targetplatform=${targetplatform:-x64}
+      - CodeCoverage=${runCodeCoverage:-true}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
@@ -569,7 +570,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-8.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-8.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --framework ${framework:-net6.0} --filter Category=Lambda --code-coverage ${runCodeCoverage:-true}
+    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests
     volumes:
       - ./:/project
     cap_add:
@@ -577,9 +578,11 @@ services:
     environment:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
-      - framework=${framework:-netcoreapp3.1}
+      - framework=${framework:-net6.0}
       - baseImage=${baseImage:-default}
-      - runCodeCoverage=${runCodeCoverage:-true}
+      - Filter=${Filter:-Category=Lambda}
+      - File=${filter:-Category=Lambda}
+      - CodeCoverage=${runCodeCoverage:-true}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
@@ -622,7 +625,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-8.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-8.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunExplorationTests --explorationTestUseCase ${explorationTestUseCase:-debugger} --explorationTestName ${explorationTestName:-eshoponweb} --framework ${framework:-netcoreapp3.1} --code-coverage ${runCodeCoverage:-true}
+    command: dotnet /build/bin/Debug/_build.dll RunExplorationTests
     volumes:
       - ./:/project
     cap_add:
@@ -631,7 +634,7 @@ services:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
-      - runCodeCoverage=${runCodeCoverage:-true}
+      - CodeCoverage=${runCodeCoverage:-true}
       - explorationTestUseCase=${explorationTestUseCase:-debugger}
       - explorationTestName=${explorationTestName:-eshoponweb}
       - baseImage=${baseImage:-default}
@@ -695,7 +698,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-8.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-8.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests --filter ${Filter:- } --SampleName ${SampleName:- }  --framework ${framework:-netcoreapp3.1}
+    command: dotnet /build/bin/Debug/_build.dll RunLinuxIntegrationTests
     volumes:
       - ./:/project
     cap_add:
@@ -704,8 +707,9 @@ services:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
-      - Filter=${Filter:- } #optional
+      - Filter=${Filter:-} #optional
       - SampleName=${SampleName:- } #optional
+      - CodeCoverage=${runCodeCoverage:-true}
       - baseImage=${baseImage:-debian}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
@@ -790,7 +794,7 @@ services:
       args:
         - DOTNETSDK_VERSION=${dotnetCoreSdkLatestVersion:-8.0.100}
     image: dd-trace-dotnet/${baseImage:-debian}-tester:${dotnetCoreSdkLatestVersion:-8.0.100}
-    command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests --framework ${framework:-netcoreapp3.1} --targetplatform x64
+    command: dotnet /build/bin/Debug/_build.dll RunDebuggerIntegrationTests
     volumes:
       - ./:/project
     cap_add:
@@ -800,6 +804,7 @@ services:
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-debian}
+      - targetplatform=${targetplatform:-x64}
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true


### PR DESCRIPTION
## Summary of changes

- Changes the BuildId from the default definition of `$(Date:yyyyMMdd).$(Rev:r).` to `$(Date:yyyyMMdd)_$(Rev:rr)`.
- Replaces all usages of `DockerCompose@0` to try to circumvent the breaking changes they made

## Reason for change

Docker Compose tasks have started breaking with:

```
invalid project name "ddtrace_20240620.11": must consist only of lowercase alphanumeric characters, hyphens, and underscores as well as start with a letter or number
```

presumably because of a [recent change](https://learn.microsoft.com/en-us/azure/devops/release-notes/2024/sprint-240-update): `DockerCompose@0 uses Docker Compose v2 in v1 compatibility mode`. Trying to just tear out our usage of that task

## Implementation details

Change the default value, [as described here](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/run-number?view=azure-devops&tabs=yaml)

Replace all `DockerCompose@0` with explicit scripts instead. It's horrible.

## Test coverage

This is the test 🤞 

## Other details

I wish we could switch to automating this in Nuke instead, but who has time to rewrite the whole thing 😭 


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
