### PR TITLE
[ASM] Appsec events in meta struct

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/AgentConfiguration.cs
@@ -20,7 +20,8 @@ internal record AgentConfiguration
         string? telemetryProxyEndpoint,
         string? tracerFlareEndpoint,
         bool clientDropP0,
-        string? diagnosticsEndpoint)
+        string? diagnosticsEndpoint,
+        bool spanMetaStructs)
     {
         ConfigurationEndpoint = configurationEndpoint;
         DebuggerEndpoint = debuggerEndpoint;
@@ -33,6 +34,7 @@ internal record AgentConfiguration
         TelemetryProxyEndpoint = telemetryProxyEndpoint;
         TracerFlareEndpoint = tracerFlareEndpoint;
         ClientDropP0s = clientDropP0;
+        SpanMetaStructs = spanMetaStructs;
     }
 
     public string? ConfigurationEndpoint { get; }
@@ -56,4 +58,6 @@ internal record AgentConfiguration
     public string? TracerFlareEndpoint { get; }
 
     public bool ClientDropP0s { get; }
+
+    public bool SpanMetaStructs { get; }
 }

--- a/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
+++ b/tracer/src/Datadog.Trace/Agent/DiscoveryService/DiscoveryService.cs
@@ -217,6 +217,7 @@ namespace Datadog.Trace.Agent.DiscoveryService
 
             var agentVersion = jObject["version"]?.Value<string>();
             var clientDropP0 = jObject["client_drop_p0s"]?.Value<bool>() ?? false;
+            var spanMetaStructs = jObject["span_meta_structs"]?.Value<bool>() ?? false;
 
             var discoveredEndpoints = (jObject["endpoints"] as JArray)?.Values<string>().ToArray();
             string? configurationEndpoint = null;
@@ -296,7 +297,8 @@ namespace Datadog.Trace.Agent.DiscoveryService
                 eventPlatformProxyEndpoint: eventPlatformProxyEndpoint,
                 telemetryProxyEndpoint: telemetryProxyEndpoint,
                 tracerFlareEndpoint: tracerFlareEndpoint,
