### PR TITLE
Build OCI images for every branch

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3589,6 +3589,53 @@ stages:
         testResultsFiles: tracer/build_data/results/**/*.trx
       condition: succeededOrFailed()
 
+- stage: store_ssi_artifacts
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), eq(variables.isMainRepository, true))
+  dependsOn: [package_linux, package_arm64, merge_commit_id]
+  variables:
+    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
+    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
+  jobs:
+    - job: combine
+      timeoutInMinutes: 60 #default value
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+        - checkout: none
+        # Linux packages
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Alpine tar packages
+          inputs:
+            artifact: linux-packages-linux-musl-x64
+            patterns: "*.tar.gz"
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux x64 packages
+          inputs:
+            artifact: linux-packages-linux-x64
+            patterns: "*.tar.gz"
+            path: $(Build.ArtifactStagingDirectory)
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux Arm64 packages
+          inputs:
+            artifact: linux-packages-linux-arm64
+            patterns: "*.tar.gz"
+            path: $(Build.ArtifactStagingDirectory)
+
+        - bash: |
+            TAR_NAME=$(basename $(Build.ArtifactStagingDirectory)/datadog-dotnet-apm-*.arm64.tar.gz)
+            VERSION_NUMBER=${TAR_NAME:19:-13}
+            echo "Detected version: $VERSION_NUMBER"
+            echo "$VERSION_NUMBER" > $(Build.ArtifactStagingDirectory)/version.txt
+          displayName: Write tracer version number to version.txt
+
+        # publish all tar files as single artifact
+        - publish: "$(Build.ArtifactStagingDirectory)"
+          displayName: Publish ssi artifacts
+          artifact: ssi-artifacts
+
 - stage: upload_to_azure
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), eq(variables.isMainRepository, true))
   dependsOn: [package_windows, package_linux, package_arm64, dotnet_tool, merge_commit_id]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -56,13 +56,20 @@ wait-for-single-step-artifacts:
     artifactName="ssi-artifacts"
 
     echo "Waiting for the azure devops build for branch '$branchName' for commit '$CI_COMMIT_SHA' to start"
-    allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName"
+    allBuildsForBranchUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName&reasonFilter=manual,individualCI"
 
