### PR TITLE
[ASM] Iast/Rasp vulnerability manager

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
+++ b/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
@@ -1,0 +1,30 @@
+// <copyright file="IastRaspVulnerabilityManager.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.AppSec.Rasp;
+using Datadog.Trace.Iast;
+
+namespace Datadog.Trace.AppSec;
+
+internal static class IastRaspVulnerabilityManager
+{
+    internal static void OnPathTraversal(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            IastModule.OnPathTraversal(path);
+            RaspModule.OnLfi(path);
+        }
+    }
+
+    internal static void OnSSRF(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            IastModule.OnSSRF(path);
+            RaspModule.OnSSRF(path);
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
+++ b/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using Datadog.Trace.AppSec.Rasp;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast;
 
 namespace Datadog.Trace.AppSec;
@@ -25,6 +26,15 @@ internal static class IastRaspVulnerabilityManager
         {
             IastModule.OnSSRF(path);
             RaspModule.OnSSRF(path);
+        }
+    }
+
+    internal static void OnSqlI(string path, IntegrationId integrationId)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            IastModule.OnSqlQuery(path, integrationId);
+            RaspModule.OnSqlQuery(path, integrationId);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
+++ b/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
@@ -7,6 +7,8 @@ using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast;
 
+#nullable enable
+
 namespace Datadog.Trace.AppSec;
 
 internal static class IastRaspVulnerabilityManager
@@ -20,21 +22,21 @@ internal static class IastRaspVulnerabilityManager
         }
     }
 
-    internal static void OnSSRF(string path)
+    internal static void OnSSRF(string uriText)
     {
-        if (string.IsNullOrEmpty(path))
+        if (string.IsNullOrEmpty(uriText))
         {
-            IastModule.OnSSRF(path);
-            RaspModule.OnSSRF(path);
+            IastModule.OnSSRF(uriText);
+            RaspModule.OnSSRF(uriText);
         }
     }
 
