### PR TITLE
Stop testing with a specific build in macos smoke tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5777,12 +5777,6 @@ stages:
           inputs:
             artifact: runner-dotnet-tool
             path: $(smokeTestAppDir)/artifacts
-            buildType: 'specific'
-            project: 'dd-trace-dotnet'
-            definition: 54
-            buildVersionToDownload: 'specific'
-            pipelineId: 159827
-
 
         - script: |
             mkdir -p tracer/build_data/snapshots


### PR DESCRIPTION
## Summary of changes

Make the macos smoke tests do what they're supposed to do

## Reason for change

In #5710 I wanted to speed up my test flow. In doing so I downloaded from a specific build instead of the current, for faster iteration. I then forgot to change that when I made the PR 🤦‍♂️ 

## Implementation details

Delete the bit that shouldn't be there

## Test coverage

[Will run a specific test for it](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=160818&view=results)

## Other details


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
