### PR TITLE
[Tracing] fix precedence of remote vs local sampling rules

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -38,6 +38,7 @@ namespace Datadog.Trace.Configuration
         private readonly IReadOnlyDictionary<string, string> _globalTags;
         private readonly double? _globalSamplingRate;
         private readonly bool _runtimeMetricsEnabled;
+        private readonly string? _customSamplingRulesInternal;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableTracerSettings"/> class
@@ -98,7 +99,7 @@ namespace Datadog.Trace.Configuration
             AnalyticsEnabledInternal = settings.AnalyticsEnabledInternal;
 #pragma warning restore 618
             MaxTracesSubmittedPerSecondInternal = settings.MaxTracesSubmittedPerSecondInternal;
-            CustomSamplingRulesInternal = settings.CustomSamplingRulesInternal;
+            _customSamplingRulesInternal = settings.CustomSamplingRulesInternal;
             CustomSamplingRulesFormat = settings.CustomSamplingRulesFormat;
             SpanSamplingRules = settings.SpanSamplingRules;
             _globalSamplingRate = settings.GlobalSamplingRateInternal;
@@ -298,14 +299,9 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.CustomSamplingRules"/>
         [GeneratePublicApi(PublicApiUsage.ImmutableTracerSettings_CustomSamplingRules_Get)]
-        internal string? CustomSamplingRulesInternal { get; }
+        internal string? CustomSamplingRulesInternal => DynamicSettings.SamplingRules ?? _customSamplingRulesInternal;
 
-        /// <summary>
-        /// Gets the trace sampling rules from remote config.
-        /// These contain custom remote rules and dynamic (aka adaptive) rules.
-        /// They will be merged with local sampling rules.
-        /// </summary>
-        internal string? RemoteSamplingRules => DynamicSettings.SamplingRules;
+        internal bool CustomSamplingRulesInternalIsRemote => DynamicSettings.SamplingRules != null;
 
         /// <summary>
         /// Gets a value indicating the format for custom sampling rules ("regex" or "glob").

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -38,7 +38,7 @@ namespace Datadog.Trace.Configuration
         private readonly IReadOnlyDictionary<string, string> _globalTags;
         private readonly double? _globalSamplingRate;
         private readonly bool _runtimeMetricsEnabled;
-        private readonly string? _customSamplingRulesInternal;
+        private readonly string? _customSamplingRules;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmutableTracerSettings"/> class
@@ -99,7 +99,7 @@ namespace Datadog.Trace.Configuration
             AnalyticsEnabledInternal = settings.AnalyticsEnabledInternal;
 #pragma warning restore 618
             MaxTracesSubmittedPerSecondInternal = settings.MaxTracesSubmittedPerSecondInternal;
-            _customSamplingRulesInternal = settings.CustomSamplingRulesInternal;
+            _customSamplingRules = settings.CustomSamplingRulesInternal;
             CustomSamplingRulesFormat = settings.CustomSamplingRulesFormat;
             SpanSamplingRules = settings.SpanSamplingRules;
             _globalSamplingRate = settings.GlobalSamplingRateInternal;
@@ -299,9 +299,9 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <seealso cref="ConfigurationKeys.CustomSamplingRules"/>
         [GeneratePublicApi(PublicApiUsage.ImmutableTracerSettings_CustomSamplingRules_Get)]
-        internal string? CustomSamplingRulesInternal => DynamicSettings.SamplingRules ?? _customSamplingRulesInternal;
+        internal string? CustomSamplingRulesInternal => DynamicSettings.SamplingRules ?? _customSamplingRules;
 
-        internal bool CustomSamplingRulesInternalIsRemote => DynamicSettings.SamplingRules != null;
+        internal bool CustomSamplingRulesIsRemote => DynamicSettings.SamplingRules != null;
 
         /// <summary>
         /// Gets a value indicating the format for custom sampling rules ("regex" or "glob").

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -407,9 +407,6 @@ namespace Datadog.Trace
                     writer.WritePropertyName("sampling_rules");
                     writer.WriteValue(instanceSettings.CustomSamplingRulesInternal);
 
