### PR TITLE
[Profiler] Signal-based profiler/Non-Signal-based: prevent deadlock

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -44,6 +44,7 @@ namespace Samples.Computer01
         private NullThreadNameBugCheck _nullThreadNameBugCheck;
         private MethodsSignature _methodsSignature;
         private SigSegvHandlerExecution _sigsegvHandler;
+        private LinuxDlIteratePhdrDeadlock _linuxDlIteratePhdrDeadlock;
 
 #if NET5_0_OR_GREATER
         private OpenLdapCrash _openldapCrash;
@@ -181,6 +182,10 @@ namespace Samples.Computer01
                     StartStringConcat(parameter);
                     break;
 
+                case Scenario.LinuxDlIteratePhdrDeadlock:
+                    StartLinuxDlIteratePhdrDeadlock();
+                    break;
+
                 default:
                     throw new ArgumentOutOfRangeException(nameof(scenario), $"Unsupported scenario #{_scenario}");
             }
@@ -310,6 +315,10 @@ namespace Samples.Computer01
 
                 case Scenario.StringConcat:
                     StopStringConcat();
+                    break;
+
+                case Scenario.LinuxDlIteratePhdrDeadlock:
+                    StopLinuxDlIteratePhdrDeadlock();
                     break;
             }
         }
@@ -575,6 +584,12 @@ namespace Samples.Computer01
             _linuxMallockDeadlock.Start();
         }
 
+        private void StartLinuxDlIteratePhdrDeadlock()
+        {
+            _linuxDlIteratePhdrDeadlock = new LinuxDlIteratePhdrDeadlock();
+            _linuxDlIteratePhdrDeadlock.Start();
+        }
+
         private void StartMeasureAllocations()
         {
             _measureAllocations = new MeasureAllocations();
@@ -747,6 +762,11 @@ namespace Samples.Computer01
         private void StopLinuxMallocDeadlock()
         {
             _linuxMallockDeadlock.Stop();
+        }
+
+        private void StopLinuxDlIteratePhdrDeadlock()
+        {
+            _linuxDlIteratePhdrDeadlock.Stop();
         }
 
         private void StopMeasureAllocations()

--- a/profiler/src/Demos/Samples.Computer01/LinuxDlIteratePhdrDeadlock.cs
+++ b/profiler/src/Demos/Samples.Computer01/LinuxDlIteratePhdrDeadlock.cs
@@ -1,0 +1,124 @@
+// <copyright file="LinuxDlIteratePhdrDeadlock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Samples.Computer01
+{
+    internal class LinuxDlIteratePhdrDeadlock
+    {
+        private ManualResetEvent _stopEvent;
+        private Task _exceptionTask;
+        private Thread _worker;
+
+        public void Start()
+        {
+            if (_stopEvent != null)
+            {
+                throw new InvalidOperationException("Already running...");
+            }
+
+            _stopEvent = new ManualResetEvent(false);
+
+            _worker = new Thread(ExecuteCallToDlOpenDlClose)
+            {
+                IsBackground = false // set to false to prevent the app from shutting down. The test will fail
+            };
+            _worker.Start();
+
+            _exceptionTask = Task.Factory.StartNew(
+                        () =>
+                        {
+                            var nbException = 0;
+                            var loggingClock = Stopwatch.StartNew();
+                            while (!IsEventSet())
+                            {
+                                if (loggingClock.ElapsedMilliseconds >= 1000)
+                                {
+                                    Console.WriteLine($"* Nb thrown exception {nbException}");
+                                    Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                                    nbException = 0;
+                                    loggingClock.Restart();
+                                }
+
+                                for (var i = 0; i < 20; i++)
+                                {
+                                    try
+                                    {
+                                        throw new Exception("dl_iterate_phdr deadlock exception");
+                                    }
+                                    catch { }
+                                    nbException++;
+                                }
+
+                                // wait a bit randomly (23 is a prime number chosen randomly)
+                                Thread.Sleep(TimeSpan.FromMilliseconds(23));
+                            }
+                        },
+                        TaskCreationOptions.LongRunning);
+        }
+
+        public void Run()
+        {
+            Start();
+            Thread.Sleep(TimeSpan.FromSeconds(10));
+            Stop();
+        }
+
+        public void Stop()
+        {
+            if (_stopEvent == null)
+            {
+                throw new InvalidOperationException("Not running...");
+            }
+
+            _stopEvent.Set();
+
+            _worker.Join();
+            _exceptionTask.Wait();
+
+            _stopEvent.Dispose();
+            _stopEvent = null;
+        }
+
+        [DllImport("libdl.so", EntryPoint = "dlopen")]
+        private static extern IntPtr Dlopen(string filename, int flags);
+
+        [DllImport("libdl.so", EntryPoint = "dlclose")]
+        private static extern void DlClose(IntPtr handle);
+
+        private void ExecuteCallToDlOpenDlClose()
+        {
+            var loggingClock = Stopwatch.StartNew();
+            var counter = 0;
+
+            while (!IsEventSet())
+            {
+                if (loggingClock.ElapsedMilliseconds >= 1000)
+                {
+                    Console.WriteLine($"* Nb execution {counter}");
+                    Thread.Sleep(TimeSpan.FromMilliseconds(500));
+                    counter = 0;
+                    loggingClock.Restart();
+                }
+
+                var handle = Dlopen("libc.so.6", 2);
+                Thread.Sleep(TimeSpan.FromMilliseconds(10));
+                DlClose(handle);
+
+                counter++;
+            }
+        }
+
+        private bool IsEventSet()
+        {
+            return _stopEvent.WaitOne(0);
+        }
+    }
+}

--- a/profiler/src/Demos/Samples.Computer01/Program.cs
+++ b/profiler/src/Demos/Samples.Computer01/Program.cs
@@ -40,6 +40,7 @@ namespace Samples.Computer01
         Obfuscation,
         ThreadSpikes,
         StringConcat, // parameter = number of strings to concatenate
+        LinuxDlIteratePhdrDeadlock,
     }
 
     public class Program
