### PR TITLE
Revert "Add workflow monitor to all workflows (#5733)"

### DIFF
--- a/.github/workflows/auto-trigger-aas-release.yml
+++ b/.github/workflows/auto-trigger-aas-release.yml
@@ -9,10 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Trigger AAS release
         run: |
           curl -X POST \

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -13,10 +13,6 @@ jobs:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Version Bump]') == false
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -9,10 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -8,10 +8,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      with:
-        config: ${{ vars.PERMISSIONS_CONFIG }}
-
     - uses: octokit/request-action@v2.x
       name: 'Get Milestones'
       id: milestones

--- a/.github/workflows/auto_deploy_aas_test_apps.yml
+++ b/.github/workflows/auto_deploy_aas_test_apps.yml
@@ -13,10 +13,6 @@ jobs:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -9,10 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -12,10 +12,6 @@ jobs:
       && !endsWith(github.event.release.tag_name, '-prerelease')
     runs-on: ubuntu-latest
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -15,10 +15,6 @@ jobs:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      with:
-        config: ${{ vars.PERMISSIONS_CONFIG }}
-
     - name: Clone dd-trace-dotnet repository
       uses: actions/checkout@v3
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -15,10 +15,6 @@ jobs:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Clone dd-trace-dotnet repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,10 +20,6 @@ jobs:
       security-events: write
 
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      with:
-        config: ${{ vars.PERMISSIONS_CONFIG }}
-
     - name: Checkout repository
       uses: actions/checkout@v2
 

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -22,10 +22,6 @@ jobs:
     env:
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      with:
-        config: ${{ vars.PERMISSIONS_CONFIG }}
-
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -32,10 +32,6 @@ jobs:
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -6,10 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Datadog Static Analyzer
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout
         uses: actions/checkout@v3
       - name: Check code meets quality standards

--- a/.github/workflows/lib-injection-test.yml
+++ b/.github/workflows/lib-injection-test.yml
@@ -29,10 +29,6 @@ jobs:
       RUNTIME: ${{ inputs.runtime }}
       BUILDX_PLATFORMS: linux/amd64
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Checkout system tests
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/lib-injection.yml
+++ b/.github/workflows/lib-injection.yml
@@ -22,10 +22,6 @@ jobs:
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
       COMMIT_SHA: "${{ github.event.inputs.commit_id || github.sha }}" 
     steps:
-    - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-      with:
-        config: ${{ vars.PERMISSIONS_CONFIG }}
-
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -8,10 +8,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          config: ${{ vars.PERMISSIONS_CONFIG }}
-
       - name: Fail if branch is not version-bump PR
         if: ${{ !startsWith(github.ref, 'refs/heads/version-bump-') }}
         run: |


### PR DESCRIPTION
## Summary of changes

Reverts the workflow monitor

## Reason for change

It appears to absolutely _cripple_ the GitHub action network speed. Actions have been failing on master ever since we merged this PR, but here are some examples:

Checkout stage
- Before: 9s
- After: 3min 30s

Install .NET stage 
- Before: 7s
- After: 7min

Download Azure Build assets
- Before: 40s (it's _big_)
- After: timeout after 140s

## Implementation details

Revert the monitor, we'll have to YOLO the permissions changes with what we have

## Test coverage

I've tested this is the cause by disabling it using the variable. But if it's disabled, there's kind of no point in including it in the workflows, so may as well tear it out

## Other details

grmbl grmbl, gonna have to just YOLO our permission changes in that case

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
