### PR TITLE
Add ability to disable `ActivitySource`s from being listened to

### DIFF
--- a/tracer/src/Datadog.Trace/Activity/ActivityListenerHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/ActivityListenerHandler.cs
@@ -48,16 +48,34 @@ namespace Datadog.Trace.Activity
             {
                 if (source is IActivitySource activitySource)
                 {
-                    if (handler.ShouldListenTo(sName, activitySource.Version) && HandlerBySource.TryAdd(sName, handler))
+                    if (handler.ShouldListenTo(sName, activitySource.Version))
+                    {
+                        if (handler is DisableActivityHandler)
+                        {
+                            Log.Information("ActivityListenerHandler: {SourceName} will not be listened to by the .NET Tracer.", sName);
+                            return false;
+                        }
+
+                        if (HandlerBySource.TryAdd(sName, handler))
+                        {
+                            Log.Debug("ActivityListenerHandler: {SourceName} will be handled by {Handler}.", sName, handler);
+                            return true;
+                        }
+                    }
+                }
+                else if (handler.ShouldListenTo(sName, null))
+                {
+                    if (handler is DisableActivityHandler)
+                    {
+                        Log.Information("ActivityListenerHandler: {SourceName} will not be listened to by the .NET Tracer.", sName);
+                        return false;
+                    }
+
+                    if (HandlerBySource.TryAdd(sName, handler))
                     {
                         Log.Debug("ActivityListenerHandler: {SourceName} will be handled by {Handler}.", sName, handler);
                         return true;
                     }
-                }
-                else if (handler.ShouldListenTo(sName, null) && HandlerBySource.TryAdd(sName, handler))
-                {
-                    Log.Debug("ActivityListenerHandler: {SourceName} will be handled by {Handler}.", sName, handler);
-                    return true;
                 }
             }
 

