### PR TITLE
Correctly set `activityKey` when we change the Trace ID

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlerCommon.cs
@@ -58,11 +58,6 @@ namespace Datadog.Trace.Activity.Handlers
                 var activityTraceId = w3cActivity.TraceId;
                 var activitySpanId = w3cActivity.SpanId;
 
-                if (activityTraceId != null! && activitySpanId != null!)
-                {
-                    activityKey = activityTraceId + activitySpanId;
-                }
-
                 // If the user has specified a parent context, get the parent Datadog SpanContext
                 if (w3cActivity is { ParentSpanId: { } parentSpanId, ParentId: { } parentId })
                 {
@@ -110,6 +105,7 @@ namespace Datadog.Trace.Activity.Handlers
                     {
                         // TraceId (always 32 chars long even when using 64-bit ids)
                         w3cActivity.TraceId = activeSpan.Context.RawTraceId;
+                        activityTraceId = w3cActivity.TraceId;
 
                         // SpanId (always 16 chars long)
                         w3cActivity.ParentSpanId = activeSpan.Context.RawSpanId;
@@ -136,6 +132,11 @@ namespace Datadog.Trace.Activity.Handlers
 
                     rawTraceId = activityTraceId;
                     rawSpanId = activitySpanId;
+                }
+
+                if (activityTraceId != null! && activitySpanId != null!)
+                {
+                    activityKey = activityTraceId + activitySpanId;
                 }
             }
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/OpenTelemetrySdkTests.cs
@@ -118,16 +118,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var otelSpans = spans.Where(s => s.Service == "MyServiceName");
                 var activitySourceSpans = spans.Where(s => s.Service == CustomServiceName);
 
-                if (string.IsNullOrEmpty(packageVersion) || new Version(packageVersion) >= new Version("1.7.0"))
-                {
-                    otelSpans.Count().Should().Be(expectedSpanCount - 3); // there is another span w/ service == ServiceNameOverride
-                    activitySourceSpans.Count().Should().Be(2);
-                }
-                else
-                {
-                    otelSpans.Count().Should().Be(expectedSpanCount - 2); // there is another span w/ service == ServiceNameOverride
-                    activitySourceSpans.Count().Should().Be(1);
-                }
+                otelSpans.Count().Should().Be(expectedSpanCount - 2); // there is another span w/ service == ServiceNameOverride
+                activitySourceSpans.Count().Should().Be(1);
 
                 ValidateIntegrationSpans(otelSpans, metadataSchemaVersion: "v0", expectedServiceName: "MyServiceName", isExternalSpan: false);
                 ValidateIntegrationSpans(activitySourceSpans, metadataSchemaVersion: "v0", expectedServiceName: CustomServiceName, isExternalSpan: false);
@@ -173,14 +165,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 using var s = new AssertionScope();
                 var otelSpans = spans.Where(s => s.Service == "MyServiceName");
 
-                if (string.IsNullOrEmpty(packageVersion) || new Version(packageVersion) >= new Version("1.7.0"))
-                {
-                    otelSpans.Count().Should().Be(expectedSpanCount - 2); // there is another span w/ service == ServiceNameOverride
-                }
-                else
-                {
-                    otelSpans.Count().Should().Be(expectedSpanCount - 1); // there is another span w/ service == ServiceNameOverride
-                }
+                otelSpans.Count().Should().Be(expectedSpanCount - 1); // there is another span w/ service == ServiceNameOverride
 
                 ValidateIntegrationSpans(otelSpans, metadataSchemaVersion: "v0", expectedServiceName: "MyServiceName", isExternalSpan: false);
 

--- a/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests.verified.txt
@@ -689,7 +689,7 @@
     SpanId: Id_29,
     Name: internal,
     Resource: StartRootSpan,
-    Service: CustomServiceName,
+    Service: MyServiceName,
     Type: custom,
     ParentId: Id_26,
     Tags: {
@@ -698,12 +698,14 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_4,
-      runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
-      version: 1.0.x
-    },
-    Metrics: {
-      _dd.top_level: 1.0
+      telemetry.sdk.language: dotnet,
+      telemetry.sdk.name: opentelemetry,
+      telemetry.sdk.version: sdk-version,
+      _dd.base_service: CustomServiceName
     }
   },
   {

--- a/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTestsWithActivitySource.verified.txt
@@ -689,7 +689,7 @@
     SpanId: Id_29,
     Name: internal,
     Resource: StartRootSpan,
-    Service: CustomServiceName,
+    Service: MyServiceName,
     Type: custom,
     ParentId: Id_26,
     Tags: {
@@ -698,12 +698,14 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_4,
-      runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
-      version: 1.0.x
-    },
-    Metrics: {
-      _dd.top_level: 1.0
+      telemetry.sdk.language: dotnet,
+      telemetry.sdk.name: opentelemetry,
+      telemetry.sdk.version: sdk-version,
+      _dd.base_service: CustomServiceName
     }
   },
   {

--- a/tracer/test/snapshots/OpenTelemetrySdkTests_withLegacyOperationName.verified.txt
+++ b/tracer/test/snapshots/OpenTelemetrySdkTests_withLegacyOperationName.verified.txt
@@ -689,7 +689,7 @@
     SpanId: Id_29,
     Name: MyServiceName.internal,
     Resource: StartRootSpan,
-    Service: CustomServiceName,
+    Service: MyServiceName,
     Type: custom,
     ParentId: Id_26,
     Tags: {
@@ -698,12 +698,14 @@
       otel.library.name: MyServiceName,
       otel.status_code: STATUS_CODE_UNSET,
       otel.trace_id: Guid_4,
-      runtime-id: Guid_2,
+      service.instance.id: Guid_3,
+      service.name: MyServiceName,
+      service.version: 1.0.x,
       span.kind: internal,
-      version: 1.0.x
-    },
-    Metrics: {
-      _dd.top_level: 1.0
+      telemetry.sdk.language: dotnet,
+      telemetry.sdk.name: opentelemetry,
+      telemetry.sdk.version: sdk-version,
+      _dd.base_service: CustomServiceName
     }
   },
   {


### PR DESCRIPTION
## Summary of changes

This delays the computation of `activityKey` (used to map an `Activity` to a Datadog `Scope`) by it's `TraceID` + `SpanID` to be _after_ we could potentially modify those values.

## Reason for change

We do modify the `TraceId` of an `Activity`. The previous way would cause `MISSING SCOPE` logs as we'd use the outdated Trace Id when searching for the mapping.

## Implementation details

- Move setting of `activityKey` later
- Update `activityTraceId` when we change the Activity's TraceId

## Test coverage

- Had to update the `OpenTelemetryTests` as they weren't correct

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
