### PR TITLE
[Profiler] LibrariesInfoCache: fix reload bug

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.cpp
@@ -49,7 +49,7 @@ void LibrariesInfoCache::UpdateCache()
     {
         auto previous = NbCallsToDlopenDlclose;
         NbCallsToDlopenDlclose = dd_nb_calls_to_dlopen_dlclose();
-        shouldReload = previous == NbCallsToDlopenDlclose;
+        shouldReload = previous != NbCallsToDlopenDlclose;
     }
 
     if (!shouldReload)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LibrariesInfoCache.h
@@ -15,6 +15,12 @@ public:
     static LibrariesInfoCache* Get();
     ~LibrariesInfoCache();
 
+    LibrariesInfoCache(LibrariesInfoCache const &) = delete;
+    LibrariesInfoCache& operator=(LibrariesInfoCache const&) = delete;
+
+    LibrariesInfoCache(LibrariesInfoCache&&) = delete;
+    LibrariesInfoCache& operator=(LibrariesInfoCache&&) = delete;
+
     void UpdateCache();
 
 private:


### PR DESCRIPTION
## Summary of changes

Fix bug relative to the `LibrariesInfoCache`

## Reason for change

The cache was reloaded when it was not necessary. (the logic was reversed)
![image](https://github.com/user-attachments/assets/f5c8d788-ebf3-4754-ac19-1e4d62d6f826)

## Implementation details

Fix condition
## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
