### PR TITLE
[Exception Replay] Mitigating an exception thrown while processing the methods participating in exception stack traces

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -2499,18 +2499,10 @@ void DebuggerMethodRewriter::AdjustExceptionHandlingClauses(ILInstr* pFromInstr,
         {
             ehClauses[ehIndex].m_pTryBegin = pToInstr;
         }
-        else if (ehClauses[ehIndex].m_pTryEnd == pFromInstr)
-        {
-            ehClauses[ehIndex].m_pTryEnd = pToInstr;
-        }
 
         if (ehClauses[ehIndex].m_pHandlerBegin == pFromInstr)
         {
             ehClauses[ehIndex].m_pHandlerBegin = pToInstr;
-        }
-        else if (ehClauses[ehIndex].m_pHandlerEnd == pFromInstr)
-        {
-            ehClauses[ehIndex].m_pHandlerEnd = pToInstr;
         }
 
         if (ehClauses[ehIndex].m_pFilter == pFromInstr)

--- a/tracer/src/Datadog.Tracer.Native/fault_tolerant_method_duplicator.cpp
+++ b/tracer/src/Datadog.Tracer.Native/fault_tolerant_method_duplicator.cpp
@@ -99,7 +99,7 @@ void fault_tolerant::FaultTolerantMethodDuplicator::DuplicateOne(const ModuleID 
     }
     else
     {
-        Logger::Warn("    * Succeeded in the creation of the new <Original> method. MethodDef: ",
+        Logger::Info("    * Succeeded in the creation of the new <Original> method. MethodDef: ",
                      shared::TokenStr(&methodDef), " Method Name:",
                      functionInfo.type.name + WStr(".") + newMethodName + WStr(", Module Path: ") +
                      moduleInfo.path);
@@ -123,7 +123,7 @@ void fault_tolerant::FaultTolerantMethodDuplicator::DuplicateOne(const ModuleID 
     }
     else
     {
-        Logger::Warn("    * Succeeded in the creation of the new <Instrumented> method. MethodDef: ",
+        Logger::Info("    * Succeeded in the creation of the new <Instrumented> method. MethodDef: ",
                      shared::TokenStr(&methodDef), " Method Name:",
                      functionInfo.type.name + WStr(".") + newMethodName + WStr(", Module Path: ") +
                      moduleInfo.path);


### PR DESCRIPTION
## Summary of changes
There was an exception that was thrown while processed the methods participating in exception stack traces. the getter of `MemberInfo.MetadataToken` threw `InvalidOperationException`. When it happened, the whole processing of the exception was shuttered, leading to missing debug info for these errors in Error Tracking.

## Reason for change
Make the processing of the exception more resilient to a broader `MethodBase` derived implementations.

## Implementation details
Touching the `MetadataToken` property with a try/catch block, and skipping the methods that yield any exception.