### PR TITLE
Disable keep-alive in HttpClientRequestFactory

### DIFF
--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
@@ -32,6 +32,9 @@ namespace Datadog.Trace.Agent.Transports
             {
                 _client.DefaultRequestHeaders.Add(pair.Key, pair.Value);
             }
+
+            // Disable keep-alive
+            _client.DefaultRequestHeaders.ConnectionClose = true;
         }
 
         public Uri GetEndpoint(string relativePath) => UriHelpers.Combine(_baseEndpoint, relativePath);


### PR DESCRIPTION
## Summary of changes

Disable keep-alive in HttpClientRequestFactory

## Reason for change

Polling the remote configuration regularly fails (~once per minute) with this error:

```
System.Net.Http.HttpIOException: The response ended prematurely. (ResponseEnded)
```

We have a pending escalation that seems to indicate the error can also occur when sending logs.

After looking into it, it seems to happen when the keep-alive connection is reset.

The behavior is new to .NET 6: https://github.com/dotnet/runtime/issues/95516#issuecomment-1836319124

In theory we could limit the change to .NET 6+ and/or implement a retry logic for those particular failures, but I don't think it's worth the complexity.

Moreover, keep-alive is already disabled on .NET Framework (it's disabled by default and we never enabled it) so we know the performance hit is acceptable.

## Implementation details

Just set the `ConnectionClose` property on the HttpClient.

## Test coverage

Tested on my machine, the errors disappear after this change.
