### PR TITLE
[Exception Replay] Improved exceptions capturing accuracy + fixed a crash caused by mishandling of exception case probe statuses

### DIFF
--- a/Datadog.Trace.Debugger.slnf
+++ b/Datadog.Trace.Debugger.slnf
@@ -19,6 +19,7 @@
       "tracer\\test\\Datadog.Trace.TestHelpers.AutoInstrumentation\\Datadog.Trace.TestHelpers.AutoInstrumentation.csproj",
       "tracer\\test\\Datadog.Trace.TestHelpers\\Datadog.Trace.TestHelpers.csproj",
       "tracer\\test\\Datadog.Trace.Tests\\Datadog.Trace.Tests.csproj",
+	  "tracer\\test\\Datadog.Tracer.Native.Tests\\Datadog.Tracer.Native.Tests.vcxproj",
       "tracer\\test\\test-applications\\debugger\\Samples.Probes\\Samples.Probes.csproj",
       "tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.External\\Samples.Probes.External.csproj",
       "tracer\\test\\test-applications\\debugger\\dependency-libs\\Samples.Probes.TestRuns\\Samples.Probes.TestRuns.csproj",

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionProbeProcessor.cs
@@ -101,12 +101,6 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 }
             }
 
-            if (instrumentedProbes.Any(p => p.ProbeStatus is Status.RECEIVED))
-            {
-                // Not all probes have been confirmed as installed, instrumented or errored out yet
-                return null;
-            }
-
             if (instrumentedProbes.Any(p => !p.MayBeOmittedFromCallStack && p.ProbeStatus == Status.INSTALLED))
             {
                 // Not all request rejit carried out yet.

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayDiagnosticTagNames.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayDiagnosticTagNames.cs
@@ -1,0 +1,31 @@
+// <copyright file="ExceptionReplayDiagnosticTagNames.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+#nullable enable
+namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
+{
+    /// <summary>
+    /// Assigned as a tag on incoming spans by <see cref="ExceptionTrackManager"/> for diagnostics purposes.
+    /// </summary>
+    internal static class ExceptionReplayDiagnosticTagNames
+    {
+        public const string None = nameof(None);
+        public const string Eligible = nameof(Eligible);
+        public const string EmptyShadowStack = nameof(EmptyShadowStack);
+        public const string ExceptionTrackManagerNotInitialized = nameof(ExceptionTrackManagerNotInitialized);
+        public const string NotRootSpan = nameof(NotRootSpan);
+        public const string ExceptionObjectIsNull = nameof(ExceptionObjectIsNull);
+        public const string NonSupportedExceptionType = nameof(NonSupportedExceptionType);
+        public const string CachedDoneExceptionCase = nameof(CachedDoneExceptionCase);
+        public const string InvalidatedExceptionCase = nameof(InvalidatedExceptionCase);
+        public const string CircuitBreakerIsOpen = nameof(CircuitBreakerIsOpen);
+    }
+}

--- a/tracer/src/Datadog.Trace/Span.cs
+++ b/tracer/src/Datadog.Trace/Span.cs
@@ -429,10 +429,7 @@ namespace Datadog.Trace
                     SetTag(Trace.Tags.ErrorType, exception.GetType().ToString());
                     SetTag(Trace.Tags.ErrorStack, exception.ToString());
 
-                    if (IsRootSpan)
-                    {
-                        ExceptionDebugging.Report(this, exception);
-                    }
+                    ExceptionDebugging.Report(this, exception);
                 }
                 catch (Exception ex)
                 {

--- a/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
+++ b/tracer/src/Datadog.Tracer.Native/clr_helpers.cpp
@@ -979,43 +979,24 @@ bool FindTypeDefByName(const shared::WSTRING& instrumentationTargetMethodTypeNam
                        const ComPtr<IMetaDataImport2>& metadata_import, mdTypeDef& typeDef)
 {
     mdTypeDef parentTypeDef = mdTypeDefNil;
-    auto nameParts = shared::Split(instrumentationTargetMethodTypeName, '+');
-    auto instrumentedMethodTypeName = instrumentationTargetMethodTypeName;
+    const auto nameParts = shared::Split(instrumentationTargetMethodTypeName, '+');
 
-    if (nameParts.size() == 2)
+    for (const auto& namePart : nameParts)
     {
-        // We're instrumenting a nested class, find the parent first
-        auto hr = metadata_import->FindTypeDefByName(nameParts[0].c_str(), mdTokenNil, &parentTypeDef);
+        auto hr = metadata_import->FindTypeDefByName(namePart.c_str(), parentTypeDef, &parentTypeDef);
 
         if (FAILED(hr))
         {
             // This can happen between .NET framework and .NET core, not all apis are
             // available in both. Eg: WinHttpHandler, CurlHandler, and some methods in
             // System.Data
-            Logger::Debug("Can't load the parent TypeDef: ", nameParts[0],
-                  " for nested class: ", instrumentationTargetMethodTypeName, ", Module: ", assemblyName);
+            Logger::Debug("Can't load the TypeDef for: ", instrumentationTargetMethodTypeName,
+                          ", Module: ", assemblyName);
             return false;
         }
-        instrumentedMethodTypeName = nameParts[1];
-    }
-    else if (nameParts.size() > 2)
-    {
-        Logger::Warn("Invalid TypeDef-only one layer of nested classes are supported: ", instrumentationTargetMethodTypeName,
-             ", Module: ", assemblyName);
-        return false;
     }
 
-    // Find the type we're instrumenting
-    auto hr = metadata_import->FindTypeDefByName(instrumentedMethodTypeName.c_str(), parentTypeDef, &typeDef);
-    if (FAILED(hr))
-    {
-        // This can happen between .NET framework and .NET core, not all apis are
-        // available in both. Eg: WinHttpHandler, CurlHandler, and some methods in
-        // System.Data
-        Logger::Debug("Can't load the TypeDef for: ", instrumentedMethodTypeName, ", Module: ", assemblyName);
-        return false;
-    }
-
+    typeDef = parentTypeDef;
     return true;
 }
 

--- a/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_probes_instrumentation_requester.cpp
@@ -656,6 +656,12 @@ int DebuggerProbesInstrumentationRequester::GetProbesStatuses(WCHAR** probeIds, 
 
     for (auto probeIndex = 0; probeIndex < probeIdsLength; probeIndex++)
     {
+        if (probeIds[probeIndex] == nullptr)
+        {
+            Logger::Warn("Received null probeId at index ", probeIndex);
+            continue;
+        }
+
         const auto& probeId = shared::WSTRING(probeIds[probeIndex]);
         std::shared_ptr<ProbeMetadata> probeMetadata;
         if (ProbesMetadataTracker::Instance()->TryGetMetadata(probeId, probeMetadata))

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RecursionWithInnerRefStructTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/snapshots/ProbeTests.RecursionWithInnerRefStructTest.verified.txt
@@ -1,0 +1,1905 @@
+﻿[
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "0"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "0"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "1"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "1"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "10"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "10"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "2"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "2"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "3"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "3"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "4"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "4"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "5"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "5"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "6"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "6"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "7"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "7"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "8"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "8"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "9"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iterations": {
+                "type": "Int32",
+                "value": "9"
+              },
+              "this": {
+                "type": "RecursionWithInnerRefStructTest",
+                "value": "RecursionWithInnerRefStructTest"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Recursive",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Recursive",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "0"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "0"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "1"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "1"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "2"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "2"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "3"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "3"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "4"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "4"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "5"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "5"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "6"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "6"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "7"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "7"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "8"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "8"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  },
+  {
+    "dd.span_id": "ScrubbedValue",
+    "dd.trace_id": "ScrubbedValue",
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "snapshot": {
+        "captures": {
+          "entry": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "9"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            }
+          },
+          "return": {
+            "arguments": {
+              "iteration": {
+                "type": "Int32",
+                "value": "9"
+              },
+              "method": {
+                "fields": {
+                  "_invocationCount": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_invocationList": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodBase": {
+                    "isNull": "true",
+                    "type": "Object"
+                  },
+                  "_methodPtr": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_methodPtrAux": {
+                    "type": "IntPtr",
+                    "value": "ScrubbedValue"
+                  },
+                  "_target": {
+                    "type": "Object",
+                    "value": "Object"
+                  }
+                },
+                "type": "Func`2",
+                "value": "Func`2"
+              }
+            },
+            "locals": {
+              "@return": {
+                "type": "Int32",
+                "value": "2147483647"
+              }
+            }
+          }
+        },
+        "duration": "ScrubbedValue",
+        "evaluationErrors": [
+          {
+            "expr": "\"1\")",
+            "message": "ScrubbedValue"
+          }
+        ],
+        "id": "ScrubbedValue",
+        "language": "dotnet",
+        "probe": {
+          "id": "ScrubbedValue",
+          "location": {
+            "method": "Me",
+            "type": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged"
+          },
+          "version": 0
+        },
+        "stack": "ScrubbedValue",
+        "timestamp": "ScrubbedValue"
+      }
+    },
+    "logger": {
+      "method": "Me",
+      "name": "Samples.Probes.TestRuns.SmokeTests.RecursionWithInnerRefStructTest+Deeper+PingPonged",
+      "thread_id": "ScrubbedValue",
+      "thread_name": "ScrubbedValue",
+      "version": "2"
+    },
+    "message": "ScrubbedValue",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NotSupportedFailureTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.NotSupportedFailureTest.verified.txt
@@ -32,6 +32,20 @@
     "debugger": {
       "diagnostics": {
         "exception": null,
+        "probeId": "22df6346-f993-1027-bd1a-f25f3a06ca56",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 22df6346-f993-1027-bd1a-f25f3a06ca56.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
         "probeId": "23827d5e-fc78-6898-4039-dec54409f8c4",
         "probeVersion": 0,
         "runtimeId": "scrubbed",
@@ -102,20 +116,6 @@
     "debugger": {
       "diagnostics": {
         "exception": null,
-        "probeId": "b16773f7-ded8-a522-43ce-b51d18f9205e",
-        "probeVersion": 0,
-        "runtimeId": "scrubbed",
-        "status": "EMITTING"
-      }
-    },
-    "message": "Emitted probe b16773f7-ded8-a522-43ce-b51d18f9205e.",
-    "service": "probes"
-  },
-  {
-    "ddsource": "dd_debugger",
-    "debugger": {
-      "diagnostics": {
-        "exception": null,
         "probeId": "f23aa325-ec46-b774-3f32-a89b9879ce7d",
         "probeVersion": 0,
         "runtimeId": "scrubbed",
@@ -123,24 +123,6 @@
       }
     },
     "message": "Emitted probe f23aa325-ec46-b774-3f32-a89b9879ce7d.",
-    "service": "probes"
-  },
-  {
-    "ddsource": "dd_debugger",
-    "debugger": {
-      "diagnostics": {
-        "exception": {
-          "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
-          "stacktrace": null,
-          "type": "NO_TYPE"
-        },
-        "probeId": "22df6346-f993-1027-bd1a-f25f3a06ca56",
-        "probeVersion": 0,
-        "runtimeId": "scrubbed",
-        "status": "ERROR"
-      }
-    },
-    "message": "Error installing probe 22df6346-f993-1027-bd1a-f25f3a06ca56.",
     "service": "probes"
   },
   {
@@ -202,6 +184,24 @@
     "debugger": {
       "diagnostics": {
         "exception": {
+          "message": "Dynamic Instrumentation of methods in a `ref-struct` is not yet supported.",
+          "stacktrace": null,
+          "type": "NO_TYPE"
+        },
+        "probeId": "b16773f7-ded8-a522-43ce-b51d18f9205e",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "ERROR"
+      }
+    },
+    "message": "Error installing probe b16773f7-ded8-a522-43ce-b51d18f9205e.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": {
           "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
           "stacktrace": null,
           "type": "NO_TYPE"
@@ -220,7 +220,7 @@
     "debugger": {
       "diagnostics": {
         "exception": {
-          "message": "Dynamic Instrumentation of methods in a `ref-struct` is not yet supported.",
+          "message": "Dynamic Instrumentation of methods that return a `ref struct` is not yet supported.",
           "stacktrace": null,
           "type": "NO_TYPE"
         },

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.RecursionWithInnerRefStructTest.verified.txt
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Approvals/statuses/ProbeTests.RecursionWithInnerRefStructTest.verified.txt
@@ -1,0 +1,30 @@
+﻿[
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "3410cda1-5b13-a34e-6f84-a54adf7a0ea0",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 3410cda1-5b13-a34e-6f84-a54adf7a0ea0.",
+    "service": "probes"
+  },
+  {
+    "ddsource": "dd_debugger",
+    "debugger": {
+      "diagnostics": {
+        "exception": null,
+        "probeId": "8286d046-9740-a3e4-95cf-ff46699c73c4",
+        "probeVersion": 0,
+        "runtimeId": "scrubbed",
+        "status": "EMITTING"
+      }
+    },
+    "message": "Emitted probe 8286d046-9740-a3e4-95cf-ff46699c73c4.",
+    "service": "probes"
+  }
+]

--- a/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
+++ b/tracer/test/Datadog.Tracer.Native.Tests/clr_helper_test.cpp
@@ -251,18 +251,30 @@ TEST_F(CLRHelperTest, FindNestedTypeDefsByName) {
   }
 }
 
-TEST_F(CLRHelperTest, DoesNotFindDoubleNestedTypeDefsByName) {
+TEST_F(CLRHelperTest, FindDoubleNestedTypeDefsByName) {
   std::vector<shared::WSTRING> expected_types = {
-      WStr("Samples.ExampleLibrary.NotARealClass"),
       WStr("Samples.ExampleLibrary.FakeClient.Biscuit+Cookie+Raisin")};
 
   for (auto& def : expected_types) {
     mdTypeDef typeDef = mdTypeDefNil;
     auto found = FindTypeDefByName(def, WStr("Samples.ExampleLibrary"),
                                    metadata_import_, typeDef);
-    EXPECT_FALSE(found) << "Failed type is : " << shared::ToString(def) << std::endl;
-    EXPECT_EQ(typeDef, mdTypeDefNil) << "Failed type is : " << shared::ToString(def) << std::endl;
+    EXPECT_TRUE(found) << "Failed type is : " << shared::ToString(def) << std::endl;
+    EXPECT_NE(typeDef, mdTypeDefNil) << "Failed type is : " << shared::ToString(def) << std::endl;
   }
+}
+
+TEST_F(CLRHelperTest, DoesNotFindDoubleNestedTypeDefsByName)
+{
+    std::vector<shared::WSTRING> expected_types = {WStr("Samples.ExampleLibrary.NotARealClass")};
+
+    for (auto& def : expected_types)
+    {
+        mdTypeDef typeDef = mdTypeDefNil;
+        auto found = FindTypeDefByName(def, WStr("Samples.ExampleLibrary"), metadata_import_, typeDef);
+        EXPECT_FALSE(found) << "Failed type is : " << shared::ToString(def) << std::endl;
+        EXPECT_EQ(typeDef, mdTypeDefNil) << "Failed type is : " << shared::ToString(def) << std::endl;
+    }
 }
 
 TEST_F(CLRHelperTest, TypeSignatureGetTypeTokName) {

--- a/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/RecursionWithInnerRefStructTest.cs
+++ b/tracer/test/test-applications/debugger/dependency-libs/Samples.Probes.TestRuns/SmokeTests/RecursionWithInnerRefStructTest.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Samples.Probes.TestRuns.SmokeTests
+{
+    internal class RecursionWithInnerRefStructTest : IAsyncRun
+    {
+        public async Task RunAsync()
+        {
+            await Recursive(10);
+        }
+
+        [LogMethodProbeTestData(expectedNumberOfSnapshots: 11)]
+        public async Task<int> Recursive(int iterations)
+        {
+            if (iterations <= 0)
+            {
+                return int.MaxValue;
+            }
+
+            await Task.Yield();
+            return await Deeper.PingPonged.Me(async (int iteration) => await Recursive(iteration), iterations - 1);
+        }
+
+        class Deeper
+        {
+            internal ref struct PingPonged
+            {
+                [LogMethodProbeTestData(expectedNumberOfSnapshots: 10)]
+                public static async Task<int> Me(Func<int, Task<int>> method, int iteration)
+                {
+                    await Task.Yield();
+                    return await method(iteration);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
- Improved the accuracy of capturing exceptions.
- Improved the diagnostic capabilities for the scenarios we fail to capture exception info, by introducing a new internal tag named `_dd.di.er` that will hold the phase of the exception case.
- Fixed a crash caused by querying invalid probe ids for instrumentation status via P/Invoke.

## Reason for change
There was a crash one of the early adopters of Exception Replay experienced. We also got feedback that there are certain exceptions which could not be captured by Exception Replay, thus showing no debug information. This PR aims to improve that.

## Implementation details
- Prevented exception probes from querying instrumentation status from the native side, similar safeguard is put in place in the native side as well.
- Handling a race condition that prevented us from tracking an exception to completion, when participating methods has failed in the lookup phase for instrumentation.
- Unlocked the ability to put probe in inner classes beyond one level of nesting. Previously, we supported only 1-level - now we support any level of nesting. It improves the coverage of Dynamic Instrumentation probes, and as result the coverage of Exception Replay.
- Improved our ability to proactively troubleshoot capturing issues of Exception Replay by introducing a new inner tag named `_dd.di.er` which holds a value representing the phase in which the exception resides. We can see this tag from within our Support Admin to have a better understating why a given case was not captured. Going forward, we may choose to use it for a better UX by communicating the phase with the customer.

## Test coverage
- Added a new test `RecursionWithInnerRefStructTest` that covers the nesting improvement.
- Exception Replay testing suite is WIP.