### PR TITLE
Filter out .NET Core 3.1 NuGet tests in prerelease versions

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -972,8 +972,9 @@ partial class Build : NukeBuild
                             // (publishFramework: TargetFramework.NET8_0, "8.0-jammy-chiseled-composite"), // we can't run scripts in chiseled containers, so need to update the dockerfiles
                             new (publishFramework: TargetFramework.NET7_0, "7.0-bullseye-slim"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-bullseye-slim"),
+                            // We can't install prerelease versions of the dotnet-tool nuget in .NET Core 3.1, because the --prerelease flag isn't available 
                             new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-bullseye"),
-                        },
+                        }.Where(x=> IsPrerelease || x.PublishFramework != TargetFramework.NETCOREAPP3_1).ToArray(),
                         platformSuffix: "linux-x64",
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
                     );
@@ -986,7 +987,8 @@ partial class Build : NukeBuild
                             new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
                             new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
                             new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.15"),
-                        },
+                            // We can't install prerelease versions of the dotnet-tool nuget in .NET Core 3.1, because the --prerelease flag isn't available 
+                        }.Where(x=> IsPrerelease || x.PublishFramework != TargetFramework.NETCOREAPP3_1).ToArray(),
                         platformSuffix: "linux-musl-x64",
                         dockerName: "mcr.microsoft.com/dotnet/sdk"
                     );


### PR DESCRIPTION
## Summary of changes

Skips the .NET Core 3.1 NuGet dotnet-tool installer tests on prerelease versions

## Reason for change

[The `--prerelease` flag isn't available < .NET 6](https://github.com/dotnet/sdk/issues/9037), so we can't easily install the prerelease package in these runtime images 

## Implementation details

Just skip these smoke tests on <.NET 6. It's only a specific case of the NuGet install with these earlier runtimes, so it's very low risk

## Test coverage

It _should_ run in this branch, but when we rebase v3-main on top, it shouldn't run

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
