### PR TITLE
[ASM][IAST] XSS Set marks only when escaped stays the same

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastModule.Escape.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.Escape.cs
@@ -44,8 +44,11 @@ internal static partial class IastModule
                 return res;
             }
 
-            // Add the mark (exclusion) to the tainted ranges
-            tainted.Ranges = Ranges.CopyWithMark(tainted.Ranges, SecureMarks.Xss);
+            if (ReferenceEquals(res, text))
+            {
+                // Add the mark (exclusion) to the tainted ranges
+                tainted.Ranges = Ranges.CopyWithMark(tainted.Ranges, SecureMarks.Xss);
+            }
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary of changes

Added a condition to check if the input (res) and output (text) strings are the same object reference.

## Reason for change

Ensures that secure marks are correctly applied only to the escaped strings.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
