### PR TITLE
[ASM] Fix WAF timeout false positives

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafResultStruct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/NativeBindings/DdwafResultStruct.cs
@@ -12,7 +12,7 @@ namespace Datadog.Trace.AppSec.Waf.NativeBindings
     internal struct DdwafResultStruct
     {
         /** Whether there has been a timeout during the operation **/
-        public bool Timeout;
+        public byte Timeout;
         /** Array of events generated, this is guaranteed to be an array **/
         public DdwafObjectStruct Events;
         /** Array of actions generated, this is guaranteed to be an array **/

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Result.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.AppSec.Waf
                 AggregatedTotalRuntimeWithBindings = aggregatedTotalRuntimeWithBindings;
             }
 
-            Timeout = returnStruct.Timeout;
+            Timeout = returnStruct.Timeout > 0;
         }
 
         public WafReturnCode ReturnCode { get; }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ActionChangeTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ActionChangeTests.cs
@@ -38,7 +38,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
         waf.Should().NotBeNull();
         using var context = waf.CreateContext();
         var result = context.Run(args, TimeoutMicroSeconds);
-        result.Timeout.Should().BeFalse();
+        result.Timeout.Should().BeFalse("Timeout should be false");
         result.BlockInfo["status_code"].Should().Be("403");
         var jsonString = JsonConvert.SerializeObject(result.Data);
         var resultData = JsonConvert.DeserializeObject<WafMatch[]>(jsonString).FirstOrDefault();
@@ -52,7 +52,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
         res.Success.Should().BeTrue();
         using var contextNew = waf.CreateContext();
         result = contextNew.Run(args, TimeoutMicroSeconds);
-        result.Timeout.Should().BeFalse();
+        result.Timeout.Should().BeFalse("Timeout should be false");
         if (actionType == BlockingAction.BlockRequestType)
         {
             result.BlockInfo["status_code"].Should().Be(newStatus.ToString());
@@ -83,7 +83,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
 
         using var context = waf.CreateContext();
         var result = context.Run(args, TimeoutMicroSeconds);
-        result.Timeout.Should().BeFalse();
+        result.Timeout.Should().BeFalse("Timeout should be false");
         result.BlockInfo["status_code"].Should().Be("500");
     }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ActionChangeTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ActionChangeTests.cs
@@ -38,6 +38,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
         waf.Should().NotBeNull();
         using var context = waf.CreateContext();
         var result = context.Run(args, TimeoutMicroSeconds);
+        result.Timeout.Should().BeFalse();
         result.BlockInfo["status_code"].Should().Be("403");
         var jsonString = JsonConvert.SerializeObject(result.Data);
         var resultData = JsonConvert.DeserializeObject<WafMatch[]>(jsonString).FirstOrDefault();
@@ -51,6 +52,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
         res.Success.Should().BeTrue();
         using var contextNew = waf.CreateContext();
         result = contextNew.Run(args, TimeoutMicroSeconds);
+        result.Timeout.Should().BeFalse();
         if (actionType == BlockingAction.BlockRequestType)
         {
             result.BlockInfo["status_code"].Should().Be(newStatus.ToString());
@@ -81,6 +83,7 @@ public class ActionChangeTests : WafLibraryRequiredTest
 
         using var context = waf.CreateContext();
         var result = context.Run(args, TimeoutMicroSeconds);
+        result.Timeout.Should().BeFalse();
         result.BlockInfo["status_code"].Should().Be("500");
     }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
@@ -107,7 +107,7 @@ public class ContextTests : WafLibraryRequiredTest
 
                         args.Add(AddressesConstants.RequestBody, new List<string> { "dog1", "dog2", "dog3", "dog4" });
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
-                        result.Timeout.Should().BeFalse();
+                        result.Timeout.Should().BeFalse("Timeout should be false");
                         result.ReturnCode.Should().Be(WafReturnCode.Ok);
                         args.Clear();
 