-    internal static void OnSqlI(string path, IntegrationId integrationId)
+    internal static void OnSqlI(string query, IntegrationId integrationId)
     {
-        if (string.IsNullOrEmpty(path))
+        if (string.IsNullOrEmpty(query))
         {
-            IastModule.OnSqlQuery(path, integrationId);
-            RaspModule.OnSqlQuery(path, integrationId);
+            IastModule.OnSqlQuery(query, integrationId);
+            RaspModule.OnSqlI(query, integrationId);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
+++ b/tracer/src/Datadog.Trace/AppSec/IastRaspVulnerabilityManager.cs
@@ -15,7 +15,7 @@ internal static class IastRaspVulnerabilityManager
 {
     internal static void OnPathTraversal(string path)
     {
-        if (string.IsNullOrEmpty(path))
+        if (!string.IsNullOrEmpty(path))
         {
             IastModule.OnPathTraversal(path);
             RaspModule.OnLfi(path);
@@ -24,7 +24,7 @@ internal static class IastRaspVulnerabilityManager
 
     internal static void OnSSRF(string uriText)
     {
-        if (string.IsNullOrEmpty(uriText))
+        if (!string.IsNullOrEmpty(uriText))
         {
             IastModule.OnSSRF(uriText);
             RaspModule.OnSSRF(uriText);
@@ -33,7 +33,7 @@ internal static class IastRaspVulnerabilityManager
 
     internal static void OnSqlI(string query, IntegrationId integrationId)
     {
-        if (string.IsNullOrEmpty(query))
+        if (!string.IsNullOrEmpty(query))
         {
             IastModule.OnSqlQuery(query, integrationId);
             RaspModule.OnSqlI(query, integrationId);

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -39,7 +39,7 @@ internal static class RaspModule
         CheckVulnerability(new Dictionary<string, object> { [AddressesConstants.UrlAccess] = url }, AddressesConstants.UrlAccess);
     }
 
-    internal static void OnSqlI(string sql, IntegrationId id)
+    internal static void OnSqlQuery(string sql, IntegrationId id)
     {
         var ddbbType = SqlIntegrationIdToDDBBType(id);
         CheckVulnerability(new Dictionary<string, object> { [AddressesConstants.DBStatement] = sql, [AddressesConstants.DBSystem] = ddbbType }, AddressesConstants.DBStatement);

--- a/tracer/src/Datadog.Trace/AppSec/VulnerabilitiesModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/VulnerabilitiesModule.cs
@@ -1,4 +1,4 @@
-// <copyright file="IastRaspVulnerabilityManager.cs" company="Datadog">
+// <copyright file="VulnerabilitiesModule.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -11,7 +11,7 @@ using Datadog.Trace.Iast;
 
 namespace Datadog.Trace.AppSec;
 
-internal static class IastRaspVulnerabilityManager
+internal static class VulnerabilitiesModule
 {
     internal static void OnPathTraversal(string path)
     {

--- a/tracer/src/Datadog.Trace/AppSec/VulnerabilitiesModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/VulnerabilitiesModule.cs
@@ -31,12 +31,12 @@ internal static class VulnerabilitiesModule
         }
     }
 
-    internal static void OnSqlI(string query, IntegrationId integrationId)
+    internal static void OnSqlQuery(string query, IntegrationId integrationId)
     {
         if (!string.IsNullOrEmpty(query))
         {
             IastModule.OnSqlQuery(query, integrationId);
-            RaspModule.OnSqlI(query, integrationId);
+            RaspModule.OnSqlQuery(query, integrationId);
         }
     }
 }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                 }
 
                 // We might block the SQL call from RASP depending on the query
-                VulnerabilitiesModule.OnSqlI(commandText, integrationId);
+                VulnerabilitiesModule.OnSqlQuery(commandText, integrationId);
 
                 tags = tracer.CurrentTraceSettings.Schema.Database.CreateSqlTags();
                 tags.DbType = dbType;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -53,13 +53,8 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     return null;
                 }
 
-                if (Iast.Iast.Instance.Settings.Enabled)
-                {
-                    IastModule.OnSqlQuery(commandText, integrationId);
-                }
-
                 // We might block the SQL call from RASP depending on the query
-                RaspModule.OnSqlI(commandText, integrationId);
+                IastRaspVulnerabilityManager.OnSqlI(commandText, integrationId);
 
                 tags = tracer.CurrentTraceSettings.Schema.Database.CreateSqlTags();
                 tags.DbType = dbType;

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -54,7 +54,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                 }
 
                 // We might block the SQL call from RASP depending on the query
-                IastRaspVulnerabilityManager.OnSqlI(commandText, integrationId);
+                VulnerabilitiesModule.OnSqlI(commandText, integrationId);
 
                 tags = tracer.CurrentTraceSettings.Schema.Database.CreateSqlTags();
                 tags.DbType = dbType;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Data.Common;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
@@ -31,11 +32,7 @@ public class EntityCommandAspect
         if (command is DbCommand dbCommand)
         {
             var commandText = dbCommand.CommandText;
-            if (!string.IsNullOrEmpty(commandText))
-            {
-                IastModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
-                RaspModule.OnSqlI(commandText, IntegrationId.SqlClient);
-            }
+            IastRaspVulnerabilityManager.OnSqlI(commandText, IntegrationId.SqlClient);
         }
 
         return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -32,7 +32,7 @@ public class EntityCommandAspect
         if (command is DbCommand dbCommand)
         {
             var commandText = dbCommand.CommandText;
-            VulnerabilitiesModule.OnSqlI(commandText, IntegrationId.SqlClient);
+            VulnerabilitiesModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
         }
 
         return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -32,7 +32,7 @@ public class EntityCommandAspect
         if (command is DbCommand dbCommand)
         {
             var commandText = dbCommand.CommandText;
-            IastRaspVulnerabilityManager.OnSqlI(commandText, IntegrationId.SqlClient);
+            VulnerabilitiesModule.OnSqlI(commandText, IntegrationId.SqlClient);
         }
 
         return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -32,7 +32,7 @@ public class EntityFrameworkCoreAspect
     [AspectMethodInsertBefore("Microsoft.EntityFrameworkCore.RelationalQueryableExtensions::FromSqlRaw(Microsoft.EntityFrameworkCore.DbSet`1<!!0>,System.String,System.Object[])", 1)]
     public static object ReviewSqlString(string sqlAsString)
     {
-        VulnerabilitiesModule.OnSqlI(sqlAsString, IntegrationId.SqlClient);
+        VulnerabilitiesModule.OnSqlQuery(sqlAsString, IntegrationId.SqlClient);
         return sqlAsString;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -32,7 +32,7 @@ public class EntityFrameworkCoreAspect
     [AspectMethodInsertBefore("Microsoft.EntityFrameworkCore.RelationalQueryableExtensions::FromSqlRaw(Microsoft.EntityFrameworkCore.DbSet`1<!!0>,System.String,System.Object[])", 1)]
     public static object ReviewSqlString(string sqlAsString)
     {
-        IastRaspVulnerabilityManager.OnSqlI(sqlAsString, IntegrationId.SqlClient);
+        VulnerabilitiesModule.OnSqlI(sqlAsString, IntegrationId.SqlClient);
         return sqlAsString;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
@@ -31,8 +32,7 @@ public class EntityFrameworkCoreAspect
     [AspectMethodInsertBefore("Microsoft.EntityFrameworkCore.RelationalQueryableExtensions::FromSqlRaw(Microsoft.EntityFrameworkCore.DbSet`1<!!0>,System.String,System.Object[])", 1)]
     public static object ReviewSqlString(string sqlAsString)
     {
-        IastModule.OnSqlQuery(sqlAsString, IntegrationId.SqlClient);
-        RaspModule.OnSqlI(sqlAsString, IntegrationId.SqlClient);
+        IastRaspVulnerabilityManager.OnSqlI(sqlAsString, IntegrationId.SqlClient);
         return sqlAsString;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -28,7 +28,7 @@ public class ISessionAspect
     [AspectMethodInsertBefore("NHibernate.ISession::CreateSQLQuery(System.String)", 0)]
     public static object AnalyzeQuery(string query)
     {
-        IastRaspVulnerabilityManager.OnSqlI(query, IntegrationId.NHibernate);
+        VulnerabilitiesModule.OnSqlI(query, IntegrationId.NHibernate);
         return query;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -28,7 +28,7 @@ public class ISessionAspect
     [AspectMethodInsertBefore("NHibernate.ISession::CreateSQLQuery(System.String)", 0)]
     public static object AnalyzeQuery(string query)
     {
-        VulnerabilitiesModule.OnSqlI(query, IntegrationId.NHibernate);
+        VulnerabilitiesModule.OnSqlQuery(query, IntegrationId.NHibernate);
         return query;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
@@ -27,8 +28,7 @@ public class ISessionAspect
     [AspectMethodInsertBefore("NHibernate.ISession::CreateSQLQuery(System.String)", 0)]
     public static object AnalyzeQuery(string query)
     {
-        IastModule.OnSqlQuery(query, IntegrationId.NHibernate);
-        RaspModule.OnSqlI(query, IntegrationId.NHibernate);
+        IastRaspVulnerabilityManager.OnSqlI(query, IntegrationId.NHibernate);
         return query;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System.Data.Common;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
@@ -30,12 +31,7 @@ public class DbCommandAspect
         if (command is DbCommand entityCommand && command.GetType().Name == "EntityCommand")
         {
             var commandText = entityCommand.CommandText;
-
-            if (!string.IsNullOrEmpty(commandText))
-            {
-                IastModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
-                RaspModule.OnSqlI(commandText, IntegrationId.SqlClient);
-            }
+            IastRaspVulnerabilityManager.OnSqlI(commandText, IntegrationId.SqlClient);
         }
 
         return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -31,7 +31,7 @@ public class DbCommandAspect
         if (command is DbCommand entityCommand && command.GetType().Name == "EntityCommand")
         {
             var commandText = entityCommand.CommandText;
-            IastRaspVulnerabilityManager.OnSqlI(commandText, IntegrationId.SqlClient);
+            VulnerabilitiesModule.OnSqlI(commandText, IntegrationId.SqlClient);
         }
 
         return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -31,7 +31,7 @@ public class DbCommandAspect
         if (command is DbCommand entityCommand && command.GetType().Name == "EntityCommand")
         {
             var commandText = entityCommand.CommandText;
-            VulnerabilitiesModule.OnSqlI(commandText, IntegrationId.SqlClient);
+            VulnerabilitiesModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
         }
 
         return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -75,7 +75,7 @@ public class DirectoryAspect
     [AspectMethodInsertBefore("System.IO.Directory::SetCurrentDirectory(System.String)")]
     public static string ReviewPath(string path)
     {
-        IastRaspVulnerabilityManager.OnPathTraversal(path);
+        VulnerabilitiesModule.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -74,8 +75,7 @@ public class DirectoryAspect
     [AspectMethodInsertBefore("System.IO.Directory::SetCurrentDirectory(System.String)")]
     public static string ReviewPath(string path)
     {
-        IastModule.OnPathTraversal(path);
-        RaspModule.OnLfi(path);
+        IastRaspVulnerabilityManager.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -60,7 +60,7 @@ public class DirectoryInfoAspect
 #endif
     public static string ReviewPath(string path)
     {
-        IastRaspVulnerabilityManager.OnPathTraversal(path);
+        VulnerabilitiesModule.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -59,8 +60,7 @@ public class DirectoryInfoAspect
 #endif
     public static string ReviewPath(string path)
     {
-        IastModule.OnPathTraversal(path);
-        RaspModule.OnLfi(path);
+        IastRaspVulnerabilityManager.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -5,6 +5,8 @@
 
 #nullable enable
 
+using System;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -102,8 +104,7 @@ public class FileAspect
     [AspectMethodInsertBefore("System.IO.File::Replace(System.String,System.String,System.String,System.Boolean)", new int[] { 1, 2, 3 })]
     public static string ReviewPath(string path)
     {
-        IastModule.OnPathTraversal(path);
-        RaspModule.OnLfi(path);
+        IastRaspVulnerabilityManager.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -104,7 +104,7 @@ public class FileAspect
     [AspectMethodInsertBefore("System.IO.File::Replace(System.String,System.String,System.String,System.Boolean)", new int[] { 1, 2, 3 })]
     public static string ReviewPath(string path)
     {
-        IastRaspVulnerabilityManager.OnPathTraversal(path);
+        VulnerabilitiesModule.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -32,8 +33,7 @@ public class FileInfoAspect
     [AspectMethodInsertBefore("System.IO.FileInfo::Replace(System.String,System.String,System.Boolean)", new int[] { 1, 2 })]
     public static string ReviewPath(string path)
     {
-        IastModule.OnPathTraversal(path);
-        RaspModule.OnLfi(path);
+        IastRaspVulnerabilityManager.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -33,7 +33,7 @@ public class FileInfoAspect
     [AspectMethodInsertBefore("System.IO.FileInfo::Replace(System.String,System.String,System.Boolean)", new int[] { 1, 2 })]
     public static string ReviewPath(string path)
     {
-        IastRaspVulnerabilityManager.OnPathTraversal(path);
+        VulnerabilitiesModule.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -36,8 +37,7 @@ public class FileStreamAspect
 #endif
     public static string ReviewPath(string path)
     {
-        IastModule.OnPathTraversal(path);
-        RaspModule.OnLfi(path);
+        IastRaspVulnerabilityManager.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -37,7 +37,7 @@ public class FileStreamAspect
 #endif
     public static string ReviewPath(string path)
     {
-        IastRaspVulnerabilityManager.OnPathTraversal(path);
+        VulnerabilitiesModule.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -33,7 +33,7 @@ public class StreamReaderAspect
 #endif
     public static string ReviewPath(string path)
     {
-        IastRaspVulnerabilityManager.OnPathTraversal(path);
+        VulnerabilitiesModule.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -32,8 +33,7 @@ public class StreamReaderAspect
 #endif
     public static string ReviewPath(string path)
     {
-        IastModule.OnPathTraversal(path);
-        RaspModule.OnLfi(path);
+        IastRaspVulnerabilityManager.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
@@ -32,7 +32,7 @@ public class StreamWriterAspect
     [AspectMethodInsertBefore("System.IO.StreamWriter::.ctor(System.String,System.Boolean,System.Text.Encoding,System.Int32)", 3)]
     public static string ReviewPath(string path)
     {
-        IastRaspVulnerabilityManager.OnPathTraversal(path);
+        VulnerabilitiesModule.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
@@ -5,6 +5,7 @@
 
 #nullable enable
 
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -31,8 +32,7 @@ public class StreamWriterAspect
     [AspectMethodInsertBefore("System.IO.StreamWriter::.ctor(System.String,System.Boolean,System.Text.Encoding,System.Int32)", 3)]
     public static string ReviewPath(string path)
     {
-        IastModule.OnPathTraversal(path);
-        RaspModule.OnLfi(path);
+        IastRaspVulnerabilityManager.OnPathTraversal(path);
         return path;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -54,7 +54,7 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::DeleteAsync(System.String,System.Threading.CancellationToken)", 1)]
     public static string Review(string parameter)
     {
-        IastRaspVulnerabilityManager.OnSSRF(parameter);
+        VulnerabilitiesModule.OnSSRF(parameter);
         return parameter;
     }
 
@@ -88,7 +88,7 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::set_BaseAddress(System.Uri)")]
     public static Uri ReviewUri(Uri parameter)
     {
-        IastRaspVulnerabilityManager.OnSSRF(parameter.OriginalString);
+        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
         return parameter;
     }
 
@@ -115,7 +115,7 @@ public class HttpClientAspect
 
         if (uri is not null)
         {
-            IastRaspVulnerabilityManager.OnSSRF(uri.OriginalString);
+            VulnerabilitiesModule.OnSSRF(uri.OriginalString);
         }
 
         return parameter;
@@ -127,7 +127,7 @@ public class HttpClientAspect
 
         if (uri is not null)
         {
-            IastRaspVulnerabilityManager.OnSSRF(uri.OriginalString);
+            VulnerabilitiesModule.OnSSRF(uri.OriginalString);
         }
 
         return parameter;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -8,6 +8,8 @@ using System.Net.Http;
 #endif
 using System;
 using Datadog.Trace.AppSec.Rasp;
+using Datadog.Trace.AppSec;
+
 #if NETFRAMEWORK
 using Datadog.Trace.DuckTyping;
 #endif
@@ -53,8 +55,7 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::DeleteAsync(System.String,System.Threading.CancellationToken)", 1)]
     public static string Review(string parameter)
     {
-        IastModule.OnSSRF(parameter);
-        RaspModule.OnSSRF(parameter);
+        IastRaspVulnerabilityManager.OnSSRF(parameter);
         return parameter;
     }
 
@@ -88,8 +89,7 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::set_BaseAddress(System.Uri)")]
     public static Uri ReviewUri(Uri parameter)
     {
-        IastModule.OnSSRF(parameter.OriginalString);
-        RaspModule.OnSSRF(parameter.OriginalString);
+        IastRaspVulnerabilityManager.OnSSRF(parameter);
         return parameter;
     }
 
@@ -116,8 +116,7 @@ public class HttpClientAspect
 
         if (uri is not null)
         {
-            IastModule.OnSSRF(uri.OriginalString);
-            RaspModule.OnSSRF(uri.OriginalString);
+            IastRaspVulnerabilityManager.OnSSRF(uri.OriginalString);
         }
 
         return parameter;
@@ -129,8 +128,7 @@ public class HttpClientAspect
 
         if (uri is not null)
         {
-            IastModule.OnSSRF(uri.OriginalString);
-            RaspModule.OnSSRF(uri.OriginalString);
+            IastRaspVulnerabilityManager.OnSSRF(uri.OriginalString);
         }
 
         return parameter;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -7,7 +7,6 @@
 using System.Net.Http;
 #endif
 using System;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.AppSec;
 
 #if NETFRAMEWORK
@@ -89,7 +88,7 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::set_BaseAddress(System.Uri)")]
     public static Uri ReviewUri(Uri parameter)
     {
-        IastRaspVulnerabilityManager.OnSSRF(parameter);
+        IastRaspVulnerabilityManager.OnSSRF(parameter.OriginalString);
         return parameter;
     }
 

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -4,11 +4,8 @@
 // </copyright>
 
 using System;
-using System.Net;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
-using Datadog.Trace.Iast.Propagation;
 
 #nullable enable
 

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Net;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 using Datadog.Trace.Iast.Propagation;
@@ -55,8 +56,7 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::set_BaseAddress(System.String)")]
     public static object Review(string parameter)
     {
-        IastModule.OnSSRF(parameter);
-        RaspModule.OnSSRF(parameter);
+        IastRaspVulnerabilityManager.OnSSRF(parameter);
         return parameter;
     }
 
@@ -118,8 +118,7 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::UploadValuesTaskAsync(System.Uri,System.String,System.Collections.Specialized.NameValueCollection)", 2)]
     public static object ReviewUri(Uri parameter)
     {
-        IastModule.OnSSRF(parameter.OriginalString);
-        RaspModule.OnSSRF(parameter.OriginalString);
+        IastRaspVulnerabilityManager.OnSSRF(parameter.OriginalString);
         return parameter;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -53,7 +53,7 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::set_BaseAddress(System.String)")]
     public static object Review(string parameter)
     {
-        IastRaspVulnerabilityManager.OnSSRF(parameter);
+        VulnerabilitiesModule.OnSSRF(parameter);
         return parameter;
     }
 
@@ -115,7 +115,7 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::UploadValuesTaskAsync(System.Uri,System.String,System.Collections.Specialized.NameValueCollection)", 2)]
     public static object ReviewUri(Uri parameter)
     {
-        IastRaspVulnerabilityManager.OnSSRF(parameter.OriginalString);
+        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
         return parameter;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -5,7 +5,6 @@
 
 using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 #nullable enable

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -4,6 +4,7 @@
 // </copyright>
 
 using System;
+using Datadog.Trace.AppSec;
 using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -26,8 +27,7 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.String)")]
     public static object Review(string parameter)
     {
-        IastModule.OnSSRF(parameter);
-        RaspModule.OnSSRF(parameter);
+        IastRaspVulnerabilityManager.OnSSRF(parameter);
         return parameter;
     }
 
@@ -41,8 +41,7 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.Uri)")]
     public static object Review(Uri parameter)
     {
-        IastModule.OnSSRF(parameter.OriginalString);
-        RaspModule.OnSSRF(parameter.OriginalString);
+        IastRaspVulnerabilityManager.OnSSRF(parameter.OriginalString);
         return parameter;
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -26,7 +26,7 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.String)")]
     public static object Review(string parameter)
     {
-        IastRaspVulnerabilityManager.OnSSRF(parameter);
+        VulnerabilitiesModule.OnSSRF(parameter);
         return parameter;
     }
 
@@ -40,7 +40,7 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.Uri)")]
     public static object Review(Uri parameter)
     {
-        IastRaspVulnerabilityManager.OnSSRF(parameter.OriginalString);
+        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
         return parameter;
     }
 }


### PR DESCRIPTION
## Summary of changes

A class has been created to encapsulate the calls to IAST and RASP when both are called at the same instrumentation point.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
