### PR TITLE
Add attribute for skipping tests in CI without using `[Fact(Skip = "")]`

### DIFF
--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -125,9 +125,9 @@ partial class Build
                 {
                     var filter = (IsWin, IsArm64) switch
                     {
-                        (true, _) => "(RunOnWindows=True)",
-                        (_, true) => "(Category!=ArmUnsupported)",
-                        _ => "(Category!=LinuxUnsupported)",
+                        (true, _) => "(RunOnWindows=True)&(SkipInCI!=True)",
+                        (_, true) => "(Category!=ArmUnsupported)&(SkipInCI!=True)",
+                        _ => "(Category!=LinuxUnsupported)&(SkipInCI!=True)",
                     };
 
                     return Filter is null ? filter : $"{Filter}&{filter}";

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1009,7 +1009,7 @@ partial class Build
                 .ToList();
 
             testProjects.ForEach(EnsureResultsDirectory);
-            var filter = string.IsNullOrWhiteSpace(Filter) && IsArm64 ? "(Category!=ArmUnsupported)&(Category!=AzureFunctions)" : Filter;
+            var filter = string.IsNullOrWhiteSpace(Filter) && IsArm64 ? "(Category!=ArmUnsupported)&(Category!=AzureFunctions)&(SkipInCI!=True)" : Filter;
             var exceptions = new List<Exception>();
             try
             {
@@ -1424,7 +1424,7 @@ partial class Build
                     //.WithMemoryDumpAfter(timeoutInMinutes: 30)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "RunOnWindows=True&LoadFromGAC!=True&IIS!=True&Category!=AzureFunctions" : Filter)
+                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&(LoadFromGAC!=True)&(IIS!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)" : Filter)
                     .SetTestTargetPlatform(TargetPlatform)
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
@@ -1494,7 +1494,7 @@ partial class Build
                     //.WithMemoryDumpAfter(timeoutInMinutes: 30)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "RunOnWindows=True&Category=AzureFunctions" : Filter)
+                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&(Category=AzureFunctions)&(SkipInCI!=True)" : Filter)
                     .SetTestTargetPlatform(TargetPlatform)
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
@@ -1535,7 +1535,7 @@ partial class Build
                     .EnableCrashDumps()
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "Category=Smoke&LoadFromGAC!=True&Category!=AzureFunctions" : Filter)
+                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(Category=Smoke)&(LoadFromGAC!=True)&(Category!=AzureFunctions)&(SkipInCI!=True)" : Filter)
                     .SetTestTargetPlatform(TargetPlatform)
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
@@ -1587,7 +1587,7 @@ partial class Build
                                 .SetFramework(Framework)
                                 .EnableNoRestore()
                                 .EnableNoBuild()
-                                .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&LoadFromGAC=True&Category!=AzureFunctions" : Filter)
+                                .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&(LoadFromGAC=True)&(Category!=AzureFunctions)&(SkipInCI!=True)" : Filter)
                                 .SetTestTargetPlatform(TargetPlatform)
                                 .SetIsDebugRun(isDebugRun)
                                 .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
@@ -1626,7 +1626,7 @@ partial class Build
                     .SetFramework(Framework)
                     .EnableNoRestore()
                     .EnableNoBuild()
-                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&MSI=True&Category!=AzureFunctions" : Filter)
+                    .SetFilter(string.IsNullOrWhiteSpace(Filter) ? "(RunOnWindows=True)&(MSI=True)&(Category!=AzureFunctions)&(SkipInCI!=True)" : Filter)
                     .SetTestTargetPlatform(TargetPlatform)
                     .SetIsDebugRun(isDebugRun)
                     .SetProcessEnvironmentVariable("MonitoringHomeDirectory", MonitoringHomeDirectory)
@@ -1927,7 +1927,7 @@ partial class Build
             var filter = string.IsNullOrWhiteSpace(Filter) switch
             {
                 false => $"({Filter}){dockerFilter}{armFilter}",
-                true => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions){dockerFilter}{armFilter}",
+                true => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
             };
 
             try
