### PR TITLE
[Dynamic Instrumentation] DEBUG-2664 Remove `this` from static methods arguments upload

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -6,7 +6,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Datadog.Trace.Debugger.Symbols.Model;
 using Datadog.Trace.Logging;

--- a/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Symbols/SymbolExtractor.cs
@@ -691,7 +691,7 @@ namespace Datadog.Trace.Debugger.Symbols
             foreach (var parameterHandle in parameters)
             {
                 var parameterDef = MetadataReader.GetParameter(parameterHandle);
-                if (index == 0)
+                if (index == 0 && !method.IsStaticMethod())
                 {
                     argsSymbol[index] = new Symbol { Name = "this", SymbolType = SymbolType.Arg, Line = UnknownFieldAndArgLine, Type = method.GetDeclaringType().FullName(MetadataReader) };
                     index++;
@@ -700,12 +700,6 @@ namespace Datadog.Trace.Debugger.Symbols
                     {
                         continue;
                     }
-                }
-
-                // Since we increment the index for `index == 0`, we have to make sure we don't exceed the bound of the array
-                if (index >= argsSymbol.Length)
-                {
-                    break;
                 }
 
                 argsSymbol[index] = new Symbol

--- a/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
+++ b/tracer/src/Datadog.Trace/PDBs/DatadogMetadataReader.cs
@@ -562,20 +562,16 @@ namespace Datadog.Trace.Pdb
 
         internal bool IsCompilerGeneratedAttributeDefinedOnMethod(int methodRid)
         {
-            if (_isDnlibPdbReader)
-            {
-                var attributes = _dnlibModule!.ResolveMethod((uint)methodRid)?.CustomAttributes;
-                return attributes?.IsDefined(CompilerGeneratedAttribute) ?? false;
-            }
+            var method = GetMethodDef(methodRid);
+            var attributes = method.GetCustomAttributes();
+            return IsCompilerGeneratedAttributeDefine(attributes);
+        }
 
-            if (PdbReader != null)
-            {
-                var method = GetMethodDef(methodRid);
-                var attributes = method.GetCustomAttributes();
-                return IsCompilerGeneratedAttributeDefine(attributes);
-            }
-
-            return false;
+        internal bool IsCompilerGeneratedAttributeDefinedOnType(int typeRid)
+        {
+            var nestedType = MetadataReader.GetTypeDefinition(TypeDefinitionHandle.FromRowId(typeRid));
+            var attributes = nestedType.GetCustomAttributes();
+            return IsCompilerGeneratedAttributeDefine(attributes);
         }
 
         private bool IsCompilerGeneratedAttributeDefine(CustomAttributeHandleCollection attributes)
@@ -610,24 +606,6 @@ namespace Datadog.Trace.Pdb
                 {
                     return true;
                 }
-            }
-
-            return false;
-        }
-
-        internal bool IsCompilerGeneratedAttributeDefinedOnType(int typeRid)
-        {
-            if (_isDnlibPdbReader)
-            {
-                var attributes = _dnlibModule!.ResolveTypeDefOrRef((uint)typeRid).CustomAttributes;
-                return attributes.IsDefined(CompilerGeneratedAttribute);
-            }
-
-            if (PdbReader != null)
-            {
-                var nestedType = MetadataReader.GetTypeDefinition(TypeDefinitionHandle.FromRowId(typeRid));
-                var attributes = nestedType.GetCustomAttributes();
-                return IsCompilerGeneratedAttributeDefine(attributes);
             }
 
             return false;


### PR DESCRIPTION
## Summary of changes
We don't want to upload `this` argument for static method

## Test coverage
Existing symbol extractor unit tests
