### PR TITLE
Run CallTargetNativeTests on Windows

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1453,6 +1453,7 @@ partial class Build
             {
                 // This does some "unnecessary" rebuilding and restoring
                 var includeIntegration = TracerDirectory.GlobFiles("test/test-applications/integrations/**/*.csproj");
+                var includeInstrumentation = TracerDirectory.GlobFiles("test/test-applications/instrumentation/**/*.csproj");
                 // Don't build aspnet full framework sample in this step
                 var includeSecurity = TracerDirectory.GlobFiles("test/test-applications/security/*/*.csproj");
 
@@ -1461,6 +1462,7 @@ partial class Build
                                              .Concat(TracerDirectory.GlobFiles("test/test-applications/integrations/Samples.AzureServiceBus/*.csproj"));
 
                 var projects = includeIntegration
+                    .Concat(includeInstrumentation)
                     .Concat(includeSecurity)
                     .Select(x => Solution.GetProject(x))
                     .Where(project =>

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CallTargetNativeTests.cs
@@ -34,6 +34,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         [SkippableTheory]
         [MemberData(nameof(MethodArgumentsData))]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task MethodArgumentsInstrumentation(int numberOfArguments, bool fastPath)
         {
             SetInstrumentationVerification();
@@ -86,6 +87,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task MethodRefArguments()
         {
             SetInstrumentationVerification();
@@ -117,6 +119,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task MethodOutArguments()
         {
             SetInstrumentationVerification();
@@ -147,6 +150,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task MethodAbstract()
         {
             SetInstrumentationVerification();
@@ -177,6 +181,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         }
 
         [SkippableFact]
+        [Trait("RunOnWindows", "True")]
         public async Task MethodInterface()
         {
             int agentPort = TcpPortProvider.GetOpenPort();
@@ -205,6 +210,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task RemoveIntegrations()
         {
             SetInstrumentationVerification();
@@ -228,6 +234,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task ExtraIntegrations()
         {
             SetInstrumentationVerification();
@@ -248,6 +255,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task CallTargetBubbleUpExceptionIntegrations()
         {
             SetInstrumentationVerification();
@@ -262,6 +270,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task CategorizedCallTargetIntegrations()
         {
             SetInstrumentationVerification();
@@ -283,6 +292,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         [SkippableFact]
         [Trait("SupportsInstrumentationVerification", "True")]
+        [Trait("RunOnWindows", "True")]
         public async Task MethodRefStructArguments()
         {
             SetInstrumentationVerification();

--- a/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/ProfilerHelper.cs
@@ -125,7 +125,7 @@ namespace Datadog.Trace.TestHelpers
             }
 
             output?.WriteLine($"Updating {Path.GetFileName(executable)} using {setBit}");
-            var opts = new ProcessStartInfo(corFlagsExe, $"\"{executable}\" {setBit}")
+            var opts = new ProcessStartInfo(corFlagsExe, $"\"{executable}\" {setBit} /force")
             {
                 CreateNoWindow = true,
                 UseShellExecute = false


### PR DESCRIPTION
## Summary of changes

Runs the `CallTargetNativeTests` on Windows

## Reason for change

We weren't running these on Windows, and we should be

## Implementation details

Add the `RunOnWindows` trait. Longer term I want to reverse the role of this trait, i.e. we run on windows by default and you add `RunOnWindows=False` to disable that.

## Test coverage

More now

## Other details

~~I thought we had a bug related to ref structs here, but it appears to be a Schrödinger's bug~~ Oops, no, there it is!

@tonyredondo found the source of the issue - the `/32BITREQ+` modification was failing because `CallTargetNativeTest.exe` is strong named, so we had to add the `/force` flag. And it _has_ to be strong named because it references Datadog.Trace directly