### PR TITLE
[Samples] Update IIS sample Dockerfile

### DIFF
--- a/tracer/samples/IISInDocker/.dockerignore
+++ b/tracer/samples/IISInDocker/.dockerignore
@@ -1,0 +1,8 @@
+.idea
+.vs
+.vscode
+README.md
+src/bin/
+src/obj/
+src/**/*.user
+src/**/*.suo

--- a/tracer/samples/IISInDocker/Dockerfile
+++ b/tracer/samples/IISInDocker/Dockerfile
@@ -22,9 +22,7 @@ COPY install-dd-trace-dotnet.ps1 startup.ps1 ./
 # Install the Datadog SDK for .NET using the msi installer
 RUN .\install-dd-trace-dotnet.ps1
 
-# Remove the default ENTRYPOINT "C:\ServiceMonitor.exe w3svc"
-ENTRYPOINT []
-
 # Note: Normally an IIS reset is also required but 'C:\ServiceMonitor.exe w3svc'
 # will restart IIS and update the environment variables received by the child w3wp processes
-CMD .\startup.ps1
+# Replace the default ENTRYPOINT "C:\ServiceMonitor.exe w3svc"
+ENTRYPOINT .\startup.ps1

--- a/tracer/samples/IISInDocker/Dockerfile
+++ b/tracer/samples/IISInDocker/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/framework/sdk:4.8 AS build
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
-COPY *.sln .
+COPY *.sln ./
 COPY src/*.csproj ./src/
 COPY src/*.config ./src/
 RUN nuget restore
@@ -15,24 +15,16 @@ RUN msbuild /p:Configuration=Release
 
 ### Stage: runtime
 FROM mcr.microsoft.com/dotnet/framework/aspnet:4.8-windowsservercore-ltsc2019 AS runtime
-SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
-
 WORKDIR /inetpub/wwwroot
 COPY --from=build /app/src/. ./
-COPY startup.ps1 .
+COPY install-dd-trace-dotnet.ps1 startup.ps1 ./
 
-# Install the .NET Tracer MSI
+# Install the Datadog SDK for .NET using the msi installer
+RUN .\install-dd-trace-dotnet.ps1
+
+# Remove the default ENTRYPOINT "C:\ServiceMonitor.exe w3svc"
+ENTRYPOINT []
+
 # Note: Normally an IIS reset is also required but 'C:\ServiceMonitor.exe w3svc'
 # will restart IIS and update the environment variables received by the child w3wp processes
-RUN Write-Host 'Determining latest release' ;\
-    $releases = 'https://api.github.com/repos/DataDog/dd-trace-dotnet/releases' ;\
-    $tag = (Invoke-WebRequest $releases -UseBasicParsing | ConvertFrom-Json)[0].tag_name ;\
-    $version = $tag.Split('v')[1] ;\
-    Write-Host "Downloading Datadog .NET Tracer $tag" ;\
-    (New-Object System.Net.WebClient).DownloadFile('https://github.com/DataDog/dd-trace-dotnet/releases/download/' + $tag + '/datadog-dotnet-apm-' + $version + '-x64.msi', 'datadog-apm.msi') ;\
-    Write-Host 'Installing Datadog .NET Tracer' ;\
-    Start-Process -Wait msiexec -ArgumentList '/i datadog-apm.msi /quiet /qn /norestart /log datadog-apm-msi-installer.log' ; \
-    Write-Host 'Datadog .NET Tracer installed, removing installer file' ;\
-    Remove-Item 'datadog-apm.msi' ;
-
-ENTRYPOINT ["powershell.exe", ".\\startup.ps1"]
+CMD .\startup.ps1

--- a/tracer/samples/IISInDocker/README.md
+++ b/tracer/samples/IISInDocker/README.md
@@ -1,5 +1,5 @@
 # ASP.NET Docker Sample
-This sample demonstrates how to build and deploy an ASP.NET Framework application in IIS using a Windows container. This also demonstrates how to configure environment variables using at the time of container startup, which may be the earliest that time that IP's and networking values are populated.
+This sample demonstrates how to build and deploy an ASP.NET application in IIS using a Windows container. This also demonstrates how to configure environment variables during container startup, which may be the earliest time that IPs and networking values are populated.
 
 ## Build and Run
 To build and run the application, open a terminal in this directory and run the following commands:

--- a/tracer/samples/IISInDocker/install-dd-trace-dotnet.ps1
+++ b/tracer/samples/IISInDocker/install-dd-trace-dotnet.ps1
@@ -1,0 +1,23 @@
+$outPath = $env:TEMP # change this to save the msi and log file to a different path
+
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+Write-Host 'Finding latest release of Datadog SDK for .NET.'
+$releases = 'https://api.github.com/repos/DataDog/dd-trace-dotnet/releases/latest'
+$tag = (Invoke-WebRequest $releases -UseBasicParsing | ConvertFrom-Json)[0].tag_name
+$version = $tag.Substring(1)
+$msiFilename = "$outPath\datadog-dotnet-apm-$version-x64.msi"
+$logFilename = "$outPath\datadog-dotnet-apm-$version-x64.log"
+$url = "https://github.com/DataDog/dd-trace-dotnet/releases/download/$tag/datadog-dotnet-apm-$version-x64.msi"
+
+Write-Host "Found installer for Datadog SDK for .NET $tag"
+Write-Host "- downloading from ""$url"""
+Write-Host "- saving to ""$msiFilename"""
+Invoke-WebRequest -Uri $url -OutFile $msiFilename
+
+Write-Host "Installing. Logs will be saved to ""$logFilename""."
+Start-Process -Wait 'C:\Windows\system32\msiexec.exe' -ArgumentList "/i ""$msiFilename"" /quiet /qn /norestart /log ""$logFilename"""
+
+Write-Host "Installation finished. Deleting installer file ""$msiFilename""."
+Remove-Item $msiFilename

--- a/tracer/samples/IISInDocker/startup.ps1
+++ b/tracer/samples/IISInDocker/startup.ps1
@@ -1,5 +1,8 @@
 # startup.ps1: Startup script to customize the environment when the container starts but before starting IIS
 
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
 # For example, set DD_AGENT_HOST at launch time, which may be necessary for ECS applications sending traces to their EC2 instance
 # $dockerHost = (curl http://169.254.169.254/latest/meta-data/local-ipv4).Content
 # [Environment]::SetEnvironmentVariable("DD_AGENT_HOST", "$dockerHost")


### PR DESCRIPTION
## Summary of changes

Improve the `Dockerfile` used to install `dd-trace-dotnet` in the containerized IIS app sample in `tracer/samples/IISInDocker`.

## Reason for change

A user reported having issues with the Dockerfile, and I was able to reproduce.

## Implementation details

- move install script to a separate `ps1` file
- use absolute paths for msi download and log file (this is the main reason for this PR, the relative paths fail in common scenarios)
- use PowerShell's built-in `Invoke-WebRequest` instead of .NET's `System.Net.WebClient.DownloadFile()`
(which is [obsolete](https://learn.microsoft.com/en-us/dotnet/api/system.net.webclient#remarks))
- get the github release flagged as `latest` instead of the most recent (not the same thing! this would've downloaded preview versions of v3.x, for example)
- add more verbosity in console messages (show url, download path, log path, etc) to ease troubleshooting
- add basic `.dockerignore` file

## Test coverage

Tested manually.

<!--
## Other details
-->

<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
