### PR TITLE
Improve handling of OOM

### DIFF
--- a/tracer/src/Datadog.Trace/LifetimeManager.cs
+++ b/tracer/src/Datadog.Trace/LifetimeManager.cs
@@ -80,6 +80,12 @@ namespace Datadog.Trace
 
         private void CurrentDomain_UnhandledException(object? sender, UnhandledExceptionEventArgs e)
         {
+            if (e == null || e.ExceptionObject is OutOfMemoryException)
+            {
+                // At this point, the runtime is in a bad state so we give up on exiting gracefully
+                return;
+            }
+
             Log.Warning("Application threw an unhandled exception: {Exception}", e.ExceptionObject);
             RunShutdownTasks(e.ExceptionObject as Exception);
             AppDomain.CurrentDomain.UnhandledException -= CurrentDomain_UnhandledException;


### PR DESCRIPTION
## Summary of changes

Make the tracer (and more specifically, the runtime metrics and the shutdown logic) more resilient to OutOfMemory exceptions.

## Reason for change

We've seen crash reports where the runtime metrics turn a recoverable OOM into an unrecoverable crash.

## Implementation details

There are a few problems fixed here:
 - We can't allocate when the system runs out of memory, so I added a specific allocation-free path for OOM in runtime metrics.
 - When things go horribly wrong, the `FirstChanceExceptionEventArgs` argument of the `FirstChanceException` method can be null. I'm not sure if it's expected or if it's a runtime bug.
 - In `LifetimeManager.CurrentDomain_UnhandledException`, bail out in case of OOM, since it's unlikely that we will be able to flush the traces anyway.

## Test coverage

Tested on my machine with a repro project, but because it's random I can't 100% guarantee the problem is gone. Given all the creative ways that it can crash the runtime, I don't think we want to build a test that OOMs on purpose.
