### PR TITLE
[ASM] Capture ObjectDisposedException

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -17,6 +17,8 @@ namespace Datadog.Trace.AppSec.Coordinator;
 
 internal abstract class HttpTransportBase
 {
+    private bool _isAdditiveContextDisposed;
+
     internal abstract bool IsBlocked { get; }
 
     internal abstract int StatusCode { get; }
@@ -32,7 +34,13 @@ internal abstract class HttpTransportBase
     /// <summary>
     /// Disposes the WAF's context stored in HttpContext.Items[]. If it doesn't exist, nothing happens, no crash
     /// </summary>
-    internal void DisposeAdditiveContext() => GetAdditiveContext()?.Dispose();
+    internal void DisposeAdditiveContext()
+    {
+        GetAdditiveContext()?.Dispose();
+        _isAdditiveContextDisposed = true;
+    }
+
+    internal bool AdditiveContextDisposed() => _isAdditiveContextDisposed;
 
     internal abstract void SetAdditiveContext(IContext additiveContext);
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/HttpTransportBase.cs
@@ -40,7 +40,7 @@ internal abstract class HttpTransportBase
         _isAdditiveContextDisposed = true;
     }
 
-    internal bool AdditiveContextDisposed() => _isAdditiveContextDisposed;
+    internal bool IsAdditiveContextDisposed() => _isAdditiveContextDisposed;
 
     internal abstract void SetAdditiveContext(IContext additiveContext);
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -72,9 +72,9 @@ internal readonly partial struct SecurityCoordinator
         return _httpTransport.Context is not null;
     }
 
-    public bool AdditiveContextDisposed()
+    public bool IsAdditiveContextDisposed()
     {
-        return _httpTransport.AdditiveContextDisposed();
+        return _httpTransport.IsAdditiveContextDisposed();
     }
 
     public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, bool isRasp = false)

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -83,7 +83,16 @@ internal readonly partial struct SecurityCoordinator
         IResult? result = null;
         try
         {
-            var additiveContext = _httpTransport.GetAdditiveContext();
+            IContext? additiveContext;
+            try
+            {
+                additiveContext = _httpTransport.GetAdditiveContext();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Context.Features is null and we can't access it
+                return null;
+            }
 
             if (additiveContext == null)
             {

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -88,17 +88,7 @@ internal readonly partial struct SecurityCoordinator
         IResult? result = null;
         try
         {
-            IContext? additiveContext;
-            try
-            {
-                additiveContext = _httpTransport.GetAdditiveContext();
-            }
-            catch (ObjectDisposedException ex)
-            {
-                // This should not happen
-                Log.Error(ex, "Context has already been disposed");
-                return null;
-            }
+            var additiveContext = _httpTransport.GetAdditiveContext();
 
             if (additiveContext == null)
             {

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.cs
@@ -72,6 +72,11 @@ internal readonly partial struct SecurityCoordinator
         return _httpTransport.Context is not null;
     }
 
+    public bool AdditiveContextDisposed()
+    {
+        return _httpTransport.AdditiveContextDisposed();
+    }
+
     public IResult? RunWaf(Dictionary<string, object> args, bool lastWafCall = false, bool runWithEphemeral = false, bool isRasp = false)
     {
         if (!HasContext())
@@ -88,9 +93,10 @@ internal readonly partial struct SecurityCoordinator
             {
                 additiveContext = _httpTransport.GetAdditiveContext();
             }
-            catch (ObjectDisposedException)
+            catch (ObjectDisposedException ex)
             {
-                // Context.Features is null and we can't access it
+                // This should not happen
+                Log.Error(ex, "Context has already been disposed");
                 return null;
             }
 

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -84,7 +84,7 @@ internal static class RaspModule
         var securityCoordinator = new SecurityCoordinator(Security.Instance, rootSpan);
 
         // We need a context for RASP
-        if (!securityCoordinator.HasContext())
+        if (!securityCoordinator.HasContext() || securityCoordinator.AdditiveContextDisposed())
         {
             return;
         }

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -84,7 +84,7 @@ internal static class RaspModule
         var securityCoordinator = new SecurityCoordinator(Security.Instance, rootSpan);
 
         // We need a context for RASP
-        if (!securityCoordinator.HasContext() || securityCoordinator.AdditiveContextDisposed())
+        if (!securityCoordinator.HasContext() || securityCoordinator.IsAdditiveContextDisposed())
         {
             return;
         }

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -47,7 +47,7 @@ internal static class RaspModule
 
         var rootSpan = Tracer.Instance.InternalActiveScope?.Root?.Span;
 
-        if (rootSpan is null)
+        if (rootSpan is null || rootSpan.IsFinished)
         {
             return;
         }

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -47,7 +47,7 @@ internal static class RaspModule
 
         var rootSpan = Tracer.Instance.InternalActiveScope?.Root?.Span;
 
-        if (rootSpan is null || rootSpan.IsFinished)
+        if (rootSpan is null || rootSpan.IsFinished || rootSpan.Type != SpanTypes.Web)
         {
             return;
         }


### PR DESCRIPTION
## Summary of changes

We were getting a [ObjectDisposedException error](https://app.datadoghq.com/logs?query=issue.id%3A9b8fd566-28ca-11ef-83fb-da7ad0900002%20source%3Adotnet%20%2AAppSec%2A%20version%3A2.53.2.0&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZBKfG0kjUG1TAAAAAAAAAAYAAAAAEFaQktmRzBrQUFDcGJwMVF0MzYxWXdBQQAAACQAAAAAMDE5MDRhODctNjJiYi00ZGU5LWFhZTUtNTg0OGFkZjE0NTI5&fromUser=true&index=instrumentation-telemetry-data&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1719150573716&to_ts=1719236973716&live=false) in the SecurityCoordinator.

In RASP (and IAST), we are instrumenting methods that can be called out of a request context, even when running web apps. For instance, we are instrumenting methods of the class File.

This error occurs when we try to access Context.Features and that field is null. The class DefaultHttpContext checks for null values in that property and launches an exception when it's null. This can happen, for instance, if the method Uninitialize() from DefaultHttpContext is called. 

While it was not possible to reproduce this particular exception, some checks were added that could prevent this from happening again. These checks include checking if the additive context has been disposed, if the root span has been closed or if we are not running in a web context. In all of these cases, RASP is not required to run.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
