### PR TITLE
Report `IsServerBuild` correctly

### DIFF
--- a/.azure-pipelines/steps/run-in-docker.yml
+++ b/.azure-pipelines/steps/run-in-docker.yml
@@ -73,6 +73,7 @@ steps:
         --env IncludeMinorPackageVersions=$(IncludeMinorPackageVersions) \
         --env NUGET_ENABLE_EXPERIMENTAL_HTTP_RETRY=true \
         --env enable_crash_dumps=$(enable_crash_dumps) \
+        --env TF_BUILD \
         --env DD_COLLECTOR_CPU_USAGE="1" \
         --env DD_LOGGER_DD_API_KEY="$(DD_LOGGER_DD_API_KEY)" \
         --env DD_LOGGER_DD_SERVICE \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -343,6 +343,7 @@ services:
     ports:
     - "8080:80"
     environment:
+      - TF_BUILD
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
@@ -390,6 +391,7 @@ services:
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
       - IncludeMinorPackageVersions=${IncludeMinorPackageVersions:-false}
       - enable_crash_dumps=${enable_crash_dumps:-true}
+      - TF_BUILD
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
@@ -467,6 +469,7 @@ services:
       - COUCHBASE_HOST=couchbase
       - COUCHBASE_PORT=8091
       - CONTAINER_HOSTNAME=http://integrationtests
+      - TF_BUILD
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
@@ -536,6 +539,7 @@ services:
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
+      - TF_BUILD
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
@@ -591,6 +595,7 @@ services:
       - DiffEngine_Disabled=true
       - CONTAINER_HOSTNAME=http://integrationtests
       - IncludeAllTestFrameworks
+      - TF_BUILD
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
@@ -640,6 +645,7 @@ services:
       - baseImage=${baseImage:-default}
       - IncludeAllTestFrameworks
       - DD_CLR_ENABLE_NGEN=${DD_CLR_ENABLE_NGEN:-1}
+      - TF_BUILD
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
@@ -731,6 +737,7 @@ services:
       - MYSQL_PORT=3306
       - RABBITMQ_HOST=rabbitmq_arm64
       - AWS_SDK_HOST=localstack_arm64:4566
+      - TF_BUILD
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV
@@ -808,6 +815,7 @@ services:
       - enable_crash_dumps=${enable_crash_dumps:-true}
       - Verify_DisableClipboard=true
       - DiffEngine_Disabled=true
+      - TF_BUILD
       - DD_LOGGER_DD_API_KEY
       - DD_LOGGER_DD_SERVICE
       - DD_LOGGER_DD_ENV


### PR DESCRIPTION
## Summary of changes

Fixes `IsServerBuild` calculation in CI

## Reason for change

It wasn't working correctly, e.g. [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=160073&view=logs&j=4d2bd072-69d2-52f9-9ef7-1ebf54e62e75&t=932c758b-5f44-5d34-a86c-84ce5d520f99&l=6417)

## Implementation details

Passes the `TF_BUILD` env var through to docker builds to ensure 

## Test coverage

Tested in a build [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=160159&view=results) and looks correct (it's running the snapshot stage in CI)

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