@@ -119,7 +119,7 @@ public class ContextTests : WafLibraryRequiredTest
                         args.Add(AddressesConstants.RequestPathParams, new Dictionary<string, object> { { "controller", "Home" }, { "action", "Index" }, { "id", "appscan_fingerprint" } });
 #endif
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
-                        result.Timeout.Should().BeFalse();
+                        result.Timeout.Should().BeFalse("Timeout should be false");
                         args.Clear();
 
 #if NETFRAMEWORK
@@ -128,14 +128,14 @@ public class ContextTests : WafLibraryRequiredTest
                         args.Add(AddressesConstants.RequestPathParams, new Dictionary<string, object> { { "id", "appscan_fingerprint" } });
 #endif
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
-                        result.Timeout.Should().BeFalse();
+                        result.Timeout.Should().BeFalse("Timeout should be false");
                         args.Clear();
 
                         args.Add(AddressesConstants.ResponseBody, new List<object> { "dog1", true, 1.5, 1.40d, "dummy_rule", longArraylist, longArraylist });
                         args.Add(AddressesConstants.ResponseHeaderNoCookies, new Dictionary<string, ArrayList> { { "content-type", longArraylist } });
                         args.Add(AddressesConstants.ResponseStatus, "200");
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
-                        result.Timeout.Should().BeFalse();
+                        result.Timeout.Should().BeFalse("Timeout should be false");
                         result.ReturnCode.Should().Be(WafReturnCode.Ok);
                         args.Clear();
                     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
@@ -28,7 +28,6 @@ public class ContextTests : WafLibraryRequiredTest
     // here we use just 1 sec instead of the 20sec common one as we dont really care about the result, just that it runs
     public const int WafRunTimeoutMicroSeconds = 1_000_000;
 
-    [Ignore]
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/ContextTests.cs
@@ -28,6 +28,7 @@ public class ContextTests : WafLibraryRequiredTest
     // here we use just 1 sec instead of the 20sec common one as we dont really care about the result, just that it runs
     public const int WafRunTimeoutMicroSeconds = 1_000_000;
 
+    [Ignore]
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
@@ -107,6 +108,7 @@ public class ContextTests : WafLibraryRequiredTest
 
                         args.Add(AddressesConstants.RequestBody, new List<string> { "dog1", "dog2", "dog3", "dog4" });
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
+                        result.Timeout.Should().BeFalse();
                         result.ReturnCode.Should().Be(WafReturnCode.Ok);
                         args.Clear();
 
@@ -118,6 +120,7 @@ public class ContextTests : WafLibraryRequiredTest
                         args.Add(AddressesConstants.RequestPathParams, new Dictionary<string, object> { { "controller", "Home" }, { "action", "Index" }, { "id", "appscan_fingerprint" } });
 #endif
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
+                        result.Timeout.Should().BeFalse();
                         args.Clear();
 
 #if NETFRAMEWORK
@@ -126,12 +129,14 @@ public class ContextTests : WafLibraryRequiredTest
                         args.Add(AddressesConstants.RequestPathParams, new Dictionary<string, object> { { "id", "appscan_fingerprint" } });
 #endif
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
+                        result.Timeout.Should().BeFalse();
                         args.Clear();
 
                         args.Add(AddressesConstants.ResponseBody, new List<object> { "dog1", true, 1.5, 1.40d, "dummy_rule", longArraylist, longArraylist });
                         args.Add(AddressesConstants.ResponseHeaderNoCookies, new Dictionary<string, ArrayList> { { "content-type", longArraylist } });
                         args.Add(AddressesConstants.ResponseStatus, "200");
                         result = context.Run(args, WafRunTimeoutMicroSeconds);
+                        result.Timeout.Should().BeFalse();
                         result.ReturnCode.Should().Be(WafReturnCode.Ok);
                         args.Clear();
                     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
