### PR TITLE
[ASM] Standalone Billing (part 2: Propagation)

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -479,6 +479,7 @@ namespace Datadog.Trace.AppSec
             else if (_rateLimiter?.Allowed(span) ?? false)
             {
                 span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+                span.Context.TraceContext?.Tags.SetTag(Tags.PropagatedAppSec, "1");
             }
         }
 

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -479,7 +479,7 @@ namespace Datadog.Trace.AppSec
             else if (_rateLimiter?.Allowed(span) ?? false)
             {
                 span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
-                span.Context.TraceContext?.Tags.SetTag(Tags.PropagatedAppSec, "1");
+                span.Context.TraceContext?.Tags.SetTag(Tags.Propagated.AppSec, "1");
             }
         }
 

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -562,7 +562,7 @@ internal static partial class IastModule
         {
             traceContext.IastRequestContext?.AddVulnerability(vulnerability);
             traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
-            traceContext.Tags.SetTag(Tags.PropagatedAppSec, "1");
+            traceContext.Tags.SetTag(Tags.Propagated.AppSec, "1");
 
             return IastModuleResponse.Vulnerable;
         }
@@ -637,7 +637,7 @@ internal static partial class IastModule
             if (isRequest)
             {
                 traceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
-                traceContext?.Tags.SetTag(Tags.PropagatedAppSec, "1");
+                traceContext?.Tags.SetTag(Tags.Propagated.AppSec, "1");
 
                 traceContext?.IastRequestContext?.AddVulnerability(vulnerability);
                 return IastModuleResponse.Vulnerable;
@@ -694,7 +694,7 @@ internal static partial class IastModule
         scope.Span.Type = SpanTypes.IastVulnerability;
         tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(integrationId);
         scope.Span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
-        scope.Span.Context.TraceContext?.Tags.SetTag(Tags.PropagatedAppSec, "1");
+        scope.Span.Context.TraceContext?.Tags.SetTag(Tags.Propagated.AppSec, "1");
         return new IastModuleResponse(scope);
     }
 

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -562,6 +562,7 @@ internal static partial class IastModule
         {
             traceContext.IastRequestContext?.AddVulnerability(vulnerability);
             traceContext.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+            traceContext.Tags.SetTag(Tags.PropagatedAppSec, "1");
 
             return IastModuleResponse.Vulnerable;
         }
@@ -636,6 +637,8 @@ internal static partial class IastModule
             if (isRequest)
             {
                 traceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+                traceContext?.Tags.SetTag(Tags.PropagatedAppSec, "1");
+
                 traceContext?.IastRequestContext?.AddVulnerability(vulnerability);
                 return IastModuleResponse.Vulnerable;
             }
@@ -691,6 +694,7 @@ internal static partial class IastModule
         scope.Span.Type = SpanTypes.IastVulnerability;
         tracer.TracerManager.Telemetry.IntegrationGeneratedSpan(integrationId);
         scope.Span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
+        scope.Span.Context.TraceContext?.Tags.SetTag(Tags.PropagatedAppSec, "1");
         return new IastModuleResponse(scope);
     }
 

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -72,6 +72,7 @@ namespace Datadog.Trace.Propagators
             var samplingPriority = ParseUtility.ParseInt32(carrier, carrierGetter, HttpHeaderNames.SamplingPriority);
             var origin = ParseUtility.ParseString(carrier, carrierGetter, HttpHeaderNames.Origin);
             var propagatedTraceTags = ParseUtility.ParseString(carrier, carrierGetter, HttpHeaderNames.PropagatedTags);
