### PR TITLE
Better logs folder creation in chiseled smoke test

### DIFF
--- a/tracer/build/_build/docker/smoke.chiseled.dockerfile
+++ b/tracer/build/_build/docker/smoke.chiseled.dockerfile
@@ -11,8 +11,8 @@ COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 ARG PUBLISH_FRAMEWORK
 RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
-# Creating a placeholder file we can copy in the publish stage to create the logs folder
-RUN mkdir -p /install && touch /install/.placeholder
+# Creating an empty we can copy in the publish stage to create the logs folder
+RUN mkdir -p /empty
 
 ###########################################################
 FROM $RUNTIME_IMAGE AS publish
@@ -27,15 +27,8 @@ ENV DD_INTERNAL_WORKAROUND_77973_ENABLED=1
 
 ENV ASPNETCORE_URLS=http://localhost:5000
 
-USER root
-
-# Copy the placeholder file to create the logs directory
-# THIS DOESN'T WORK, but SOMETHING like it hopefully will... so leaving as inspiration 
-#COPY --chown=64198 --chmod=777 --from=builder /install /var/log/datadog/dotnet
-COPY --from=builder /install/.placeholder /var/log/datadog/dotnet/.placeholder
-
-# Use the non-root user
-USER $APP_UID
+# Copy the empty folder to create the logs directory
+COPY --chown=$APP_UID --from=builder /empty/ /var/log/datadog/dotnet/
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary of changes

The docker setup on a chiseled base image was using a placeholder file to create an empty directory, this is actually not needed, we can copy empty directories with the COPY command (what was missing from the commented code was trailing slashes).
I also changed the `chown` argument, because I don't know where 64198 was coming from. It's important that the user `$APP_UID` owns the logs folder, otherwise they cannot write to it (somehow, `chmod=777` alone didn't work when I tested it).
~In the existing setup before this PR, I'm not sure any logs were written.~ -> I checked and logs were actually produced, but I prefer the new setup :)
