### PR TITLE
[IAST] Broaden AspNet cookies filtering (#5830 -> v2)

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/CookieAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/Iast/CookieAnalyzer.cs
@@ -132,7 +132,7 @@ internal static class CookieAnalyzer
 
     private static bool IsExcluded(string cookieName)
     {
-        return string.IsNullOrWhiteSpace(cookieName) || cookieName.StartsWith(".AspNetCore.Correlation.", StringComparison.OrdinalIgnoreCase);
+        return string.IsNullOrWhiteSpace(cookieName) || cookieName.StartsWith(".AspNetCore.", StringComparison.OrdinalIgnoreCase);
     }
 
 #endif

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.RedactionEnabled.verified.txt
@@ -81,20 +81,6 @@
           }
         ]
       }
-    },
-    {
-      "type": "NO_SAMESITE_COOKIE",
-      "hash": -1222453805,
-      "evidence": {
-        "value": ".AspNetCore.Session"
-      }
-    },
-    {
-      "type": "INSECURE_COOKIE",
-      "hash": 1343789722,
-      "evidence": {
-        "value": ".AspNetCore.Session"
-      }
     }
   ],
   "sources": [

--- a/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
+++ b/tracer/test/snapshots/Iast.TrustBoundaryViolation.AspNetCore5.IastEnabled.verified.txt
@@ -81,20 +81,6 @@
           }
         ]
       }
-    },
-    {
-      "type": "NO_SAMESITE_COOKIE",
-      "hash": -1222453805,
-      "evidence": {
-        "value": ".AspNetCore.Session"
-      }
-    },
-    {
-      "type": "INSECURE_COOKIE",
-      "hash": 1343789722,
-      "evidence": {
-        "value": ".AspNetCore.Session"
-      }
     }
   ],
   "sources": [


### PR DESCRIPTION
## Summary of changes
Filter all cookies starting with `.AspNet.` as all of them are auto generated and random.

## Reason for change
Until now we only filtered some of these auto gen AspNet cookies. We have broaden the search to filter all of them, as they have different hashes, generating a myriad of cookie related vulns in backed.

## Implementation details
Filter all cookies starting with `.AspNet.` in `CookieAnalyzer` filter
