### PR TITLE
Switch system-tests to python 3.12

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4568,8 +4568,8 @@ stages:
 
       - task: UsePythonVersion@0
         inputs:
-            versionSpec: '3.9'
-        displayName: Install python 3.9
+            versionSpec: '3.12'
+        displayName: Install python 3.12
 
       - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo


### PR DESCRIPTION
## Summary of changes

Switch system-tests to python 3.12

## Reason for change

System tests now use python 3.12

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
