### PR TITLE
Add Callsite aspects analyzer to check for "safe" patterns

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
@@ -1,0 +1,176 @@
+﻿// <copyright file="BeforeAfterAspectAnalyzer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+
+/// <summary>
+/// An analyzer that analyzers aspects that use [AspectMethodInsertAfter] and [AspectMethodInsertBefore]
+/// for example, and checks that they are all wrapped in a try-catch block. These methods should never throw
+/// so they should always have a try-catch block around them.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class BeforeAfterAspectAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The diagnostic ID displayed in error messages
+    /// </summary>
+    public const string DiagnosticId = "DD0004";
+
+    /// <summary>
+    /// The severity of the diagnostic
+    /// </summary>
+    public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+#pragma warning disable RS2008 // Enable analyzer release tracking for the analyzer project
+    private static readonly DiagnosticDescriptor MissingTryCatchRule = new(
+        DiagnosticId,
+        title: "Aspect is missing try-catch block",
+        messageFormat: "Aspect method bodies should contain a try-catch block at the top level",
+        category: "Reliability",
+        defaultSeverity: Severity,
+        isEnabledByDefault: true,
+        description: "[AspectMethodInsertBefore] and [AspectMethodInsertAfter] Aspects should guarantee safety if possible. Please wrap the aspect in a try-catch block.");
+#pragma warning restore RS2008
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingTryCatchRule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Consider registering other actions that act on syntax instead of or in addition to symbols
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+        context.RegisterSyntaxNodeAction(AnalyseMethod, SyntaxKind.MethodDeclaration);
+    }
+
+    private void AnalyseMethod(SyntaxNodeAnalysisContext context)
+    {
+        // assume that generated code is safe, so bail out for perf reasons
+        if (context.IsGeneratedCode || context.Node is not MethodDeclarationSyntax methodDeclaration)
+        {
+            return;
+        }
+
+        var attributes = methodDeclaration.AttributeLists;
+        if (!attributes.Any())
+        {
+            // no attributes, let's just bail
+            return;
+        }
+
+        var hasAspectAttribute = false;
+        foreach (var attributeList in attributes)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                var name = attribute.Name.ToString();
+                if (name is "AspectMethodInsertBefore" or "AspectMethodInsertAfter"
+                    or "AspectMethodInsertBeforeAttribute" or "AspectMethodInsertAfterAttribute")
+                {
+                    hasAspectAttribute = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasAspectAttribute)
+        {
+            // not an aspect
+            return;
+        }
+
+        var bodyBlock = methodDeclaration.Body;
+        if (bodyBlock is null)
+        {
+            // If we don't have a bodyBlock, it's probably a lambda or expression bodied member
+            // These can't have try catch blocks, so we should bail out
+            var location = methodDeclaration.ExpressionBody?.GetLocation() ?? methodDeclaration.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, location));
+            return;
+        }
+
+        // first statement should be a try-catch block
+        if (!bodyBlock.Statements.Any())
+        {
+            // ignore this case, for now, if there's nothing in there, it's safe, and we don't want to hassle users too soon
+            return;
+        }
+
+        if (bodyBlock.Statements.Count != 1)
+        {
+            // oops, you should have a try block here, and it should be the only child
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        if (bodyBlock.Statements[0] is not TryStatementSyntax tryCatchStatement)
+        {
+            // oops, you should have a try block here
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        CatchClauseSyntax? catchClause = null;
+        var hasFilter = false;
+        var isSystemException = false;
+        var isRethrowing = false;
+
+        foreach (var catchSyntax in tryCatchStatement.Catches)
+        {
+            catchClause = catchSyntax;
+            isSystemException = false;
+            isRethrowing = false;
+
+            // check that it's catching _everything_
+            hasFilter = catchClause.Filter is not null;
+            if (hasFilter)
+            {
+                // Skipping because we shouldn't be letting anything through
+                continue;
+            }
+
+            var exceptionTypeName = catchSyntax.Declaration?.Type is { } exceptionType
+                                        ? context.SemanticModel.GetSymbolInfo(exceptionType).Symbol?.ToString()
+                                        : null;
+            isSystemException = exceptionTypeName is null or "System.Exception";
+            if (!isSystemException)
+            {
+                // skipping because it's not broad enough
+                continue;
+            }
+
+            // final requirement, must not be rethrowing
+            foreach (var statement in catchSyntax.Block.Statements)
+            {
+                if (statement is ThrowStatementSyntax)
+                {
+                    isRethrowing = true;
+                    break;
+                }
+            }
+
+            // if we get here, we know one of the loops is all good, so we can break
+            break;
+        }
+
+        if (catchClause is null || hasFilter || !isSystemException || isRethrowing)
+        {
+            // oops, no good
+            var location = catchClause?.GetLocation() ?? tryCatchStatement.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, location));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
@@ -29,7 +29,7 @@ public class BeforeAfterAspectAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// The severity of the diagnostic
     /// </summary>
-    public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+    public const DiagnosticSeverity Severity = DiagnosticSeverity.Info;
 
 #pragma warning disable RS2008 // Enable analyzer release tracking for the analyzer project
     private static readonly DiagnosticDescriptor MissingTryCatchRule = new(

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
@@ -1,0 +1,150 @@
+﻿// <copyright file="BeforeAfterAspectCodeFixProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.ThreadAbortAnalyzer;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+
+/// <summary>
+/// A CodeFixProvider for the <see cref="ThreadAbortAnalyzer"/>
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(BeforeAfterAspectCodeFixProvider))]
+[Shared]
+public class BeforeAfterAspectCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc />
+    public sealed override ImmutableArray<string> FixableDiagnosticIds
+    {
+        get => ImmutableArray.Create(BeforeAfterAspectAnalyzer.DiagnosticId);
+    }
+
+    /// <inheritdoc />
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc />
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the methodDeclaration identified by the diagnostic.
+        var methodDeclaration = root?.FindToken(diagnosticSpan.Start)
+                                    .Parent
+                                    ?.AncestorsAndSelf()
+                                    .OfType<MethodDeclarationSyntax>()
+                                    .First();
+
+        if (methodDeclaration is null)
+        {
+            return;
+        }
+
+        // Register a code action that will invoke the fix.
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: "Wrap aspect with exception handler",
+                createChangedDocument: c => AddTryCatch(context.Document, methodDeclaration, c),
+                equivalenceKey: nameof(BeforeAfterAspectCodeFixProvider)),
+            diagnostic);
+    }
+
+    private async Task<Document> AddTryCatch(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken cancellationToken)
+    {
+        var paramName = methodDeclaration.ParameterList.Parameters.FirstOrDefault()?.Identifier.Text;
+        var blockSyntax = methodDeclaration.Body ?? CreateBasicBlock(methodDeclaration.ExpressionBody) ?? null;
+        if (blockSyntax is null)
+        {
+            // weirdness, bail out
+            return document;
+        }
+
+        var parentType = methodDeclaration.AncestorsAndSelf()
+                                        .FirstOrDefault(x => x is TypeDeclarationSyntax or RecordDeclarationSyntax or StructDeclarationSyntax);
+
+        var typeName = parentType switch
+        {
+            StructDeclarationSyntax t => t.Identifier.Text,
+            RecordDeclarationSyntax t => t.Identifier.Text,
+            TypeDeclarationSyntax t => t.Identifier.Text,
+            _ => "UNKNOWN",
+        };
+
+        var methodName = methodDeclaration.Identifier.Text;
+
+        // check if we already have a try catch
+        TryStatementSyntax tryCatch;
+        if (blockSyntax.Statements.Count == 1 && blockSyntax.Statements[0] is TryStatementSyntax tryStatementSyntax)
+        {
+            tryCatch = tryStatementSyntax;
+        }
+        else
+        {
+            tryCatch = SyntaxFactory.TryStatement().WithBlock(blockSyntax);
+        }
+
+        // create the trystatementsyntax with the internals of the method declaration
+        var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
+        var logExpression = SyntaxFactory.ExpressionStatement(
+            SyntaxFactory.ParseExpression($$"""Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+        var returnStatement = paramName is not null
+                                  ? SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(paramName))
+                                  : SyntaxFactory.ReturnStatement();
+        var syntaxList = SyntaxFactory.List(new StatementSyntax[] { logExpression, returnStatement });
+
+        var catchSyntax = SyntaxFactory.CatchClause()
+                                       .WithDeclaration(catchDeclaration)
+                                       .WithBlock(SyntaxFactory.Block(syntaxList));
+
+        var updatedTryCatch = tryCatch.AddCatches(catchSyntax);
+        var newBlock = SyntaxFactory.Block(updatedTryCatch)
+                                    .WithAdditionalAnnotations(Formatter.Annotation);
+
+        // remove the expression body if we have one
+        var newMethodDeclaration = methodDeclaration.ExpressionBody is not null
+                                       ? methodDeclaration
+                                        .WithExpressionBody(null)
+                                        .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None))
+                                       : methodDeclaration;
+
+        newMethodDeclaration = newMethodDeclaration.WithBody(newBlock);
+
+        // replace the syntax and return updated document
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        root = root!.ReplaceNode(methodDeclaration, newMethodDeclaration);
+        return document.WithSyntaxRoot(root);
+    }
+
+    private BlockSyntax? CreateBasicBlock(ArrowExpressionClauseSyntax? expressionBodyExpression)
+    {
+        if (expressionBodyExpression is null)
+        {
+            return null;
+        }
+
+        return SyntaxFactory.Block()
+                            .WithStatements(
+                                 SyntaxFactory.SingletonList<StatementSyntax>(
+                                     SyntaxFactory.ReturnStatement(expressionBodyExpression.Expression)));
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectAnalyzer.cs
@@ -28,7 +28,7 @@ public class ReplaceAspectAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// The severity of the diagnostic
     /// </summary>
-    public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+    public const DiagnosticSeverity Severity = DiagnosticSeverity.Info;
 
 #pragma warning disable RS2008 // Enable analyzer release tracking for the analyzer project
     private static readonly DiagnosticDescriptor MissingTryCatchRule = new(

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectAnalyzer.cs
@@ -1,0 +1,204 @@
+﻿// <copyright file="ReplaceAspectAnalyzer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+
+/// <summary>
+/// An analyzer that analyzers aspects that use [AspectMethodInsertAfter] and [AspectMethodInsertBefore]
+/// for example, and checks that they are all wrapped in a try-catch block. These methods should never throw
+/// so they should always have a try-catch block around them.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class ReplaceAspectAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The diagnostic ID displayed in error messages
+    /// </summary>
+    public const string DiagnosticId = "DD0005";
+
+    /// <summary>
+    /// The severity of the diagnostic
+    /// </summary>
+    public const DiagnosticSeverity Severity = DiagnosticSeverity.Warning;
+
+#pragma warning disable RS2008 // Enable analyzer release tracking for the analyzer project
+    private static readonly DiagnosticDescriptor MissingTryCatchRule = new(
+        DiagnosticId,
+        title: "Aspect is in incorrect format",
+        messageFormat: "Aspect method bodies should contain a single expression to set the result variable, and then have a try-catch block, and then return the created variable",
+        category: "Reliability",
+        defaultSeverity: Severity,
+        isEnabledByDefault: true,
+        description: "[AspectCtorReplace] and [AspectMethodReplace] Aspects should guarantee safety if possible. Please execute the target method first, then wrap the remainder of the aspect in a try-catch block, and finally return the variable.");
+#pragma warning restore RS2008
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingTryCatchRule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Consider registering other actions that act on syntax instead of or in addition to symbols
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+        context.RegisterSyntaxNodeAction(AnalyseMethod, SyntaxKind.MethodDeclaration);
+    }
+
+    private void AnalyseMethod(SyntaxNodeAnalysisContext context)
+    {
+        // assume that generated code is safe, so bail out for perf reasons
+        if (context.IsGeneratedCode || context.Node is not MethodDeclarationSyntax methodDeclaration)
+        {
+            return;
+        }
+
+        var attributes = methodDeclaration.AttributeLists;
+        if (!attributes.Any())
+        {
+            // no attributes, let's just bail
+            return;
+        }
+
+        var hasAspectAttribute = false;
+        foreach (var attributeList in attributes)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                var name = attribute.Name.ToString();
+                if (name is "AspectCtorReplace" or "AspectMethodReplace"
+                    or "AspectCtorReplaceAttribute" or "AspectMethodReplaceAttribute")
+                {
+                    hasAspectAttribute = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasAspectAttribute)
+        {
+            // not an aspect
+            return;
+        }
+
+        var bodyBlock = methodDeclaration.Body;
+        if (bodyBlock is null)
+        {
+            // If we don't have a bodyBlock, it's probably a lambda or expression bodied member
+            // These can't have try catch blocks, so we should bail out
+            var location = methodDeclaration.ExpressionBody?.GetLocation() ?? methodDeclaration.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, location));
+            return;
+        }
+
+        if (!bodyBlock.Statements.Any())
+        {
+            // ignore this case, for now, if there's nothing in there, it's safe, and we don't want to hassle users too soon
+            return;
+        }
+
+        if (bodyBlock.Statements.Count != 3)
+        {
+            // We require exactly 3 statements, so this must be an error
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        // check the first statement
+        if (bodyBlock.Statements[0] is not LocalDeclarationStatementSyntax localDeclaration)
+        {
+            // this is an error, and we can't go much further
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        if (bodyBlock.Statements[1] is not TryStatementSyntax tryCatchStatement)
+        {
+            // oops, you should have a try block here
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        CatchClauseSyntax? catchClause = null;
+        var hasFilter = false;
+        var isSystemException = false;
+        var isRethrowing = false;
+
+        foreach (var catchSyntax in tryCatchStatement.Catches)
+        {
+            catchClause = catchSyntax;
+            isSystemException = false;
+            isRethrowing = false;
+
+            // check that it's catching _everything_
+            hasFilter = catchClause.Filter is not null;
+            if (hasFilter)
+            {
+                // Skipping because we shouldn't be letting anything through
+                continue;
+            }
+
+            var exceptionTypeName = catchSyntax.Declaration?.Type is { } exceptionType
+                                        ? context.SemanticModel.GetSymbolInfo(exceptionType).Symbol?.ToString()
+                                        : null;
+            isSystemException = exceptionTypeName is null or "System.Exception";
+            if (!isSystemException)
+            {
+                // skipping because it's not broad enough
+                continue;
+            }
+
+            // final requirement, must not be rethrowing
+            foreach (var statement in catchSyntax.Block.Statements)
+            {
+                if (statement is ThrowStatementSyntax)
+                {
+                    isRethrowing = true;
+                    break;
+                }
+            }
+
+            // if we get here, we know one of the loops is all good, so we can break
+            break;
+        }
+
+        if (catchClause is null || hasFilter || !isSystemException || isRethrowing)
+        {
+            // oops, no good
+            var location = catchClause?.GetLocation() ?? tryCatchStatement.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, location));
+        }
+
+        // final check, do we return the variable?
+        if (bodyBlock.Statements[2] is not ReturnStatementSyntax returnStatement)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        // should be returning the variable
+        if (returnStatement.Expression is not IdentifierNameSyntax identifierName)
+        {
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        if (!localDeclaration.Declaration.Variables.Any()
+         || localDeclaration.Declaration.Variables[0] is not { } variable
+         || variable.Identifier.ToString() != identifierName.Identifier.ToString())
+        {
+            // not returning the right thing
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/ReplaceAspectCodeFixProvider.cs
@@ -1,0 +1,126 @@
+﻿// <copyright file="ReplaceAspectCodeFixProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.ThreadAbortAnalyzer;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+
+/// <summary>
+/// A CodeFixProvider for the <see cref="ThreadAbortAnalyzer"/>
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ReplaceAspectCodeFixProvider))]
+[Shared]
+public class ReplaceAspectCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc />
+    public sealed override ImmutableArray<string> FixableDiagnosticIds
+    {
+        get => ImmutableArray.Create(ReplaceAspectAnalyzer.DiagnosticId);
+    }
+
+    /// <inheritdoc />
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc />
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the methodDeclaration identified by the diagnostic.
+        var methodDeclaration = root?.FindToken(diagnosticSpan.Start)
+                                     .Parent
+                                    ?.AncestorsAndSelf()
+                                     .OfType<MethodDeclarationSyntax>()
+                                     .First();
+
+        if (methodDeclaration?.Body is { Statements.Count: >2 } body
+         && body.Statements[0] is LocalDeclarationStatementSyntax localDeclaration
+         && body.Statements[body.Statements.Count - 1] is ReturnStatementSyntax { Expression: IdentifierNameSyntax identifierName }
+         && localDeclaration.Declaration.Variables.Count == 1
+         && localDeclaration.Declaration.Variables[0] is { } variable
+         && variable.Identifier.ToString() == identifierName.Identifier.ToString())
+        {
+            // Register a code action that will invoke the fix.
+            context.RegisterCodeFix(
+                CodeAction.Create(
+                    title: "Wrap internals with exception handler",
+                    createChangedDocument: c => AddTryCatch(context.Document, methodDeclaration, c),
+                    equivalenceKey: nameof(ReplaceAspectCodeFixProvider)),
+                diagnostic);
+        }
+    }
+
+    private async Task<Document> AddTryCatch(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken cancellationToken)
+    {
+        // we know we're calling this with something we can fix,
+        // we just need to work out if we need to wrap the internals in a try-catch
+        // or add a catch statement
+        var body = methodDeclaration.Body!;
+        var localDeclaration = (LocalDeclarationStatementSyntax)body.Statements[0];
+        var returnSyntax = (ReturnStatementSyntax)body.Statements[body.Statements.Count - 1];
+        TryStatementSyntax tryCatch;
+
+        if (body.Statements.Count == 3 && body.Statements[1] is TryStatementSyntax tryStatementSyntax)
+        {
+            tryCatch = tryStatementSyntax;
+        }
+        else
+        {
+            var block = SyntaxFactory.Block(body.Statements.Skip(1).Take(body.Statements.Count - 2));
+            tryCatch = SyntaxFactory.TryStatement().WithBlock(block);
+        }
+
+        // Add the catch statement to the try-catch block
+        var parentType = methodDeclaration.AncestorsAndSelf()
+                                          .FirstOrDefault(x => x is TypeDeclarationSyntax or RecordDeclarationSyntax or StructDeclarationSyntax);
+        var typeName = parentType switch
+        {
+            StructDeclarationSyntax t => t.Identifier.Text,
+            RecordDeclarationSyntax t => t.Identifier.Text,
+            TypeDeclarationSyntax t => t.Identifier.Text,
+            _ => "UNKNOWN",
+        };
+
+        var methodName = methodDeclaration.Identifier.Text;
+
+        var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
+        var logExpression = SyntaxFactory.ExpressionStatement(
+            SyntaxFactory.ParseExpression($$"""Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+
+        var catchSyntax = SyntaxFactory.CatchClause()
+                                       .WithDeclaration(catchDeclaration)
+                                       .WithBlock(SyntaxFactory.Block(logExpression));
+
+        var updatedTryCatch = tryCatch.AddCatches(catchSyntax);
+        var newBody = SyntaxFactory.Block(localDeclaration, updatedTryCatch, returnSyntax)
+                                   .WithAdditionalAnnotations(Formatter.Annotation);
+
+        var newMethodDeclaration = methodDeclaration.WithBody(newBody);
+
+        // replace the syntax and return updated document
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        root = root!.ReplaceNode(methodDeclaration, newMethodDeclaration);
+        return document.WithSyntaxRoot(root);
+    }
+}

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -1,0 +1,291 @@
+﻿// <copyright file="BeforeAfterAspectAnalyzerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.BeforeAfterAspectAnalyzer,
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.BeforeAfterAspectCodeFixProvider>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests.AspectAnalyzers;
+
+public class BeforeAfterAspectAnalyzerTests
+{
+    private const string DiagnosticId = BeforeAfterAspectAnalyzer.DiagnosticId;
+    private const DiagnosticSeverity Severity = BeforeAfterAspectAnalyzer.Severity;
+
+    // No diagnostics expected to show up
+    [Fact]
+    public async Task EmptySourceShouldNotHaveDiagnostics()
+    {
+        var test = string.Empty;
+
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagMethodWithoutAttributes()
+    {
+        var method =
+            """
+            string TestMethod(string myParam)
+            {
+                // does something
+                return myParam;
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagMethodWithTryCatch()
+    {
+        var method =
+            """
+            [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            string TestMethod(string myParam)
+            {
+                try
+                {
+                    // does something
+                    return myParam;
+                }
+                catch (Exception ex)
+                {
+                    // the contents don't actually matter here
+                    return myParam;
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagEmptyMethod()
+    {
+        var method =
+            """
+            [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            void TestMethod(string myParam)
+            {
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldFlagExpressionBodiedMember()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:=> myParam|};
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodWithoutTryCatch()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        // does something
+                        return myParam;
+                    }|}
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodWithDerivedException()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        {|#0:catch (SystemException ex)
+                        {
+                            return myParam;
+                        }|}
+                    }
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        catch (SystemException ex)
+                        {
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodWithFilter()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        {|#0:catch (Exception ex) when (ex.Message == "test")
+                        {
+                            return myParam;
+                        }|}
+                    }
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        catch (Exception ex) when (ex.Message == "test")
+                        {
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    private static string GetTestCode(string testFragment)
+        =>
+            $$"""
+              using System;
+              using System.Collections.Generic;
+              using System.Linq;
+              using System.Text;
+              using System.Threading;
+              using System.Threading.Tasks;
+              using System.Diagnostics;
+
+              namespace ConsoleApplication1
+              {
+                  class TestClass
+                  {
+                      private static readonly IDatadogLogger Log = new DatadogLogging();
+
+              {{testFragment}}
+                  }
+              
+                  [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+                  internal abstract class AspectAttribute : Attribute { } 
+              
+                  internal sealed class AspectMethodInsertBeforeAttribute : AspectAttribute
+                  {
+                      public AspectMethodInsertBeforeAttribute(string targetMethod) { }
+                  }
+
+                  internal sealed class AspectMethodInsertAfterAttribute : AspectAttribute { }
+                  
+                  interface IDatadogLogger
+                  {
+                      void Error(Exception? exception, string messageTemplate);
+                  }
+                  
+                  class DatadogLogging : IDatadogLogger
+                  {
+                      public void Error(Exception? exception, string messageTemplate) { }
+                  }
+              }
+              """;
+}

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/ReplaceAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/ReplaceAspectAnalyzerTests.cs
@@ -1,0 +1,614 @@
+﻿// <copyright file="ReplaceAspectAnalyzerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.ReplaceAspectAnalyzer,
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.ReplaceAspectCodeFixProvider>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests.AspectAnalyzers;
+
+public class ReplaceAspectAnalyzerTests
+{
+    private const string DiagnosticId = ReplaceAspectAnalyzer.DiagnosticId;
+    private const DiagnosticSeverity Severity = ReplaceAspectAnalyzer.Severity;
+
+    // No diagnostics expected to show up
+    [Fact]
+    public async Task EmptySourceShouldNotHaveDiagnostics()
+    {
+        var test = string.Empty;
+
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagMethodWithoutAttributes()
+    {
+        var method =
+            """
+            string TestMethod(string myParam)
+            {
+                // does something
+                return myParam;
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagCtorMethodWithoutAttributes()
+    {
+        var method =
+            """
+            TestClass TestMethod(string myParam)
+            {
+                // does something
+                return new TestClass();
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagMethodWithCorrectFormat()
+    {
+        var method =
+            """
+            [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            string TestMethod(string myParam)
+            {
+                var result = myParam + "/";
+                try
+                {
+                    // does something
+                    return myParam;
+                }
+                catch (Exception ex)
+                {
+                    // the contents don't actually matter here
+                    return myParam;
+                }
+                return result;
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagCtorWithCorrectFormat()
+    {
+        var method =
+            """
+            [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            TestClass TestMethod(string myParam)
+            {
+                var result = new TestClass();
+
+                try
+                {
+                    // does something
+                }
+                catch (Exception ex)
+                {
+                    // the contents don't actually matter here
+                }
+
+                return result;
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldFlagExpressionBodiedMember()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:=> myParam|};
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        await Verifier.VerifyAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodThatDoesntFitSpec_Nothing()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        // does something
+                        return myParam;
+                    }|}
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        // can't fix as no good options
+        await Verifier.VerifyAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodThatDoesntFitSpec_NoTryCatch()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        var result = myParam + "/";
+
+                        _ = myParam;
+
+                        return result;
+                    }|}
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        var result = myParam + "/";
+                        try
+                        {
+                            _ = myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                        }
+
+                        return result;
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodThatDoesntFitSpec_NoTryCatchMultiBlock()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        var result = myParam + "/";
+
+                        _ = myParam;
+                        var x = myParam + myParam;
+
+                        return result;
+                    }|}
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        var result = myParam + "/";
+                        try
+                        {
+                            _ = myParam;
+                            var x = myParam + myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                        }
+
+                        return result;
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodThatDoesntFitSpec_MultiBlockTryCatch()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        var result = myParam + "/";
+
+                        _ = myParam;
+                        try
+                        {
+                            var x = myParam + myParam;
+                        }
+                        catch (Exception e)
+                        {
+                            // the contents don't actually matter here
+                        }
+            
+                        return result;
+                    }|}
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        var result = myParam + "/";
+                        try
+                        {
+                            _ = myParam;
+                            try
+                            {
+                                var x = myParam + myParam;
+                            }
+                            catch (Exception e)
+                            {
+                                // the contents don't actually matter here
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                        }
+
+                        return result;
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodThatDoesntFitSpec_ReturnsWrongValue()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        var result = myParam + "/";
+                    
+                        try
+                        {
+                            // does something
+                        }
+                        catch (Exception ex)
+                        {
+                            // the contents don't actually matter here
+                        }
+                    
+                        return myParam;
+                    }|}
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        // can't fix as no good options
+        await Verifier.VerifyAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodThatDoesntFitSpec_NotALocalDeclaration()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        string.Concat(myParam, "/");
+                    
+                        try
+                        {
+                            // does something
+                        }
+                        catch (Exception ex)
+                        {
+                            // the contents don't actually matter here
+                        }
+                    
+                        return myParam;
+                    }|}
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        // can't fix as no good options
+        await Verifier.VerifyAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodThatDoesntFitSpec_InsufficientCatch()
+    {
+        var method =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        var result = myParam + "/";
+
+                        try
+                        {
+                            // does something
+                        }
+                        {|#0:catch (SystemException ex)
+                        {
+                            // using too narrow an exception here
+                        }|}
+
+                        return result;
+                    }
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        var result = myParam + "/";
+
+                        try
+                        {
+                            // does something
+                        }
+                        catch (SystemException ex)
+                        {
+                            // using too narrow an exception here
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                        }
+
+                        return result;
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagCtorThatDoesntFitSpec_Nothing()
+    {
+        var method =
+            """
+                    [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    TestClass TestMethod(string myParam)
+                    {|#0:{
+                        // does something
+                        return new();
+                    }|}
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        // can't fix as no good options
+        await Verifier.VerifyAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagCtorThatDoesntFitSpec_NoTryCatch()
+    {
+        var method =
+            """
+                    [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    TestClass TestMethod(string myParam)
+                    {|#0:{
+                        var result = new TestClass();
+
+                        _ = myParam;
+
+                        return result;
+                    }|}
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    TestClass TestMethod(string myParam)
+                    {|#0:{
+                        var result = new TestClass();
+                        try
+                        {
+                            _ = myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                        }
+
+                        return result;
+                    }|}
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagCtorThatDoesntFitSpec_ReturnsWrongValue()
+    {
+        var method =
+            """
+                    [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    TestClass TestMethod(string myParam)
+                    {|#0:{
+                        var result = new TestClass();
+                    
+                        try
+                        {
+                            // does something
+                        }
+                        catch (Exception ex)
+                        {
+                            // the contents don't actually matter here
+                        }
+                    
+                        return new TestClass();
+                    }|}
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        // can't fix as no good options
+        await Verifier.VerifyAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagCtorThatDoesntFitSpec_NotALocalDeclaration()
+    {
+        var method =
+            """
+                    [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    TestClass TestMethod(string myParam)
+                    {|#0:{
+                        new TestClass();
+
+                        try
+                        {
+                            // does something
+                        }
+                        catch (Exception ex)
+                        {
+                            // the contents don't actually matter here
+                        }
+                    
+                        return new TestClass();
+                    }|}
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        // can't fix as no good options
+        await Verifier.VerifyAnalyzerAsync(code, expected);
+    }
+
+    [Fact]
+    public async Task ShouldFlagCtorThatDoesntFitSpec_InsufficientCatch()
+    {
+        var method =
+            """
+                    [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    TestClass TestMethod(string myParam)
+                    {
+                        var result = new TestClass();
+
+                        try
+                        {
+                            // does something
+                        }
+                        {|#0:catch (SystemException ex)
+                        {
+                            // using too narrow an exception here
+                        }|}
+
+                        return result;
+                    }
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectCtorReplace("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    TestClass TestMethod(string myParam)
+                    {
+                        var result = new TestClass();
+
+                        try
+                        {
+                            // does something
+                        }
+                        catch (SystemException ex)
+                        {
+                            // using too narrow an exception here
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                        }
+
+                        return result;
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    private static string GetTestCode(string testFragment)
+        =>
+            $$"""
+              using System;
+              using System.Collections.Generic;
+              using System.Linq;
+              using System.Text;
+              using System.Threading;
+              using System.Threading.Tasks;
+              using System.Diagnostics;
+
+              namespace ConsoleApplication1
+              {
+                  class TestClass
+                  {
+                      private static readonly IDatadogLogger Log = new DatadogLogging();
+
+              {{testFragment}}
+                  }
+              
+                  [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+                  internal abstract class AspectAttribute : Attribute { } 
+              
+                  internal sealed class AspectCtorReplaceAttribute : AspectAttribute
+                  {
+                      public AspectCtorReplaceAttribute(string targetMethod) { }
+                  }
+              
+                  internal sealed class AspectMethodReplaceAttribute : AspectAttribute
+                  {
+                      public AspectMethodReplaceAttribute(string targetMethod) { }
+                  }
+                  
+                  interface IDatadogLogger
+                  {
+                      void Error(Exception? exception, string messageTemplate);
+                  }
+                  
+                  class DatadogLogging : IDatadogLogger
+                  {
+                      public void Error(Exception? exception, string messageTemplate) { }
+                  }
+              }
+              """;
+}


### PR DESCRIPTION
## Summary of changes

Adds two analyzers that check for "safe" usage of the callsite arguments

## Reason for change

In CallTarget we explicitly wrap all the custom code in try-catch statements for safety. It's not technically easy to do that with CallSite, so this provides the next best thing - an analyzer that enforces specific patterns.

## Implementation details

There are two analyzers included

- `BeforeAfterAspectAnalyzer` that works with `[AspectMethodInsertBefore]` and `[AspectMethodInsertAfter]`
- `ReplaceAspectAnalyzer` that works with `[AspectCtorReplace]` and `[AspectMethodReplace]`

> The CodeFixProvider for `ReplaceAspectAnalyzer` is "best effort", and only works for aspects that follow an expected pattern, as otherwise there's too much risk of introducing a bug.

The easiest way to show what they do is to look at the unit tests, or the following GIFs of the analyzers and code fixes in action

![aspect analyzer](https://github.com/user-attachments/assets/6b09c721-8d6f-4e37-bfba-dc60e9a6ad99)

![aspect analyzer2](https://github.com/user-attachments/assets/b796c6ce-f88e-4a77-a34c-75336427318f)

## Test coverage

Unit tests for the behaviour. Also verified that they show up in the IDE

## Other details

Setting the severity of these analyzers to `Warning` or `Error` breaks the build, as most of our aspects are non-compliant. For now, I've set it to `Info` so that nothing breaks, but you only get a minimal info about the error in the IDE:

![image](https://github.com/user-attachments/assets/4d343d12-a010-401c-a74b-1747d538fd5b)

When we fix these issues, we should be sure to change the severity of the analyzers to `Error` first, as it will make them easier to fix, and we will know we caught them all.

