### PR TITLE
[Dynamic Instrumentation] Fixed Instrumentation failures revealed by the Exploration Tests of Line & Method probes

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/debugger_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_constants.h
@@ -54,6 +54,8 @@ const WSTRING invalid_method_probe_probe_is_not_supported =
     WStr("The method where the probe should have been placed is not supported.");
 const WSTRING line_probe_il_offset_lookup_failure =
     WStr("There was a failure in determining the exact location where the line probe was supposed to be placed.");
+const WSTRING line_probe_il_offset_lookup_failure_2 =
+    WStr("There was a failure in determining the exact location where the line probe was supposed to be placed. [2]");
 const WSTRING line_probe_in_async_generic_method_in_optimized_code =
     WStr("Placing line probes in async generic methods in Release builds is currently not supported.");
 const WSTRING invalid_probe_probe_cctor_ctor_not_supported =

--- a/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_method_rewriter.cpp
@@ -472,6 +472,13 @@ HRESULT DebuggerMethodRewriter::CallLineProbe(
     if (lineProbeFirstInstruction->m_opcode == CEE_NOP || lineProbeFirstInstruction->m_opcode == CEE_BR_S ||
         lineProbeFirstInstruction->m_opcode == CEE_BR)
     {
+        if (lineProbeFirstInstruction->m_pNext == rewriterWrapper.GetILRewriter()->GetILList())
+        {
+            // Note we are not sabotaging the whole rewriting upon failure to lookup for a specific bytecode offset.
+            ProbesMetadataTracker::Instance()->SetErrorProbeStatus(lineProbe->probeId, line_probe_il_offset_lookup_failure_2);
+            return E_NOTIMPL;
+        }
+
         lineProbeFirstInstruction = lineProbeFirstInstruction->m_pNext;
     }
 
@@ -2310,7 +2317,7 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
     // BEGIN LINE PROBES PART
     // ***
 
-    auto beforeLineProbe = rewriterWrapper.GetCurrentILInstr();
+    auto beforeLineProbe = rewriterWrapper.GetCurrentILInstr()->m_pPrev;
 
     // TODO support multiple line probes & multiple line probes on the same bytecode offset (by deduplicating the probe ids)
 
@@ -2345,6 +2352,8 @@ HRESULT DebuggerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler,
 
         appliedAtLeastOneLineProbeInstrumentation = hr == S_OK;
     }
+
+    beforeLineProbe = beforeLineProbe->m_pNext;
 
     // ***
     // BEGIN METHOD PROBE PART
@@ -2495,6 +2504,11 @@ void DebuggerMethodRewriter::AdjustExceptionHandlingClauses(ILInstr* pFromInstr,
 
     for (unsigned ehIndex = 0; ehIndex < ehCount; ehIndex++)
     {
+        if (ehClauses[ehIndex].m_pTryEnd == pFromInstr)
+        {
+            ehClauses[ehIndex].m_pTryEnd = pToInstr;
+        }
+
         if (ehClauses[ehIndex].m_pTryBegin == pFromInstr)
         {
             ehClauses[ehIndex].m_pTryBegin = pToInstr;


### PR DESCRIPTION
## Summary of changes
In the past few weeks, we've been working internally to extend the Exploration Tests of DI to work in conjunction with Line Probes, alongside the current support of Method Probes. Meaning, for each JIT-compiled method, we apply method probe instrumentation (surrounding the method body with try/catch, unify the return points, capture method variables on entry and leave, etc) with line instrumentation of each line in the given method. By doing so, we test an extreme scenario of instrumentation and validate our stability. By employing this technique, we found a bunch of instrumentation issues that prevented Protobuf from passing green with the aforementioned instrumentations. This PR introduces fixes that makes Protobuf run to completion without any instrumentation issues in its 1000+ tests.

## Reason for change
Make DI instrumentation more stable in extreme Method & Line probe instrumentations.

## Implementation details
This PR introduced a fix for the following issues:
- When the line probe was applied to the beginning of the method, and this beginning instruction is a target of a loop (when, for example, the method body starts with a loop) - we failed to place the method probe instrumentation in a way that will surround the line instrumentation being applied to the first instruction.
- When a line probe instruction lands on a branch or a NOP instruction, we skip it to fine-tune the selection. In the protobuf exploration test, we encountered a scenario where the last instruction in the method body was a branch / NOP. In which case, going one step further encountered the first instruction (as the bytecode list is circular).
- When the line probe was placed on the end of a try block and the start of the handler (catch or finally), we have to fix the branch targets accordingly. We failed to do so in this specific scenario.


## Test coverage
Will be introduced in a separate PR that will enable the exploration test of line & method.