### PR TITLE
Fix Create Draft Release action

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1303,7 +1303,6 @@ partial class Build
         var artifactsFiles= new []
         {
             $"{awsUri}x64/en-us/datadog-dotnet-apm-{version}-x64.msi",
-            $"{awsUri}x86/en-us/datadog-dotnet-apm-{version}-x86.msi",
             $"{awsUri}windows-native-symbols.zip",
             $"{awsUri}windows-tracer-home.zip",
         };


### PR DESCRIPTION
## Summary of changes

Fixes the draft release action

## Reason for change

It's broken

## Implementation details

We don't produce the x86 msi any more, so we were failing trying to include it in the release.

## Test coverage

Nope 🤞 
