### PR TITLE
[Profiler] prevent stacksampling loop from sampling if the app is crashing

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -416,13 +416,22 @@ int execve(const char* pathname, char* const argv[], char* const envp[])
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-compare"
-    if (crashHandler != NULL && pathname != NULL)
+    
+    int isCallingCreatedump = 0;
+    
+    if (pathname != NULL)
     {
         size_t length = strlen(pathname);
+        isCallingCreatedump = length >= 11 && strcmp(pathname + length - 11, "/createdump") == 0;
+        is_app_crashing = isCallingCreatedump;
+    }
 
-        if (length >= 11 && strcmp(pathname + length - 11, "/createdump") == 0)
+    if (crashHandler != NULL && pathname != NULL)
+    {
+        //size_t length = strlen(pathname);
+
+        if (isCallingCreatedump)
         {
-            is_app_crashing = 1;
             // Execute the alternative crash handler, and prepend "createdump" to the arguments
 
             // Count the number of arguments (the list ends with a null pointer)


### PR DESCRIPTION
## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