-                clientDropP0: clientDropP0);
+                clientDropP0: clientDropP0,
+                spanMetaStructs: spanMetaStructs);
 
             // AgentConfiguration is a record, so this compares by value
             if (existingConfiguration is null || !newConfig.Equals(existingConfiguration))

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -29,7 +29,17 @@ internal class AppSecRequestContext
         {
             if (_wafSecurityEvents.Count > 0)
             {
-                span.SetMetaStruct(AppsecKey, MetaStructHelper.ObjectToByteArray(new Dictionary<string, List<object>> { { "triggers", _wafSecurityEvents } }));
+                // Older version of the Agent doesn't support meta struct
+                // Fallback to the _dd.appsec.json tag
+                if (Security.Instance.IsMetaStructSupported())
+                {
+                    span.SetMetaStruct(AppsecKey, MetaStructHelper.ObjectToByteArray(new Dictionary<string, List<object>> { { "triggers", _wafSecurityEvents } }));
+                }
+                else
+                {
+                    var triggers = JsonConvert.SerializeObject(_wafSecurityEvents);
+                    tags.SetTag(Tags.AppSecJson, "{\"triggers\":" + triggers + "}");
+                }
             }
 
             if (_raspStackTraces?.Count > 0)

--- a/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AppSecRequestContext.cs
@@ -17,6 +17,7 @@ internal class AppSecRequestContext
 {
     private const string StackKey = "_dd.stack";
     private const string ExploitStackKey = "exploit";
+    private const string AppsecKey = "appsec";
     private readonly object _sync = new();
     private readonly List<object> _wafSecurityEvents = new();
     private Dictionary<string, List<Dictionary<string, object>>>? _raspStackTraces = null;
@@ -28,8 +29,7 @@ internal class AppSecRequestContext
         {
             if (_wafSecurityEvents.Count > 0)
             {
-                var triggers = JsonConvert.SerializeObject(_wafSecurityEvents);
-                tags.SetTag(Tags.AppSecJson, "{\"triggers\":" + triggers + "}");
+                span.SetMetaStruct(AppsecKey, MetaStructHelper.ObjectToByteArray(new Dictionary<string, List<object>> { { "triggers", _wafSecurityEvents } }));
             }
 
             if (_raspStackTraces?.Count > 0)

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/MetaStructHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/MetaStructHelper.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Vendors.MessagePack.Formatters;
 
 #nullable enable
@@ -91,5 +92,11 @@ internal static class MetaStructHelper
         Array.Resize(ref buffer, bytesCopied);
 
         return buffer;
+    }
+
+    public static object ByteArrayToObject(byte[] value)
+    {
+        var formatterResolver = SpanFormatterResolver.Instance;
+        return PrimitiveObjectFormatter.Instance.Deserialize(value, 0, formatterResolver, out _);
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/MetaStructHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/MetaStructHelper.cs
@@ -5,8 +5,8 @@
 
 using System;
 using System.Collections.Generic;
-using Datadog.Trace.Agent.MessagePack;
 using Datadog.Trace.Vendors.MessagePack.Formatters;
+using Datadog.Trace.Vendors.MessagePack.Resolvers;
 
 #nullable enable
 
@@ -96,7 +96,7 @@ internal static class MetaStructHelper
 
     public static object ByteArrayToObject(byte[] value)
     {
-        var formatterResolver = SpanFormatterResolver.Instance;
+        var formatterResolver = StandardResolver.Instance;
         return PrimitiveObjectFormatter.Instance.Deserialize(value, 0, formatterResolver, out _);
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.AppSec.Rcm;
 using Datadog.Trace.AppSec.Rcm.Models.AsmDd;
 using Datadog.Trace.AppSec.Waf;
@@ -46,6 +47,8 @@ namespace Datadog.Trace.AppSec
         private WafLibraryInvoker? _wafLibraryInvoker;
         private AppSecRateLimiter? _rateLimiter;
         private InitResult? _wafInitResult;
+        private IDiscoveryService? _discoveryService;
+        private bool _spanMetaStructs;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Security"/> class with default settings.
@@ -492,6 +495,17 @@ namespace Datadog.Trace.AppSec
             }
 
             Dispose();
+        }
+
+        internal bool IsMetaStructSupported()
+        {
+            if (_discoveryService is null)
+            {
+                _discoveryService = Tracer.Instance.TracerManager.DiscoveryService;
+                _discoveryService?.SubscribeToChanges(config => _spanMetaStructs = config.SpanMetaStructs);
+            }
+
+            return _spanMetaStructs;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -580,11 +580,6 @@ namespace Datadog.Trace
         internal const string AppSecBlocked = "appsec.blocked";
 
         /// <summary>
-        /// The details of the security event
-        /// </summary>
-        internal const string AppSecJson = "_dd.appsec.json";
-
-        /// <summary>
         /// Ruleset file version, string satisfying the regular expression: [0-9]+\.[0-9]+\.[0-9]+
         /// </summary>
         internal const string AppSecRuleFileVersion = "_dd.appsec.event_rules.version";

--- a/tracer/src/Datadog.Trace/Tags.cs
+++ b/tracer/src/Datadog.Trace/Tags.cs
@@ -580,6 +580,11 @@ namespace Datadog.Trace
         internal const string AppSecBlocked = "appsec.blocked";
 
         /// <summary>
+        /// The details of the security event
+        /// </summary>
+        internal const string AppSecJson = "_dd.appsec.json";
+
+        /// <summary>
         /// Ruleset file version, string satisfying the regular expression: [0-9]+\.[0-9]+\.[0-9]+
         /// </summary>
         internal const string AppSecRuleFileVersion = "_dd.appsec.event_rules.version";

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -13,6 +13,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -44,6 +45,8 @@ namespace Datadog.Trace.Security.IntegrationTests
         private static readonly Regex AppSecRaspWafDuration = new(@"_dd.appsec.rasp.duration: \d+\.0", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex AppSecRaspWafDurationWithBindings = new(@"_dd.appsec.rasp.duration_ext: \d+\.0", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex AppSecSpanIdRegex = (new Regex("\"span_id\":\\d+"));
+        private static readonly Type MetaStructHelperType = Type.GetType("Datadog.Trace.AppSec.Rasp.MetaStructHelper, Datadog.Trace");
+        private static MethodInfo _metaStructByteArrayToObject = MetaStructHelperType.GetMethod("ByteArrayToObject", BindingFlags.Public | BindingFlags.Static);
         private readonly string _testName;
         private readonly HttpClient _httpClient;
         private readonly CookieContainer _cookieContainer;
@@ -131,11 +134,25 @@ namespace Datadog.Trace.Security.IntegrationTests
                                 }
                             }
 
-                            if (target.Tags.TryGetValue(Tags.AppSecJson, out var appsecJson))
+                            if (target.MetaStruct != null)
                             {
-                                var appSecJsonObj = JsonConvert.DeserializeObject<AppSecJson>(appsecJson);
-                                var orderedAppSecJson = JsonConvert.SerializeObject(appSecJsonObj, _jsonSerializerSettingsOrderProperty);
-                                target.Tags[Tags.AppSecJson] = orderedAppSecJson;
+                                // We want to retrieve the appsec event data from the meta struct to validate it in snapshots
+                                // But that's hard to debug if we only see the binary data
+                                // So move the meta struct appsec data to a fake tag to validate it in snapshots
+                                if (target.MetaStruct.TryGetValue("appsec", out var appsec))
+                                {
+                                    var appSecMetaStruct = _metaStructByteArrayToObject.Invoke(null, [appsec]);
+                                    var orderedAppSecJson = JsonConvert.SerializeObject(appSecMetaStruct, _jsonSerializerSettingsOrderProperty);
+                                    target.MetaStruct.Remove("appsec");
+                                    var metaStructSnapshotTestsTag = "_dd.appsec.meta-struct.test";
+                                    target.Tags.Add(metaStructSnapshotTestsTag, orderedAppSecJson);
+                                }
+
+                                // Remove all data from meta structs keys, no need to get the binary data for other keys
+                                foreach (var item in target.MetaStruct)
+                                {
+                                    target.MetaStruct[item.Key] = [];
+                                }
                             }
 
                             return VerifyHelper.ScrubStringTags(target, target.Tags);
@@ -154,7 +171,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                 settings.AddRegexScrubber(AppSecEventRulesLoaded, string.Empty);
             }
 
-            var appsecSpans = spans.Where(s => s.Tags.ContainsKey("_dd.appsec.json"));
+            var appsecSpans = spans.Where(s => s.MetaStruct != null && s.MetaStruct.ContainsKey("appsec"));
             if (appsecSpans.Any())
             {
                 appsecSpans.Should().OnlyContain(s => s.Metrics["_dd.appsec.waf.duration"] < s.Metrics["_dd.appsec.waf.duration_ext"]

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -46,7 +46,7 @@ namespace Datadog.Trace.Security.IntegrationTests
         private static readonly Regex AppSecRaspWafDurationWithBindings = new(@"_dd.appsec.rasp.duration_ext: \d+\.0", RegexOptions.IgnoreCase | RegexOptions.Compiled);
         private static readonly Regex AppSecSpanIdRegex = (new Regex("\"span_id\":\\d+"));
         private static readonly Type MetaStructHelperType = Type.GetType("Datadog.Trace.AppSec.Rasp.MetaStructHelper, Datadog.Trace");
-        private static MethodInfo _metaStructByteArrayToObject = MetaStructHelperType.GetMethod("ByteArrayToObject", BindingFlags.Public | BindingFlags.Static);
+        private static readonly MethodInfo MetaStructByteArrayToObject = MetaStructHelperType.GetMethod("ByteArrayToObject", BindingFlags.Public | BindingFlags.Static);
         private readonly string _testName;
         private readonly HttpClient _httpClient;
         private readonly CookieContainer _cookieContainer;
@@ -148,7 +148,7 @@ namespace Datadog.Trace.Security.IntegrationTests
                                 // So move the meta struct appsec data to a fake tag to validate it in snapshots
                                 if (target.MetaStruct.TryGetValue("appsec", out var appsec))
                                 {
-                                    var appSecMetaStruct = _metaStructByteArrayToObject.Invoke(null, [appsec]);
+                                    var appSecMetaStruct = MetaStructByteArrayToObject.Invoke(null, [appsec]);
                                     var json = JsonConvert.SerializeObject(appSecMetaStruct);
                                     var obj = JsonConvert.DeserializeObject<AppSecJson>(json);
                                     var orderedJson = JsonConvert.SerializeObject(obj, _jsonSerializerSettingsOrderProperty);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5.cs
@@ -92,6 +92,20 @@ namespace Datadog.Trace.Security.IntegrationTests
             : base("AspNetCore5", fixture, outputHelper, "/shutdown", ruleFile: DefaultRuleFile, testName: "AspNetCore5.SecurityEnabled")
         {
         }
+
+        [Trait("RunOnWindows", "True")]
+        [SkippableFact]
+        public async Task TestAppsecMetaStruct()
+        {
+            await TryStartApp();
+            var agent = Fixture.Agent;
+            var url = "/health?q=fun";
+
+            var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
+            var settings = VerifyHelper.GetSpanVerifierSettings(sanitisedUrl);
+            var spans = await SendRequestsAsync(agent, url, null, 1, 1, string.Empty);
+            await VerifySpans(spans, settings, testName: "AspNetCore5.SecurityEnabled.MetaStruct", forceMetaStruct: true);
+        }
     }
 
     [Collection("IisTests")]

--- a/tracer/test/Datadog.Trace.TestHelpers/MockSpan.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockSpan.cs
@@ -14,8 +14,6 @@ namespace Datadog.Trace.TestHelpers
     [DebuggerDisplay("{ToString(),nq}")]
     public class MockSpan
     {
-        private Dictionary<string, byte[]> _metastruct;
-
         [Key("trace_id")]
         public ulong TraceId { get; set; }
 
@@ -53,27 +51,7 @@ namespace Datadog.Trace.TestHelpers
         public Dictionary<string, double> Metrics { get; set; }
 
         [Key("meta_struct")]
-        public Dictionary<string, byte[]> MetaStruct
-        {
-            get
-            {
-                return _metastruct;
-            }
-
-            set
-            {
-                if (value is not null)
-                {
-                    _metastruct = new Dictionary<string, byte[]>();
-
-                    foreach (var key in value.Keys)
-                    {
-                        // No need to store the binary data
-                        _metastruct[key] = Array.Empty<byte>();
-                    }
-                }
-            }
-        }
+        public Dictionary<string, byte[]> MetaStruct { get; set; }
 
         [Key("span_links")]
         public List<MockSpanLink> SpanLinks { get; set; }

--- a/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MockTracerAgent.cs
@@ -1027,6 +1027,9 @@ namespace Datadog.Trace.TestHelpers
 
             [JsonProperty("version")]
             public string AgentVersion { get; set; }
+
+            [JsonProperty("span_meta_structs")]
+            public bool SpanMetaStructs { get; set; } = true;
         }
 
         public class TcpUdpAgent : MockTracerAgent

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceMock.cs
@@ -25,7 +25,8 @@ internal class DiscoveryServiceMock : IDiscoveryService
         string eventPlatformProxyEndpoint = "eventPlatformProxyEndpoint",
         string telemetryProxyEndpoint = "telemetryProxyEndpoint",
         string tracerFlareEndpoint = "tracerFlareEndpoint",
-        bool clientDropP0 = true)
+        bool clientDropP0 = true,
+        bool spanMetaStructs = true)
         => TriggerChange(
             new AgentConfiguration(
                 configurationEndpoint: configurationEndpoint,
@@ -38,7 +39,8 @@ internal class DiscoveryServiceMock : IDiscoveryService
                 eventPlatformProxyEndpoint: eventPlatformProxyEndpoint,
                 telemetryProxyEndpoint: telemetryProxyEndpoint,
                 tracerFlareEndpoint: tracerFlareEndpoint,
-                clientDropP0: clientDropP0));
+                clientDropP0: clientDropP0,
+                spanMetaStructs: spanMetaStructs));
 
     public void TriggerChange(AgentConfiguration config)
     {

--- a/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/DiscoveryServiceTests.cs
@@ -263,7 +263,8 @@ public class DiscoveryServiceTests
             eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
             telemetryProxyEndpoint: "telemetryProxyEndpoint",
             tracerFlareEndpoint: "tracerFlareEndpoint",
-            clientDropP0: false);
+            clientDropP0: false,
+            spanMetaStructs: true);
 
         // same config
         var config2 = new AgentConfiguration(
@@ -277,7 +278,8 @@ public class DiscoveryServiceTests
             eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
             telemetryProxyEndpoint: "telemetryProxyEndpoint",
             tracerFlareEndpoint: "tracerFlareEndpoint",
-            clientDropP0: false);
+            clientDropP0: false,
+            spanMetaStructs: true);
 
         // different
         var config3 = new AgentConfiguration(
@@ -291,7 +293,8 @@ public class DiscoveryServiceTests
             eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
             telemetryProxyEndpoint: "telemetryProxyEndpoint",
             tracerFlareEndpoint: "tracerFlareEndpoint",
-            clientDropP0: false);
+            clientDropP0: false,
+            spanMetaStructs: true);
 
         config1.Equals(config2).Should().BeTrue();
         config1.Equals(config3).Should().BeFalse();

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMetaStructTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMetaStructTests.cs
@@ -21,6 +21,7 @@ public class SpanMetaStructTests
 {
     private const string MetaStructStr = "meta_struct";
     private const string DdStackKey = "_dd.stack.exploit";
+    private const string AppsecKey = "appsec";
     private const string StringKey = "StringKey";
     private const string StringValue = "value";
     private static readonly IFormatterResolver FormatterResolver = SpanFormatterResolver.Instance;
@@ -36,13 +37,59 @@ public class SpanMetaStructTests
                     MetaStructHelper.StackTraceInfoToDictionary("type2222", "dotnet", "test55555", null, new List<Dictionary<string, object>>() { stackFrame3, stackFrame4 }),
                 };
 
