### PR TITLE
Fix some macOS build issues

### DIFF
--- a/build/cmake/FindRe2.cmake
+++ b/build/cmake/FindRe2.cmake
@@ -12,7 +12,7 @@ if (ISMACOS)
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_IN_SOURCE TRUE
-        BUILD_COMMAND ${CMAKE_COMMAND} -E env LDFLAGS=-arch\ ${OSX_ARCH} ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -D_GLIBCXX_USE_CXX11_ABI=0 make -j
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env LDFLAGS=-arch\ ${OSX_ARCH} ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -target\ ${OSX_ARCH}-apple-darwin${CMAKE_HOST_SYSTEM_VERSION}\ -Wno-unused-but-set-variable\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j
         BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
     )
 elseif(ISLINUX)
@@ -23,7 +23,7 @@ elseif(ISLINUX)
         CONFIGURE_COMMAND ""
         UPDATE_COMMAND ""
         BUILD_IN_SOURCE TRUE
-        BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 make -j
+        BUILD_COMMAND ${CMAKE_COMMAND} -E env ARFLAGS=-r\ -s\ -c CXXFLAGS=-O3\ -g\ -fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0 $(MAKE) -j
         BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/re2-prefix/src/re2/obj/libre2.a
     )
 endif()

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1162,9 +1162,7 @@ partial class Build : NukeBuild
                 {
                     var matrix = new Dictionary<string, object>
                     {
-                        { "macos-11_netcoreapp3.1", new { vmImage = "macos-11", publishFramework = "netcoreapp3.1" } },
-                        { "macos-11_net6.0", new { vmImage = "macos-11", publishFramework = "net6.0" } },
-                        { "macos-11_net8.0", new { vmImage = "macos-11", publishFramework = "net8.0" } },
+                        // macos-11 environments are no longer available in Azure Devops
                         { "macos-12_netcoreapp3.1", new { vmImage = "macos-12", publishFramework = "netcoreapp3.1" } },
                         { "macos-12_net6.0", new { vmImage = "macos-12", publishFramework = "net6.0" } },
                         { "macos-12_net8.0", new { vmImage = "macos-12", publishFramework = "net8.0" } },


### PR DESCRIPTION
## Summary of changes

- Fix some warnings introduced from macos-12
- Stop running smoke tests on macos-11

## Reason for change

The macos-11 tests were only temporary, Azure are killing them so we can't use them for much longer anyway.

Also when we updated to macos-12 we started getting this warning from the third-party re2

```
re2/prog.cc:613:7: warning: variable 'total' set but not used [-Wunused-but-set-variable]
```

## Implementation details

There's nothing we can do about the warning as it's in 3rd party code, so we're just disabling that warning on macos. It's benign anyway (just dead code)

## Test coverage

This is the test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
