### PR TITLE
[v3] Minor updates 

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -9,6 +9,10 @@ parameters:
     type: boolean
     default: true
 
+  - name: isNoop
+    type: boolean
+    default: false
+
   - name: 'apiKey'
     type: string
     default: ''
@@ -71,7 +75,7 @@ steps:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
 
 - bash: |
-    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) ${{ parameters.target }}
+    docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e PROFILER_IS_NOT_REQUIRED=${{ parameters.isNoop }} ${{ parameters.target }}
   env:
     dockerTag: $(dockerTag)
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
@@ -90,13 +94,29 @@ steps:
   env:
     DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
 
-- ${{ if eq(parameters.isLinux, true) }}:
+- ${{ if and(eq(parameters.isLinux, true), eq(parameters.isNoop, false)) }}:
   - bash: |
       echo "Verifying snapshot session (fail on mis-match)"
       docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --w '\nGetting a 400 means there is a diff in snapshots. You can diff the files with the artifacts generated. You can also run the tests locally. Follow the doc in /docs/development/CI/RunSmokeTestsLocally\n' --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
     displayName: check snapshots
     env:
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}
+- ${{ elseif and(eq(parameters.isLinux, true), eq(parameters.isNoop, true)) }}:
+    - bash: |
+        path="/debug_snapshots/${{ parameters.snapshotPrefix }}_requests.json"
+        echo "Verifying noop snapshot session (requests should be empty)"
+        if [ -s $path ]; then
+          echo "$path is not empty"
+          if [ "$(cat "$path" | tr -d '\n')" = "[]" ]; then
+            echo "$path contains no requests[]"
+          else
+            echo "The file unexpectedly contained requests"
+          exit 1
+          fi
+        else
+          echo "$path was empty"
+        fi
+      displayName: check noop snapshots
 - ${{ else }}:
   - bash: |
       echo "Verifying snapshot session (fail on mis-match)"
@@ -120,7 +140,7 @@ steps:
   continueOnError: true
 
 # Run crash tests
