### PR TITLE
Simplify determining whether it's a debug run or not

### DIFF
--- a/tracer/build/_build/Build.Profiler.Steps.cs
+++ b/tracer/build/_build/Build.Profiler.Steps.cs
@@ -303,25 +303,25 @@ partial class Build
         .After(BuildProfilerSamples)
         .Description("Run the profiler container tests")
         .Requires(() => IsLinux && !IsArm64)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            await BuildAndRunProfilerIntegrationTestsInternal("(Category=CpuLimitTest)");
+            BuildAndRunProfilerIntegrationTestsInternal("(Category=CpuLimitTest)");
         });
 
     Target BuildAndRunProfilerIntegrationTests => _ => _
         .After(BuildProfilerSamples)
         .Description("Builds and runs the profiler integration tests")
         .Requires(() => !IsArm64)
-        .Executes(async () =>
+        .Executes(() =>
         {
             // Exclude CpuLimitTest from this path: They are already launched in a specific step + specific setup
             var filter = $"{(IsLinux ? "(Category!=WindowsOnly)" : "(Category!=LinuxOnly)")}&(Category!=CpuLimitTest)";
-            await BuildAndRunProfilerIntegrationTestsInternal(filter);
+            BuildAndRunProfilerIntegrationTestsInternal(filter);
         });
 
-    private async Task BuildAndRunProfilerIntegrationTestsInternal(string filter)
+    private void BuildAndRunProfilerIntegrationTestsInternal(string filter)
     {
-        var isDebugRun = await IsDebugRun();
+        var isDebugRun = IsDebugRun();
 
         EnsureExistingDirectory(ProfilerTestLogsDirectory);
 

--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -95,9 +95,9 @@ partial class Build
         .After(BuildDebuggerIntegrationTests)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             EnsureResultsDirectory(DebuggerIntegrationTests);
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1439,9 +1439,9 @@ partial class Build
         .Requires(() => IsWin)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
@@ -1533,9 +1533,9 @@ partial class Build
         .Requires(() => IsWin)
         .Requires(() => Framework)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             var project = Solution.GetProject(Projects.ClrProfilerIntegrationTests);
             EnsureExistingDirectory(TestLogsDirectory);
             EnsureResultsDirectory(project);
@@ -1575,9 +1575,9 @@ partial class Build
         .After(BuildNativeLoader)
         .Requires(() => IsWin)
         .Requires(() => Framework)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
 
@@ -1616,7 +1616,7 @@ partial class Build
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
-        .Executes(async () => await RunWindowsIisIntegrationTests(
+        .Executes(() => RunWindowsIisIntegrationTests(
                       Solution.GetProject(Projects.ClrProfilerIntegrationTests)));
 
     Target RunWindowsSecurityIisIntegrationTests => _ => _
@@ -1626,12 +1626,12 @@ partial class Build
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
-        .Executes(async () => await RunWindowsIisIntegrationTests(
+        .Executes(() => RunWindowsIisIntegrationTests(
                       Solution.GetProject(Projects.AppSecIntegrationTests)));
 
-    async Task RunWindowsIisIntegrationTests(Project project)
+    void RunWindowsIisIntegrationTests(Project project)
     {
-        var isDebugRun = await IsDebugRun();
+        var isDebugRun = IsDebugRun();
         EnsureResultsDirectory(project);
         try
         {
@@ -1666,9 +1666,9 @@ partial class Build
         .After(PublishIisSamples)
         .Triggers(PrintSnapshotsDiff)
         .Requires(() => Framework)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             var project = Solution.GetProject(Projects.ClrProfilerIntegrationTests);
             var resultsDirectory = GetResultsDirectory(project);
             EnsureCleanDirectory(resultsDirectory);
@@ -1962,9 +1962,9 @@ partial class Build
         .Requires(() => Framework)
         .Requires(() => !IsWin)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
@@ -2043,9 +2043,9 @@ partial class Build
         .Requires(() => Framework)
         .Requires(() => IsOsx)
         .Triggers(PrintSnapshotsDiff)
-        .Executes(async () =>
+        .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             EnsureExistingDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
@@ -2194,9 +2194,9 @@ partial class Build
     Target RunToolArtifactTests => _ => _
        .Description("Runs the tool artifacts tests")
        .After(BuildToolArtifactTests)
-       .Executes(async () =>
+       .Executes(() =>
         {
-            var isDebugRun = await IsDebugRun();
+            var isDebugRun = IsDebugRun();
             var project = Solution.GetProject(Projects.DdTraceArtifactsTests);
 
             DotNetTest(config => config
@@ -2216,11 +2216,11 @@ partial class Build
        .Description("Runs the dd-dotnet artifacts tests")
        .After(BuildDdDotnetArtifactTests)
        .After(CopyDdDotnet)
-       .Executes(async () =>
+       .Executes(() =>
        {
            try
            {
-               var isDebugRun = await IsDebugRun();
+               var isDebugRun = IsDebugRun();
                var project = Solution.GetProject(Projects.DdDotnetArtifactsTests);
 
                DotNetTest(config => config

--- a/tracer/build/_build/Build.Utilities.cs
+++ b/tracer/build/_build/Build.Utilities.cs
@@ -452,7 +452,7 @@ partial class Build
         }
     }
 
-    private async Task<bool> IsDebugRun()
+    private bool IsDebugRun()
     {
         var forceDebugRun = Environment.GetEnvironmentVariable("ForceDebugRun");
         if (!string.IsNullOrEmpty(forceDebugRun)
@@ -461,36 +461,14 @@ partial class Build
             return true;
         }
 
-        var buildId = Environment.GetEnvironmentVariable("BUILD_BUILDID");
-        if (string.IsNullOrEmpty(buildId))
+        var scheduleName = Environment.GetEnvironmentVariable("BUILD_CRONSCHEDULE_DISPLAYNAME");
+        if (string.IsNullOrEmpty(scheduleName))
         {
             // not in CI
             return false;
         }
-
-        try
-        {
-            var azDoApi = $"https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/{buildId}";
-            using var client = new HttpClient();
-            using var stream = await client.GetStreamAsync(azDoApi);
-            using var json = await JsonDocument.ParseAsync(stream);
-            var triggerInfo = json.RootElement.GetProperty("triggerInfo");
-            if (triggerInfo.TryGetProperty("scheduleName", out var scheduleNameElement))
-            {
-                var scheduleName = scheduleNameElement.ToString();
-                return scheduleName == "Daily Debug Run";
-            }
-            else
-            {
-                // scheduleName not found - this will happen on PRs etc
-                return false;
-            }
-        }
-        catch (Exception ex)
-        {
-            Logger.Warning(ex, "Error calling Azdo API to check for debug run");
-            return false;
-        }
+        
+        return scheduleName == "Daily Debug Run";
     } 
 
     private static MSBuildTargetPlatform GetDefaultTargetPlatform()


### PR DESCRIPTION
## Summary of changes

Simplify the check for "is debug run" in CI

## Reason for change

We were making it more complicated than it needs to be

## Implementation details

[There's a variable `Build.CronSchedule.DisplayName` that has the value we need](https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml#build-variables-devops-services)

## Test coverage

Added logs so we can check if it works, but not easy to test beforehand, as dependent on what AzDo does, and can't see a way to view that. So just try it and see what happens IMO

## Other details

Spotted while working on something else