### PR TITLE
[Dynamic Instrumentation] Fixed instrumentation error (InvalidProgramException) related to EH clauses

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -2497,19 +2497,24 @@ void DebuggerMethodRewriter::AdjustExceptionHandlingClauses(ILInstr* pFromInstr,
     {
         if (ehClauses[ehIndex].m_pTryBegin == pFromInstr)
         {
-            // TODO log
+            ehClauses[ehIndex].m_pTryBegin = pToInstr;
+        }
+        else if (ehClauses[ehIndex].m_pTryEnd == pFromInstr)
+        {
             ehClauses[ehIndex].m_pTryEnd = pToInstr;
         }
 
         if (ehClauses[ehIndex].m_pHandlerBegin == pFromInstr)
         {
-            // TODO log
             ehClauses[ehIndex].m_pHandlerBegin = pToInstr;
+        }
+        else if (ehClauses[ehIndex].m_pHandlerEnd == pFromInstr)
+        {
+            ehClauses[ehIndex].m_pHandlerEnd = pToInstr;
         }
 
         if (ehClauses[ehIndex].m_pFilter == pFromInstr)
         {
-            // TODO log
             ehClauses[ehIndex].m_pFilter = pToInstr;
         }
     }

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTryCatchTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTryCatchTest.verified.txt
@@ -1,0 +1,418 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "arg": {
+                "type": "String",
+                "value": "AsyncTryCatchTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "arg": {
+                "type": "String",
+                "value": "AsyncTryCatchTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "8"
+              },
+              "ret": {
+                "type": "Int32",
+                "value": "8"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Test",
+            "type": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "28": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryCatchTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryCatchTest.cs",
+            "lines": [
+              "28"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "32": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryCatchTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryCatchTest.cs",
+            "lines": [
+              "32"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "33": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryCatchTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryCatchTest.cs",
+            "lines": [
+              "33"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "34": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryCatchTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "17"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryCatchTest.cs",
+            "lines": [
+              "34"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "38": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryCatchTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "17"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryCatchTest.cs",
+            "lines": [
+              "38"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "39": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryCatchTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "17"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryCatchTest.cs",
+            "lines": [
+              "39"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "40": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryCatchTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "8"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryCatchTest.cs",
+            "lines": [
+              "40"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTryFinallyTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.AsyncTryFinallyTest.verified.txt
@@ -1,0 +1,359 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "27": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryFinallyTest.cs",
+            "lines": [
+              "27"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "31": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryFinallyTest.cs",
+            "lines": [
+              "31"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "32": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryFinallyTest.cs",
+            "lines": [
+              "32"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "33": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "19"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryFinallyTest.cs",
+            "lines": [
+              "33"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "37": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "19"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryFinallyTest.cs",
+            "lines": [
+              "37"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "38": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "19"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryFinallyTest.cs",
+            "lines": [
+              "38"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "39": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "AsyncTryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "9"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "AsyncTryFinallyTest.cs",
+            "lines": [
+              "39"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.AsyncTryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryCatchTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryCatchTest.verified.txt
@@ -1,0 +1,238 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "27": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "TryCatchTest"
+                },
+                "this": {
+                  "type": "TryCatchTest",
+                  "value": "TryCatchTest"
+                }
+              },
+              "locals": {
+                "ret1": {
+                  "type": "Int32",
+                  "value": "0"
+                },
+                "ret2": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "TryCatchTest.cs",
+            "lines": [
+              "27"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.TryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "31": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "TryCatchTest"
+                },
+                "this": {
+                  "type": "TryCatchTest",
+                  "value": "TryCatchTest"
+                }
+              },
+              "locals": {
+                "ret1": {
+                  "type": "Int32",
+                  "value": "0"
+                },
+                "ret2": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "TryCatchTest.cs",
+            "lines": [
+              "31"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.TryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "32": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "TryCatchTest"
+                },
+                "this": {
+                  "type": "TryCatchTest",
+                  "value": "TryCatchTest"
+                }
+              },
+              "locals": {
+                "ret1": {
+                  "type": "Int32",
+                  "value": "6"
+                },
+                "ret2": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "TryCatchTest.cs",
+            "lines": [
+              "32"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.TryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "35": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "TryCatchTest"
+                },
+                "this": {
+                  "type": "TryCatchTest",
+                  "value": "TryCatchTest"
+                }
+              },
+              "locals": {
+                "ret1": {
+                  "type": "Int32",
+                  "value": "6"
+                },
+                "ret2": {
+                  "type": "Int32",
+                  "value": "2"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "TryCatchTest.cs",
+            "lines": [
+              "35"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.TryCatchTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryFinallyTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.TryFinallyTest.verified.txt
@@ -1,0 +1,57 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "lines": {
+            "23": {
+              "arguments": {
+                "arg": {
+                  "type": "String",
+                  "value": "TryFinallyTest"
+                },
+                "this": {
+                  "type": "TryFinallyTest",
+                  "value": "TryFinallyTest"
+                }
+              },
+              "locals": {
+                "ret": {
+                  "type": "Int32",
+                  "value": "0"
+                }
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "file": "TryFinallyTest.cs",
+            "lines": [
+              "23"
+            ]
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Test",
+      "name": "Samples.Probes.TestRuns.SmokeTests.TryFinallyTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncTryCatchTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncTryCatchTest.verified.txt
@@ -1,0 +1,114 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "17c1e39c-e46c-828e-4e02-21be0f3b5358",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "1828a3f0-e94b-eb91-81e3-12bcf19ac41a",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3c5a4d30-f652-b355-51d6-9589d1d290b4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "86a95ec1-5bda-bd57-3f8e-e610398f9334",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "a48bde4f-873f-cac7-08f6-3404c6ceec6d",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe a48bde4f-873f-cac7-08f6-3404c6ceec6d.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "b1fd073e-cd92-947d-4b6b-d9bd0380b1f2",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe b1fd073e-cd92-947d-4b6b-d9bd0380b1f2.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncTryFinallyTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.AsyncTryFinallyTest.verified.txt
@@ -1,0 +1,100 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "17c1e39c-e46c-828e-4e02-21be0f3b5358",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "1828a3f0-e94b-eb91-81e3-12bcf19ac41a",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3c5a4d30-f652-b355-51d6-9589d1d290b4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 3c5a4d30-f652-b355-51d6-9589d1d290b4.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "86a95ec1-5bda-bd57-3f8e-e610398f9334",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 86a95ec1-5bda-bd57-3f8e-e610398f9334.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "b1fd073e-cd92-947d-4b6b-d9bd0380b1f2",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe b1fd073e-cd92-947d-4b6b-d9bd0380b1f2.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.TryCatchTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.TryCatchTest.verified.txt
@@ -1,0 +1,58 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "17c1e39c-e46c-828e-4e02-21be0f3b5358",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 17c1e39c-e46c-828e-4e02-21be0f3b5358.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "1828a3f0-e94b-eb91-81e3-12bcf19ac41a",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 1828a3f0-e94b-eb91-81e3-12bcf19ac41a.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.TryFinallyTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.TryFinallyTest.verified.txt
@@ -1,0 +1,16 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/AsyncTryCatchTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/AsyncTryCatchTest.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    [LogLineProbeTestData(28)]
+    [LogLineProbeTestData(32)]
+    [LogLineProbeTestData(33)]
+    [LogLineProbeTestData(34)]
+    [LogLineProbeTestData(38)]
+    [LogLineProbeTestData(39)]
+    [LogLineProbeTestData(40)]
+    internal class AsyncTryCatchTest : IAsyncRun
+    {
+        public async Task RunAsync()
+        {
+            await Test(nameof(AsyncTryCatchTest));
+        }
+
+        [LogMethodProbeTestData]
+        private async Task<int> Test(string arg)
+        {
+            int ret;
+
+            await Task.Yield();
+
+            try
+            {
+                await Task.Yield();
+                ret = arg.Length;
+                await Task.Yield();
+            }
+            finally
+            {
+                await Task.Yield();
+                ret = arg.Length / 2;
+                await Task.Yield();
+            }
+
+            await Task.Yield();
+            return ret;
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/AsyncTryFinallyTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/AsyncTryFinallyTest.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    [LogLineProbeTestData(27)]
+    [LogLineProbeTestData(31)]
+    [LogLineProbeTestData(32)]
+    [LogLineProbeTestData(33)]
+    [LogLineProbeTestData(37)]
+    [LogLineProbeTestData(38)]
+    [LogLineProbeTestData(39)]
+    internal class AsyncTryFinallyTest : IAsyncRun
+    {
+        public async Task RunAsync()
+        {
+            await Test(nameof(AsyncTryFinallyTest));
+        }
+
+        private async Task<int> Test(string arg)
+        {
+            int ret;
+
+            await Task.Yield();
+
+            try
+            {
+                await Task.Yield();
+                ret = arg.Length;
+                await Task.Yield();
+            }
+            finally
+            {
+                await Task.Yield();
+                ret = arg.Length / 2;
+                await Task.Yield();
+            }
+
+            await Task.Yield();
+            return ret;
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/TryCatchTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/TryCatchTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    [LogLineProbeTestData(27)]
+    [LogLineProbeTestData(31)]
+    [LogLineProbeTestData(32)]
+    [LogLineProbeTestData(35)]
+    internal class TryCatchTest : IRun
+    {
+        public void Run()
+        {
+            Test(nameof(TryCatchTest));
+        }
+
+        private int Test(string arg)
+        {
+            var ret1 = 0;
+            var ret2 = 0;
+
+            try
+            {
+                ret1 = arg.Length / 0;
+            }
+            catch
+            {
+                ret1 = arg.Length / 2;
+                ret2 = ret1 / 3;
+            }
+
+            return ret1 + ret2;
+        }
+    }
+}

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/TryFinallyTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/TryFinallyTest.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    [LogLineProbeTestData(23)]
+    internal class TryFinallyTest : IRun
+    {
+        public void Run()
+        {
+            Test(nameof(TryFinallyTest));
+        }
+
+        private int Test(string arg)
+        {
+            int ret;
+
+            try
+            {
+                ret = arg.Length;
+            }
+            finally
+            {
+                ret = arg.Length / 2;
+            }
+
+            return ret;
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
Fixed `InvalidProgramException` thrown due to malformed bytecode born from DI Line Probe instrumentation, discovered by Exploration Testing of Method + Line Probes.

## Reason for change
When a customer chooses a line for instrumentation through DI, a bunch of bytecode is being placed in front of the chosen line, to capture the method state.
When the original line was a target of an exception handling clauses (e.g the line was the beginning of a catch/finally blocks, the line was the end of a try block, etc) - in those cases, we retarget the exception handling pointers to point to the new bytecode being placed. The code that handled it missed two assignment: TryEnd and HandlerEnd. Meaning, when the target line was an end of finally/catch block or at the end of a try block, we missed fixing the pointers, resulting in `InvalidProgramException`.

## Implementation details
Correctly assinging `TryEnd` & `HandlerEnd` EH clauses.

## Test coverage
Four new tests were added, that previously were broken with `InvalidProgramException`:
- `TryFinallyTest`.
- `AsyncTryFinallyTest`
- `TryCatchTest`
- `AsyncTryCatchTest`