### PR TITLE
Tracer flare - Inspect the AGENT_CONFIG content to set the log level

### DIFF
--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -370,7 +370,7 @@ internal class TracerFlareManager : ITracerFlareManager
         }
         catch (Exception ex)
         {
-            Log.Warning(ex, "Invalid configuration provided for tracer flare");
+            Log.Error(ex, "Invalid configuration provided for tracer flare");
         }
 
         return false;

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -354,9 +354,17 @@ internal class TracerFlareManager : ITracerFlareManager
     {
         try
         {
+            var remoteConfigPath = remoteConfig.Path;
+
+            if (remoteConfigPath.Id.Equals("flare-log-level.debug", StringComparison.Ordinal)
+                || remoteConfigPath.Id.Equals("flare-log-level.trace", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
             var json = JObject.Parse(EncodingHelpers.Utf8NoBom.GetString(remoteConfig.Contents));
 
-            var logLevel = json["log_level"]?.Value<string>();
+            var logLevel = json["config"]?["log_level"]?.Value<string>();
 
             return logLevel is not null
                 && (logLevel.Equals("debug", StringComparison.OrdinalIgnoreCase)

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -370,7 +370,7 @@ internal class TracerFlareManager : ITracerFlareManager
         }
         catch (Exception ex)
         {
-            Log.Debug(ex, "Invalid configuration provided for tracer flare");
+            Log.Warning(ex, "Invalid configuration provided for tracer flare");
         }
 
         return false;

--- a/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
+++ b/tracer/src/Datadog.Trace/Logging/TracerFlare/TracerFlareManager.cs
@@ -6,11 +6,9 @@
 #nullable enable
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
@@ -110,7 +108,7 @@ internal class TracerFlareManager : ITracerFlareManager
          && requestedConfig.Count > 0)
         {
             var handled = await HandleTracerFlareRequested(requestedConfig).ConfigureAwait(false);
-            results = results is null ? handled : [.. results, .. handled];
+            results = results is null ? handled : [..results, ..handled];
         }
 
         if (removedConfigByProduct?.TryGetValue(RcmProducts.TracerFlareInitiated, out var removedConfig) == true


### PR DESCRIPTION
## Summary of changes

When receiving the AGENT_CONFIG remote config, inspect the json to extract the log level, instead of relying only on the filename.

## Reason for change

The filename is subject to change.

## Implementation details

In theory we should remove entirely the old behavior (checking the file name) but the AGENT_CONFIG seems broken at the moment so I can't properly test it. To play it safe, I just merged the new and old logic.

## Test coverage

Added a test case with a file name that doesn't contain the log level.