### PR TITLE
Replace re-directed `dotnet-install.ps1`

### DIFF
--- a/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
+++ b/.azure-pipelines/steps/install-dotnet-sdk-manually.yml
@@ -20,7 +20,7 @@ steps:
       $sdkVersion = "${{ parameters.sdkVersion }}"
 
       echo "Downloading dotnet-install.ps1"
-      Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile dotnet-install.ps1
+      Invoke-WebRequest -Uri "https://raw.githubusercontent.com/dotnet/install-scripts/7e6edf599d114134a3d35a6b775d65d06bcddf2a/src/dotnet-install.ps1" -OutFile dotnet-install.ps1
 
       if( "${{ parameters.is64bit }}" -eq "true") {
         $path = "$HOME\AppData\Local\Microsoft\dotnet"

--- a/tracer/build/_build/docker/smoke.windows.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dd-dotnet.dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 ARG CHANNEL_32_BIT
 RUN if($env:CHANNEL_32_BIT){ \
     echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
-    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    curl 'https://raw.githubusercontent.com/dotnet/install-scripts/7e6edf599d114134a3d35a6b775d65d06bcddf2a/src/dotnet-install.ps1' -o dotnet-install.ps1; \
     ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
     [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
     rm ./dotnet-install.ps1; }

--- a/tracer/build/_build/docker/smoke.windows.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 ARG CHANNEL_32_BIT
 RUN if($env:CHANNEL_32_BIT){ \
     echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
-    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    curl 'https://raw.githubusercontent.com/dotnet/install-scripts/7e6edf599d114134a3d35a6b775d65d06bcddf2a/src/dotnet-install.ps1' -o dotnet-install.ps1; \
     ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
     [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
     rm ./dotnet-install.ps1; }

--- a/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.dotnet-tool.dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 ARG CHANNEL_32_BIT
 RUN if($env:CHANNEL_32_BIT){ \
     echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
-    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    curl 'https://raw.githubusercontent.com/dotnet/install-scripts/7e6edf599d114134a3d35a6b775d65d06bcddf2a/src/dotnet-install.ps1' -o dotnet-install.ps1; \
     ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
     [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
     rm ./dotnet-install.ps1; }

--- a/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app
 ARG CHANNEL_32_BIT
 RUN if($env:CHANNEL_32_BIT){ \
     echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
-    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    curl 'https://raw.githubusercontent.com/dotnet/install-scripts/7e6edf599d114134a3d35a6b775d65d06bcddf2a/src/dotnet-install.ps1' -o dotnet-install.ps1; \
     ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
     [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
     rm ./dotnet-install.ps1; }

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -25,7 +25,7 @@ WORKDIR /app
 ARG CHANNEL_32_BIT
 RUN if($env:CHANNEL_32_BIT){ \
     echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
-    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    curl 'https://raw.githubusercontent.com/dotnet/install-scripts/7e6edf599d114134a3d35a6b775d65d06bcddf2a/src/dotnet-install.ps1' -o dotnet-install.ps1; \
     ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
     [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
     rm ./dotnet-install.ps1; }

--- a/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.tracer-home.dockerfile
@@ -19,7 +19,7 @@ WORKDIR /app
 ARG CHANNEL_32_BIT
 RUN if($env:CHANNEL_32_BIT){ \
     echo 'Installing x86 dotnet runtime ' + $env:CHANNEL_32_BIT; \
-    curl 'https://dot.net/v1/dotnet-install.ps1' -o dotnet-install.ps1; \
+    curl 'https://raw.githubusercontent.com/dotnet/install-scripts/7e6edf599d114134a3d35a6b775d65d06bcddf2a/src/dotnet-install.ps1' -o dotnet-install.ps1; \
     ./dotnet-install.ps1 -Architecture x86 -Runtime aspnetcore -Channel $env:CHANNEL_32_BIT -InstallDir c:\cli; \
     [Environment]::SetEnvironmentVariable('Path',  'c:\cli;' + $env:Path, [EnvironmentVariableTarget]::Machine); \
     rm ./dotnet-install.ps1; }


### PR DESCRIPTION
## Summary of changes

Replace current URL for `dotnet-install.ps1` to use the raw GitHub content

## Reason for change

https://dotnet.microsoft.com is down, which breaks this download, so using the URL it redirects to

## Implementation details

Use the direct GitHub link instead

## Test coverage

This is the test

## Other details

https://github.com/dotnet/runtime/issues/104230

When I'm feeling stronger, we can download this ahead of time and update all the docker images and VMs too...

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