+    // _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-913-120","name":"Known security scanner filename/argument","tags":{"category":"attack_attempt","type":"security_scanner"}},"rule_matches":[{"operator":"phrase_match","operator_value":"","parameters":[{"address":"server.request.path_params","highlight":["appscan_fingerprint"],"key_path":["id"],"value":"appscan_fingerprint"}]}]}]},
+    private static List<object> appsecData =
+                new()
+                {
+                    new Dictionary<string, object>()
+                    {
+                        {
+                            "rule", new Dictionary<string, object>
+                            {
+                                { "id", "crs-913-120" },
+                                { "name", "Known security scanner filename/argument" },
+                                {
+                                    "tags", new Dictionary<string, object>
+                                    {
+                                        { "category", "attack_attempt" },
+                                        { "type", "security_scanner" }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "rule_matches", new List<object>
+                            {
+                                new Dictionary<string, object>
+                                {
+                                    { "operator", "phrase_match" },
+                                    { "operator_value", string.Empty },
+                                    {
+                                        "parameters", new List<object>
+                                        {
+                                            new Dictionary<string, object>
+                                            {
+                                                { "address", "server.request.path_params" },
+                                                { "highlight", new List<string> { "appscan_fingerprint" } },
+                                                { "key_path", new List<string>() { "id" } },
+                                                { "value", "appscan_fingerprint" }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
     public static TheoryData<List<Tuple<string, object?>>> Data
     => new()
        {
             new()
             {
                    new(StringKey, StringValue),
-                   new(DdStackKey, stackData)
+                   new(DdStackKey, stackData),
+                   new(AppsecKey, appsecData),
             },
             new()
             {

--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMetaStructTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMetaStructTests.cs
@@ -37,7 +37,7 @@ public class SpanMetaStructTests
                     MetaStructHelper.StackTraceInfoToDictionary("type2222", "dotnet", "test55555", null, new List<Dictionary<string, object>>() { stackFrame3, stackFrame4 }),
                 };
 
-    // _dd.appsec.json: {"triggers":[{"rule":{"id":"crs-913-120","name":"Known security scanner filename/argument","tags":{"category":"attack_attempt","type":"security_scanner"}},"rule_matches":[{"operator":"phrase_match","operator_value":"","parameters":[{"address":"server.request.path_params","highlight":["appscan_fingerprint"],"key_path":["id"],"value":"appscan_fingerprint"}]}]}]},
+    // appsec event: {"triggers":[{"rule":{"id":"crs-913-120","name":"Known security scanner filename/argument","tags":{"category":"attack_attempt","type":"security_scanner"}},"rule_matches":[{"operator":"phrase_match","operator_value":"","parameters":[{"address":"server.request.path_params","highlight":["appscan_fingerprint"],"key_path":["id"],"value":"appscan_fingerprint"}]}]}]},
     private static List<object> appsecData =
                 new()
                 {

--- a/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/StatsAggregatorTests.cs
@@ -455,7 +455,8 @@ namespace Datadog.Trace.Tests.Agent
                              eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
                              telemetryProxyEndpoint: "telemetryProxyEndpoint",
                              tracerFlareEndpoint: "tracerFlareEndpoint",
-                             clientDropP0: true));
+                             clientDropP0: true,
+                             spanMetaStructs: true));
             }
 
             public void RemoveSubscription(Action<AgentConfiguration> callback)

--- a/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/LiveDebuggerTests.cs
@@ -96,7 +96,8 @@ public class LiveDebuggerTests
                     eventPlatformProxyEndpoint: "eventPlatformProxyEndpoint",
                     telemetryProxyEndpoint: "telemetryProxyEndpoint",
                     tracerFlareEndpoint: "tracerFlareEndpoint",
-                    clientDropP0: false));
+                    clientDropP0: false,
+                    spanMetaStructs: true));
         }
 
         public void RemoveSubscription(Action<AgentConfiguration> callback)

--- a/tracer/test/snapshots/AspNetCore5.SecurityEnabled.MetaStruct._.verified.txt
+++ b/tracer/test/snapshots/AspNetCore5.SecurityEnabled.MetaStruct._.verified.txt
@@ -1,0 +1,43 @@
+﻿[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: aspnet_core.request,
+    Resource: GET /health,
+    Service: Samples.Security.AspNetCore5,
+    Type: web,
+    Tags: {
+      actor.ip: 86.242.244.246,
+      appsec.blocked: true,
+      appsec.event: true,
+      component: aspnet_core,
+      env: integration_tests,
+      http.client_ip: 127.0.0.1,
+      http.method: GET,
+      http.request.headers.host: localhost:00000,
+      http.request.headers.user-agent: Mistake Not...,
+      http.request.headers.x-forwarded-for: 86.242.244.246,
+      http.response.headers.content-type: application/json,
+      http.status_code: 403,
+      http.url: http://localhost:00000/health?q=fun,
+      http.useragent: Mistake Not...,
+      language: dotnet,
+      network.client.ip: 127.0.0.1,
+      runtime-id: Guid_1,
+      span.kind: server,
+      _dd.appsec.json: {"triggers":[{"rule":{"id":"tst-037-011","name":"No fun","tags":{"category":"attack_attempt","type":"lfi"}},"rule_matches":[{"operator":"match_regex","operator_value":"fun","parameters":[{"address":"server.request.uri.raw","highlight":["fun"],"key_path":[],"value":"/health?q=fun"}]}]}]},
+      _dd.appsec.json.metastruct.test: true,
+      _dd.origin: appsec,
+      _dd.runtime_family: dotnet
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.appsec.enabled: 1.0,
+      _dd.appsec.waf.duration: 0.0,
+      _dd.appsec.waf.duration_ext: 0.0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 2.0
+    }
+  }
+]

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Endpoints/Endpoints.cs
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/Endpoints/Endpoints.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;


### PR DESCRIPTION
## Summary of changes

Move appsec event data from the `_dd.appsec.json` tag to a messagepack-encoded data serialized into meta struct.
[RFC Linked to that change.](https://docs.google.com/document/d/1iWQsOfT6Lg_IFyvQeqry9wVmXOE2Yav0X4MgOTk7mks/)

# Implementation details

- Check for meta struct compatibility with the connected agent
- Fallback to json serialization if not supported

## Reason for change

Better performance.

## Test coverage

- By default, now the mocked trace agent is set to support meta struct, so all appsec events will be set on meta struct
- To keep all existing snapshots unchanged, meta struct appsec events are set back as json on the same tag into snapshots
- Add a new option in the test: "forceMetaStruct". When enabled, the tag `_dd.appsec.json.metastruct.test` is set when appsec events from metastruct are serialized back to json. This is to be sure that meta struct is used in the test.