@@ -2008,7 +2008,7 @@ partial class Build
             var filter = string.IsNullOrWhiteSpace(Filter) switch
             {
                 false => Filter,
-                true => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions){dockerFilter}{armFilter}",
+                true => $"(Category!=LinuxUnsupported)&(Category!=Lambda)&(Category!=AzureFunctions)&(SkipInCI!=True){dockerFilter}{armFilter}",
             };
 
             var targetPlatform = IsArm64 ? (MSBuildTargetPlatform)"arm64" : TargetPlatform;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AspNet/AspNetWebFormsTests.cs
@@ -63,10 +63,11 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 "1.0.0");
         }
 
-        [Fact(Skip = "This test requires Elasticsearch to be running on the host, which is not currently enabled in CI.")]
+        [Fact]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
+        [Trait("SkipInCI", "True")] // This test requires Elasticsearch to be running on the host, which is not currently enabled in CI.
         public async Task NestedAsyncElasticCallSubmitsTrace()
         {
             var testStart = DateTime.UtcNow;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/AzureServiceBusTests.cs
@@ -41,9 +41,10 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.Azure
             _ => throw new ArgumentException($"span.Tags[\"span.kind\"] is not a supported value for the AWS SQS integration: {span.Tags["span.kind"]}", nameof(span)),
         };
 
-        [SkippableTheory(Skip = "We are unable to test all the features of Azure Service Bus with an emulator. For now, run only locally with a connection string to a live Azure Service Bus namespace")]
+        [SkippableTheory]
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]
+        [Trait("SkipInCI", "True")] // We are unable to test all the features of Azure Service Bus with an emulator. For now, run only locally with a connection string to a live Azure Service Bus namespace
         public async Task SubmitsTraces(string packageVersion, string metadataSchemaVersion)
         {
             SetEnvironmentVariable("DD_TRACE_SPAN_ATTRIBUTE_SCHEMA", metadataSchemaVersion);

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Azure/DataStreamsMonitoringAzureServiceBusTests.cs
@@ -31,9 +31,10 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
         => from packageVersionArray in new string[] { string.Empty }
            select new string[] { packageVersionArray };
 
-    [SkippableTheory(Skip = "This has only been tested on a live Azure Service Bus namespace using a connection string. Unskip this if you'd like to run locally or if you've correctly configured piotr-rojek/devopsifyme-sbemulator in CI")]
+    [SkippableTheory]
     [MemberData(nameof(GetPackageVersions))]
     [Trait("Category", "EndToEnd")]
+    [Trait("SkipInCI", "True")] // "This has only been tested on a live Azure Service Bus namespace using a connection string. Unskip this if you'd like to run locally or if you've correctly configured piotr-rojek/devopsifyme-sbemulator in CI"
     public async Task HandleProduceAndConsume(string packageVersion)
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");
@@ -59,9 +60,10 @@ public class DataStreamsMonitoringAzureServiceBusTests : TestHelper
         }
     }
 
-    [SkippableTheory(Skip = "This has only been tested on a live Azure Service Bus namespace using a connection string. Unskip this if you'd like to run locally or if you've correctly configured piotr-rojek/devopsifyme-sbemulator in CI")]
+    [SkippableTheory]
     [MemberData(nameof(GetPackageVersions))]
     [Trait("Category", "EndToEnd")]
+    [Trait("SkipInCI", "True")] // This has only been tested on a live Azure Service Bus namespace using a connection string. Unskip this if you'd like to run locally or if you've correctly configured piotr-rojek/devopsifyme-sbemulator in CI
     public async Task ValidateSpanTags(string packageVersion)
     {
         SetEnvironmentVariable(ConfigurationKeys.DataStreamsMonitoring.Enabled, "1");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CosmosTests.cs
@@ -34,12 +34,13 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
         public override Result ValidateIntegrationSpan(MockSpan span, string metadataSchemaVersion) => span.IsCosmosDb(metadataSchemaVersion);
 
-        [SkippableTheory(Skip = "Cosmos emulator is too flaky at the moment")]
+        [SkippableTheory]
         [MemberData(nameof(GetEnabledConfig))]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "LinuxUnsupported")]
         [Trait("Category", "ArmUnsupported")]
