### PR TITLE
[Profiler] Fix bug when create thread lifetime event

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawThreadLifetimeSample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawThreadLifetimeSample.cpp
@@ -22,5 +22,5 @@ void RawThreadLifetimeSample::OnTransform(
     }
 
     // Set an arbitratry value to avoid being discarded by the backend
-    sample->AddValue(valueOffset[0], 1);
+    sample->AddValue(1, valueOffset[0]);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawThreadLifetimeSample.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawThreadLifetimeSample.cpp
@@ -20,4 +20,7 @@ void RawThreadLifetimeSample::OnTransform(
         sample->AddFrame({EmptyModule, StopFrame, "", 0});
         sample->AddLabel(Label(Sample::TimelineEventTypeLabel, Sample::TimelineEventTypeThreadStop));
     }
+
+    // Set an arbitratry value to avoid being discarded by the backend
+    sample->AddValue(valueOffset[0], 1);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ThreadLifetimeProvider.cpp
@@ -39,7 +39,7 @@ RawThreadLifetimeSample ThreadLifetimeProvider::CreateSample(std::shared_ptr<Man
     rawSample.Timestamp = GetCurrentTimestamp();
     rawSample.LocalRootSpanId = 0;
     rawSample.SpanId = 0;
-    rawSample.AppDomainId = (AppDomainID) nullptr;
+    rawSample.AppDomainId = pThreadInfo->GetAppDomainId();
     rawSample.ThreadInfo = std::move(pThreadInfo);
     rawSample.Kind = kind;
 


### PR DESCRIPTION
## Summary of changes

Fix a bug when creating thread lifetime events.

## Reason for change

Currently thread lifetime samples (which contain the `event` label set to `thread start` or  `thread stop`) are not attached to any application and feel like the events are lost 😢 
+ add a value for the `timeline`: currently there is no value and the backend discards event without values.

## Implementation details

- set `AppDomainId` field to the thread app domain id.
- set `1` as value for the `timeline` column

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
