### PR TITLE
Fix flake in `SimpleActivitiesAndSpansTest`

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Activity.Handlers
                 {
                     // We ensure the activity follows the same TraceId as the span
                     // And marks the ParentId the current spanId
-                    if ((activity.Parent is null || activity.Parent.StartTimeUtc < activeSpan.StartTime.UtcDateTime)
+                    if ((activity.Parent is null || activity.Parent.StartTimeUtc <= activeSpan.StartTime.UtcDateTime)
                         && activitySpanId is not null
                         && activityTraceId is not null)
                     {


### PR DESCRIPTION
## Summary of changes

Updates condition for considering activity a parent

## Reason for change

`SimpleActivitiesAndSpansTest` is super-flaky on macos, especially since we updated to `macos-12`. I'm 99.9% sure it's due to the condition in `ActivityHandlerCommon` here, and I _think_ the fix is OK for production.

## Implementation details

Macos in a VM has _terrible_ resolution of the clock. So essentially a child span is getting the _same_ start time as the parent span. When we come to do the re-parenting/conversion to datadog spans, we currently decide that this _can't_ be a child, and so don't add it to the same trace. Changing the condition from `<` to `<=` seems to fix it and I believe it's _potentialy_ a valid fix for "in the wild" behaviour?

## Test coverage

I [ran the macos unit tests repeatedly](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=160206&view=results) and didn't see any flake, so I'm pretty confident

## Other details

Does make me wonder if we should be doing something more deterministic here, e.g. storing the "original" activity traceId in the `TraceContext`, and using that to identify the proper parentage here? It requires increasing the size of `TraceContext`, but removes this heuristic in place of something deterministic? It's very possible I'm wrong though and that's not possible, so will defer to @zacharycmontoya and @bouwkast here!

This required an additional fix:
- https://github.com/DataDog/dd-trace-dotnet/pull/5739

So _now_ it should do the job 🤞 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