@@ -17,7 +17,7 @@ using FluentAssertions;
 using Xunit;
 using Action = Datadog.Trace.AppSec.Rcm.Models.Asm.Action;
 
-namespace Datadog.Trace.Rasp.Unit.Tests;
+namespace Datadog.Trace.Security.Unit.Tests;
 
 public class RaspWafTests : WafLibraryRequiredTest
 {
@@ -35,6 +35,7 @@ public class RaspWafTests : WafLibraryRequiredTest
         var argsVulnerable = new Dictionary<string, object> { { AddressesConstants.FileAccess, value } };
         var resultEph = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true);
         resultEph.BlockInfo["status_code"].Should().Be("403");
+        resultEph.Timeout.Should().BeFalse();
         var jsonString = JsonConvert.SerializeObject(resultEph.Data);
         var resultData = JsonConvert.DeserializeObject<WafMatch[]>(jsonString).FirstOrDefault();
         resultData.Rule.Id.Should().Be(rule);
@@ -49,6 +50,7 @@ public class RaspWafTests : WafLibraryRequiredTest
         context = waf.CreateContext();
         context.Run(args, TimeoutMicroSeconds);
         var resultEphNew = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true);
+        resultEphNew.Timeout.Should().BeFalse();
         resultEphNew.BlockInfo["status_code"].Should().Be("500");
         resultEphNew.AggregatedTotalRuntimeRasp.Should().BeGreaterThan(0);
         resultEphNew.AggregatedTotalRuntimeWithBindingsRasp.Should().BeGreaterThan(0);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
@@ -55,55 +55,6 @@ public class RaspWafTests : WafLibraryRequiredTest
     }
 
     [Theory]
-    [InlineData(0, 1000000)]
-    // [InlineData(10, 10)]
-    public void TimeoutTestRasp(int queryLength, ulong timeout)
-    {
-        var ttt = sizeof(bool);
-        Console.Write(ttt);
-        ttt.Should().Be(1);
-
-        var query = "select * from employees where name = 'Jihn'";
-
-        for (int i = 0; i < queryLength; i++)
-        {
-            query += $" or name = 'John{i.ToString()}'";
-        }
-
-        query += " or '1' = '1'";
-
-        var args = CreateArgs("John' or '1' = '1");
-        var context = InitWaf(true, "rasp-rule-set.json", args, out _);
-        var argsVulnerable = new Dictionary<string, object>
-        {
-            { AddressesConstants.DBStatement, "select * from employees where name = 'John' or '1' = '1'" },
-            { "server.db.system", "sqlite" }
-        };
-
-        System.Diagnostics.Stopwatch stopwatch = new();
-        stopwatch.Start();
-        var resultEph = context.RunWithEphemeral(argsVulnerable, timeout, true);
-        stopwatch.Stop();
-
-        if (resultEph.Timeout)
-        {
-            resultEph.AggregatedTotalRuntimeRasp.Should().BeGreaterThan(timeout / 1000);
-            resultEph.ShouldBlock.Should().BeFalse();
-        }
-        else
-        {
-            (resultEph.AggregatedTotalRuntimeRasp * 0.5).Should().BeLessThan(timeout / 1000);
-            resultEph.ShouldBlock.Should().BeTrue();
-        }
-
-        // else
-        // {
-        //     stopwatch.ElapsedMilliseconds.Should().BeLessThan((timeout * 5) / 1000);
-        // }
-    }
-
-    [Theory]
-    [InlineData("select * from employees where name = 'John' or '1' = '1'", "John' or '1' = '1", "rasp-942-100", BlockingAction.BlockDefaultActionName, BlockingAction.BlockRequestType, AddressesConstants.DBStatement)]
     [InlineData("../../../../../../../../../etc/passwd", "../../../../../../../../../etc/passwd", "rasp-001-001", "customBlock", BlockingAction.BlockRequestType, AddressesConstants.FileAccess)]
     [InlineData("https://169.254.169.254/somewhere/in/the/app", "169.254.169.254", "rasp-002-001", BlockingAction.BlockDefaultActionName, BlockingAction.BlockRequestType, AddressesConstants.UrlAccess)]
     public void GivenARaspRule_WhenInsecureAccess_ThenBlock(string value, string paramValue, string rule, string action, string actionType, string address)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