-                    writer.WritePropertyName("remote_sampling_rules");
-                    writer.WriteRawValue(instanceSettings.RemoteSamplingRules);
-
                     writer.WritePropertyName("tags");
                     WriteDictionary(instanceSettings.GlobalTagsInternal);
 

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -264,7 +264,7 @@ namespace Datadog.Trace
             // The first rule that matches will be used to determine the sampling rate.
             var sampler = new TraceSampler(new TracerRateLimiter(settings.MaxTracesSubmittedPerSecondInternal));
 
-            // sampling rules
+            // sampling rules (remote value overrides local value)
             var samplingRulesJson = settings.CustomSamplingRulesInternal;
 
             // check if the rules are remote or local because they have different JSON schemas

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -262,40 +262,40 @@ namespace Datadog.Trace
 
             // Note: the order that rules are registered is important, as they are evaluated in order.
             // The first rule that matches will be used to determine the sampling rate.
-
-            // Remote and local "custom" sampling rules:
-            // Unlike most settings, local custom sampling rules configuration (DD_TRACE_SAMPLING_RULES) is not
-            // simply overriden with the remote configuration. Instead, remote rules are merged with local rules,
-            // with remote rules taking precedence.
-
             var sampler = new TraceSampler(new TracerRateLimiter(settings.MaxTracesSubmittedPerSecondInternal));
 
-            // remote sampling rules
-            var remoteSamplingRulesJson = settings.RemoteSamplingRules;
+            // sampling rules
+            var samplingRulesJson = settings.CustomSamplingRulesInternal;
 
-            if (!string.IsNullOrWhiteSpace(remoteSamplingRulesJson))
+            // check if the rules are remote or local because they have different JSON schemas
+            if (settings.CustomSamplingRulesInternalIsRemote)
             {
-                var remoteSamplingRules =
-                    RemoteCustomSamplingRule.BuildFromConfigurationString(
-                        remoteSamplingRulesJson,
-                        RegexBuilder.DefaultTimeout);
+                // remote sampling rules
+                if (!string.IsNullOrWhiteSpace(samplingRulesJson))
+                {
+                    var remoteSamplingRules =
+                        RemoteCustomSamplingRule.BuildFromConfigurationString(
+                            samplingRulesJson,
+                            RegexBuilder.DefaultTimeout);
 
-                sampler.RegisterRules(remoteSamplingRules);
+                    sampler.RegisterRules(remoteSamplingRules);
+                }
             }
-
-            // local sampling rules
-            var patternFormatIsValid = SamplingRulesFormat.IsValid(settings.CustomSamplingRulesFormat, out var samplingRulesFormat);
-            var localSamplingRulesJson = settings.CustomSamplingRulesInternal;
-
-            if (patternFormatIsValid && !string.IsNullOrWhiteSpace(localSamplingRulesJson))
+            else
             {
-                var localSamplingRules =
-                    LocalCustomSamplingRule.BuildFromConfigurationString(
-                        localSamplingRulesJson,
-                        samplingRulesFormat,
-                        RegexBuilder.DefaultTimeout);
+                // local sampling rules
+                var patternFormatIsValid = SamplingRulesFormat.IsValid(settings.CustomSamplingRulesFormat, out var samplingRulesFormat);
 
-                sampler.RegisterRules(localSamplingRules);
+                if (patternFormatIsValid && !string.IsNullOrWhiteSpace(samplingRulesJson))
+                {
+                    var localSamplingRules =
+                        LocalCustomSamplingRule.BuildFromConfigurationString(
+                            samplingRulesJson,
+                            samplingRulesFormat,
+                            RegexBuilder.DefaultTimeout);
+
+                    sampler.RegisterRules(localSamplingRules);
+                }
             }
 
             // global sampling rate (remote value overrides local value)

--- a/tracer/src/Datadog.Trace/TracerManagerFactory.cs
+++ b/tracer/src/Datadog.Trace/TracerManagerFactory.cs
@@ -268,7 +268,7 @@ namespace Datadog.Trace
             var samplingRulesJson = settings.CustomSamplingRulesInternal;
 
             // check if the rules are remote or local because they have different JSON schemas
