### PR TITLE
Fix error checking for CallTargetBubbleUpException

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/calltarget_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/calltarget_tokens.cpp
@@ -556,7 +556,7 @@ ModuleMetadata* CallTargetTokens::GetMetadata()
 
 HRESULT CallTargetTokens::EnsureBaseCalltargetTokens()
 {
-    std::lock_guard<std::mutex> guard(metadata_mutex);
+    std::lock_guard<std::recursive_mutex> guard(metadata_mutex);
 
     auto hr = EnsureCorLibTokens();
     if (FAILED(hr))

--- a/tracer/src/Datadog.Tracer.Native/calltarget_tokens.h
+++ b/tracer/src/Datadog.Tracer.Native/calltarget_tokens.h
@@ -26,7 +26,6 @@ class CallTargetTokens
 {
 private:
     ModuleMetadata* module_metadata_ptr = nullptr;
-    std::mutex metadata_mutex;
 
     // CorLib tokens
     volatile mdAssemblyRef corLibAssemblyRef = mdAssemblyRefNil;
@@ -53,6 +52,8 @@ private:
 protected:
     // CallTarget tokens
     volatile mdAssemblyRef profilerAssemblyRef = mdAssemblyRefNil;
+
+    std::recursive_mutex metadata_mutex;
 
     const bool enable_by_ref_instrumentation = false;
     const bool enable_calltarget_state_by_ref = false;

--- a/tracer/src/Datadog.Tracer.Native/debugger_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/debugger_tokens.cpp
@@ -158,6 +158,8 @@ HRESULT DebuggerTokens::WriteLogArgOrLocal(void* rewriterWrapperPtr, const TypeS
 
 HRESULT DebuggerTokens::EnsureBaseCalltargetTokens()
 {
+    std::lock_guard<std::recursive_mutex> guard(metadata_mutex);
+
     auto hr = CallTargetTokens::EnsureBaseCalltargetTokens();
 
     IfFailRet(hr);

--- a/tracer/src/Datadog.Tracer.Native/fault_tolerant_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/fault_tolerant_tokens.cpp
@@ -5,6 +5,8 @@
 
 HRESULT fault_tolerant::FaultTolerantTokens::EnsureBaseCalltargetTokens()
 {
+    std::lock_guard<std::recursive_mutex> guard(metadata_mutex);
+
     auto hr = CallTargetTokens::EnsureBaseCalltargetTokens();
 
     IfFailRet(hr);

--- a/tracer/src/Datadog.Tracer.Native/tracer_method_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/tracer_method_rewriter.cpp
@@ -433,7 +433,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     // *** BeginMethod exception handling clause
     EHClause beginMethodExClause{};
-    if (m_corProfiler->call_target_bubble_up_exception_available)
+    if (filter != nullptr)
     {
         beginMethodExClause.m_Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
         beginMethodExClause.m_pTryBegin = firstInstruction;
@@ -580,7 +580,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     ILInstr* filterEnd = nullptr;
     ILInstr* endMethodCatchFirstInstr = nullptr;
-    if (m_corProfiler->call_target_bubble_up_exception_available)
+    if (m_corProfiler->call_target_bubble_up_exception_available && bubbleup_exception_typeref != mdTypeRefNil)
     {
         Logger::Debug("Creating filter for try / catch for CallTargetBubbleUpException (end method).");
         filterEnd = CreateFilterForException(&reWriterWrapper, tracerTokens->GetExceptionTypeRef(),
@@ -598,7 +598,7 @@ HRESULT TracerMethodRewriter::Rewrite(RejitHandlerModule* moduleHandler, RejitHa
 
     // *** EndMethod exception handling clause
     EHClause endMethodExClause{};
-    if (m_corProfiler->call_target_bubble_up_exception_available)
+    if (filterEnd != nullptr)
     {
         endMethodExClause.m_Flags = COR_ILEXCEPTION_CLAUSE_FILTER;
         endMethodExClause.m_pTryBegin = endMethodTryStartInstr;

--- a/tracer/src/Datadog.Tracer.Native/tracer_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/tracer_tokens.cpp
@@ -157,6 +157,8 @@ const shared::WSTRING& TracerTokens::GetCallTargetRefStructType()
 
 HRESULT TracerTokens::EnsureBaseCalltargetTokens()
 {
+    std::lock_guard<std::recursive_mutex> guard(metadata_mutex);
+
     HRESULT hr = CallTargetTokens::EnsureBaseCalltargetTokens();
     if (FAILED(hr))
     {


### PR DESCRIPTION
## Summary of changes

Fix error checking when emitting the CallTargetBubbleUpException code.
As a bonus, add synchronization when creating the metadata tokens.

## Reason for change

If for some reason we fail to create the metadata tokens, we could create an invalid EH clause, which causes an access violation later on.

## Implementation details

Converted the calltarget_tokens mutex to a recursive mutex, because the `EnsureBaseCalltargetTokens` methods call each other.

## Test coverage

Hard to test, but coincidentally I discovered that the the added synchronization fixes a crash when running powershell with SentinelOne activated.

## Other details

Fixes #5799