+        [Trait("SkipInCI", "True")] // Cosmos emulator is too flaky in CI at the moment
         public async Task SubmitTraces(string packageVersion, string metadataSchemaVersion)
         {
             var expectedSpanCount = 14;

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SmokeTests/StackExchangeRedisAssemblyConflictLegacyProjectSmokeTest.cs
@@ -19,8 +19,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests.SmokeTests
         {
         }
 
-        [Fact(Skip = ".NET Framework test, but cannot run on Windows because it requires Redis")]
+        [Fact]
         [Trait("Category", "Smoke")]
+        [Trait("SkipInCI", "True")] // .NET Framework test, but cannot run on Windows in CI because it requires Redis
         public async Task NoExceptions()
         {
             await CheckForSmoke(shouldDeserializeTraces: false);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore2RateLimiter.cs
@@ -34,7 +34,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             this.fixture.SetOutput(null);
         }
 
-        [SkippableTheory(Skip = "Don't run in CI as test is slow, can be run manually by removing this attribute")]
+        [SkippableTheory]
         [InlineData(true, 90, 100)]
         [InlineData(false, 90, 100)]
         [InlineData(true, 110, 100)]
@@ -43,6 +43,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(false, 30, 20)]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
+        [Trait("SkipInCI", "True")] // Don't run in CI as test is slow, can be run manually by removing this attribute
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int traceRateLimit, string url = DefaultAttackUrl)
         {
             EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_TRACE_RATE_LIMIT", traceRateLimit.ToString());

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5RateLimiter.cs
@@ -29,7 +29,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             this.fixture.SetOutput(null);
         }
 
-        [SkippableTheory(Skip = "Don't run in CI as test is slow, can be run manually by removing this attribute")]
+        [SkippableTheory]
         [InlineData(true, 90, 100)]
         [InlineData(false, 90, 100)]
         [InlineData(true, 110, 100)]
@@ -38,6 +38,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         [InlineData(false, 30, 20)]
         [Trait("RunOnWindows", "True")]
         [Trait("Category", "ArmUnsupported")]
+        [Trait("SkipInCI", "True")] // Don't run in CI as test is slow, can be run manually by removing this attribute
         public async Task TestRateLimiterSecurity(bool enableSecurity, int totalRequests, int? traceRateLimit, string url = DefaultAttackUrl)
         {
             EnvironmentHelper.CustomEnvironmentVariables.Add("DD_APPSEC_TRACE_RATE_LIMIT", traceRateLimit.ToString());

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5RateLimiter.cs
@@ -112,10 +112,11 @@ namespace Datadog.Trace.Security.IntegrationTests
             }
         }
 
+        [SkippableTheory]
         [Trait("Category", "EndToEnd")]
         [Trait("RunOnWindows", "True")]
         [Trait("LoadFromGAC", "True")]
-        [SkippableTheory(Skip = "Don't run in CI as test is slow, can be run manually by removing this attribute")]
+        [Trait("SkipInCI", "True")] // Don't run in CI as test is slow, can be run manually by removing this attribute
         [InlineData(110, DefaultAttackUrl)]
         [InlineData(30, DefaultAttackUrl)]
         public async Task TestRateLimiterSecurity(int totalRequests, string url = DefaultAttackUrl)


### PR DESCRIPTION
## Summary of changes

Adds a new trait, `SkipInCI` that can be used to skip tests in CI

## Reason for change

We currently use the built-in `[Fact(Skip="..."])` or `[Theory(Skip="..."])` to skip tests that we don't want to run in CI. The downside to this is if you want to run a test locally, you have to explicitly change the code to remove the `Skip`, run the test, and remember to add it back later. 

Instead, we can change the default `Filter` used by Nuke for each stage to be `SkipInCI!=True`. That way the tests are still excluded from CI (or if you run the "default" test suite locally), but you can still easily run the test without making code modifications if you want to run it directly from VS/Rider, or using `nuke RunWindowsIntegrationTests -Filter SomeSkippedTest` (for example).

## Implementation details

Replaced existing usages of 
```csharp
[Fact(Skip="Some reason"])
```

with 

```
[Trait("SkipInCI", "True")] // Some reason
```

and changed the default filters used by Nuke to exclude tests with this trait

## Test coverage

This PR is the test - if it passes, we're good.

## Other details

It would be nice to have the skip reason as the _value_ of the trait, but the [dotnet test syntax](https://learn.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests?pivots=xunit) doesn't make it easy to select just based on the key, it's Key=Value, so we're stuck with comments.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