-            if (settings.CustomSamplingRulesInternalIsRemote)
+            if (settings.CustomSamplingRulesIsRemote)
             {
                 // remote sampling rules
                 if (!string.IsNullOrWhiteSpace(samplingRulesJson))

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/DynamicConfigurationTests.cs
@@ -213,7 +213,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 // json["debug"]?.Value<bool>().Should().Be(expectedConfig.DebugLogsEnabled);
                 json["log_injection_enabled"]?.Value<bool>().Should().Be(expectedConfig.LogInjectionEnabled);
                 json["sample_rate"]?.Value<double?>().Should().Be(expectedConfig.TraceSampleRate);
-                JsonConfigurationSource.JTokenToString(json["remote_sampling_rules"]).Should().Be(expectedConfig.TraceSamplingRules);
+                JsonConfigurationSource.JTokenToString(json["sampling_rules"]).Should().Be(expectedConfig.TraceSamplingRules);
                 // json["span_sampling_rules"]?.Value<string>().Should().Be(expectedConfig.SpanSamplingRules);
                 // json["data_streams_enabled"]?.Value<bool>().Should().Be(expectedConfig.DataStreamsEnabled);
                 FlattenJsonArray(json["header_tags"]).Should().Be(expectedConfig.TraceHeaderTags ?? string.Empty);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -126,7 +126,7 @@ namespace Datadog.Trace.Tests.Configuration
             TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings), TracerManagerFactory.Instance);
 
             TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().Be(localSamplingRulesJson);
-            TracerManager.Instance.Settings.CustomSamplingRulesInternalIsRemote.Should().BeFalse();
+            TracerManager.Instance.Settings.CustomSamplingRulesIsRemote.Should().BeFalse();
 
             var rules = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
 
@@ -157,7 +157,7 @@ namespace Datadog.Trace.Tests.Configuration
 
             var remoteSamplingRulesJson = JsonConvert.SerializeObject(remoteSamplingRulesConfig);
             TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().Be(remoteSamplingRulesJson);
-            TracerManager.Instance.Settings.CustomSamplingRulesInternalIsRemote.Should().BeTrue();
+            TracerManager.Instance.Settings.CustomSamplingRulesIsRemote.Should().BeTrue();
 
             rules = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
 

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -114,7 +114,8 @@ namespace Datadog.Trace.Tests.Configuration
             TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings), TracerManagerFactory.Instance);
 
             // sampling rules is null by default
-            TracerManager.Instance.Settings.RemoteSamplingRules.Should().BeNull();
+            TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().BeNull();
+            TracerManager.Instance.Settings.CustomSamplingRulesInternalIsRemote.Should().BeFalse();
 
             var singleAgentRuleOnly = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
             singleAgentRuleOnly.Should().ContainSingle().And.AllBeOfType<AgentSamplingRule>();
@@ -129,7 +130,9 @@ namespace Datadog.Trace.Tests.Configuration
 
             // set sampling rules "remotely"
             DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_sampling_rules", samplingRulesConfig)));
-            TracerManager.Instance.Settings.RemoteSamplingRules.Should().Be(samplingRulesJson);
+            TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().Be(samplingRulesJson);
+            TracerManager.Instance.Settings.CustomSamplingRulesInternalIsRemote.Should().BeTrue();
+
             var rules = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
 
             rules.Should()

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -4,8 +4,8 @@
 // </copyright>
 
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Threading;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Configuration.ConfigurationSources;
 using Datadog.Trace.Configuration.Telemetry;
@@ -110,31 +110,56 @@ namespace Datadog.Trace.Tests.Configuration
         [Fact]
         public void SetSamplingRules()
         {
-            var tracerSettings = new TracerSettings();
+            // start with local sampling rules only
+            var localSamplingRulesConfig = new[]
+            {
+                new { sample_rate = 0.5,  service = "Service3", resource = "Resource3", },
+            };
+
+            var localSamplingRulesJson = JsonConvert.SerializeObject(localSamplingRulesConfig);
+            var configValues = new Dictionary<string, string> { { "DD_TRACE_SAMPLING_RULES", localSamplingRulesJson } };
+
+            IConfigurationSource configSource = new DictionaryConfigurationSource(configValues);
+            var tracerSettings = new TracerSettings(configSource);
             TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings), TracerManagerFactory.Instance);
 
-            // sampling rules is null by default
-            TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().BeNull();
+            TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().Be(localSamplingRulesJson);
             TracerManager.Instance.Settings.CustomSamplingRulesInternalIsRemote.Should().BeFalse();
 
-            var singleAgentRuleOnly = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
-            singleAgentRuleOnly.Should().ContainSingle().And.AllBeOfType<AgentSamplingRule>();
+            var rules = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
 