@@ -35,7 +35,7 @@ public class RaspWafTests : WafLibraryRequiredTest
         var argsVulnerable = new Dictionary<string, object> { { AddressesConstants.FileAccess, value } };
         var resultEph = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true);
         resultEph.BlockInfo["status_code"].Should().Be("403");
-        resultEph.Timeout.Should().BeFalse();
+        resultEph.Timeout.Should().BeFalse("Timeout should be false");
         var jsonString = JsonConvert.SerializeObject(resultEph.Data);
         var resultData = JsonConvert.DeserializeObject<WafMatch[]>(jsonString).FirstOrDefault();
         resultData.Rule.Id.Should().Be(rule);
@@ -50,7 +50,7 @@ public class RaspWafTests : WafLibraryRequiredTest
         context = waf.CreateContext();
         context.Run(args, TimeoutMicroSeconds);
         var resultEphNew = context.RunWithEphemeral(argsVulnerable, TimeoutMicroSeconds, true);
-        resultEphNew.Timeout.Should().BeFalse();
+        resultEphNew.Timeout.Should().BeFalse("Timeout should be false");
         resultEphNew.BlockInfo["status_code"].Should().Be("500");
         resultEphNew.AggregatedTotalRuntimeRasp.Should().BeGreaterThan(0);
         resultEphNew.AggregatedTotalRuntimeWithBindingsRasp.Should().BeGreaterThan(0);
@@ -105,7 +105,7 @@ public class RaspWafTests : WafLibraryRequiredTest
         waf.Should().NotBeNull();
         var context = waf.CreateContext();
         var result = context.Run(args, TimeoutMicroSeconds);
-        result.Timeout.Should().BeFalse();
+        result.Timeout.Should().BeFalse("Timeout should be false");
         return context;
     }
 
@@ -121,7 +121,7 @@ public class RaspWafTests : WafLibraryRequiredTest
 
     private void CheckResult(string rule, string expectedAction, IResult result, string actionType)
     {
-        result.Timeout.Should().BeFalse();
+        result.Timeout.Should().BeFalse("Timeout should be false");
         result.ReturnCode.Should().Be(WafReturnCode.Match);
         result.Actions.ContainsKey(actionType).Should().BeTrue();
         var jsonString = JsonConvert.SerializeObject(result.Data);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RaspWafTests.cs
@@ -15,17 +15,13 @@ using Datadog.Trace.TestHelpers.FluentAssertionsExtensions.Json;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
 using Xunit;
-using YamlDotNet.Core.Tokens;
+
 using Action = Datadog.Trace.AppSec.Rcm.Models.Asm.Action;
 
 namespace Datadog.Trace.Security.Unit.Tests;
 
 public class RaspWafTests : WafLibraryRequiredTest
 {
-    public RaspWafTests()
-    {
-    }
-
     [Theory]
     [InlineData(1, 1000000, false)]
     [InlineData(1000, 1, true)]
@@ -125,8 +121,7 @@ public class RaspWafTests : WafLibraryRequiredTest
             string.Empty,
             string.Empty,
             useUnsafeEncoder: newEncoder,
-            embeddedRulesetPath: ruleFile,
-            wafDebugEnabled: true);
+            embeddedRulesetPath: ruleFile);
         waf = initResult.Waf;
         waf.Should().NotBeNull();
         var context = waf.CreateContext();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 #nullable enable
+using System;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Xunit;
 
