### PR TITLE
[Dynamic Instrumentation] DEBUG-2560 EL- Fix `IsEmpty` for string and collections

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -348,6 +348,8 @@ namespace Datadog.Trace.Tests.Debugger
             public Guid? NullableNullValue;
 
             public Guid? NullableNotNullValue;
+			
+			public string EmptyString { get; set; }
 
             internal class NestedObject
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/DebuggerExpressionLanguageTests.cs
@@ -348,8 +348,8 @@ namespace Datadog.Trace.Tests.Debugger
             public Guid? NullableNullValue;
 
             public Guid? NullableNotNullValue;
-			
-			public string EmptyString { get; set; }
+
+            public string EmptyString { get; set; }
 
             internal class NestedObject
             {

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
@@ -28,11 +28,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = string.IsNullOrEmpty(this.EmptyString);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
@@ -26,11 +26,13 @@ Expression: (
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
     var BooleanValue = (bool)scopeMemberArray[7].Value;
-    var IntArg = (int)scopeMemberArray[8].Value;
-    var DoubleArg = (double)scopeMemberArray[9].Value;
-    var StringArg = (string)scopeMemberArray[10].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var IntArg = (int)scopeMemberArray[10].Value;
+    var DoubleArg = (double)scopeMemberArray[11].Value;
+    var StringArg = (string)scopeMemberArray[12].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
     var $dd_el_result = string.IsNullOrEmpty(this.EmptyString);
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmpty.verified.txt
@@ -1,0 +1,38 @@
+﻿Condition:
+Json:
+{
+  "isEmpty": [
+    {
+      "ref": "EmptyString"
+    }
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
+    var $dd_el_result = string.IsNullOrEmpty(this.EmptyString);
+
+    return $dd_el_result;
+}
+Result: True

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyCollection.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyCollection.verified.txt
@@ -26,11 +26,13 @@ Expression: (
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
     var BooleanValue = (bool)scopeMemberArray[7].Value;
-    var IntArg = (int)scopeMemberArray[8].Value;
-    var DoubleArg = (double)scopeMemberArray[9].Value;
-    var StringArg = (string)scopeMemberArray[10].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var IntArg = (int)scopeMemberArray[10].Value;
+    var DoubleArg = (double)scopeMemberArray[11].Value;
+    var StringArg = (string)scopeMemberArray[12].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
     var $dd_el_result = this.Collection.Count == 0;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyCollection.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyCollection.verified.txt
@@ -28,11 +28,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
     var $dd_el_result = this.Collection.Count == 0;
 
     return $dd_el_result;

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyCollection.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyCollection.verified.txt
@@ -1,0 +1,38 @@
+﻿Condition:
+Json:
+{
+  "isEmpty": [
+    {
+      "ref": "Collection"
+    }
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
+    var $dd_el_result = this.Collection.Count == 0;
+
+    return $dd_el_result;
+}
+Result: False

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyUnsupportedType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyUnsupportedType.verified.txt
@@ -1,0 +1,40 @@
+﻿Condition:
+Json:
+{
+  "isEmpty": [
+    {
+      "ref": "IntNumber"
+    }
+  ]
+}
+Expression: (
+    scopeMember,
+    scopeMember,
+    scopeMember,
+    exception,
+    scopeMemberArray) =>
+{
+    bool $dd_el_result;
+    var this = (DebuggerExpressionLanguageTests.TestStruct)scopeMember.Value;
+    var @return = (string)scopeMember.Value;
+    var @duration = (TimeSpan)scopeMember.Value;
+    var @exception = exception;
+    var IntLocal = (int)scopeMemberArray[0].Value;
+    var DoubleLocal = (double)scopeMemberArray[1].Value;
+    var StringLocal = (string)scopeMemberArray[2].Value;
+    var CollectionLocal = (List<string>)scopeMemberArray[3].Value;
+    var DictionaryLocal = (Dictionary<string, string>)scopeMemberArray[4].Value;
+    var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
+    var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
+    var BooleanValue = (bool)scopeMemberArray[7].Value;
+    var IntArg = (int)scopeMemberArray[8].Value;
+    var DoubleArg = (double)scopeMemberArray[9].Value;
+    var StringArg = (string)scopeMemberArray[10].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
+
+    return true;
+}
+Result: True
+Errors:
+EvaluationError { Expression = this.IntNumber.IsEmpty, Message = Source must be an array or implement ICollection or IReadOnlyCollection, or a string }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyUnsupportedType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyUnsupportedType.verified.txt
@@ -29,11 +29,13 @@ Expression: (
     var BooleanValue = (bool)scopeMemberArray[7].Value;
     var Char = (char)scopeMemberArray[8].Value;
     var AnotherChar = (char)scopeMemberArray[9].Value;
-    var IntArg = (int)scopeMemberArray[10].Value;
-    var DoubleArg = (double)scopeMemberArray[11].Value;
-    var StringArg = (string)scopeMemberArray[12].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
+    var NullableNotNullValueLocal = (Guid?)scopeMemberArray[10].Value;
+    var NullableNullValueLocal = (Guid?)scopeMemberArray[11].Value;
+    var IntArg = (int)scopeMemberArray[12].Value;
+    var DoubleArg = (double)scopeMemberArray[13].Value;
+    var StringArg = (string)scopeMemberArray[14].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[15].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[16].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyUnsupportedType.verified.txt
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Approvals/DebuggerExpressionLanguageTests.IsEmptyUnsupportedType.verified.txt
@@ -27,11 +27,13 @@ Expression: (
     var NestedObjectLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[5].Value;
     var NullLocal = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[6].Value;
     var BooleanValue = (bool)scopeMemberArray[7].Value;
-    var IntArg = (int)scopeMemberArray[8].Value;
-    var DoubleArg = (double)scopeMemberArray[9].Value;
-    var StringArg = (string)scopeMemberArray[10].Value;
-    var CollectionArg = (List<string>)scopeMemberArray[11].Value;
-    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[12].Value;
+    var Char = (char)scopeMemberArray[8].Value;
+    var AnotherChar = (char)scopeMemberArray[9].Value;
+    var IntArg = (int)scopeMemberArray[10].Value;
+    var DoubleArg = (double)scopeMemberArray[11].Value;
+    var StringArg = (string)scopeMemberArray[12].Value;
+    var CollectionArg = (List<string>)scopeMemberArray[13].Value;
+    var NestedObjectArg = (DebuggerExpressionLanguageTests.TestStruct.NestedObject)scopeMemberArray[14].Value;
 
     return true;
 }

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsEmpty.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsEmpty.json
@@ -1,0 +1,8 @@
+{
+  "dsl": "isEmpty(ref EmptyString)",
+  "isEmpty": [
+    {
+      "ref": "EmptyString"
+    }
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsEmptyCollection.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsEmptyCollection.json
@@ -1,0 +1,8 @@
+{
+  "dsl": "isEmpty(ref Collection)",
+  "isEmpty": [
+    {
+      "ref": "Collection"
+    }
+  ]
+}

--- a/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsEmptyUnsupportedType.json
+++ b/tracer/test/Datadog.Trace.Tests/Debugger/ProbeExpressionsResources/Conditions/IsEmptyUnsupportedType.json
@@ -1,0 +1,8 @@
+{
+  "dsl": "isEmpty(ref IntNumber)",
+  "isEmpty": [
+    {
+      "ref": "IntNumber"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary of changes
This PR fix a bug when checking for empty or null string. It also approve the error handling in case of unsupported type.

## Test coverage
IsEmpty
IsEmptyCollection
IsEmptyUnsupportedType
