### PR TITLE
Fix Gitlab build and codeCoverage bugs

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2399,6 +2399,7 @@ stages:
       displayName: docker-compose run --no-deps ProfilerIntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
 
     - publish: profiler/build_data
       artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
@@ -2984,6 +2985,9 @@ stages:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
     - script: docker-compose -f docker-compose.yml -f docker-compose.ci.azdo.yml -p $(DockerComposeProjectName) down
+      env:
+        baseImage: $(baseImage) # for interpolation in the docker-compose file
+        azdo_network: $(agent.containernetwork)
       displayName: docker-compose stop services
       condition: succeededOrFailed()
       continueOnError: true

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -116,7 +116,7 @@ variables:
   isPullRequest: $[eq(variables['Build.Reason'], 'PullRequest')]
   # Only run code coverage when requested
   # Coverlet relies on IL rewriting, which currently breaks tests which explictly check the IL
-  runCodeCoverage: $[eq(variables['run_code_coverage'], 'true')]
+  CodeCoverageEnabled: $[eq(variables['run_code_coverage'], 'true')]
   DD_DOTNET_TRACER_MSBUILD:
   NugetPackageDirectory: $(System.DefaultWorkingDirectory)/packages
   relativeNugetPackageDirectory: packages
@@ -1065,7 +1065,7 @@ stages:
       - template: steps/install-dotnet.yml
       - template: steps/restore-working-directory.yml
 
-      - script: tracer\build.cmd BuildAndRunManagedUnitTests --code-coverage $(runCodeCoverage)
+      - script: tracer\build.cmd BuildAndRunManagedUnitTests --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build and Test
         env:
           DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1114,7 +1114,7 @@ stages:
           artifact: build-macos-native_tracer
           path: $(monitoringHome)
 
-      - script: ./tracer/build.sh BuildAndRunManagedUnitTests --code-coverage $(runCodeCoverage)
+      - script: ./tracer/build.sh BuildAndRunManagedUnitTests --code-coverage-enabled $(CodeCoverageEnabled)
         displayName: Build and Test
         retryCountOnTaskFailure: 1
         env:
@@ -1170,7 +1170,7 @@ stages:
       parameters:
         build: true
         baseImage: $(baseImage)
-        command: "BuildAndRunManagedUnitTests --code-coverage $(runCodeCoverage)"
+        command: "BuildAndRunManagedUnitTests --code-coverage-enabled $(CodeCoverageEnabled)"
         apiKey: $(DD_LOGGER_DD_API_KEY)
 
     - publish: tracer/build_data
@@ -1274,7 +1274,7 @@ stages:
       displayName: 'Initialize LocalDB'
       workingDirectory: $(Build.Repository.LocalPath)
 
-    - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --code-coverage $(runCodeCoverage)
+    - script: tracer\build.cmd BuildAndRunWindowsIntegrationTests BuildAndRunWindowsRegressionTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Run integration tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1338,7 +1338,7 @@ stages:
 
     - template: steps/restore-working-directory.yml
 
-    - script: tracer\build.cmd BuildAndRunDebuggerIntegrationTests -Framework $(framework) --TargetPlatform $(targetPlatform) --DebugType $(debugType) --Optimize $(optimize) --code-coverage $(runCodeCoverage)
+    - script: tracer\build.cmd BuildAndRunDebuggerIntegrationTests -Framework $(framework) --TargetPlatform $(targetPlatform) --DebugType $(debugType) --Optimize $(optimize) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Run integration tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1398,7 +1398,7 @@ stages:
         includeX86: true
     - template: steps/restore-working-directory.yml
 
-    - script: tracer\build.cmd BuildAspNetIntegrationTests RunWindowsTracerIisIntegrationTests -Framework $(framework) --code-coverage $(runCodeCoverage)
+    - script: tracer\build.cmd BuildAspNetIntegrationTests RunWindowsTracerIisIntegrationTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: RunWindowsIisTracerIntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1458,7 +1458,7 @@ stages:
         includeX86: true
     - template: steps/restore-working-directory.yml
 
-    - script: tracer\build.cmd BuildAspNetIntegrationTests RunWindowsSecurityIisIntegrationTests -Framework $(framework) --code-coverage $(runCodeCoverage)
+    - script: tracer\build.cmd BuildAspNetIntegrationTests RunWindowsSecurityIisIntegrationTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: RunWindowsIisSecurityIntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1530,7 +1530,7 @@ stages:
       workingDirectory: $(Pipeline.Workspace)
       retryCountOnTaskFailure: 5
 
