### PR TITLE
Skip flaky `ActivityTests` on macos

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/ActivityTests.cs
@@ -30,9 +30,13 @@ namespace Datadog.Trace.Tests
             _fixture = fixture;
         }
 
-        [Fact]
+        [SkippableFact]
         public void SimpleActivitiesAndSpansTest()
         {
+            // macos 12 is crazy flaky around timings
+            // We should unskip this once we have resolved the issues around Hierarchical IDs
+            SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
             var settings = new TracerSettings();
             var tracer = TracerHelper.CreateWithFakeAgent(settings);
             Tracer.UnsafeSetTracerInstance(tracer);


### PR DESCRIPTION
## Summary of changes

Skips the `SimpleActivitiesAndSpansTest` on macOS

## Reason for change

It's _super_ flaky since we updated to macOS 12. There are timing requirements around how activities work (see https://github.com/DataDog/dd-trace-dotnet/pull/5735) which on macOS just fail. Unfortunately, fixing those revealed _other_ issues around hierarchical IDs (https://github.com/DataDog/dd-trace-dotnet/pull/5739). Given the test is _so_ flaky, just skip it on macos for now

## Implementation details

Skip the test on macOS

## Test coverage

Less than before

## Other details

If/when we fix the underlying issue, we should unskip this test again

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