+
             var traceTags = TagPropagation.ParseHeader(propagatedTraceTags);
 
             // reconstruct 128-bit trace id from the lower 64 bits in "x-datadog-traceid"

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -24,12 +24,6 @@ namespace Datadog.Trace.Propagators
         public void Inject<TCarrier, TCarrierSetter>(SpanContext context, TCarrier carrier, TCarrierSetter carrierSetter)
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
-            // If appsec standalone is enabled and appsec propagation is disabled (no ASM events) -> stop propagation
-            if (context.TraceContext?.Tracer.Settings?.AppsecStandaloneEnabledInternal == true && context.TraceContext.Tags.GetTag(Tags.Propagated.AppSec) != "1")
-            {
-                return;
-            }
-
             TelemetryFactory.Metrics.RecordCountContextHeaderStyleInjected(MetricTags.ContextHeaderStyle.Datadog);
             var invariantCulture = CultureInfo.InvariantCulture;
 

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -25,7 +25,7 @@ namespace Datadog.Trace.Propagators
             where TCarrierSetter : struct, ICarrierSetter<TCarrier>
         {
             // If appsec standalone is enabled and appsec propagation is disabled (no ASM events) -> stop propagation
-            if (context.TraceContext?.Tracer.Settings?.AppsecStandaloneEnabledInternal == true && context.TraceContext.Tags.GetTag(Tags.PropagatedAppSec) != "1")
+            if (context.TraceContext?.Tracer.Settings?.AppsecStandaloneEnabledInternal == true && context.TraceContext.Tags.GetTag(Tags.Propagated.AppSec) != "1")
             {
                 return;
             }

--- a/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/SpanContextPropagator.cs
@@ -115,6 +115,12 @@ namespace Datadog.Trace.Propagators
             if (context == null!) { ThrowHelper.ThrowArgumentNullException(nameof(context)); }
             if (carrier == null) { ThrowHelper.ThrowArgumentNullException(nameof(carrier)); }
 
+            // If appsec standalone is enabled and appsec propagation is disabled (no ASM events) -> stop propagation
+            if (context.TraceContext?.Tracer.Settings?.AppsecStandaloneEnabledInternal == true && context.TraceContext.Tags.GetTag(Tags.Propagated.AppSec) != "1")
+            {
+                return;
+            }
+
             // trigger a sampling decision if it hasn't happened yet
             _ = context.GetOrMakeSamplingDecision();
 

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -602,6 +602,12 @@ namespace Datadog.Trace
         internal const string AppSecWafInitRuleErrors = "_dd.appsec.event_rules.errors";
 
         /// <summary>
+        /// A boolean allowing the propagation to downstream services the information that the current distributed trace
+        /// is containing at least one ASM security event, no matter its type (threats, business logic events, IAST, etc.).
+        /// </summary>
+        internal const string PropagatedAppSec = "_dd.p.appsec";
+
+        /// <summary>
         /// Should contain the public IP of the host initiating the request.
         /// </summary>
         internal const string ActorIp = "actor.ip";

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -602,12 +602,6 @@ namespace Datadog.Trace
         internal const string AppSecWafInitRuleErrors = "_dd.appsec.event_rules.errors";
 
         /// <summary>
-        /// A boolean allowing the propagation to downstream services the information that the current distributed trace
-        /// is containing at least one ASM security event, no matter its type (threats, business logic events, IAST, etc.).
-        /// </summary>
-        internal const string PropagatedAppSec = "_dd.p.appsec";
-
-        /// <summary>
         /// Should contain the public IP of the host initiating the request.
         /// </summary>
         internal const string ActorIp = "actor.ip";
@@ -731,6 +725,12 @@ namespace Datadog.Trace
             /// lower-case hexadecimal string with no zero-padding or `0x` prefix.
             /// </summary>
             internal const string TraceIdUpper = "_dd.p.tid";
+
+            /// <summary>
+            /// A boolean allowing the propagation to downstream services the information that the current distributed trace
+            /// is containing at least one ASM security event, no matter its type (threats, business logic events, IAST, etc.).
+            /// </summary>
+            internal const string AppSec = "_dd.p.appsec";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -428,7 +428,7 @@ namespace Datadog.Trace
                     if (Settings?.AppsecStandaloneEnabledInternal == true)
                     {
                         // If the trace has appsec propagation tag, the default priority is user keep
-                        samplingPriority = propagatedTags?.GetTag(Tags.PropagatedAppSec) != "1" ? SamplingPriorityValues.Default : SamplingPriorityValues.UserKeep;
+                        samplingPriority = propagatedTags?.GetTag(Tags.Propagated.AppSec) != "1" ? SamplingPriorityValues.Default : SamplingPriorityValues.UserKeep;
                     }
 
                     // If parent is SpanContext but its TraceContext is null, then it was extracted from propagation headers.

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -419,13 +419,25 @@ namespace Datadog.Trace
 
                 if (traceContext == null)
                 {
-                    // If parent is SpanContext but its TraceContext is null, then it was extracted from
-                    // propagation headers. Create a new TraceContext (this will start a new trace) and initialize
+                    var propagatedTags = parentSpanContext.PropagatedTags;
+                    var samplingPriority = parentSpanContext.SamplingPriority;
+
+                    // When in appsec standalone mode, only distributed traces with the `_dd.p.appsec` tag
+                    // are propagated downstream, however we need 1 trace per minute sent to the backend, so
+                    // we unset sampling priority so the rate limiter decides.
+                    if (Settings?.AppsecStandaloneEnabledInternal == true)
+                    {
+                        // If the trace has appsec propagation tag, the default priority is user keep
+                        samplingPriority = propagatedTags?.GetTag(Tags.PropagatedAppSec) != "1" ? SamplingPriorityValues.Default : SamplingPriorityValues.UserKeep;
+                    }
+
+                    // If parent is SpanContext but its TraceContext is null, then it was extracted from propagation headers.
+                    // Create a new TraceContext (this will start a new trace) and initialize
                     // it with the propagated values (sampling priority, origin, tags, W3C trace state, etc).
-                    traceContext = new TraceContext(this, parentSpanContext.PropagatedTags);
+                    traceContext = new TraceContext(this, propagatedTags);
                     TelemetryFactory.Metrics.RecordCountTraceSegmentCreated(MetricTags.TraceContinuation.Continued);
 
-                    var samplingPriority = parentSpanContext.SamplingPriority ?? DistributedTracer.Instance.GetSamplingPriority();
+                    samplingPriority ??= DistributedTracer.Instance.GetSamplingPriority();
                     traceContext.SetSamplingPriority(samplingPriority);
                     traceContext.Origin = parentSpanContext.Origin;
                     traceContext.AdditionalW3CTraceState = parentSpanContext.AdditionalW3CTraceState;

--- a/tracer/src/Datadog.Trace/Tracer.cs
+++ b/tracer/src/Datadog.Trace/Tracer.cs
@@ -428,7 +428,7 @@ namespace Datadog.Trace
                     if (Settings?.AppsecStandaloneEnabledInternal == true)
                     {
                         // If the trace has appsec propagation tag, the default priority is user keep
-                        samplingPriority = propagatedTags?.GetTag(Tags.Propagated.AppSec) != "1" ? SamplingPriorityValues.Default : SamplingPriorityValues.UserKeep;
+                        samplingPriority = propagatedTags?.GetTag(Tags.Propagated.AppSec) == "1" ? SamplingPriorityValues.UserKeep : null;
                     }
 
                     // If parent is SpanContext but its TraceContext is null, then it was extracted from propagation headers.


### PR DESCRIPTION
## Summary of changes

Part 2 of the implementation of [Standalone ASM billing](https://docs.google.com/document/d/12NBx-nD-IoQEMiCRnJXneq4Be7cbtSc6pJLOFUWTpNE/edit?pli=1#heading=h.hs091bhdmugz).
Part 1 was #5565 

This PR adds the propagated span tag `_dd.p.appsec: 1` allowing to propagate to downstream services the information that the current distributed trace is containing at least one ASM security event.

## Test coverage

This fully pass the system tests for ASM Standalone.