-- ${{ if eq(parameters.isLinux, true) }}:
+- ${{ if and(eq(parameters.isLinux, true), eq(parameters.isNoop, false)) }}:
   - bash: |
       LOGS=$(docker-compose -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
       echo $LOGS

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5610,6 +5610,79 @@ stages:
         baseImage: debian
         command: "CheckSmokeTestsForErrors"
 
+- stage: installer_noop_smoke_tests_arm64
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [package_arm64, generate_variables, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+    - template: steps/update-github-status-jobs.yml
+      parameters:
+        jobs: [linux]
+
+    - job: linux
+      timeoutInMinutes: 45 # should take ~15 mins
+      strategy:
+        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_noop_smoke_tests_arm64_matrix'] ]
+      variables:
+        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
+      pool:
+        name: aws-arm64-auto-scaling
+
+      steps:
+        - template: steps/clone-repo.yml
+          parameters:
+            targetShaId: $(targetShaId)
+            targetBranch: $(targetBranch)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download artifacts to smoke test directory
+          inputs:
+            artifact: $(linuxArtifacts)
+            path: $(smokeTestAppDir)/artifacts
+
+        # Run the "normal" noop installer smoke tests 
+        - script: |
+            docker-compose -p $(DockerComposeProjectName) build \
+              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
+              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+              smoke-tests
+          env:
+            dockerTag: $(dockerTag)
+            DD_LOGGER_DD_API_KEY: $(ddApiKey)
+          displayName: docker-compose build smoke-tests
+          retryCountOnTaskFailure: 3
+
+        - template: steps/run-snapshot-test.yml
+          parameters:
+            target: 'smoke-tests'
+            snapshotPrefix: "smoke_test"
+            isNoop: true
+        
+        # Run the "dd-dotnet" "unsupported tfm" installer smoke tests
+        - script: |
+            echo "Expected installer: $(expectedInstaller)"
+
+            cd tracer/build/artifacts
+            result=$(docker run --rm -v ${PWD}:/app --entrypoint /app/dd-dotnet.sh $(runtimeImage))
+            if [[ "$result" != *"$(expectedInstaller)"* ]]; then
+              echo "Incorrect message. Expected '$(expectedInstaller)', but found:"
+              echo $result
+              exit 1
+            fi
+
+            echo "Received expected response:"
+            echo $result
+
+          displayName: Run artifact test (expecting failure)
+
+        - publish: tracer/build_data
+          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+          condition: succeededOrFailed()
+          continueOnError: true
+
 - stage: nuget_installer_smoke_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
   dependsOn: [dotnet_tool, package_windows, generate_variables, merge_commit_id]

--- a/docs/MIGRATING.md
+++ b/docs/MIGRATING.md
@@ -99,19 +99,24 @@ Several settings have changed their default values:
 - `DD_TRACE_WCF_WEB_HTTP_RESOURCE_NAMES_ENABLED` now defaults to `true`. This setting provides a better experience in the majority of cases.
 - `DD_TRACE_SAMPLING_RULES_FORMAT` now defaults to `glob` instead of `regex`. This setting is consistent with other language client libraries. 
 
+Some settings have been removed
+- `DD_TRACE_OTEL_LEGACY_OPERATION_NAME_ENABLED` has been removed. This setting was not widely used and was not necessary for most users, thanks to an improved operation name calculation.
+
 #### What action should you take?
-We recommend using the new settings if possible. If this is not possible, you can manually change the value for each setting to it's previous value, for example: `DD_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED=false`
+We recommend using the new settings if possible. If this is not possible, you can manually change the value for each setting to its previous value, for example: `DD_TRACE_DELAY_WCF_INSTRUMENTATION_ENABLED=false`
 
 ### Changes in behavior
 
 #### What changed and why?
-Some settings have changed their behavior, and there are some changes to reported tags
+Some settings have changed their behavior:
 - `DD_TRACE_HEADER_TAGS` [no longer replaces periods or spaces in names](https://github.com/DataDog/dd-trace-dotnet/pull/4599). The new behavior is consistent with the behavior of other tracer languages.
 - `DD_TRACE_HEADER_TAGS` [now considers trailing `:` in entries as invalid, and splits key-value pairs on the last `:` in the entry](https://github.com/DataDog/dd-trace-dotnet/pull/5438). The new behavior is consistent with the behavior of other tracer languages.
-- The `language` tag is [now added to added to all spans](https://github.com/DataDog/dd-trace-dotnet/pull/4839) with the value `dotnet`. Previously, some spans were not tagged, but were subsequently tagged with the value `.NET`. This change removes the inconsistency
 - `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_JSON` now refers to an absolute file path instead of providing the template content directly. This makes it easier to provide custom values.
 - `DD_APPSEC_HTTP_BLOCKED_TEMPLATE_HTML` now refers to an absolute file path instead of providing the template content directly. This makes it easier to provide custom values.
 - `DD_API_SECURITY_REQUEST_SAMPLING ` now requires a value from 0 to 1.0, not a percentage from 0 to 100.
+
+There are also changes to some reported tags added to spans:
+- The `language` tag is [now added to added to all spans](https://github.com/DataDog/dd-trace-dotnet/pull/4839) with the value `dotnet`. Previously, some spans were not tagged, but were subsequently tagged with the value `.NET`. This change removes the inconsistency.
 
 #### What action should you take?
 If you require the previous `DD_TRACE_HEADER_TAGS` normalization behavior, you must apply this normalization yourself, replacing periods and spaces with underscores in the value you pass to `DD_TRACE_HEADER_TAGS`.
@@ -154,7 +159,7 @@ If you don't set `COR_ENABLE_PROFILING=0`/`CORECLR_ENABLE_PROFILING=1` and conti
 
 In version 1.x.x and 2.x.x of the tracer, it was possible to reference the `Datadog.Trace.AspNet` module in your application's `web.config` file, although this wasn't required for ASP.NET support in general. In version 3.x.x, referencing the `Datadog.Trace.AspNet` in your application's `web.config` will cause an error, and may cause your application to fail to start, with the error:
 
-> "There was an error when performing this operation"
+> "Could not load file or assembly 'Datadog.Trace.AspNet' or one of its dependencies. The system cannot find the file specified."
 
 #### Why did we change it?
 The `Datadog.Trace.AspNet` module is obsolete and is not required for tracing ASP.NET applications. We are removing the `Datadog.Trace.AspNet` module to remove a point of failure when upgrading the .NET client library. Referencing the module in an application's `web.config` file, and the required installation into the [Global Assembly Cache (GAC)](https://learn.microsoft.com/en-us/dotnet/framework/app-domains/gac), can make the update experience harder; by removing the module, we remove this constraint. 

--- a/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.csproj
+++ b/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Version>3.0.0-prerelease</Version>
     <!-- Unconditionally add a prerelease suffix to the package, but keep the rest of the name so we can associate it with the rest of the release -->
-    <Version>$(Version)-prerelease</Version>
+    <Version Condition="!$(Version.EndsWith('-prerelease'))">$(Version)-prerelease</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -15,9 +15,11 @@ namespace AspNetCoreSmokeTest
         public static volatile int ExitCode = 0;
         public static async Task<int> Main(string[] args)
         {
-            if (!IsProfilerAttached() && Environment.GetEnvironmentVariable("PROFILER_IS_NOT_REQUIRED") != "True")
+            var profilerNotRequired = Environment.GetEnvironmentVariable("PROFILER_IS_NOT_REQUIRED");
+
+            if (!IsProfilerAttached() &&  profilerNotRequired != "True")
             {
-                Console.WriteLine($"Error: Profiler is required and is not loaded. PROFILER_IS_NOT_REQUIRED={Environment.GetEnvironmentVariable("PROFILER_IS_NOT_REQUIRED")}.");
+                Console.WriteLine($"Error: Profiler is required and is not loaded. PROFILER_IS_NOT_REQUIRED={profilerNotRequired}.");
                 return 1;
             }
 

--- a/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
+++ b/tracer/test/test-applications/regression/AspNetCoreSmokeTest/Program.cs
@@ -15,9 +15,9 @@ namespace AspNetCoreSmokeTest
         public static volatile int ExitCode = 0;
         public static async Task<int> Main(string[] args)
         {
-            if (!IsProfilerAttached())
+            if (!IsProfilerAttached() && Environment.GetEnvironmentVariable("PROFILER_IS_NOT_REQUIRED") != "True")
             {
-                Console.WriteLine("Error: Profiler is required and is not loaded.");
+                Console.WriteLine($"Error: Profiler is required and is not loaded. PROFILER_IS_NOT_REQUIRED={Environment.GetEnvironmentVariable("PROFILER_IS_NOT_REQUIRED")}.");
                 return 1;
             }
 


### PR DESCRIPTION
## Summary of changes

- Rename the trimming package to avoid `-prerelease-prerelease` suffix
- Update the migration docs
- Add smoke tests to show that we don't crash if "glibc" bundle is used on alpine in arm64

## Reason for change

- Currently the Datadog.Trace.Trimming adds the `-prerelease` suffix twice
- Migration doc needed updates
  - The ASP.NET module error should describe the exact error the customer sees for easier discovery
  - Document removal of `DD_TRACE_OTEL_LEGACY_OPERATION_NAME_ENABLED` in https://github.com/DataDog/dd-trace-dotnet/pull/5787
  - Tweaks to doc
- Prior to universal binaries, if a customer used the arm64 `tar.gz` on alpine, we would crash. After the universal binaries, we still don't support alpine on arm64 yet, but we won't _crash_.

## Implementation details

Fairly obvious I hope

## Test coverage

- [x] Check the trimming NuGet is fixed
- [x] [Check the new noop tests pass](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=161239&view=results)