-    # We should _definitely_ have the build by now, so if not, we bail out straight away with an error
-    buildId=$(curl -sS $allBuildsUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
+    # We should _definitely_ have the build by now, so if not, there probably won't be one
+    buildId=$(curl -sS $allBuildsForBranchUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
 
     if [ -z "${buildId}" ]; then
-      echo "No build found for commit '$CI_COMMIT_SHA' on branch '$branchName'"
+      echo "No build found for commit '$CI_COMMIT_SHA' on branch '$branchName'. Checking for PR builds..."
+      allBuildsForPrUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&reasonFilter=pullRequest"
+    
+      buildId=$(curl -sS $allBuildsForPrUrl | jq --arg version $CI_COMMIT_SHA --arg branch $CI_COMMIT_BRANCH '.value[] | select(.triggerInfo["pr.sourceBranch"] == $branch and .triggerInfo["pr.sourceSha"] == $version)  | .id' | head -n 1)
+    fi
+
+    if [ -z "${buildId}" ]; then
+      echo "No build found for commit '$CI_COMMIT_SHA' on branch '$branchName' (including PRs)"
       exit 1
     fi
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 
 stages:
   - build
-  - wait_for_artifacts
+  - single-step-testing
   - package
   - publish
   - deploy
@@ -42,7 +42,7 @@ build:
     - artifacts
 
 wait-for-single-step-artifacts:
-  stage: wait_for_artifacts
+  stage: single-step-testing
   image: registry.ddbuild.io/images/ci_docker_base
   tags: [ "runner:docker" ]
   when: delayed
@@ -104,7 +104,7 @@ wait-for-single-step-artifacts:
 compute-ci-package-snapshot-version:
   image: registry.ddbuild.io/ci/auto_inject/gitlab:current
   tags: ["arch:amd64"]
-  stage: wait_for_artifacts
+  stage: single-step-testing
   needs:
     - wait-for-single-step-artifacts
   script:
@@ -113,9 +113,11 @@ compute-ci-package-snapshot-version:
       echo "Generating CI DEV configuration from template"
       if test -f "artifacts/version.txt"; then
         #Set the version of the package
-        DOTNET_PACKAGE_DEV_VERSION=$(cat artifacts/version.txt).dev.${CI_COMMIT_SHORT_SHA}
+        DOTNET_PACKAGE_SPECIFIC_VERSION=$(cat artifacts/version.txt)
+        DOTNET_PACKAGE_DEV_VERSION=${DOTNET_PACKAGE_SPECIFIC_VERSION}.dev.${CI_COMMIT_SHORT_SHA}
       
         DOTNET_PACKAGE_MAJOR_VERSION=$(cat artifacts/version.txt | cut -d '.' -f 1)
+        echo "DOTNET_PACKAGE_SPECIFIC_VERSION=${DOTNET_PACKAGE_SPECIFIC_VERSION}"
         echo "DOTNET_PACKAGE_DEV_VERSION=${DOTNET_PACKAGE_DEV_VERSION}"
         echo "DOTNET_PACKAGE_MAJOR_VERSION=${DOTNET_PACKAGE_MAJOR_VERSION}"
 
@@ -133,6 +135,18 @@ compute-ci-package-snapshot-version:
   artifacts:
     paths:
       - gitlab-ci-snapshot-package-test.yml
+
+trigger-package-snapshot-testing:
+  stage: single-step-testing
+  needs:
+    - compute-ci-package-snapshot-version
+  variables:
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID
+  trigger:
+    strategy: depend
+    include:
+      - artifact: gitlab-ci-snapshot-package-test.yml
+        job: compute-ci-package-snapshot-version
 
 publish:
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 
 stages:
   - build
+  - wait_for_artifacts
   - package
   - publish
   - deploy
@@ -39,6 +40,99 @@ build:
     expire_in: 2 weeks
     paths:
     - artifacts
+
+wait-for-single-step-artifacts:
+  stage: wait_for_artifacts
+  image: registry.ddbuild.io/images/ci_docker_base
+  tags: [ "runner:docker" ]
+  when: delayed
+  start_in: 20 minutes
+  script: |
+    #Create a directory to store the files
+    target_dir=artifacts
+    mkdir -p $target_dir
+
+    branchName="refs/heads/$CI_COMMIT_BRANCH"
+    artifactName="ssi-artifacts"
+
+    echo "Waiting for the azure devops build for branch '$branchName' for commit '$CI_COMMIT_SHA' to start"
+    allBuildsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds?api-version=7.1&definitions=54&\$top=10&queryOrder=queueTimeDescending&branchName=$branchName"
+
+    # We should _definitely_ have the build by now, so if not, we bail out straight away with an error
+    buildId=$(curl -sS $allBuildsUrl | jq --arg version $CI_COMMIT_SHA '.value[] | select(.sourceVersion == $version and .reason != "schedule")  | .id' | head -n 1)
+
+    if [ -z "${buildId}" ]; then
+      echo "No build found for commit '$CI_COMMIT_SHA' on branch '$branchName'"
+      exit 1
+    fi
+
+    echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA' on branch '$branchName'"
+    
+    # Now try to download the ssi artifacts from the build
+    artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"
+
+    # Keep trying to get the artifact for 30 minutes
+    TIMEOUT=1800
+    STARTED=0
+    until (( STARTED == TIMEOUT )) || [ ! -z "${downloadUrl}" ] ; do
+        echo "Checking for artifacts at '$artifactsUrl'..."
+        # If the artifact doesn't exist, .resource.downloadUrl will be null, so we filter that out
+        downloadUrl=$(curl -s $artifactsUrl | jq -r '.resource.downloadUrl | select( . != null )')
+        sleep 100
+        (( STARTED += 100 ))
+    done
+    (( STARTED < TIMEOUT ))
+
+    if [ -z "${downloadUrl}" ]; then
+      echo "No downloadUrl found after 30 minutes for commit '$CI_COMMIT_SHA' on branch '$branchName'"
+      exit 1
+    fi
+
+    echo "Downloading artifacts from '$downloadUrl'..."
+    curl -o $target_dir/artifacts.zip "$downloadUrl"
+    unzip $target_dir/artifacts.zip -d $target_dir
+    mv $target_dir/$artifactName/* $target_dir
+    rm -rf $target_dir/artifacts.zip
+    rmdir $target_dir/$artifactName
+
+    ls -l $target_dir
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+    - artifacts
+    
+compute-ci-package-snapshot-version:
+  image: registry.ddbuild.io/ci/auto_inject/gitlab:current
+  tags: ["arch:amd64"]
+  stage: wait_for_artifacts
+  needs:
+    - wait-for-single-step-artifacts
+  script:
+    - cp .gitlab/.gitlab-ci-snapshot-package-test-template.yml gitlab-ci-snapshot-package-test.yml
+    - |
+      echo "Generating CI DEV configuration from template"
+      if test -f "artifacts/version.txt"; then
+        #Set the version of the package
+        DOTNET_PACKAGE_DEV_VERSION=$(cat artifacts/version.txt).dev.${CI_COMMIT_SHORT_SHA}
+      
+        DOTNET_PACKAGE_MAJOR_VERSION=$(cat artifacts/version.txt | cut -d '.' -f 1)
+        echo "DOTNET_PACKAGE_DEV_VERSION=${DOTNET_PACKAGE_DEV_VERSION}"
+        echo "DOTNET_PACKAGE_MAJOR_VERSION=${DOTNET_PACKAGE_MAJOR_VERSION}"
+
+        #Set values in the gitlab-ci file
+        sed -i "s/DOTNET_PACKAGE_SPECIFIC_VERSION:/DOTNET_PACKAGE_SPECIFIC_VERSION: ${DOTNET_PACKAGE_SPECIFIC_VERSION}/g" gitlab-ci-snapshot-package-test.yml 
+        sed -i 's/description: "Three parts version for current build"/##/g' gitlab-ci-snapshot-package-test.yml
+        sed -i "s/DOTNET_PACKAGE_DEV_VERSION:/DOTNET_PACKAGE_DEV_VERSION: ${DOTNET_PACKAGE_DEV_VERSION}/g" gitlab-ci-snapshot-package-test.yml 
+        sed -i 's/description: "Specific version for current build"/##/g' gitlab-ci-snapshot-package-test.yml
+        sed -i "s/DOTNET_PACKAGE_MAJOR_VERSION:/DOTNET_PACKAGE_MAJOR_VERSION: ${DOTNET_PACKAGE_MAJOR_VERSION}/g" gitlab-ci-snapshot-package-test.yml 
+        sed -i 's/description: "Major version. By default all builds are generated with the same major version"/##/g' gitlab-ci-snapshot-package-test.yml
+      fi
+      echo "----------------------------------"
+      echo "----------------------------------"
+      cat gitlab-ci-snapshot-package-test.yml   
+  artifacts:
+    paths:
+      - gitlab-ci-snapshot-package-test.yml
 
 publish:
   only:

--- a/.gitlab/.gitlab-ci-snapshot-package-test-template.yml
+++ b/.gitlab/.gitlab-ci-snapshot-package-test-template.yml
@@ -1,0 +1,95 @@
+
+stages:
+  - package
+  - single-step-instrumentation-tests
+  - publish
+  - release
+
+include:
+  - remote: https://gitlab-templates.ddbuild.io/apm/packaging.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/single-step-instrumentation-tests.yml
+
+variables:
+  GIT_PROFILER_REF: master
+  DOTNET_PACKAGE_SPECIFIC_VERSION:
+    description: "Three parts version for current build"
+  DOTNET_PACKAGE_DEV_VERSION:
+    description: "Specific version for current build"
+  DOTNET_PACKAGE_MAJOR_VERSION:
+    description: "Major version. By default all builds are generated with the same major version"
+  DOCKER_BINARIES_IMAGE: ghcr.io/datadog/dd-trace-dotnet/apm-library-dotnet
+
+download-extract-binaries:
+  stage: package
+  image: registry.ddbuild.io/images/ci_docker_base
+  tags: ["runner:docker"]
+  before_script:
+    - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-dotnet.gh_ghcr_token --with-decryption --query "Parameter.Value" --out text)
+  script:
+    - mkdir -p artifacts
+    - echo $GH_TOKEN|docker login ghcr.io -u publisher --password-stdin
+    - .gitlab/extract_docker_image.sh ${DOCKER_BINARIES_IMAGE}:${CI_COMMIT_SHA} artifacts
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - artifacts/
+
+package-snapshot:
+  extends: .package
+  needs: [download-extract-binaries]
+  rules:
+    - if: $DOTNET_PACKAGE_DEV_VERSION
+      when: on_success
+  script:
+    - ../.gitlab/build-deb-rpm.sh
+  variables:
+    ARCH: amd64
+
+package-arm-snapshot:
+  extends: .package-arm
+  needs: [download-extract-binaries]
+  rules:
+    - if: $DOTNET_PACKAGE_DEV_VERSION
+      when: on_success
+  script:
+    - ../.gitlab/build-deb-rpm.sh
+  variables:
+    ARCH: arm64
+
+package-oci-snapshot:
+  stage: package
+  needs: [download-extract-binaries]
+  extends: .package-oci
+  rules:
+    - if: $DOTNET_PACKAGE_DEV_VERSION
+      when: on_success
+  script:
+    - ../.gitlab/build-oci.sh
+  parallel:
+    matrix:
+      - ARCH:
+          - arm64
+          - amd64
+
+onboarding_tests:
+  extends: .base_job_onboarding
+  stage: single-step-instrumentation-tests
+  needs: [package-snapshot,package-arm-snapshot,package-oci-snapshot]
+  allow_failure: false
+  variables:
+    TEST_LIBRARY: dotnet
+    ONBOARDING_FILTER_ENV: prod
+  parallel:
+    matrix:
+      - ONBOARDING_FILTER_WEBLOG: [test-app-dotnet]
+        SCENARIO: [SIMPLE_HOST_AUTO_INJECTION]
+      - ONBOARDING_FILTER_WEBLOG: [test-app-dotnet-container]
+        SCENARIO: [SIMPLE_CONTAINER_AUTO_INJECTION]
+  script:
+    - git clone https://git@github.com/DataDog/system-tests.git system-tests
+    - cp packaging/*.rpm system-tests/binaries
+    - cp packaging/*.deb system-tests/binaries
+    - ls system-tests/binaries
+    - cd system-tests
+    - ./build.sh -i runner
+    - timeout 2700s ./run.sh $SCENARIO --vm-weblog ${ONBOARDING_FILTER_WEBLOG} --vm-env prod --vm-library ${TEST_LIBRARY} --vm-provider aws --vm-skip-branches ubuntu18_amd64

--- a/.gitlab/.gitlab-ci-snapshot-package-test-template.yml
+++ b/.gitlab/.gitlab-ci-snapshot-package-test-template.yml
@@ -19,24 +19,12 @@ variables:
     description: "Major version. By default all builds are generated with the same major version"
   DOCKER_BINARIES_IMAGE: ghcr.io/datadog/dd-trace-dotnet/apm-library-dotnet
 
-download-extract-binaries:
-  stage: package
-  image: registry.ddbuild.io/images/ci_docker_base
-  tags: ["runner:docker"]
-  before_script:
-    - export GH_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-trace-dotnet.gh_ghcr_token --with-decryption --query "Parameter.Value" --out text)
-  script:
-    - mkdir -p artifacts
-    - echo $GH_TOKEN|docker login ghcr.io -u publisher --password-stdin
-    - .gitlab/extract_docker_image.sh ${DOCKER_BINARIES_IMAGE}:${CI_COMMIT_SHA} artifacts
-  artifacts:
-    expire_in: 2 weeks
-    paths:
-      - artifacts/
 
 package-snapshot:
   extends: .package
-  needs: [download-extract-binaries]
+  needs:
+    - pipeline: $PARENT_PIPELINE_ID
+      job: wait-for-single-step-artifacts
   rules:
     - if: $DOTNET_PACKAGE_DEV_VERSION
       when: on_success
@@ -47,7 +35,9 @@ package-snapshot:
 
 package-arm-snapshot:
   extends: .package-arm
-  needs: [download-extract-binaries]
+  needs:
+    - pipeline: $PARENT_PIPELINE_ID
+      job: wait-for-single-step-artifacts
   rules:
     - if: $DOTNET_PACKAGE_DEV_VERSION
       when: on_success
@@ -58,7 +48,9 @@ package-arm-snapshot:
 
 package-oci-snapshot:
   stage: package
-  needs: [download-extract-binaries]
+  needs:
+    - pipeline: $PARENT_PIPELINE_ID
+      job: wait-for-single-step-artifacts
   extends: .package-oci
   rules:
     - if: $DOTNET_PACKAGE_DEV_VERSION

--- a/.gitlab/build-deb-rpm.sh
+++ b/.gitlab/build-deb-rpm.sh
@@ -10,25 +10,49 @@ if [ -z "$ARCH" ]; then
   ARCH=amd64
 fi
 
-curl --location --fail \
-  --output datadog-dotnet-apm.old \
-  "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$DOTNET_PACKAGE_VERSION/datadog-dotnet-apm_${DOTNET_PACKAGE_VERSION}_$ARCH.deb"
+if [ "$ARCH" == "amd64" ]; then
+  SUFFIX=""
+elif [ "$ARCH" == "arm64" ]; then
+  SUFFIX=".arm64"
+else
+  echo "Unsupported architecture: $ARCH"
+  exit 1
+fi
 
-fpm --input-type deb \
-  --output-type dir \
-  --name datadog-dotnet-apm \
-  datadog-dotnet-apm.old
+if [ -n "$DOTNET_PACKAGE_SPECIFIC_VERSION" ]; then
+  echo "Generating packages using local binaries. Set dev version: $DOTNET_PACKAGE_DEV_VERSION"
+  DOTNET_PACKAGE_VERSION=${DOTNET_PACKAGE_DEV_VERSION}
+  SRC_TAR="../artifacts/datadog-dotnet-apm-$DOTNET_PACKAGE_SPECIFIC_VERSION${SUFFIX}.tar.gz"
+
+  if [ ! -f $SRC_TAR ]; then
+      echo "$SRC_TAR was not found!"
+      exit 1
+  fi
+
+  cp $SRC_TAR datadog-dotnet-apm.tar.gz
+  
+else
+  curl --location --fail \
+    --output datadog-dotnet-apm.tar.gz \
+    "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$DOTNET_PACKAGE_VERSION/datadog-dotnet-apm-${DOTNET_PACKAGE_VERSION}${SUFFIX}.tar.gz"
+fi
+
+# extract the tarball, making sure to preserve the owner and permissions
+OUT_DIR=datadog-dotnet-apm.dir
+mkdir -p $OUT_DIR
+tar --same-owner -pxvzf datadog-dotnet-apm.tar.gz -C $OUT_DIR
 
 echo -n $DOTNET_PACKAGE_VERSION > auto_inject-dotnet.version
+cp auto_inject-dotnet.version $OUT_DIR/version
 
-cp auto_inject-dotnet.version datadog-dotnet-apm.dir/opt/datadog/version
+ls -l $OUT_DIR
 
 # Build packages
 fpm_wrapper "datadog-apm-library-dotnet" "$DOTNET_PACKAGE_VERSION" \
   --input-type dir \
-  --chdir=datadog-dotnet-apm.dir/opt/datadog \
+  --chdir=$OUT_DIR \
   --prefix "$LIBRARIES_INSTALL_BASE/dotnet" \
-  --after-install datadog-dotnet-apm.dir/opt/datadog/createLogPath.sh \
+  --after-install $OUT_DIR/createLogPath.sh \
   --url "https://github.com/DataDog/dd-trace-dotnet" \
   --license "Apache License 2.0" \
   --description "Datadog APM client library for .NET" \

--- a/.gitlab/build-oci.sh
+++ b/.gitlab/build-oci.sh
@@ -10,21 +10,44 @@ if [ -z "$ARCH" ]; then
   ARCH=amd64
 fi
 
+if [ "$ARCH" == "amd64" ]; then
+  SUFFIX=""
+elif [ "$ARCH" == "arm64" ]; then
+  SUFFIX=".arm64"
+else
+  echo "Unsupported architecture: $ARCH"
+  exit 1
+fi
+
 TMP_DIR=$(mktemp --dir)
+ 
+if [ -n "$DOTNET_PACKAGE_SPECIFIC_VERSION" ]; then
+  echo "Generating packages using local binaries. Set dev version: $DOTNET_PACKAGE_DEV_VERSION"
+  DOTNET_PACKAGE_VERSION=${DOTNET_PACKAGE_DEV_VERSION}
+  SRC_TAR="../artifacts/datadog-dotnet-apm-$DOTNET_PACKAGE_SPECIFIC_VERSION${SUFFIX}.tar.gz"
 
-curl --location --fail \
-  --output $TMP_DIR/datadog-dotnet-apm.old \
-  "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$DOTNET_PACKAGE_VERSION/datadog-dotnet-apm_${DOTNET_PACKAGE_VERSION}_$ARCH.deb"
+  if [ ! -f $SRC_TAR ]; then
+      echo "$SRC_TAR was not found!"
+      exit 1
+  fi
 
-fpm --input-type deb \
-  --output-type dir \
-  --name datadog-dotnet-apm \
-  --package $TMP_DIR \
-  $TMP_DIR/datadog-dotnet-apm.old
+  cp $SRC_TAR $TMP_DIR/datadog-dotnet-apm.tar.gz
+  
+else
+  curl --location --fail \
+    --output $TMP_DIR/datadog-dotnet-apm.tar.gz \
+    "https://github.com/DataDog/dd-trace-dotnet/releases/download/v$DOTNET_PACKAGE_VERSION/datadog-dotnet-apm-${DOTNET_PACKAGE_VERSION}${SUFFIX}.tar.gz"
+fi
+
+# extract the tarball, making sure to preserve the owner and permissions
+OUT_DIR=$TMP_DIR/datadog-dotnet-apm.dir
+mkdir -p $OUT_DIR
+tar --same-owner -pxvzf $TMP_DIR/datadog-dotnet-apm.tar.gz -C $OUT_DIR
 
 echo -n $DOTNET_PACKAGE_VERSION > auto_inject-dotnet.version
+cp auto_inject-dotnet.version $OUT_DIR/version
 
-cp auto_inject-dotnet.version $TMP_DIR/datadog-dotnet-apm.dir/opt/datadog/version
+ls -l $OUT_DIR
 
 # Build packages
 datadog-package create \
@@ -34,4 +57,4 @@ datadog-package create \
     --archive-path="datadog-apm-library-dotnet-$DOTNET_PACKAGE_VERSION-$ARCH.tar" \
     --arch "$ARCH" \
     --os "linux" \
-    $TMP_DIR/datadog-dotnet-apm.dir/opt/datadog
+    $OUT_DIR


### PR DESCRIPTION
## Summary of changes

- Adds a convenience stage to Azure Devops for collating SSI artifacts (tar.gz)
- Update OCI/deb/rpm to build based on tar artifacts instead of deb/rpm
- Add stages to GitLab to automatically build and test the OCI/deb/rpm images on every branch

## Reason for change

- We want to switch to using the tar.gz artifacts as we're going to include the musl artifacts in there later, so this makes things easier
- We currently are YOLOing the OCI releases without any testing. That's bad. This adds some testing at least.

## Implementation details

Brace yourself for some contrived situations...

1. When a branch is pushed, GitLab triggers a build, which delays for 20mins...
2. Azure Devops build runs on PRs/master/manually etc.
3. Azure Devops creates an `ssi-artifacts` artifact that contains all the tar.gz files (x64/musl-x64/arm64)
4. After 20 mins, the Gitlab job triggers, calls the Azure Devops REST API to list the builds associated with the current branch, and searches for the first build that matches the commit (yes, there are edge cases here, no, we don't care too much right now tbh)
5. The GitLab job tries to grab the `ssi-artifacts` for the given build. If it's not there, it sleeps and polls until it's available, or until it times out (again, hacky, but YOLO)
6. If it finds the artifacts, it downloads them, and generates the SSI build and test pipeline stages
7. Generate deb/rpm/OCI images based on the downloaded tar.gz artifacts (when running in the branch) or the _release_ tar files (when running as part of the release)
8. Runs the OCI/deb tests against the artifacts 🎉 

## Test coverage

- Ran a test [here](https://gitlab.ddbuild.io/DataDog/dd-trace-dotnet/-/pipelines/39929160) and all looks good AFAICT
- Compared the generated deb and OCI images, and they look the same to me (except one small caveat, the `tar` file versions include a `.scripts` folder that wasn't there in the debs, but that's benign.
- My only concern is that the `build-oci.sh` scripts break when we _Actually_ do the release, but I think we'll deal with that as we come to it. As long as the updated `curl` command is correct, I think we should be pretty safe 🤞 

## Other details

Caveats:

- Based on this PR by @robertomonteromiguel:
  - https://github.com/DataDog/dd-trace-dotnet/pull/5498
- This will all be replaced by one-pipeline soon, but we still want to get this in ASAP
- We don't currently test the musl artifacts
- There's some annoying differences between the oci and deb scripts that I'd love to normalize, but now is not the time...