@@ -19,6 +20,8 @@ public class WafLibraryRequiredTest
 
     static WafLibraryRequiredTest()
     {
+        Environment.SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
+        Environment.SetEnvironmentVariable("DD_APPSEC_WAF_DEBUG", "true");
         var result = WafLibraryInvoker.Initialize();
         WafLibraryInvoker = result.WafLibraryInvoker;
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -20,8 +20,6 @@ public class WafLibraryRequiredTest
 
     static WafLibraryRequiredTest()
     {
-        Environment.SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
-        Environment.SetEnvironmentVariable("DD_APPSEC_WAF_DEBUG", "true");
         var result = WafLibraryInvoker.Initialize();
         WafLibraryInvoker = result.WafLibraryInvoker;
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -1,9 +1,10 @@
-﻿// <copyright file="WafLibraryRequiredTest.cs" company="Datadog">
+// <copyright file="WafLibraryRequiredTest.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
 #nullable enable
+using System;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Xunit;
 
@@ -19,6 +20,8 @@ public class WafLibraryRequiredTest
 
     static WafLibraryRequiredTest()
     {
+        Environment.SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
+        Environment.SetEnvironmentVariable("DD_APPSEC_WAF_DEBUG", "true");
         var result = WafLibraryInvoker.Initialize();
         WafLibraryInvoker = result.WafLibraryInvoker;
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Utils/WafLibraryRequiredTest.cs
@@ -4,7 +4,6 @@
 // </copyright>
 
 #nullable enable
-using System;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Xunit;
 
@@ -20,8 +19,6 @@ public class WafLibraryRequiredTest
 
     static WafLibraryRequiredTest()
     {
-        Environment.SetEnvironmentVariable("DD_TRACE_DEBUG", "true");
-        Environment.SetEnvironmentVariable("DD_APPSEC_WAF_DEBUG", "true");
         var result = WafLibraryInvoker.Initialize();
         WafLibraryInvoker = result.WafLibraryInvoker;
     }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
@@ -109,7 +109,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             {
                 var args = MakeDictionary(address, values[i]);
                 var result = context.RunWithEphemeral(args, TimeoutMicroSeconds, false);
-                result.Timeout.Should().BeFalse();
+                result.Timeout.Should().BeFalse("Timeout should be false");
 
                 // by convention attack is last item in the array
                 if (matches[i])

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafEphemeralDataTests.cs
@@ -109,6 +109,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             {
                 var args = MakeDictionary(address, values[i]);
                 var result = context.RunWithEphemeral(args, TimeoutMicroSeconds, false);
+                result.Timeout.Should().BeFalse();
 
                 // by convention attack is last item in the array
                 if (matches[i])

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafIpBlockTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafIpBlockTests.cs
@@ -37,6 +37,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             res.HasErrors.Should().BeFalse();
             using var context = initResult.Waf.CreateContext();
             var result = context!.Run(new Dictionary<string, object> { { AddressesConstants.RequestClientIp, "51.222.158.205" } }, WafTests.TimeoutMicroSeconds);
+            result!.Timeout.Should().BeFalse();
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Match);
             result!.Actions.Should().NotBeEmpty();
@@ -44,6 +45,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.RequestClientIp, "188.243.182.156" } },
                 WafTests.TimeoutMicroSeconds);
+            result!.Timeout.Should().BeFalse();
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Ok);
             result.Actions.Should().BeEmpty();
@@ -87,6 +89,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var result = context!.Run(
                 new Dictionary<string, object> { { AddressesConstants.RequestClientIp, "188.243.182.156" } },
                 WafTests.TimeoutMicroSeconds);
+            result!.Timeout.Should().BeFalse();
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Match);
             result.Actions.Should().NotBeEmpty();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafIpBlockTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafIpBlockTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             res.HasErrors.Should().BeFalse();
             using var context = initResult.Waf.CreateContext();
             var result = context!.Run(new Dictionary<string, object> { { AddressesConstants.RequestClientIp, "51.222.158.205" } }, WafTests.TimeoutMicroSeconds);
