### PR TITLE
Fix GitLab release process

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,10 +121,6 @@ compute-ci-package-snapshot-version:
   image: registry.ddbuild.io/ci/auto_inject/gitlab:current
   tags: ["arch:amd64"]
   stage: single-step-testing
-  rules:
-    # We don't run on commit pushes, because there's no associated build
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: never
   needs:
     - wait-for-single-step-artifacts
   script:
@@ -158,10 +154,6 @@ compute-ci-package-snapshot-version:
 
 trigger-package-snapshot-testing:
   stage: single-step-testing
-  rules:
-    # We don't run on commit pushes, because there's no associated build
-    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
-      when: never
   needs:
     - compute-ci-package-snapshot-version
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,8 +45,12 @@ wait-for-single-step-artifacts:
   stage: single-step-testing
   image: registry.ddbuild.io/images/ci_docker_base
   tags: [ "runner:docker" ]
-  when: delayed
-  start_in: 20 minutes
+  rules:
+      # We don't run on commit pushes, because there's no associated build
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: never
+    - when: delayed
+      start_in: 20 minutes
   script: |
     #Create a directory to store the files
     target_dir=artifacts
@@ -112,6 +116,10 @@ compute-ci-package-snapshot-version:
   image: registry.ddbuild.io/ci/auto_inject/gitlab:current
   tags: ["arch:amd64"]
   stage: single-step-testing
+  rules:
+    # We don't run on commit pushes, because there's no associated build
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: never
   needs:
     - wait-for-single-step-artifacts
   script:
@@ -145,6 +153,10 @@ compute-ci-package-snapshot-version:
 
 trigger-package-snapshot-testing:
   stage: single-step-testing
+  rules:
+    # We don't run on commit pushes, because there's no associated build
+    - if: '$CI_COMMIT_TAG =~ /^v[0-9]+\.[0-9]+\.[0-9]+$/'
+      when: never
   needs:
     - compute-ci-package-snapshot-version
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 
 stages:
   - build
-  - single-step-testing
   - package
+  - single-step-testing
   - publish
   - deploy
   - benchmarks
@@ -55,6 +55,11 @@ wait-for-single-step-artifacts:
     #Create a directory to store the files
     target_dir=artifacts
     mkdir -p $target_dir
+
+    if [ -z "${CI_COMMIT_BRANCH}" ]; then
+      echo "Not on a branch, skipping test"
+      exit 0
+    fi
 
     branchName="refs/heads/$CI_COMMIT_BRANCH"
     artifactName="ssi-artifacts"


### PR DESCRIPTION
## Summary of changes

Fixes the fact that the gitlab pipeline that triggers on a tag push is currently broken

## Reason for change

The GitLab pipeline is currently broken for release

## Implementation details

We don't want to run the single-step testing stage on tag pushes, because there's no associated build, which causes that stage to fail.

GitLab adds _implicit_ dependencies on previous stages which means that you can never run the manual tasks, and the release is blocked.

## Test coverage

yeah.... I tested this in prod on the last release 🙈 

## Other details

We want this in both v2 and v3, so will include it in the `release/2.x` branch