### PR TITLE
[Dynamic Instrumentation] Fixed SymDB upload when PDB is absent

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Root.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Root.cs
@@ -11,13 +11,18 @@ namespace Datadog.Trace.Debugger.Symbols.Model
 {
     internal enum SymbolType
     {
+        Field,
+        StaticField,
+        Arg,
+        Local
+    }
+
+    internal enum ScopeType
+    {
         Assembly,
         Class,
         Method,
         Closure,
-        Field,
-        StaticField,
-        Arg,
         Local
     }
 

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Scope.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/Model/Scope.cs
@@ -14,7 +14,7 @@ internal record struct Scope
 {
     [JsonProperty("scope_type")]
     [JsonConverter(typeof(StringEnumConverter), converterParameters: typeof(SnakeCaseNamingStrategy))]
-    internal SymbolType ScopeType { get; set; }
+    internal ScopeType ScopeType { get; set; }
 
     [JsonProperty("name")]
     internal string? Name { get; set; }

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -100,7 +100,7 @@ namespace Datadog.Trace.Debugger.Symbols
             var assemblyScope = new Model.Scope
             {
                 Name = assemblyName,
-                ScopeType = SymbolType.Assembly,
+                ScopeType = ScopeType.Assembly,
                 SourceFile = string.IsNullOrEmpty(_assemblyPath) ? null : _assemblyPath,
             };
 
@@ -213,7 +213,7 @@ namespace Datadog.Trace.Debugger.Symbols
                 classScope = new Model.Scope
                 {
                     Name = typeDefinitionHandle.FullName(MetadataReader),
-                    ScopeType = SymbolType.Class,
+                    ScopeType = ScopeType.Class,
                     Symbols = fieldSymbols,
                     Scopes = allScopes,
                     StartLine = linesAndSource.StartLine,
@@ -567,7 +567,7 @@ namespace Datadog.Trace.Debugger.Symbols
 
             var methodScope = new Model.Scope
             {
-                ScopeType = SymbolType.Method,
+                ScopeType = ScopeType.Method,
                 Name = methodName,
                 LanguageSpecifics = methodLanguageSpecifics,
                 Symbols = argsSymbol,
@@ -700,6 +700,12 @@ namespace Datadog.Trace.Debugger.Symbols
                     {
                         continue;
                     }
+                }
+
+                // Since we increment the index for `index == 0`, we have to make sure we don't exceed the bound of the array
+                if (index >= argsSymbol.Length)
+                {
+                    break;
                 }
 
                 argsSymbol[index] = new Symbol

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolPdbExtractor.cs
@@ -130,7 +130,7 @@ internal class SymbolPdbExtractor : SymbolExtractor
 
         var closureMethodScope = CreateMethodScope(nestedType, generatedMethod);
         closureMethodScope.Name = methodName;
-        closureMethodScope.ScopeType = SymbolType.Closure;
+        closureMethodScope.ScopeType = ScopeType.Closure;
         return closureMethodScope;
     }
 
@@ -188,7 +188,7 @@ internal class SymbolPdbExtractor : SymbolExtractor
             }
 
             scope.Symbols = localSymbols.Slice(0, localIndex).ToArray();
-            scope.ScopeType = SymbolType.Local;
+            scope.ScopeType = ScopeType.Local;
             scope.StartLine = methodScope.StartLine;
             scope.EndLine = methodScope.EndLine;
             scope.SourceFile = methodScope.SourceFile;
@@ -319,7 +319,7 @@ internal class SymbolPdbExtractor : SymbolExtractor
             }
 
             scope.Symbols = localSymbols.Slice(0, localIndex).ToArray();
-            scope.ScopeType = SymbolType.Local;
+            scope.ScopeType = ScopeType.Local;
             scope.StartLine = methodScope.StartLine;
             scope.EndLine = methodScope.EndLine;
             scope.SourceFile = methodScope.SourceFile;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/SymbolsTests/SymbolUploaderTest.cs
@@ -62,7 +62,7 @@ public class SymbolUploaderTest
         Assert.True(result.Scopes.Count == root.Scopes.Count);
         Assert.True(classesScope?.Length == 1);
         Assert.True(!string.IsNullOrEmpty(classesScope[0].Name));
-        Assert.True(classesScope[0].ScopeType == SymbolType.Class);
+        Assert.True(classesScope[0].ScopeType == ScopeType.Class);
     }
 
     [Fact]
@@ -84,7 +84,7 @@ public class SymbolUploaderTest
             Assert.NotNull(classesScope);
             Assert.True(root1.Scopes.Count == root.Scopes.Count);
             Assert.True(!string.IsNullOrEmpty(classesScope[0].Name));
-            Assert.True(classesScope.All(cls => cls.ScopeType == SymbolType.Class));
+            Assert.True(classesScope.All(cls => cls.ScopeType == ScopeType.Class));
         }
     }
 
@@ -134,7 +134,7 @@ public class SymbolUploaderTest
             Language = "dotnet",
             Service = nameof(SymbolUploaderTest),
             Version = "0",
-            Scopes = new List<Trace.Debugger.Symbols.Model.Scope> { new() { ScopeType = SymbolType.Assembly, Scopes = null } }
+            Scopes = new List<Trace.Debugger.Symbols.Model.Scope> { new() { ScopeType = ScopeType.Assembly, Scopes = null } }
         };
 
         var scopes = new List<Trace.Debugger.Symbols.Model.Scope?>();
@@ -143,7 +143,7 @@ public class SymbolUploaderTest
             scopes.Add(new Trace.Debugger.Symbols.Model.Scope
             {
                 Name = $"type: {i}",
-                ScopeType = SymbolType.Class,
+                ScopeType = ScopeType.Class,
             });
         }
 


### PR DESCRIPTION
## Summary of changes
We had some issues in building up the symbols when PDB is absent which lead to failure in uploading them.

## Reason for change
We are entering into the Open Beta of "Autocomplete and Search" feature of the Dynamic Instrumentation product and want to make sure things are working before shipping it. The absent of PDBs is a common scenario and we still want to display Methods and Classes information that exist in the assembly itself. Failing to build the symbols may yield bad user experience and possibly hurt the adoption of DI for .NET.

## Implementation details
Mainly fixed a miscalculation of an index that lead to `IndexOutOfBoundsException`.