### PR TITLE
Fix builds on release/2.x

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -199,7 +199,7 @@ stages:
         if [[ "$TARGET_BRANCH" == refs/heads/hotfix/* ]] || [[ "$TARGET_BRANCH" == refs/heads/release/* ]]; then
           TARGET_BRANCH=$(echo $TARGET_BRANCH| cut -c 11-)
         elif [[ "$TARGET_BRANCH" == hotfix/* ]] || [[ "$TARGET_BRANCH" == release/* ]]; then
-          echo "No ned to change the branch name"
+          echo "No need to change the branch name"
         else
           TARGET_BRANCH=master
         fi

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -196,8 +196,10 @@ stages:
     - bash: |
         TARGET_BRANCH=$SYSTEM_PULLREQUEST_TARGETBRANCH
         echo "SYSTEM_PULLREQUEST_TARGETBRANCH=$TARGET_BRANCH"
-        if [[ "$TARGET_BRANCH" == refs/heads/hotfix/* ]]; then
+        if [[ "$TARGET_BRANCH" == refs/heads/hotfix/* ]] || [[ "$TARGET_BRANCH" == refs/heads/release/* ]]; then
           TARGET_BRANCH=$(echo $TARGET_BRANCH| cut -c 11-)
+        elif [[ "$TARGET_BRANCH" == hotfix/* ]] || [[ "$TARGET_BRANCH" == release/* ]]; then
+          echo "No ned to change the branch name"
         else
           TARGET_BRANCH=master
         fi

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -181,7 +181,8 @@ partial class Build
 
     bool RequiresThoroughTesting()
     {
-        var gitChangedFiles = GetGitChangedFiles(baseBranch: "origin/master");
+        var baseBranch = string.IsNullOrEmpty(TargetBranch) ? "origin/master" : $"origin/{TargetBranch}";
+        var gitChangedFiles = GetGitChangedFiles(baseBranch);
         var integrationChangedFiles = TargetFrameworks
             .SelectMany(tfm => new[]
             {

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -64,7 +64,7 @@ partial class Build : NukeBuild
 
                 void GenerateConditionVariableBasedOnGitChange(string variableName, string[] filters, string[] exclusionFilters)
                 {
-                    const string baseBranch = "origin/master";
+                    var baseBranch = string.IsNullOrEmpty(TargetBranch) ? "origin/master" : $"origin/{TargetBranch}";
                     bool isChanged;
                     var forceExplorationTestsWithVariableName = $"force_exploration_tests_with_{variableName}";
 


### PR DESCRIPTION
## Summary of changes

Fix PRs targeting `release/2.x`

## Reason for change

PRs targeting `release/2.x` currently don't work

## Implementation details

Make sure we merge to the correct branch

## Test coverage

This is the test

## Other details

Will cherry pick to master afterwards, but easier to check here.