### PR TITLE
[Dynamic Instrumentation] Improved instrumentation matching of symbols received through SymDb

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebuggingSettings.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebuggingSettings.cs
@@ -17,7 +17,7 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 {
     internal class ExceptionDebuggingSettings
     {
-        public const int DefaultMaxFramesToCapture = 3;
+        public const int DefaultMaxFramesToCapture = 4;
         public const int DefaultRateLimitSeconds = 60 * 60; // 1 hour
         public const int DefaultMaxExceptionAnalysisLimit = 100;
 

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayDiagnosticTagNames.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionReplayDiagnosticTagNames.cs
@@ -17,7 +17,6 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
     /// </summary>
     internal static class ExceptionReplayDiagnosticTagNames
     {
-        public const string None = nameof(None);
         public const string Eligible = nameof(Eligible);
         public const string EmptyShadowStack = nameof(EmptyShadowStack);
         public const string ExceptionTrackManagerNotInitialized = nameof(ExceptionTrackManagerNotInitialized);
@@ -27,5 +26,11 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
         public const string CachedDoneExceptionCase = nameof(CachedDoneExceptionCase);
         public const string InvalidatedExceptionCase = nameof(InvalidatedExceptionCase);
         public const string CircuitBreakerIsOpen = nameof(CircuitBreakerIsOpen);
+        public const string NonCachedDoneExceptionCase = nameof(NonCachedDoneExceptionCase);
+        public const string NotSupportedExceptionType = nameof(NotSupportedExceptionType);
+        public const string NoFramesToInstrument = nameof(NoFramesToInstrument);
+        public const string EmptyCallStackTreeWhileCollecting = nameof(EmptyCallStackTreeWhileCollecting);
+        public const string InvalidatedCase = nameof(InvalidatedCase);
+        public const string NewCase = nameof(NewCase);
     }
 }

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionTrackManager.cs
@@ -139,11 +139,21 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
             if (allParticipatingFramesFlattened.Length == 0)
             {
+                if (rootSpan != null)
+                {
+                    SetDiagnosticTag(rootSpan, ExceptionReplayDiagnosticTagNames.NoFramesToInstrument);
+                }
+
                 return;
             }
 
             if (!ShouldReportException(exception, allParticipatingFramesFlattened))
             {
+                if (rootSpan != null)
+                {
+                    SetDiagnosticTag(rootSpan, ExceptionReplayDiagnosticTagNames.NotSupportedExceptionType);
+                }
+
                 Log.Information(exception, "Skipping the processing of an exception by Exception Debugging.");
                 return;
             }
@@ -163,6 +173,10 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
 
             if (trackedExceptionCase.IsDone)
             {
+                if (rootSpan != null)
+                {
+                    SetDiagnosticTag(rootSpan, ExceptionReplayDiagnosticTagNames.NonCachedDoneExceptionCase);
+                }
             }
             else if (trackedExceptionCase.IsInvalidated)
             {
@@ -254,6 +268,18 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                         Log.Information("Invalidating the exception case of the empty stack tree since none of the methods were instrumented, for exception: {Name}, Message: {Message}, StackTrace: {StackTrace}", exception.GetType().Name, exception.Message, exception.StackTrace);
                         trackedExceptionCase.InvalidateCase();
                         _invalidatedCases.Add(exception.ToString());
+
+                        if (rootSpan != null)
+                        {
+                            SetDiagnosticTag(rootSpan, ExceptionReplayDiagnosticTagNames.InvalidatedCase);
+                        }
+                    }
+                    else
+                    {
+                        if (rootSpan != null)
+                        {
+                            SetDiagnosticTag(rootSpan, ExceptionReplayDiagnosticTagNames.EmptyCallStackTreeWhileCollecting);
+                        }
                     }
 
                     return;
@@ -361,6 +387,11 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
             {
                 Log.Information("New exception case occurred, initiating data collection for exception: {Name}, Message: {Message}, StackTrace: {StackTrace}", exception.GetType().Name, exception.Message, exception.StackTrace);
                 trackedExceptionCase.Instrument();
+
+                if (rootSpan != null)
+                {
+                    SetDiagnosticTag(rootSpan, ExceptionReplayDiagnosticTagNames.NewCase);
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -9,6 +9,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Datadog.Trace.Agent.DiscoveryService;
@@ -25,6 +26,8 @@ using Datadog.Trace.Debugger.Snapshots;
 using Datadog.Trace.DogStatsd;
 using Datadog.Trace.Logging;
 using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.Util;
+using Datadog.Trace.Vendors.dnlib.DotNet;
 using Datadog.Trace.Vendors.StatsdClient;
 using ProbeInfo = Datadog.Trace.Debugger.Expressions.ProbeInfo;
 
@@ -246,15 +249,17 @@ namespace Datadog.Trace.Debugger
 
                         case ProbeLocationType.Method:
                         {
+                            var signature = SignatureParser.SafeParse(probe.Where.Signature);
+
                             fetchProbeStatus.Add(new FetchProbeStatus(probe.Id, probe.Version ?? 0));
                             if (probe is SpanProbe)
                             {
-                                var spanDefinition = new NativeSpanProbeDefinition(probe.Id, probe.Where.TypeName, probe.Where.MethodName, probe.Where.Signature?.Split(separator: ','));
+                                var spanDefinition = new NativeSpanProbeDefinition(probe.Id, probe.Where.TypeName, probe.Where.MethodName, signature);
                                 spanProbes.Add(spanDefinition);
                             }
                             else
                             {
-                                var nativeDefinition = new NativeMethodProbeDefinition(probe.Id, probe.Where.TypeName, probe.Where.MethodName, probe.Where.Signature?.Split(separator: ','));
+                                var nativeDefinition = new NativeMethodProbeDefinition(probe.Id, probe.Where.TypeName, probe.Where.MethodName, signature);
                                 methodProbes.Add(nativeDefinition);
                                 ProbeExpressionsProcessor.Instance.AddProbeProcessor(probe);
                                 SetRateLimit(probe);

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -249,7 +249,7 @@ namespace Datadog.Trace.Debugger
 
                         case ProbeLocationType.Method:
                         {
-                            var signature = SignatureParser.SafeParse(probe.Where.Signature);
+                            SignatureParser.TryParse(probe.Where.Signature, out var signature);
 
                             fetchProbeStatus.Add(new FetchProbeStatus(probe.Id, probe.Version ?? 0));
                             if (probe is SpanProbe)

--- a/tracer/src/Datadog.Trace/Debugger/SignatureParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SignatureParser.cs
@@ -1,0 +1,120 @@
+// <copyright file="SignatureParser.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Logging;
+using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
+
+#nullable enable
+namespace Datadog.Trace.Debugger
+{
+    internal static class SignatureParser
+    {
+        private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SignatureParser));
+
+        internal static string[]? SafeParse(string? signature)
+        {
+            try
+            {
+                return Parse(signature);
+            }
+            catch (Exception e)
+            {
+                Log.Error(e, "Error parsing the signature {Signature}. Fall back to empty signature", signature);
+                return null;
+            }
+        }
+
+        internal static string[]? Parse(string? signature)
+        {
+            if (string.IsNullOrWhiteSpace(signature) || signature == "()")
+            {
+                return null;
+            }
+
+            signature = signature!.Replace(" ", string.Empty);
+
+            if (signature.StartsWith("(") && signature.EndsWith(")"))
+            {
+                signature = signature.Substring(1, signature.Length - 2);
+            }
+
+            // Fast path if we don't deal with generics
+            if (!signature.Contains("<") && !signature.Contains(">"))
+            {
+                return signature.Split(',');
+            }
+
+            return ParseGenericTypes(signature);
+        }
+
+        private static string[]? ParseGenericTypes(string signature)
+        {
+            var result = new List<string>();
+            var bufferIndex = 0;
+            var genericDepth = 0;
+            var buffer = ArrayPool<char>.Shared.Rent(signature.Length);
+
+            try
+            {
+                for (var i = 0; i < signature.Length; i++)
+                {
+                    var c = signature[i];
+
+                    if (c == ',' && genericDepth == 0)
+                    {
+                        if (bufferIndex > 0)
+                        {
+                            result.Add(new string(buffer, 0, bufferIndex));
+                            bufferIndex = 0;
+                        }
+                    }
+                    else if (i < signature.Length - 1 && signature[i] == '<' && signature[i + 1] == '>')
+                    {
+                        buffer[bufferIndex++] = '<';
+                        buffer[bufferIndex++] = '>';
+                        i++; // Skip the next '>'
+                    }
+                    else if (c == '<')
+                    {
+                        genericDepth++;
+                        buffer[bufferIndex++] = '[';
+                    }
+                    else if (c == '>')
+                    {
+                        if (genericDepth == 0)
+                        {
+                            return null; // Unmatched closing generic bracket
+                        }
+
+                        genericDepth--;
+                        buffer[bufferIndex++] = ']';
+                    }
+                    else
+                    {
+                        buffer[bufferIndex++] = c;
+                    }
+                }
+
+                if (genericDepth != 0)
+                {
+                    return null; // Unmatched opening generic bracket
+                }
+
+                if (bufferIndex > 0)
+                {
+                    result.Add(new string(buffer, 0, bufferIndex));
+                }
+
+                return result.Count > 0 ? result.ToArray() : null;
+            }
+            finally
+            {
+                ArrayPool<char>.Shared.Return(buffer, true);
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/SignatureParser.cs
+++ b/tracer/src/Datadog.Trace/Debugger/SignatureParser.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Datadog.Trace.Logging;
 using Datadog.Trace.VendoredMicrosoftCode.System.Buffers;
 
@@ -15,17 +16,19 @@ namespace Datadog.Trace.Debugger
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(SignatureParser));
 
-        internal static string[]? SafeParse(string? signature)
+        internal static bool TryParse(string? signature, [NotNullWhen(true)] out string[]? signatures)
         {
             try
             {
-                return Parse(signature);
+                signatures = Parse(signature);
             }
             catch (Exception e)
             {
                 Log.Error(e, "Error parsing the signature {Signature}. Fall back to empty signature", signature);
-                return null;
+                signatures = null;
             }
+
+            return !string.IsNullOrEmpty(signature);
         }
 
         internal static string[]? Parse(string? signature)

--- a/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/debugger_rejit_preprocessor.h
@@ -38,6 +38,10 @@ protected:
     const bool GetIsExactSignatureMatch(const std::shared_ptr<MethodProbeDefinition>& definition) final;
     const bool GetIsEnabled(const std::shared_ptr<MethodProbeDefinition>& definition) final;
     const bool SupportsSelectiveEnablement() final;
+
+    bool CheckExactSignatureMatch(ComPtr<IMetaDataImport2>& metadataImport, const FunctionInfo& functionInfo,
+                                          const MethodReference& targetMethod) override;
+
     const std::unique_ptr<RejitHandlerModuleMethod>
     CreateMethod(mdMethodDef methodDef, RejitHandlerModule* module, const FunctionInfo& functionInfo,
                  const std::shared_ptr<MethodProbeDefinition>& methodProbe) final;

--- a/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_preprocessor.h
@@ -75,6 +75,9 @@ protected:
     virtual const bool GetIsEnabled(const RejitRequestDefinition& definition) = 0;
     virtual const bool SupportsSelectiveEnablement() = 0;
 
+    virtual bool CheckExactSignatureMatch(ComPtr<IMetaDataImport2>& metadataImport, const FunctionInfo& functionInfo,
+                                          const MethodReference& targetMethod);
+
     virtual bool ShouldSkipModule(const ModuleInfo& moduleInfo, const RejitRequestDefinition& definition) = 0;
 
     virtual const std::unique_ptr<RejitHandlerModuleMethod> CreateMethod(mdMethodDef methodDef,

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/Helpers/DebuggerTestHelper.cs
@@ -166,7 +166,7 @@ internal static class DebuggerTestHelper
 
     internal static ProbeDefinition CreateDefaultLogProbe(string typeName, string methodName, DeterministicGuidGenerator guidGenerator, MethodProbeTestDataAttribute probeTestData = null)
     {
-        return CreateBasicProbe<LogProbe>(probeTestData?.ProbeId ?? guidGenerator.New().ToString()).WithSampling().WithDefaultTemplate().WithCapture(probeTestData?.CaptureSnapshot).WithMethodWhere(typeName, methodName, probeTestData);
+        return CreateBasicProbe<LogProbe>(probeTestData?.ProbeId ?? guidGenerator.New().ToString()).WithSampling().WithDefaultTemplate().WithCapture(probeTestData?.CaptureSnapshot).WithMethodWhere(typeName, methodName, probeTestData: probeTestData);
     }
 
     internal static ProbeDefinition CreateLogLineProbe(Type type, LineProbeTestDataAttribute line, DeterministicGuidGenerator guidGenerator)
@@ -174,7 +174,7 @@ internal static class DebuggerTestHelper
         return CreateBasicProbe<LogProbe>(line?.ProbeId ?? guidGenerator.New().ToString()).WithCapture(line?.CaptureSnapshot).WithSampling().WithTemplate(line).WithWhen(line).WithLineProbeWhere(type, line);
     }
 
-    private static ProbeDefinition WithMethodWhere(this ProbeDefinition snapshot, string typeName, string methodName, MethodProbeTestDataAttribute probeTestData = null)
+    private static ProbeDefinition WithMethodWhere(this ProbeDefinition snapshot, string typeName, string methodName, MethodBase method = null, MethodProbeTestDataAttribute probeTestData = null)
     {
         var @where = new Where
         {
@@ -184,13 +184,14 @@ internal static class DebuggerTestHelper
 
         if (probeTestData != null)
         {
-            var signature = probeTestData.ReturnTypeName;
+            var signature = string.Empty;
             if (probeTestData.ParametersTypeName?.Any() == true)
             {
-                signature += "," + string.Join(",", probeTestData.ParametersTypeName);
+                signature = (method != null && !method.IsStatic) ? method.DeclaringType.FullName + "," : string.Empty;
+                signature += string.Join(",", probeTestData.ParametersTypeName);
             }
 
-            @where.Signature = signature;
+            @where.Signature = string.IsNullOrEmpty(signature) ? null : signature;
         }
 
         snapshot.Where = where;
@@ -310,7 +311,7 @@ internal static class DebuggerTestHelper
             throw new InvalidOperationException("This probe attribute has no metric information");
         }
 
-        return CreateBasicProbe<MetricProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithMetric(probeTestData).WithMethodWhere(typeName, method.Name, probeTestData);
+        return CreateBasicProbe<MetricProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithMetric(probeTestData).WithMethodWhere(typeName, method.Name, method, probeTestData);
     }
 
     private static ProbeDefinition CreateSpanMethodProbe(MethodBase method, DeterministicGuidGenerator guidGenerator, int testIndex)
@@ -321,7 +322,7 @@ internal static class DebuggerTestHelper
             throw new InvalidOperationException("Probe attribute is null");
         }
 
-        return CreateBasicProbe<SpanProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithMethodWhere(typeName, method.Name, probeTestData);
+        return CreateBasicProbe<SpanProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithMethodWhere(typeName, method.Name, method, probeTestData);
     }
 
     private static ProbeDefinition CreateSpanDecorationMethodProbe(MethodBase method, DeterministicGuidGenerator guidGenerator, int testIndex)
@@ -332,7 +333,7 @@ internal static class DebuggerTestHelper
             throw new InvalidOperationException("Probe attribute is null");
         }
 
-        return CreateBasicProbe<SpanDecorationProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithSpanDecoration(probeTestData).WithMethodWhere(typeName, method.Name, probeTestData);
+        return CreateBasicProbe<SpanDecorationProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithSpanDecoration(probeTestData).WithMethodWhere(typeName, method.Name, method, probeTestData);
     }
 
     private static bool IsOptimized(Assembly assembly)
@@ -350,7 +351,7 @@ internal static class DebuggerTestHelper
             throw new InvalidOperationException("Probe attribute is null");
         }
 
-        return CreateBasicProbe<LogProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithCapture(probeTestData.CaptureSnapshot).WithSampling().WithTemplate(probeTestData).WithWhen(probeTestData).WithMethodWhere(typeName, method.Name, probeTestData);
+        return CreateBasicProbe<LogProbe>(probeTestData.ProbeId ?? guidGenerator.New().ToString()).WithCapture(probeTestData.CaptureSnapshot).WithSampling().WithTemplate(probeTestData).WithWhen(probeTestData).WithMethodWhere(typeName, method.Name, method, probeTestData);
     }
 
     private static MethodProbeTestDataAttribute GetProbeTestData<T>(MethodBase method, int testIndex, out string typeName)

--- a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/SignatureParserTests.cs
+++ b/tracer/test/Datadog.Trace.Debugger.IntegrationTests/SignatureParserTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="SignatureParserTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using Datadog.Trace.Debugger.Configurations.Models;
+using Datadog.Trace.Debugger.IntegrationTests.Helpers;
+using Datadog.Trace.Debugger.Models;
+using FluentAssertions;
+using Samples.Probes.TestRuns.SmokeTests;
+using Xunit;
+
+namespace Datadog.Trace.Debugger.IntegrationTests
+{
+    public class SignatureParserTests
+    {
+        [Theory]
+        [InlineData("(P<T<V,K>>, K<T<V>, P<K>>)", new[] { "P[T[V,K]]", "K[T[V],P[K]]" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1,WebService.Controllers.Animal`1<!!0>,WebService.Controllers.Animal`1<!0>,WebService.Controllers.Animal`1<!!1>", new[] { "WebService.Controllers.MeGenericClass1`1", "WebService.Controllers.Animal`1[!!0]", "WebService.Controllers.Animal`1[!0]", "WebService.Controllers.Animal`1[!!1]" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1+MeInnerGeneric`4,WebService.Controllers.MultiAnimal`6<!1,!2,!4,!!0,!!1,WebService.Controllers.Animal`1<!!1>>,WebService.Controllers.Animal`1<!!2>", new[] { "WebService.Controllers.MeGenericClass1`1+MeInnerGeneric`4", "WebService.Controllers.MultiAnimal`6[!1,!2,!4,!!0,!!1,WebService.Controllers.Animal`1[!!1]]", "WebService.Controllers.Animal`1[!!2]" })]
+        [InlineData("(WebService.Repositories.RoomRepository+<>c__DisplayClass7_0, WebService.Models.Room)", new[] { "WebService.Repositories.RoomRepository+<>c__DisplayClass7_0", "WebService.Models.Room" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1,!0", new[] { "WebService.Controllers.MeGenericClass1`1", "!0" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1+MeInnerGeneric2`4,WebService.Controllers.MultiAnimal`6<!1,!2,!4,!!0,!!1,WebService.Controllers.Animal`1<!!1>>,WebService.Controllers.Animal`1<!!2>", new[] { "WebService.Controllers.MeGenericClass1`1+MeInnerGeneric2`4", "WebService.Controllers.MultiAnimal`6[!1,!2,!4,!!0,!!1,WebService.Controllers.Animal`1[!!1]]", "WebService.Controllers.Animal`1[!!2]" })]
+        [InlineData("WebService.Controllers.MeGenericClass2`2,!0", new[] { "WebService.Controllers.MeGenericClass2`2", "!0" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1,!0,!!0", new[] { "WebService.Controllers.MeGenericClass1`1", "!0", "!!0" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1,WebService.Controllers.Animal`1<!0>", new[] { "WebService.Controllers.MeGenericClass1`1", "WebService.Controllers.Animal`1[!0]" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1+MeInnerGeneric2`4,WebService.Controllers.MultiAnimal`6<!1,!2,!4,!!0,!!1,WebService.Controllers.Animal`1<!!1>>", new[] { "WebService.Controllers.MeGenericClass1`1+MeInnerGeneric2`4", "WebService.Controllers.MultiAnimal`6[!1,!2,!4,!!0,!!1,WebService.Controllers.Animal`1[!!1]]" })]
+        [InlineData("(WebService.Controllers.RoomsController, System.String, System.String)", new[] { "WebService.Controllers.RoomsController", "System.String", "System.String" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1,WebService.Controllers.Animal`1<WebService.Controllers.P>,!!0,!!1,!!2,!!3", new[] { "WebService.Controllers.MeGenericClass1`1", "WebService.Controllers.Animal`1[WebService.Controllers.P]", "!!0", "!!1", "!!2", "!!3" })]
+        [InlineData("()", null)]
+        [InlineData("WebService.Controllers.MeGenericClass1`1,WebService.Controllers.Animal`1<WebService.Controllers.P>", new[] { "WebService.Controllers.MeGenericClass1`1", "WebService.Controllers.Animal`1[WebService.Controllers.P]" })]
+        [InlineData("(WebService.Controllers.A, WebService.Controllers.B, WebService.Controllers.C)", new[] { "WebService.Controllers.A", "WebService.Controllers.B", "WebService.Controllers.C" })]
+        [InlineData("WebService.Controllers.GenericClass`1<GenericType>", new[] { "WebService.Controllers.GenericClass`1[GenericType]" })]
+        [InlineData("SimpleClass", new[] { "SimpleClass" })]
+        [InlineData("GenericClass`2<T1,T2>", new[] { "GenericClass`2[T1,T2]" })]
+        [InlineData("Outer`1<Inner`2<T1,T2>>", new[] { "Outer`1[Inner`2[T1,T2]]" })]
+        [InlineData("Namespace.Class+Nested`1<Namespace.Generic`2<Arg1,Arg2>>", new[] { "Namespace.Class+Nested`1[Namespace.Generic`2[Arg1,Arg2]]" })]
+        [InlineData("ClassWith1Generic`1<T1>,ClassWith2Generics`2<T1,T2>,ClassWith3Generics`3<T1,T2,T3>", new[] { "ClassWith1Generic`1[T1]", "ClassWith2Generics`2[T1,T2]", "ClassWith3Generics`3[T1,T2,T3]" })]
+        [InlineData("A,B,C,D,E,F,G", new[] { "A", "B", "C", "D", "E", "F", "G" })]
+        [InlineData("(A, B, C, D, E, F, G)", new[] { "A", "B", "C", "D", "E", "F", "G" })]
+        [InlineData("(InvalidType<)", null)]
+        [InlineData("InvalidType>)", null)]
+        [InlineData("(InvalidType>)", null)]
+        [InlineData("(A, InvalidType<)", null)]
+        [InlineData("(ValidType<>)", new[] { "ValidType<>" })]
+        [InlineData("WebService.Controllers.MeGenericClass1`1+MeInnerGeneric2`4<WebService.Controllers.MultiAnimal`6<!1,!2,!4,!!0,!!1,WebService.Controllers.Animal`1<!!1>>", null)]
+        [InlineData("Namespace1.Class1`1<Namespace2.Class2`2<Arg1, Arg2>, Namespace3.Class3>", new[] { "Namespace1.Class1`1[Namespace2.Class2`2[Arg1,Arg2],Namespace3.Class3]" })]
+        [InlineData("OuterNamespace.OuterClass`1<InnerNamespace1.InnerClass`2<Arg1,Arg2>,InnerNamespace2.InnerClass>", new[] { "OuterNamespace.OuterClass`1[InnerNamespace1.InnerClass`2[Arg1,Arg2],InnerNamespace2.InnerClass]" })]
+        [InlineData("A.B.C.D`1<A.B.C.E`2<A.B.C.F,A.B.C.G>>", new[] { "A.B.C.D`1[A.B.C.E`2[A.B.C.F,A.B.C.G]]" })]
+        [InlineData("ClassWithGeneric`1<AnotherClassWithGeneric`2<One,Two>,ThirdClass>", new[] { "ClassWithGeneric`1[AnotherClassWithGeneric`2[One,Two],ThirdClass]" })]
+        [InlineData("Namespace1.Class1`1<Namespace2.Class2`1<Namespace3.Class3>>", new[] { "Namespace1.Class1`1[Namespace2.Class2`1[Namespace3.Class3]]" })]
+        [InlineData("(Outer`1<Inner`2<T1,T2>>)", new[] { "Outer`1[Inner`2[T1,T2]]" })]
+        [InlineData("(Outer`1, Inner`2<T1>, T2>", null)]
+        [InlineData("OuterClass<InnerClass1>, A<<InnerClass2>", null)]
+        [InlineData("OuterClass<InnerClass1>, A<InnerClass2>", new[] { "OuterClass[InnerClass1]", "A[InnerClass2]" })]
+        [InlineData("(OuterClass<InnerClass1>, A<<InnerClass2>)", null)]
+        [InlineData("(OuterClass<InnerClass1>, A<InnerClass2>)", new[] { "OuterClass[InnerClass1]", "A[InnerClass2]" })]
+        [InlineData("Namespace1.Class1`1<Namespace2.Class2`1<Namespace3.Class3>", null)]
+        [InlineData("OuterClass<InnerClass1,InnerClass2>", new[] { "OuterClass[InnerClass1,InnerClass2]" })]
+        [InlineData("Class1<Class2<Class3<Class4>>>", new[] { "Class1[Class2[Class3[Class4]]]" })]
+        [InlineData("(Namespace1.Class1`1<Namespace2.Class2`1<Namespace3.Class3>)", null)]
+        [InlineData("Namespace1.Class1`1<Namespace2.<PrivateImplementationDetails>, Namespace3.Class3>", new[] { "Namespace1.Class1`1[Namespace2.[PrivateImplementationDetails],Namespace3.Class3]" })]
+        [InlineData("Namespace1.Class1`1<Namespace2.<>z__ReadOnlyArray<T>, Namespace3.Class3>", new[] { "Namespace1.Class1`1[Namespace2.<>z__ReadOnlyArray[T],Namespace3.Class3]" })]
+        public void ParseSignaturesTest(string signature, string[] expectedArgs)
+        {
+            var receivedArgs = SignatureParser.Parse(signature);
+            receivedArgs.Should().BeEquivalentTo(expectedArgs, options => options.WithStrictOrdering());
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes
We are on the edge of advancing SymDb to Open Beta. We found a few issues that blocked us in doing so:
- Generic types, methods and arguments received surrounded with `<` and `>` while the native matcher is based on `[` and `]`.
- The parser of the signature in the managed side of the debugger implemented naively, mainly splitted by `,`. Generic params are comma separated too, which failed to parse it correctly.
- Static methods were not handled correctly in the native side. It naively skipped the first param, as if all the methods it deals with are instance methods.
- The signature received by SymDb is surrounded by `(` and `)` and has space in between every param type.

## Reason for change
SymDb readiness for Open Beta.

## Implementation details
- In the managed side, upon receiving a request to instrument a method with a signature that is targeting a generic method/type, the `<` and `>` characters are replaced with `[` and `]` respectively.
- Parsing the signature in a more robust way that handles the generic case where comma could present in between every generic param.
- Static methods are now correctly handled in the native side when a request arrives with a signature exact matching.
- Correctly parsing the signature when it comes surrounded by `(` and `)`, including space in between every param type.

## Test coverage
- [SignatureParserTests](https://github.com/DataDog/dd-trace-dotnet/blob/a8a2df542625b29e3f0d2ce8c745717f27abdb0a/tracer/test/Datadog.Trace.Debugger.IntegrationTests/SignatureParserTests.cs)