-            result!.Timeout.Should().BeFalse();
+            result!.Timeout.Should().BeFalse("Timeout should be false");
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Match);
             result!.Actions.Should().NotBeEmpty();
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.RequestClientIp, "188.243.182.156" } },
                 WafTests.TimeoutMicroSeconds);
-            result!.Timeout.Should().BeFalse();
+            result!.Timeout.Should().BeFalse("Timeout should be false");
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Ok);
             result.Actions.Should().BeEmpty();
@@ -89,7 +89,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var result = context!.Run(
                 new Dictionary<string, object> { { AddressesConstants.RequestClientIp, "188.243.182.156" } },
                 WafTests.TimeoutMicroSeconds);
-            result!.Timeout.Should().BeFalse();
+            result!.Timeout.Should().BeFalse("Timeout should be false");
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Match);
             result.Actions.Should().NotBeEmpty();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
@@ -58,7 +58,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             {
                 using var context = waf.CreateContext();
                 var result = context.Run(args, TimeoutMicroSeconds);
-                result.Timeout.Should().BeFalse();
+                result.Timeout.Should().BeFalse("Timeout should be false");
                 result.ReturnCode.Should().Be(WafReturnCode.Match);
                 var jsonString = JsonConvert.SerializeObject(result.Data);
                 var resultData = JsonConvert.DeserializeObject<WafMatch[]>(jsonString).FirstOrDefault();
@@ -142,7 +142,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
             var result = context.Run(args, TimeoutMicroSeconds);
-            result.Timeout.Should().BeFalse();
+            result.Timeout.Should().BeFalse("Timeout should be false");
             if (isAttack)
             {
                 result.ReturnCode.Should().Be(WafReturnCode.Match);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafMemoryTests.cs
@@ -58,6 +58,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             {
                 using var context = waf.CreateContext();
                 var result = context.Run(args, TimeoutMicroSeconds);
+                result.Timeout.Should().BeFalse();
                 result.ReturnCode.Should().Be(WafReturnCode.Match);
                 var jsonString = JsonConvert.SerializeObject(result.Data);
                 var resultData = JsonConvert.DeserializeObject<WafMatch[]>(jsonString).FirstOrDefault();
@@ -141,6 +142,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
             var result = context.Run(args, TimeoutMicroSeconds);
+            result.Timeout.Should().BeFalse();
             if (isAttack)
             {
                 result.ReturnCode.Should().Be(WafReturnCode.Match);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
@@ -50,7 +50,7 @@ namespace Datadog.Trace.Security.Unit.Tests
                 waf.Should().NotBeNull();
                 using var context = waf.CreateContext();
                 var result = context.Run(args, TimeoutMicroSeconds);
-                result.Timeout.Should().BeFalse();
+                result.Timeout.Should().BeFalse("Timeout should be false");
                 result.ReturnCode.Should().Be(WafReturnCode.Match);
                 result.Data.Should().NotBeNull();
                 var jsonString = JsonConvert.SerializeObject(result.Data);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafObfuscationTests.cs
@@ -50,6 +50,7 @@ namespace Datadog.Trace.Security.Unit.Tests
                 waf.Should().NotBeNull();
                 using var context = waf.CreateContext();
                 var result = context.Run(args, TimeoutMicroSeconds);
+                result.Timeout.Should().BeFalse();
                 result.ReturnCode.Should().Be(WafReturnCode.Match);
                 result.Data.Should().NotBeNull();
                 var jsonString = JsonConvert.SerializeObject(result.Data);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -152,7 +152,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
             var result = context.Run(args, TimeoutMicroSeconds);
-            result.Timeout.Should().BeFalse();
+            result.Timeout.Should().BeFalse("Timeout should be false");
             if (flow is not null)
             {
                 result.ReturnCode.Should().Be(WafReturnCode.Match);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafTests.cs
@@ -152,6 +152,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
             var result = context.Run(args, TimeoutMicroSeconds);
+            result.Timeout.Should().BeFalse();
             if (flow is not null)
             {
                 result.ReturnCode.Should().Be(WafReturnCode.Match);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
             var result = context.Run(args, TimeoutMicroSeconds);
-            result.Timeout.Should().BeFalse();
+            result.Timeout.Should().BeFalse("Timeout should be false");
             var spectedResult = isAttack ? WafReturnCode.Match : WafReturnCode.Ok;
             result.ReturnCode.Should().Be(spectedResult);
             if (spectedResult == WafReturnCode.Match)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUpdateTests.cs
@@ -148,6 +148,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             waf.Should().NotBeNull();
             using var context = waf.CreateContext();
             var result = context.Run(args, TimeoutMicroSeconds);
+            result.Timeout.Should().BeFalse();
             var spectedResult = isAttack ? WafReturnCode.Match : WafReturnCode.Ok;
             result.ReturnCode.Should().Be(spectedResult);
             if (spectedResult == WafReturnCode.Match)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
@@ -37,6 +37,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.UserId, "user3" } },
                 WafTests.TimeoutMicroSeconds);
+            result!.Timeout.Should().BeFalse();
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Match);
             result!.Actions.Should().NotBeEmpty();
@@ -44,6 +45,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.UserId, "user4" } },
                 WafTests.TimeoutMicroSeconds);