--- a/tracer/src/Datadog.Trace/Activity/ActivityListenerHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/ActivityListenerHandler.cs
@@ -52,7 +52,7 @@ namespace Datadog.Trace.Activity
                     {
                         if (handler is DisableActivityHandler)
                         {
-                            Log.Information("ActivityListenerHandler: {SourceName} will not be listened to by the .NET Tracer.", sName);
+                            Log.Information("ActivityListenerHandler: The .NET Tracer will not listen to {SourceName}.", sName);
                             return false;
                         }
 
@@ -67,7 +67,7 @@ namespace Datadog.Trace.Activity
                 {
                     if (handler is DisableActivityHandler)
                     {
-                        Log.Information("ActivityListenerHandler: {SourceName} will not be listened to by the .NET Tracer.", sName);
+                        Log.Information("ActivityListenerHandler: The .NET Tracer will not listen to {SourceName}.", sName);
                         return false;
                     }
 

--- a/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlersRegister.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/ActivityHandlersRegister.cs
@@ -9,12 +9,17 @@ namespace Datadog.Trace.Activity.Handlers
 {
     internal static class ActivityHandlersRegister
     {
+        // Disable Activity Handler does not listen to the activity source at all.
+        internal static readonly DisableActivityHandler DisableHandler = new();
+
         // Ignore Activity Handler catches existing integrations that also emits activities.
         internal static readonly IgnoreActivityHandler IgnoreHandler = new();
 
         // Activity handlers in order, the first handler where ShouldListenTo returns true will always handle that source.
         internal static readonly IActivityHandler[] Handlers =
         {
+            DisableHandler,
+
             IgnoreHandler,
 
             // Azure Service Bus handlers

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DisableActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DisableActivityHandler.cs
@@ -1,0 +1,96 @@
+// <copyright file="DisableActivityHandler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Datadog.Trace.Activity.DuckTypes;
+using Datadog.Trace.Sampling;
+
+namespace Datadog.Trace.Activity.Handlers
+{
+    internal class DisableActivityHandler : IActivityHandler
+    {
+        private List<Regex>? _disabledSourceNameGlobs = null;
+        private bool _disableAll = false;
+
+        public void ActivityStarted<T>(string sourceName, T activity)
+            where T : IActivity
+        {
+            // do nothing; this should not be called
+        }
+
+        public void ActivityStopped<T>(string sourceName, T activity)
+            where T : IActivity
+        {
+            // do nothing; this should not be called
+        }
+
+        /// <summary>
+        /// Determines whether <see cref="DisableActivityHandler"/> will "listen" to <paramref name="sourceName"/>.
+        /// <para>
+        /// Note that "listen" in this case means that the created ActivityListener will not subscribe to the ActivitySource.
+        /// </para>
+        /// </summary>
+        /// <returns><see langword="true"/> when the Tracer will disable the ActivitySource; otherwise <see langword="false"/></returns>
+        public bool ShouldListenTo(string sourceName, string? version)
+        {
+            if (_disableAll)
+            {
+                return true; // "*" was specified as a pattern, short circuit to disable all
+            }
+
+            _disabledSourceNameGlobs ??= PopulateGlobs();
+            if (_disabledSourceNameGlobs.Count == 0)
+            {
+                return false; // no glob patterns specified, sourceName will not be disabled
+            }
+
+            foreach (var regex in _disabledSourceNameGlobs)
+            {
+                if (regex.IsMatch(sourceName))
+                {
+                    return true; // disable ActivitySource of "sourceName" from being listened to by the tracer
+                }
+            }
+
+            var toDisable = Tracer.Instance.Settings.DisabledActivitySources;
+            if (toDisable is null || toDisable.Length == 0)
+            {
+                return false;
+            }
+
+            // sources were specified to be disabled, but this sourceName didn't match any of them
+            return false; // sourceName will _not_ be disabled
+        }
+
+        private List<Regex> PopulateGlobs()
+        {
+            var globs = new List<Regex>();
+            var toDisable = Tracer.Instance.Settings.DisabledActivitySources;
+            if (toDisable is null || toDisable.Length == 0)
+            {
+                return globs;
+            }
+
+            foreach (var disabledSourceNameGlob in toDisable)
+            {
+                // HACK: using RegexBuilder here even though it isn't _really_ for this
+                var globRegex = RegexBuilder.Build(disabledSourceNameGlob, SamplingRulesFormat.Glob, RegexBuilder.DefaultTimeout);
+                // handle special case where a "*" pattern will be null
+                if (globRegex is null)
+                {
+                    _disableAll = true;
+                    return [];
+                }
+
+                globs.Add(globRegex);
+            }
+
+            return globs;
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Activity/Handlers/DisableActivityHandler.cs
+++ b/tracer/src/Datadog.Trace/Activity/Handlers/DisableActivityHandler.cs
@@ -57,12 +57,6 @@ namespace Datadog.Trace.Activity.Handlers
                 }
             }
 
-            var toDisable = Tracer.Instance.Settings.DisabledActivitySources;
-            if (toDisable is null || toDisable.Length == 0)
-            {
-                return false;
-            }
-
             // sources were specified to be disabled, but this sourceName didn't match any of them
             return false; // sourceName will _not_ be disabled
         }

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -104,7 +104,7 @@ namespace Datadog.Trace.Configuration
         /// Default is empty (all ActivitySources will be subscribed to by default).
         /// Supports multiple values separated with commas.
         /// </summary>
-        public const string DisabledActivitySources = "DD_DISABLED_ACTIVITY_SOURCES";
+        public const string DisabledActivitySources = "DD_TRACE_DISABLED_ACTIVITY_SOURCES";
 
         /// <summary>
         /// Configuration key for enabling or disabling default Analytics.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -100,6 +100,13 @@ namespace Datadog.Trace.Configuration
         public const string DisabledIntegrations = "DD_DISABLED_INTEGRATIONS";
 
         /// <summary>
+        /// Configuration key for a list of ActivitySource names (supports globbing) that will be disabled.
+        /// Default is empty (all ActivitySources will be subscribed to by default).
+        /// Supports multiple values separated with commas.
+        /// </summary>
+        public const string DisabledActivitySources = "DD_DISABLED_ACTIVITY_SOURCES";
+
+        /// <summary>
         /// Configuration key for enabling or disabling default Analytics.
         /// </summary>
         /// <seealso cref="TracerSettings.AnalyticsEnabled"/>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -102,8 +102,36 @@ namespace Datadog.Trace.Configuration
         /// <summary>
         /// Configuration key for a list of ActivitySource names (supports globbing) that will be disabled.
         /// Default is empty (all ActivitySources will be subscribed to by default).
+        /// <para><b>Disabling ActivitySources may break distributed tracing if those Activities are used to propagate trace context.</b></para>
+        /// <para>
         /// Supports multiple values separated with commas.
+        /// For example: "SomeGlob.*.PatternSource,Some.Specific.Source"
+        /// </para>
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When the tracer doesn't subscribe to an ActivitySource, we will <em>NOT</em> propagate the trace context from those Activities (we don't see them anymore).
+        /// <br/><b>This means that distributed tracing flows that rely on these Activities for context propagation
+        /// will break and cause disconnected traces.</b>
+        /// </para>
+        /// <para>
+        /// Potential impact on distributed tracing:
+        /// <list type="bullet">
+        /// <item>
+        ///   <description>
+        ///     Service A -> Ignored Activity -> Service B
+        ///     <para>Creates a single trace with Service A as root and Service B as child</para>
+        ///   </description>
+        /// </item>
+        /// <item>
+        ///   <description>
+        ///     Service A -> Disabled Activity -> Service B
+        ///     <para>Creates TWO separate traces with Service A and Service B each as root spans</para>
+        ///   </description>
+        /// </item>
+        /// </list>
+        /// </para>
+        /// </remarks>
         public const string DisabledActivitySources = "DD_TRACE_DISABLED_ACTIVITY_SOURCES";
 
         /// <summary>

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -602,6 +602,10 @@ namespace Datadog.Trace.Configuration
                 DisabledAdoNetCommandTypes.UnionWith(userSplit);
             }
 
+            var disabledActivitySources = config.WithKeys(ConfigurationKeys.DisabledActivitySources).AsString();
+
+            DisabledActivitySources = !string.IsNullOrEmpty(disabledActivitySources) ? TrimSplitString(disabledActivitySources, commaSeparator) : [];
+
             // we "enrich" with these values which aren't _strictly_ configuration, but which we want to track as we tracked them in v1
             telemetry.Record(ConfigTelemetryData.NativeTracerVersion, Instrumentation.GetNativeTracerVersion(), recordValue: true, ConfigurationOrigins.Default);
             telemetry.Record(ConfigTelemetryData.FullTrustAppDomain, value: AppDomain.CurrentDomain.IsFullyTrusted, ConfigurationOrigins.Default);

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -708,6 +708,12 @@ namespace Datadog.Trace.Configuration
         public HashSet<string> DisabledIntegrationNames { get; }
 
         /// <summary>
+        /// Gets the names of disabled ActivitySources.
+        /// </summary>
+        /// <seealso cref="ConfigurationKeys.DisabledActivitySources"/>
+        internal string[] DisabledActivitySources { get; }
+
+        /// <summary>
         /// Gets the transport settings that dictate how the tracer connects to the agent.
         /// </summary>
         public ExporterSettings Exporter { get; }

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
@@ -60,6 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public async Task SubmitsTraces()
         {
             SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
+            SetEnvironmentVariable("DD_DISABLED_ACTIVITY_SOURCES", "Disabled.By.ExactMatch,*.By.Glob*");
 
             using (var telemetry = this.ConfigureTelemetry())
             using (var agent = EnvironmentHelper.GetMockAgent())

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/NetActivitySdkTests.cs
@@ -60,7 +60,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         public async Task SubmitsTraces()
         {
             SetEnvironmentVariable("DD_TRACE_OTEL_ENABLED", "true");
-            SetEnvironmentVariable("DD_DISABLED_ACTIVITY_SOURCES", "Disabled.By.ExactMatch,*.By.Glob*");
+            SetEnvironmentVariable("DD_TRACE_DISABLED_ACTIVITY_SOURCES", "Disabled.By.ExactMatch,*.By.Glob*");
 
             using (var telemetry = this.ConfigureTelemetry())
             using (var agent = EnvironmentHelper.GetMockAgent())

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -552,7 +552,7 @@
   "DD_IAST_TRUNCATION_MAX_VALUE_LENGTH": "iast_truncation_max_value_length",
   "DD_IAST_DB_ROWS_TO_TAINT": "iast_db_rows_to_taint",
   "DD_IAST_COOKIE_FILTER_PATTERN": "iast_cookie_filter_pattern",
-  "DD_TRACE_DISABLED_ACTIVITY_SOURCES": "dd_trace_disabled_activity_sources",
+  "DD_TRACE_DISABLED_ACTIVITY_SOURCES": "trace_disabled_activity_sources",
   "DD_TRACE_STARTUP_LOGS": "trace_startup_logs_enabled",
   "DD_TRACE_DISABLED_ADONET_COMMAND_TYPES": "trace_disabled_adonet_command_types",
   "DD_MAX_LOGFILE_SIZE": "trace_log_file_max_size",

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -552,6 +552,7 @@
   "DD_IAST_TRUNCATION_MAX_VALUE_LENGTH": "iast_truncation_max_value_length",
   "DD_IAST_DB_ROWS_TO_TAINT": "iast_db_rows_to_taint",
   "DD_IAST_COOKIE_FILTER_PATTERN": "iast_cookie_filter_pattern",
+  "DD_TRACE_DISABLED_ACTIVITY_SOURCES": "dd_trace_disabled_activity_sources",
   "DD_TRACE_STARTUP_LOGS": "trace_startup_logs_enabled",
   "DD_TRACE_DISABLED_ADONET_COMMAND_TYPES": "trace_disabled_adonet_command_types",
   "DD_MAX_LOGFILE_SIZE": "trace_log_file_max_size",

--- a/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Program.cs
+++ b/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Program.cs
@@ -10,6 +10,9 @@ namespace NetActivitySdk;
 public static class Program
 {
     private static ActivitySource _source;
+    private static ActivitySource _ignored;
+    private static ActivitySource _disabledGlob;
+    private static ActivitySource _disabledExact;
 
     private static string SpanLinkTraceId1;
     private static string SpanLinkTraceId2;
@@ -21,12 +24,15 @@ public static class Program
     {
         Console.WriteLine($"SpanId 1: {SpanLinkSpanId1} SpanId 2: {SpanLinkSpanId2}");
         _source = new ActivitySource("Samples.NetActivitySdk");
+        _ignored = new ActivitySource("Microsoft.AspNetCore"); // this is an ignored source
+        _disabledGlob = new ActivitySource("Disabled.By.GlobPattern");
+        _disabledExact = new ActivitySource("Disabled.By.ExactMatch");
 
         var activityListener = new ActivityListener
         {
             //ActivityStarted = activity => Console.WriteLine($"{activity.DisplayName} - Started"),
             ActivityStopped = activity => PrintSpanStoppedInformation(activity),
-            ShouldListenTo = _ => true,
+            ShouldListenTo = source => { return !source.Name.Contains("Disabled"); }, // return true for all except Disabled ones
             Sample = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllData
         };
 
@@ -54,6 +60,8 @@ public static class Program
         RunActivityReservedAttributes(); // 1 span (47 total)
 
         RunManuallyUpdatedStartTime(); // 3 spans (50 total)
+
+        RunIgnoredAndDisabledSources(); // 0 spans (50 total)
 
         await Task.Delay(1000);
     }
@@ -209,6 +217,22 @@ public static class Program
                     Console.WriteLine(child.Id.Substring(1));
                 }
             }
+        }
+    }
+
+    private static void RunIgnoredAndDisabledSources()
+    {
+        using var ignoredSpan = _ignored.StartActivity("Ignored - SHOULD NOT BE IN SNAPSHOT") ?? throw new InvalidOperationException("Ignored Activity was null - was it disabled?");
+        using var disabledSpanGlob = _disabledGlob.StartActivity("DisabledGlob - SHOULD BE NULL AND NOT IN SNAPSHOT");
+        if (disabledSpanGlob is not null)
+        {
+            throw new InvalidOperationException("DisabledGlob Activity wasn't null");
+        }
+
+        using var disabledSpanExact = _disabledExact.StartActivity("DisabledExact - SHOULD BE NULL AND NOT IN SNAPSHOT");
+        if (disabledSpanExact is not null)
+        {
+            throw new InvalidOperationException("DisabledExact Activity wasn't null");
         }
     }
 

--- a/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Properties/launchSettings.json
@@ -17,7 +17,8 @@
 
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
         "DD_TRACE_OTEL_ENABLED": "true",
-        "DD_TRACE_DEBUG": "true"
+        "DD_TRACE_DEBUG": "true",
+        "DD_DISABLED_ACTIVITY_SOURCES": "Disabled.By.ExactMatch,*.By.Glob*"
       },
       "nativeDebugging": false
     },

