### PR TITLE
Skip flaky tests on .NET Core 2.1

### DIFF
--- a/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageRewriteTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.Tests/CoverageRewriteTests.cs
@@ -123,8 +123,8 @@ public class CoverageRewriteTests
     }
 
 #if NETCOREAPP2_1
-    // Due to a BCL Bug in .NET Core 2.1 [DirectoryInfo.GetDirectories()] triggered by this test, we need to skip the test if we find a NullReferenceException
-    [SkippableTheory(typeof(NullReferenceException))]
+    // Due to a BCL Bug in .NET Core 2.1 [DirectoryInfo.GetDirectories()] triggered by this test, we need to skip the test in some cases
+    [SkippableTheory(typeof(NullReferenceException), typeof(IndexOutOfRangeException))]
 #else
     [SkippableTheory]
 #endif
@@ -161,8 +161,8 @@ public class CoverageRewriteTests
     }
 
 #if NETCOREAPP2_1
-    // Due to a BCL Bug in .NET Core 2.1 [DirectoryInfo.GetDirectories()] triggered by this test, we need to skip the test if we find a NullReferenceException
-    [SkippableTheory(typeof(NullReferenceException))]
+    // Due to a BCL Bug in .NET Core 2.1 [DirectoryInfo.GetDirectories()] triggered by this test, we need to skip the test in some cases
+    [SkippableTheory(typeof(NullReferenceException), typeof(IndexOutOfRangeException))]
 #else
     [SkippableTheory]
 #endif


### PR DESCRIPTION
## Summary of changes

Skip flaky test on .NET Core 2.1 in more scenarios

## Reason for change

The `DirectoryInfo.GetDirectories()` call in this CI Visibility test flakes due to a bug in the BCL on .NET Core 2.1. We already catch and ignore manifestation, this ignores another one.

## Implementation details

Ignore `IndexOutOfRangeException` as well as `NullReferenceException`.

<details><summary>Stack trace showing the issue</summary>
<p>

```
System.IndexOutOfRangeException : Index was outside the bounds of the array.
  at System.IO.Enumeration.FileSystemEnumerator`1.MoveNext()
  at System.Collections.Generic.LargeArrayBuilder`1.AddRange(IEnumerable`1 items)
  at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source)
  at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
  at System.IO.DirectoryInfo.GetDirectories(String searchPattern, EnumerationOptions enumerationOptions)
  at System.IO.DirectoryInfo.GetDirectories()
  at ICSharpCode.Decompiler.Metadata.DotNetCorePathFinder.GetClosestVersionFolder(String basePath, Version version)
  at ICSharpCode.Decompiler.Metadata.DotNetCorePathFinder.TryResolveDotNetCoreShared(IAssemblyReference name, String& runtimePack)
  at ICSharpCode.Decompiler.Metadata.DotNetCorePathFinder.TryResolveDotNetCore(IAssemblyReference name)
  at ICSharpCode.Decompiler.Metadata.UniversalAssemblyResolver.FindAssemblyFile(IAssemblyReference name)
  at ICSharpCode.Decompiler.Metadata.UniversalAssemblyResolver.Resolve(IAssemblyReference name)
  at System.Threading.Tasks.Task`1.InnerInvoke()
  at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
  --- End of stack trace from previous location where exception was thrown ---
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
  --- End of stack trace from previous location where exception was thrown ---
  at ICSharpCode.Decompiler.TypeSystem.DecompilerTypeSystem..ctor(PEFile mainModule, IAssemblyResolver assemblyResolver, TypeSystemOptions typeSystemOptions)
  at ICSharpCode.Decompiler.CSharp.CSharpDecompiler.CreateTypeSystemFromFile(String fileName, DecompilerSettings settings)
  at Datadog.Trace.Tools.Runner.Tests.CoverageRewriteTests.NoFilter(String coverageMode) in D:\a\1\s\tracer\test\Datadog.Trace.Tools.Runner.Tests\CoverageRewriteTests.cs:line 140

```

</p>
</details> 

## Test coverage

N/A

## Other details


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
