### PR TITLE
[SSI] Bail out on known-faulty .NET 6 version

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -166,7 +166,7 @@ bool SingleStepGuardRails::ShouldForceInstrumentationOverride(const std::string&
         Log::Info(
             "SingleStepGuardRails::ShouldForceInstrumentationOverride: ",
             EnvironmentVariables::ForceEolInstrumentation,
-            "enabled, allowing unsupported runtimes and continuing");
+            " enabled, allowing unsupported runtimes and continuing");
         return true;
     }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.h
@@ -11,7 +11,7 @@ private:
     bool m_isRunningInSingleStep;
     bool m_isForcedExecution = false;
 
-    bool ShouldForceInstrumentationOverride(const std::string& eolDescription);
+    bool ShouldForceInstrumentationOverride(const std::string& eolDescription, bool isEol);
     HRESULT HandleUnsupportedNetCoreVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion, const bool isEol);
     HRESULT HandleUnsupportedNetFrameworkVersion(const std::string& unsupportedDescription, const std::string& runtimeVersion, const bool isEol);
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -2457,8 +2457,9 @@ partial class Build
            // This one is caused by the intentional crash in the crash tracking smoke test
            knownPatterns.Add(new("Application threw an unhandled exception: System.BadImageFormatException: Expected", RegexOptions.Compiled));
 
-           // We intentionally set the variables for smoke tests which means we get this warning on <= .NET Core 3.0
+           // We intentionally set the variables for smoke tests which means we get this warning on <= .NET Core 3.0 or <.NET 6.0.12 
            knownPatterns.Add(new(".*SingleStepGuardRails::ShouldForceInstrumentationOverride: Found incompatible runtime .NET Core 3.0 or lower", RegexOptions.Compiled));
+           knownPatterns.Add(new(".*SingleStepGuardRails::ShouldForceInstrumentationOverride: Found incompatible runtime .NET 6.0.12 and earlier have known crashing bugs", RegexOptions.Compiled));
            
            CheckLogsForErrors(knownPatterns, allFilesMustExist: true, minLogLevel: LogLevel.Warning);
        });


### PR DESCRIPTION
## Summary of changes

- Bails out of SSI by default on .NET 6 < 6.0.12
- Tweak log message to write correct reason for the bail out

## Reason for change

There's a known crashing bug in early versions of .NET 6: https://github.com/dotnet/runtime/pull/78670

We want to bail out of these cases by default in SSI. (Other major versions are unaffected we believe)

## Implementation details

Check if we're in .NET 6 and build version is < 13, if so, bail out by default.

## Test coverage

Manually tested locally to confirm we bail out in SSI if we're running 6.0.12, but not otherwise

## Other details


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