--- a/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Properties/launchSettings.json
+++ b/tracer/test/test-applications/integrations/Samples.NetActivitySdk/Properties/launchSettings.json
@@ -18,7 +18,7 @@
         "DD_DOTNET_TRACER_HOME": "$(SolutionDir)shared\\bin\\monitoring-home",
         "DD_TRACE_OTEL_ENABLED": "true",
         "DD_TRACE_DEBUG": "true",
-        "DD_DISABLED_ACTIVITY_SOURCES": "Disabled.By.ExactMatch,*.By.Glob*"
+        "DD_TRACE_DISABLED_ACTIVITY_SOURCES": "Disabled.By.ExactMatch,*.By.Glob*"
       },
       "nativeDebugging": false
     },


### PR DESCRIPTION
## Summary of changes

This adds the ability for `ActivitySource`s to be disabled so that they won't be listened to by the .NET Tracer.

## Reason for change

Currently there is no way to disable an `ActivitySource` if OpenTelemetry is enabled in the .NET Tracer without entirely disabling OpenTelemetry support. The `IgnoreActivityHandler` is insufficient as it will still _listen_ to the `ActivitySource` so they will create `Activity` objects.

## Implementation details

- Adds `DD_TRACE_DISABLED_ACTIVITY_SOURCES` that accepts a comma-separated list of `ActivitySource` names that supports the glob-pattern.
  - example: `"DD_TRACE_DISABLED_ACTIVITY_SOURCES": "SomeSourceName,*SomeGlobPattern*"`
- Adds `DisableActivityHandler` that will determine based on the above environment variable whether or not a given `ActivitySource` should be listened to.

## Test coverage

- Updated the `NetActivitySdk` sample project with an ignored `ActivitySource` and some that are disabled.

## Other details
<!-- Fixes #{issue} -->

When merged, get this merged: https://github.com/DataDog/dd-go/pull/171612

Fixes #5740 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