-    - script: tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage $(runCodeCoverage)
+    - script: tracer\build.cmd BuildAndRunWindowsAzureFunctionsTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: Run Azure Functions tests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1737,7 +1737,7 @@ stages:
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
 
-    - script: tracer\build.cmd RunWindowsMsiIntegrationTests -Framework $(framework) --code-coverage $(runCodeCoverage)
+    - script: tracer\build.cmd RunWindowsMsiIntegrationTests -Framework $(framework) --code-coverage-enabled $(CodeCoverageEnabled)
       displayName: RunWindowsIisIntegrationTests
       env:
         DD_LOGGER_DD_API_KEY: $(ddApiKey)
@@ -1824,7 +1824,7 @@ stages:
           run --no-deps --rm \
           -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
-          -e runCodeCoverage=$(runCodeCoverage) \
+          -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
           -e IncludeTestsRequiringDocker=false  \
           -e Filter=$(IntegrationTestFilter) \
           -e SampleName=$(IntegrationTestSampleName) \
@@ -1901,7 +1901,7 @@ stages:
         path: $(monitoringHome)
 
     - script: |
-        docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg runCodeCoverage=$(runCodeCoverage) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
+        docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) --build-arg Filter=$(IntegrationTestFilter) --build-arg SampleName=$(IntegrationTestSampleName) IntegrationTests
         docker-compose -p $(DockerComposeProjectName) run --rm StartDependencies
       env:
         baseImage: $(baseImage)
@@ -1917,7 +1917,7 @@ stages:
           run --rm \
           -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
-          -e runCodeCoverage=$(runCodeCoverage) \
+          -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
           -e IncludeTestsRequiringDocker=true \
           -e Filter=$(IntegrationTestFilter) \
           -e SampleName=$(IntegrationTestSampleName) \
@@ -2024,13 +2024,13 @@ stages:
           build \
           --build-arg baseImage=$(baseImage) \
           --build-arg framework=$(publishTargetFramework) \
-          --build-arg runCodeCoverage=$(runCodeCoverage) \
+          --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) \
           IntegrationTests.Serverless
 
         docker-compose -p $(DockerComposeProjectName) \
           -f $(System.DefaultWorkingDirectory)/docker-compose.yml \
           -f docker-compose.serverless.yml \
-          --build-arg runCodeCoverage=$(runCodeCoverage) \
+          --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) \
           --build-arg framework=$(publishTargetFramework) \
           pull --include-deps StartDependencies.Serverless
 
@@ -2052,7 +2052,7 @@ stages:
           -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
           -e lambdaBaseImage=$(lambdaBaseImage) \
-          -e runCodeCoverage=$(runCodeCoverage) \
+          -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
           IntegrationTests.Serverless
       displayName: docker-compose run IntegrationTests.Serverless
       env:
@@ -2201,7 +2201,7 @@ stages:
           run --no-deps --rm \
           -e baseImage=$(baseImage) \
           -e framework=$(publishTargetFramework) \
-          -e runCodeCoverage=$(runCodeCoverage) \
+          -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
           IntegrationTests.Debugger
       displayName: docker-compose run --no-deps IntegrationTests.Debugger
       env:
@@ -2619,7 +2619,7 @@ stages:
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
               -e framework=$(publishTargetFramework) \
-              -e runCodeCoverage=$(runCodeCoverage) \
+              -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
               -e IncludeTestsRequiringDocker=false \
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
@@ -2692,7 +2692,7 @@ stages:
             path: $(monitoringHome)
 
         - script: |
-            docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg runCodeCoverage=$(runCodeCoverage) IntegrationTests.ARM64
+            docker-compose -p $(DockerComposeProjectName) build --build-arg baseImage=$(baseImage) --build-arg framework=$(publishTargetFramework) --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) IntegrationTests.ARM64
             docker-compose -p $(DockerComposeProjectName) run --rm StartDependencies.ARM64
           env:
             baseImage: $(baseImage)
@@ -2708,7 +2708,7 @@ stages:
               run --rm \
               -e baseImage=$(baseImage) \
               -e framework=$(publishTargetFramework) \
-              -e runCodeCoverage=$(runCodeCoverage) \
+              -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
               -e IncludeTestsRequiringDocker=true \
               -e Filter=$(IntegrationTestFilter) \
               -e SampleName=$(IntegrationTestSampleName) \
@@ -2804,7 +2804,7 @@ stages:
               run --no-deps --rm \
               -e baseImage=$(baseImage) \
               -e framework=$(publishTargetFramework) \
