### PR TITLE
[ASM][IAST] Add support for CallSites in functions with by ref value type arguments

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -495,7 +495,7 @@ namespace iast
 
                     if (_aspect->_boxParam[instructionToProcess.paramIndex])
                     {
-                        //Retrieve type of the valueType in target argument
+                        // Retrieve type of the valueType in target argument
                         auto paramType = _targetParamTypeToken[instructionToProcess.paramIndex];
                         processor->InsertBefore(aspectInstruction, processor->NewILInstr(CEE_BOX, paramType));
                         inserted = processor->InsertAfter(aspectInstruction, processor->NewILInstr(CEE_UNBOX_ANY, paramType));
@@ -526,6 +526,18 @@ namespace iast
                             {
                                 auto paramType = _targetParamTypeToken[x];
                                 processor->InsertAfter(iInfo->_instruction, processor->NewILInstr(CEE_BOX, paramType));
+
+                                // Figure out if param is byref
+                                if (iInfo->IsArgument())
+                                {
+                                    auto sig = method->GetSignature();
+                                    auto param = sig->_params[iInfo->_instruction->m_Arg32];
+                                    if (param->IsByRef())
+                                    {
+                                        processor->InsertAfter(iInfo->_instruction, processor->NewILInstr(CEE_LDOBJ, paramType));
+                                    }
+                                }
+
                                 iInfo->ConvertToNonAddressLoad();
                             }
                         }

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_types.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_types.cpp
@@ -210,14 +210,18 @@ namespace iast
     {
         return (_type == ELEMENT_TYPE_ARRAY) || (_type == ELEMENT_TYPE_SZARRAY);
     }
-    //bool CType::IsClass()
-    //{
-    //    return false;
-    //}
-    //bool CType::IsValueType()
-    //{
-    //    return false;
-    //}
+    bool SignatureType::IsClass()
+    {
+        return (_type == ELEMENT_TYPE_CLASS);
+    }
+    bool SignatureType::IsValueType()
+    {
+        return (_type == ELEMENT_TYPE_VALUETYPE);
+    }
+    bool SignatureType::IsByRef()
+    {
+        return (_type == ELEMENT_TYPE_BYREF);
+    }
 
 
     WSTRING SignatureType::GetName()

--- a/tracer/src/Datadog.Tracer.Native/iast/signature_types.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/signature_types.h
@@ -37,8 +37,9 @@ namespace iast
         virtual HRESULT AddToSignature(ISignatureBuilder* pSignatureBuilder);
         virtual bool IsPrimitive();
         virtual bool IsArray();
-        //bool IsClass() override;
-        //bool IsValueType() override;
+        virtual bool IsClass();
+        virtual bool IsValueType();
+        virtual bool IsByRef();
         virtual WSTRING GetName();
         virtual mdToken GetToken();
     public:

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Samples.InstrumentedTests.csproj
@@ -25,6 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Data.Tables" Version="12.8.3" />
     <PackageReference Include="DelegateDecompiler" Version="0.32.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.8.0" />

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Json/JsonDocumentTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/Json/JsonDocumentTests.cs
@@ -27,6 +27,22 @@ public class JsonDocumentTests : InstrumentationTestsBase
     }
 
     [Fact]
+    public void AccessByRef_AzureDataTables_JsonElementExtensions()
+    {
+        var json = JsonDocument.Parse(_taintedJson);
+        var element = json.RootElement.GetProperty("key");
+        
+        // Call with reflection the method Azure.Core.JsonElementExtensions.GetObject(JsonElement& element)
+        var obj = (object)element;
+        var type = Type.GetType("Azure.Core.JsonElementExtensions, Azure.Data.Tables")!;
+        var method = type.GetMethod("GetObject", new[] { typeof(JsonElement).MakeByRefType() });
+        var result = method!.Invoke(null, new[] { obj });
+        
+        Assert.Equal("value", result);
+        AssertTainted(result);
+    }
+
+    [Fact]
     public void GivenASimpleJson_WhenParsing_GetProperty_Vulnerable()
     {
         var json = JsonDocument.Parse(_taintedJson);


### PR DESCRIPTION
## Summary of changes

Add support for Call Sites in methods with by Ref value type arguments.

## Reason for change

A crash occurred in Azure Table because a boxed param was passed by ref to the aspect method, thus caused a ObjectDisposedException

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
