### PR TITLE
Include a version.txt and index.txt in the uploaded Azure assets

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3779,6 +3779,14 @@ stages:
             path: $(Build.ArtifactStagingDirectory)
 
         - bash: |
+            # Write tracer version number to version.txt
+            echo "$(tracer_version)" > $(Build.ArtifactStagingDirectory)/version.txt
+
+            # Write file list to index.txt
+            ls "$(Build.ArtifactStagingDirectory)" > $(Build.ArtifactStagingDirectory)/index.txt
+          displayName: Write description of assets
+
+        - bash: |
             az storage blob upload-batch \
               --destination "$(AZURE_STORAGE_CONTAINER_NAME)" \
               --destination-path "$(Build.SourceVersion)" \


### PR DESCRIPTION
## Summary of changes

Adds a `version.txt` and `index.txt` to the uploaded bundle of assets

## Reason for change

To fetch the resources for a given commit, you need the exact filename. You can't easily get that without knowing the version. Index.txt similarly describes what's available.

## Implementation details

Write a version.txt and index.txt inside the SHA folder that's uploaded

## Test coverage

Running a manual `push_artifacts_to_azure_storage=true` to make sure it works