-              -e runCodeCoverage=$(runCodeCoverage) \
+              -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
               IntegrationTests.ARM64.Debugger
           displayName: docker-compose run --no-deps IntegrationTests.ARM64.Debugger
           env:
@@ -2959,7 +2959,7 @@ stages:
           --build-arg explorationTestUseCase=$(explorationTestUseCase) \
           --build-arg explorationTestName=$(explorationTestName) \
           --build-arg framework=$(publishTargetFramework) \
-          --build-arg runCodeCoverage=$(runCodeCoverage) \
+          --build-arg CodeCoverageEnabled=$(CodeCoverageEnabled) \
           ExplorationTests
       displayName: docker-compose build ExplorationTests
       env:
@@ -2975,7 +2975,7 @@ stages:
           -e explorationTestUseCase=$(explorationTestUseCase) \
           -e explorationTestName=$(explorationTestName) \
           -e framework=$(publishTargetFramework) \
-          -e runCodeCoverage=$(runCodeCoverage) \
+          -e CodeCoverageEnabled=$(CodeCoverageEnabled) \
           ExplorationTests
       displayName: docker-compose run ExplorationTests
       env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -439,7 +439,7 @@ services:
       - Filter=${Filter:- } #optional
       - SampleName=${SampleName:- } #optional
       - baseImage=${baseImage:-default}
-      - CodeCoverage=${runCodeCoverage:-true}
+      - CodeCoverageEnabled=${CodeCoverageEnabled:-false}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
@@ -531,7 +531,7 @@ services:
       - framework=${framework:-netcoreapp3.1}
       - baseImage=${baseImage:-default}
       - targetplatform=${targetplatform:-x64}
-      - CodeCoverage=${runCodeCoverage:-true}
+      - CodeCoverageEnabled=${CodeCoverageEnabled:-false}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
@@ -582,7 +582,7 @@ services:
       - baseImage=${baseImage:-default}
       - Filter=${Filter:-Category=Lambda}
       - File=${filter:-Category=Lambda}
-      - CodeCoverage=${runCodeCoverage:-true}
+      - CodeCoverageEnabled=${CodeCoverageEnabled:-false}
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
@@ -634,7 +634,7 @@ services:
       - NugetPackageDirectory=/project/${relativeNugetPackageDirectory:-packages}
       - artifacts=/project/${relativeArtifacts:-tracer/src/bin/artifacts}
       - framework=${framework:-netcoreapp3.1}
-      - CodeCoverage=${runCodeCoverage:-true}
+      - CodeCoverageEnabled=${CodeCoverageEnabled:-false}
       - explorationTestUseCase=${explorationTestUseCase:-debugger}
       - explorationTestName=${explorationTestName:-eshoponweb}
       - baseImage=${baseImage:-default}
@@ -709,7 +709,7 @@ services:
       - framework=${framework:-netcoreapp3.1}
       - Filter=${Filter:-} #optional
       - SampleName=${SampleName:- } #optional
-      - CodeCoverage=${runCodeCoverage:-true}
+      - CodeCoverageEnabled=${CodeCoverageEnabled:-false}
       - baseImage=${baseImage:-debian}
       - TestAllPackageVersions=${TestAllPackageVersions:-true}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}

--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -30,7 +30,6 @@ partial class Build
         .Unlisted()
         .Description("Compiles the native profiler assets")
         .DependsOn(CompileProfilerNativeSrcWindows)
-        .DependsOn(CompileProfilerNativeTestsWindows)
         .DependsOn(CompileProfilerNativeSrcLinux);
 
     Target CompileProfilerNativeTests => _ => _

--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -116,7 +116,7 @@ partial class Build
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .EnableTrxLogOutput(GetResultsDirectory(DebuggerIntegrationTests))
                     .WithDatadogLogger()
                     .SetProjectFile(DebuggerIntegrationTests));

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1033,7 +1033,7 @@ partial class Build
                             .SetFramework(targetFramework)
                             .EnableCrashDumps()
                             .SetLogsDirectory(TestLogsDirectory)
-                            .When(CodeCoverage, ConfigureCodeCoverage)
+                            .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                             .When(!string.IsNullOrWhiteSpace(Filter), c => c.SetFilter(Filter))
                             .CombineWith(testProjects, (x, project) => x
                                 .EnableTrxLogOutput(GetResultsDirectory(project))
@@ -1407,7 +1407,7 @@ partial class Build
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(!string.IsNullOrWhiteSpace(Filter), c => c.SetFilter(Filter))
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ParallelIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .WithDatadogLogger()
@@ -1430,7 +1430,7 @@ partial class Build
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .WithDatadogLogger()
@@ -1499,7 +1499,7 @@ partial class Build
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .EnableTrxLogOutput(GetResultsDirectory(project))
                     .WithDatadogLogger()
                     .SetProjectFile(project));