-            var samplingRulesConfig = new[]
+            rules.Should()
+                 .BeEquivalentTo(
+                      new ISamplingRule[]
+                      {
+                          new LocalCustomSamplingRule(
+                              rate: 0.1f,
+                              serviceNamePattern: "Service3",
+                              operationNamePattern: null,
+                              resourceNamePattern: "Resource3",
+                              tagPatterns: null,
+                              timeout: TimeSpan.FromSeconds(1),
+                              patternFormat: "glob"),
+                          new AgentSamplingRule()
+                      });
+
+            // set sampling rules "remotely"
+            var remoteSamplingRulesConfig = new[]
             {
                 new { sample_rate = 0.5, provenance = "customer", service = "Service1", resource = "Resource1", },
                 new { sample_rate = 0.1, provenance = "dynamic", service = "Service2", resource = "Resource2", }
             };
 
-            var samplingRulesJson = JsonConvert.SerializeObject(samplingRulesConfig);
+            var configBuilder = CreateConfig(("tracing_sampling_rules", remoteSamplingRulesConfig));
+            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(configBuilder);
 
-            // set sampling rules "remotely"
-            DynamicConfigurationManager.OnlyForTests_ApplyConfiguration(CreateConfig(("tracing_sampling_rules", samplingRulesConfig)));
-            TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().Be(samplingRulesJson);
+            var remoteSamplingRulesJson = JsonConvert.SerializeObject(remoteSamplingRulesConfig);
+            TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().Be(remoteSamplingRulesJson);
             TracerManager.Instance.Settings.CustomSamplingRulesInternalIsRemote.Should().BeTrue();
 
-            var rules = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
+            rules = ((TraceSampler)TracerManager.Instance.PerTraceSettings.TraceSampler)!.GetRules();
 
+            // new list should include the remote rules, not the local rules
             rules.Should()
                  .BeEquivalentTo(
                       new ISamplingRule[]

--- a/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/DynamicConfigurationTests.cs
@@ -117,10 +117,12 @@ namespace Datadog.Trace.Tests.Configuration
             };
 
             var localSamplingRulesJson = JsonConvert.SerializeObject(localSamplingRulesConfig);
-            var configValues = new Dictionary<string, string> { { "DD_TRACE_SAMPLING_RULES", localSamplingRulesJson } };
 
-            IConfigurationSource configSource = new DictionaryConfigurationSource(configValues);
-            var tracerSettings = new TracerSettings(configSource);
+            var tracerSettings = TracerSettings.Create(new()
+            {
+                { "DD_TRACE_SAMPLING_RULES", localSamplingRulesJson }
+            });
+
             TracerManager.ReplaceGlobalManager(new ImmutableTracerSettings(tracerSettings), TracerManagerFactory.Instance);
 
             TracerManager.Instance.Settings.CustomSamplingRulesInternal.Should().Be(localSamplingRulesJson);


### PR DESCRIPTION
## Summary of changes

When sampling rules are configured remotely, we should ignore all local sampling rules instead of merging remote and local rules into a single list.

Note that as long as there is a catch-all remote rule (effectively a remote global sampling rate using `DD_TRACE_SAMPLING_RULES` instead of `DD_TRACE_SAMPLE_RATE`, as recommended) or if Adaptive Sampling is enabled, this will have no effect, since local rules will be ignored as long as a remote rule matches a trace. The edge case fixed in this PR only occurs if all of these are true:
- there are _both_ local and remote sampling rules configured
- _none_ of the remote sampling rules match a trace
- _at least one_ of the local rules matches the same trace

In the above case, we were applying the sampling rate from the matching local rule instead of ignoring all local rules.

## Reason for change

Consistency across the language ~tracers~ ~libraries~ SDKs.
Allows us to "remove" local configuration without having to specify a catch-all remote rule.

## Implementation details

In the tracer settings, remove `RemoteSamplingRules` and keep only `CustomSamplingRulesInternal`. Its value will have either remote rules or local rules, with the remote value overriding any local value (like we do with other remote settings). Also add a `bool` property `CustomSamplingRulesIsRemote` to determine if the setting's source was local or remote so we can deserialize them correctly (they have different schemas).

## Test coverage

- Expanded unit test to cover this case.
- Covered by this parametric system test:
https://github.com/DataDog/system-tests/pull/2585

<!-- ## Other details -->
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