+            result!.Timeout.Should().BeFalse();
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Ok);
             result!.Actions.Should().BeEmpty();

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/WafUserBlockTests.cs
@@ -37,7 +37,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             var result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.UserId, "user3" } },
                 WafTests.TimeoutMicroSeconds);
-            result!.Timeout.Should().BeFalse();
+            result!.Timeout.Should().BeFalse("Timeout should be false");
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Match);
             result!.Actions.Should().NotBeEmpty();
@@ -45,7 +45,7 @@ namespace Datadog.Trace.Security.Unit.Tests
             result = context.Run(
                 new Dictionary<string, object> { { AddressesConstants.UserId, "user4" } },
                 WafTests.TimeoutMicroSeconds);
-            result!.Timeout.Should().BeFalse();
+            result!.Timeout.Should().BeFalse("Timeout should be false");
             result.Should().NotBeNull();
             result!.ReturnCode.Should().Be(WafReturnCode.Ok);
             result!.Actions.Should().BeEmpty();


### PR DESCRIPTION
## Summary of changes

In several traces, we were reporting WAF timeouts. Actually, we were getting in .Net an unusual amount of WAF timeouts compared to other libraries.

After some research, the effect could be reproduced locally, observing this:
* The WAF timeouts were not real, the WAF was not actually reporting timeouts from the native side.
* The timeout only affect telemetry, ASM and WAF run normally in these cases.
* Locally, the result of the failing tests were reproducible and consistent but they would very depending on some variables (framework, having the debugger attached, the order of the tests, etc) That suggests an erratic behavior.

Timeout checks were added in the current WAF tests.

After launching these tests in the CI, several tests were failing, more than 100 in total.

A fix was added, reading the timeout flag as byte instead of bool. Basically the native side sends a struct that contains the WAF results. The first field of that struct is a C++ bool value. In C++, that value has a 1 byte size  and contains 1 or 0, depending on the bool value. We were reading this value as a .Net bool. After reading the value as a byte instead of bool, all the tests passed.

Several solutions were tested, including, for instance, adding marshalling attributes such as [MarshalAs(UnmanagedType.Bool)]

An explanation for this issue was given by @kevingosse in comments below.

While reading the filed as byte fixes the issue, adding the attribute [MarshalAs(UnmanagedType.U1)] also works.

## Reason for change

The tracer should not report false positives for WAF timeouts.

## Implementation details

## Test coverage

The existing WAF unit tests now check the timeout flag returned. One more test was added covering a real timeout situation to ensure that we actually keep detecting real timeouts.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
