### PR TITLE
Make BuildTracerHome build the native profiler

### DIFF
--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -182,7 +182,7 @@ partial class Build : NukeBuild
     Target BuildTracerHome => _ => _
         .Description("Builds the native and managed src, and publishes the tracer home directory")
         .After(Clean)
-        .DependsOn(CompileManagedLoader, BuildNativeTracerHome, BuildManagedTracerHome);
+        .DependsOn(CompileManagedLoader, BuildNativeTracerHome, BuildManagedTracerHome, BuildNativeLoader);
 
     Target BuildProfilerHome => _ => _
         .Description("Builds the Profiler native and managed src, and publishes the profiler home directory")


### PR DESCRIPTION
## Summary of changes

- Make `BuildTracerHome` build the native loader by default

## Reason for change

In https://github.com/DataDog/dd-trace-dotnet/pull/5614 we changed the behaviour of `BuildTracerHome` so that the native loader isn't built by default. This was a precursor or the changes in https://github.com/DataDog/dd-trace-dotnet/pull/5550 where we iterate on this.

Unfortunately, that means that running locally, if you type `BuildTracerHome`, you _can't_ run integration tests, as the loader is not built, which is a burden.

## Implementation details

Make `BuildTracerHome` run `BuildNativeLoader` by default

## Test coverage

Ran it locally, it works: 

```
═════════════════════════════════════════════════════
Target                           Status      Duration
─────────────────────────────────────────────────────
Restore                          Succeeded       0:52
CreateRequiredDirectories        Succeeded     < 1sec
CompileManagedLoader             Succeeded       0:06
CompileManagedSrc                Succeeded       2:14
CreateRootDescriptorsFile        Succeeded     < 1sec
CreateMissingNullabilityFile     Succeeded       0:01
PublishManagedTracer             Succeeded       0:07
CompileNativeSrcMacOs            Skipped                // OnlyWhen: EnvironmentInfo.IsOsx
CompileTracerNativeSrcLinux      Skipped                // OnlyWhen: EnvironmentInfo.IsLinux
CompileTracerNativeSrcWindows    Succeeded       1:52
PublishNativeTracerOsx           Skipped                // OnlyWhen: EnvironmentInfo.IsOsx
PublishNativeTracerUnix          Skipped                // OnlyWhen: EnvironmentInfo.IsLinux
PublishNativeTracerWindows       Succeeded     < 1sec
DownloadLibDdwaf                 Succeeded       0:02
CopyLibDdwaf                     Succeeded     < 1sec
CompileNativeLoaderOsx           Skipped                // OnlyWhen: EnvironmentInfo.IsOsx
CompileNativeLoaderLinux         Skipped                // OnlyWhen: EnvironmentInfo.IsLinux
CompileNativeLoaderWindows       Succeeded       0:22
PublishNativeLoaderOsx           Skipped                // OnlyWhen: EnvironmentInfo.IsOsx
PublishNativeLoaderUnix          Skipped                // OnlyWhen: EnvironmentInfo.IsLinux
PublishNativeLoaderWindows       Succeeded     < 1sec
─────────────────────────────────────────────────────
Total                                            5:39
═════════════════════════════════════════════════════
```

## Other details

This will cause merge conflicts in #5550 but we can work around that

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