@@ -76,6 +77,7 @@ namespace Samples.Computer01
             // 24: use an obfuscated library
             // 25: create thread spikes
             // 26: string concatenation
+            // 27: custom dl_iterate_phdr deadlock
             //
             Console.WriteLine($"{Environment.NewLine}Usage:{Environment.NewLine} > {Process.GetCurrentProcess().ProcessName} " +
             $"[--service] [--iterations <number of iterations to execute>] " +

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -97,14 +97,14 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
     // Otherwise, the CPU consumption to collect the callstack, will be accounted as "user app CPU time"
     auto timerId = pThreadInfo->GetTimerId();
 
-    _plibrariesInfo->UpdateCache();
-
     if (selfCollect)
     {
         // In case we are self-unwinding, we do not want to be interrupted by the signal-based profilers (walltime and cpu)
         // This will crashing in libunwind (accessing a memory area  which was unmapped)
         // This lock is acquired by the signal-based profiler (see StackSamplerLoop->StackSamplerLoopManager)
         pThreadInfo->GetStackWalkLock().Acquire();
+
+        _plibrariesInfo->UpdateCache();
 
         on_leave
         {
@@ -142,6 +142,8 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
                 syscall(__NR_timer_settime, timerId, 0, &old, nullptr);
             }
         };
+
+        _plibrariesInfo->UpdateCache();
 
         std::unique_lock<std::mutex> stackWalkInProgressLock(s_stackWalkInProgressMutex);
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/DlIteratePhdrDeadlock.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/DlIteratePhdrDeadlock.cs
@@ -1,0 +1,31 @@
+// <copyright file="DlIteratePhdrDeadlock.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.SmokeTests;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Datadog.Profiler.IntegrationTests.LinuxOnly
+{
+    [Trait("Category", "LinuxOnly")]
+    public class DlIteratePhdrDeadlock
+    {
+        private const string ScenarioLinuxDliteratePhdrDeadlock = "--scenario 27";
+        private readonly ITestOutputHelper _output;
+
+        public DlIteratePhdrDeadlock(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [TestAppFact("Samples.Computer01")]
+        public void CheckApplicationDoesNotEndUpInDeadlock(string appName, string framework, string appAssembly)
+        {
+            var runner = new SmokeTestRunner(appName, framework, appAssembly, ScenarioLinuxDliteratePhdrDeadlock, _output);
+            runner.RunAndCheck();
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Prevent deadlock betwen signal-based profilers (walltime/manual cpu profilers) and non-signal based profilers (exception, contention....)

## Reason for change

When an exception occurs, the thread can be interrupted by a signal-based profiler (walltime/manual cpu). It can be interrupted while holding the lock used to update the `dl-iterate-phdr` cache.

```
Thread 18 (LWP 995):
#0  __syscall_cp_c (nr=202, u=140244538814536, v=128, w=-1, x=0, y=0, z=0) at ./arch/x86_64/syscall_arch.h:61
#1  0x00007f8dba343ccd in __futex4_cp (to=0x0, val=-1, op=128, addr=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at src/thread/__timedwait.c:24
#2  __timedwait_cp (addr=addr@entry=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>, val=val@entry=-1, clk=clk@entry=0, at=at@entry=0x0, priv=priv@entry=128) at src/thread/__timedwait.c:52
#3  0x00007f8dba343d74 in __timedwait (addr=addr@entry=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>, val=-1, clk=clk@entry=0, at=at@entry=0x0, priv=128) at src/thread/__timedwait.c:68
#4  0x00007f8dba3463e6 in __pthread_rwlock_timedrdlock (at=<optimized out>, rw=<optimized out>) at src/thread/pthread_rwlock_timedrdlock.c:18
#5  __pthread_rwlock_timedrdlock (rw=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>, at=0x0) at src/thread/pthread_rwlock_timedrdlock.c:3
#6  0x00007f8d398f3ca8 in std::__glibcxx_rwlock_rdlock (__rwlock=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/shared_mutex:73
#7  std::__shared_mutex_pthread::lock_shared (this=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/shared_mutex:224
#8  std::shared_mutex::lock_shared (this=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/shared_mutex:421
#9  std::shared_lock<std::shared_mutex>::shared_lock (this=0x7f4ca05a2ac0, __m=...) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/shared_mutex:722
#10 LibrariesInfoCache::DlIteratePhdrImpl (this=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>, callback=0x7f8d3997d900 <_Ux86_64_dwarf_callback>, data=0x7f4ca05a2b20) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp:104
#11 0x00007f8d3997e4ee in _Ux86_64_dwarf_find_proc_info (as=0x7f8d39eb2a00 <local_addr_space>, ip=140246691112115, pi=0x7f4ca05a3170, need_unwind_info=1, arg=0x7f4ca05a3411) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gfind_proc_info-lsb.c:807
#12 0x00007f8d3997e690 in fetch_proc_info (c=0x7f4ca05a3018, ip=140246691112115) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gparser.c:473
#13 0x00007f8d3998113d in find_reg_state (sr=0x7f4ca05a2dc0, c=0x7f4ca05a3018) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gparser.c:1024
#14 _Ux86_64_dwarf_step (c=c@entry=0x7f4ca05a3018) at /project/obj/libunwind-prefix/src/libunwind/src/dwarf/Gparser.c:1069
#15 0x00007f8d3997d13a in _Ux86_64_step (cursor=0x7f4ca05a3018) at /project/obj/libunwind-prefix/src/libunwind/src/x86_64/Gstep.c:75
#16 0x00007f8d398f55c8 in LinuxStackFramesCollector::CollectStackManually (this=this@entry=0x7f8d392dc6d0, ctx=ctx@entry=0x7f4ca05a3880) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp:288
#17 0x00007f8d398f53dc in LinuxStackFramesCollector::CollectCallStackCurrentThread (this=this@entry=0x7f8d392dc6d0, ctx=ctx@entry=0x7f4ca05a3880) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp:227
#18 0x00007f8d398f4672 in LinuxStackFramesCollector::CollectStackSampleSignalHandler (signal=<optimized out>, info=<optimized out>, context=0x7f4ca05a3880) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp:373
#19 0x00007f8d398fb871 in ProfilerSignalManager::CallCustomHandler (this=0x7f8d39eaf928 <ProfilerSignalManager::Get(int)::signalManagers+1944>, signal=10, info=0x7f4ca05a39b0, context=0x7f4ca05a3880) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp:197
#20 ProfilerSignalManager::SignalHandler (signal=10, info=0x7f4ca05a39b0, context=0x7f4ca05a3880) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/ProfilerSignalManager.cpp:188
#21 <signal handler called>
#22 __pthread_rwlock_unlock (rw=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at src/thread/pthread_rwlock_unlock.c:5
#23 0x00007f8d398f3bf9 in std::__glibcxx_rwlock_unlock (__rwlock=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/shared_mutex:77
#24 std::__shared_mutex_pthread::unlock (this=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/shared_mutex:208
#25 std::shared_mutex::unlock (this=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/shared_mutex:417
#26 std::unique_lock<std::shared_mutex>::unlock (this=0x7f4ca05a3e20) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/bits/unique_lock.h:194
#27 std::unique_lock<std::shared_mutex>::~unique_lock (this=0x7f4ca05a3e20) at /usr/lib/gcc/x86_64-alpine-linux-musl/10.3.1/../../../../include/c++/10.3.1/bits/unique_lock.h:103
#28 LibrariesInfoCache::UpdateCache (this=0x7f8d39eaf048 <LibrariesInfoCache::Get()::Instance>) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp:88
#29 0x00007f8d398f4e59 in LinuxStackFramesCollector::CollectStackSampleImplementation (this=0x7f8d3b91bc90, pThreadInfo=0x7f4ca06b9900, pHR=0x7f8d3a63c510, selfCollect=true) at /p--Type <RET> for more, q to quit, c to continue without paging--
roject/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp:100
#30 0x00007f8d399637ba in StackFramesCollectorBase::CollectStackSample (this=0x7f8d3b91bc90, pThreadInfo=0x7f4ca06b9900, pHR=0x7f4ca05a3fdc) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackFramesCollectorBase.cpp:185
#31 0x00007f8d3992acb9 in ExceptionsProvider::OnExceptionThrown (this=0x7f8d392a7160, thrownObjectId=139969739182080) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExceptionsProvider.cpp:149
#32 0x00007f8d39917045 in CorProfilerCallback::ExceptionThrown (this=0x7f8d392c0d20, thrownObjectId=139969739182080) at /project/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp:1734
```
## Implementation details

- move the call which updates the cache after acquiring the thread lock
- call Update before sending signal

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