@@ -1540,7 +1540,7 @@ partial class Build
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .WithDatadogLogger()
@@ -1592,7 +1592,7 @@ partial class Build
                                 .SetIsDebugRun(isDebugRun)
                                 .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                                 .SetLogsDirectory(TestLogsDirectory)
-                                .When(CodeCoverage, ConfigureCodeCoverage)
+                                .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                                 .EnableTrxLogOutput(GetResultsDirectory(project))
                                 .WithDatadogLogger()
                                 .SetProjectFile(project));
@@ -1631,7 +1631,7 @@ partial class Build
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetLogsDirectory(TestLogsDirectory)
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .EnableTrxLogOutput(resultsDirectory)
                     .WithDatadogLogger()
                     .SetProjectFile(project));
@@ -1891,7 +1891,7 @@ partial class Build
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
                     .SetTestTargetPlatform(TargetPlatform)
                     .SetLogsDirectory(TestLogsDirectory)
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .SetProjectFile(Projects.DdTraceIntegrationTests)
                     .EnableTrxLogOutput(project)
                     .WithDatadogLogger());
@@ -1948,7 +1948,7 @@ partial class Build
                         .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                         .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
                         .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                        .When(CodeCoverage, ConfigureCodeCoverage)
+                        .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                         .CombineWith(ParallelIntegrationTests, (s, project) => s
                             .EnableTrxLogOutput(GetResultsDirectory(project))
                             .WithDatadogLogger()
@@ -1970,7 +1970,7 @@ partial class Build
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                     .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
                     .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .WithDatadogLogger()
@@ -2032,7 +2032,7 @@ partial class Build
                         .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                         .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
                         .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                        .When(CodeCoverage, ConfigureCodeCoverage)
+                        .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                         .CombineWith(ParallelIntegrationTests, (s, project) => s
                             .EnableTrxLogOutput(GetResultsDirectory(project))
                             .WithDatadogLogger()
@@ -2055,7 +2055,7 @@ partial class Build
                     .When(TestAllPackageVersions, o => o.SetProcessEnvironmentVariable("TestAllPackageVersions", "true"))
                     .When(IncludeMinorPackageVersions, o => o.SetProperty("IncludeMinorPackageVersions", "true"))
                     .When(IncludeTestsRequiringDocker is not null, o => o.SetProperty("IncludeTestsRequiringDocker", IncludeTestsRequiringDocker.Value ? "true" : "false"))
-                    .When(CodeCoverage, ConfigureCodeCoverage)
+                    .When(CodeCoverageEnabled, ConfigureCodeCoverage)
                     .CombineWith(ClrProfilerIntegrationTests, (s, project) => s
                         .EnableTrxLogOutput(GetResultsDirectory(project))
                         .WithDatadogLogger()

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -80,7 +80,7 @@ partial class Build : NukeBuild
     readonly string BenchmarkCategory;
 
     [Parameter("Enables code coverage")]
-    readonly bool CodeCoverage;
+    readonly bool CodeCoverageEnabled;
 
     [Parameter("Enable or Disable fast developer loop")]
     readonly bool FastDevLoop;


### PR DESCRIPTION
## Summary of changes

- Fixes GitLab build broken in https://github.com/DataDog/dd-trace-dotnet/pull/5614
- Fixes CodeCoverage calculations broken in https://github.com/DataDog/dd-trace-dotnet/pull/5718
- Fixes profiler integration tests broken in https://github.com/DataDog/dd-trace-dotnet/pull/5718

## Reason for change

- The GitLab build was broken in #5614, due to a rogue dependency causing us to build the profiler native unit tests in GitLab
- As part of the docker changes in #5718, accidentally enabled code coverage for all builds, which slows them down a lot.
- Not all the stages were run in the previous build, so I broke some of them and didn't notice 🤦‍♂️ 

## Implementation details

- Remove the rogue dependency
- Unify `CodeCoverage` and `runCodeCoverage` variables as `CodeCoverageEnabled`. It was getting (even more) confusing to reason about what was replacing what when running in docker compose, so unified to a single variable name across Nuke and pipelines. Now it's just _very_ confusing instead of _insanely_ confusing.
- Add missing variables

## Test coverage

Did a manual test in GitLab and all looks good. This is the test of the code coverage part.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
