### PR TITLE
Ensure top-level entry points are wrapped with try-catch

### DIFF
--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -95,7 +95,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 catch
                 {
                     // sigh, nothing works, _pretend_ we're in SSI so that we don't crash the app
-                    return false;
+                    return true;
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -279,7 +279,7 @@ namespace Datadog.Trace
                     }
                     catch (Exception ex)
                     {
-                        Log.Error(ex, "Error occured in keep-live for {Process}.", path);
+                        Log.Error(ex, "Error occured in keep-alive for {Process}.", path);
                     }
                     finally
                     {

--- a/tracer/src/Datadog.Trace/AgentProcessManager.cs
+++ b/tracer/src/Datadog.Trace/AgentProcessManager.cs
@@ -222,8 +222,7 @@ namespace Datadog.Trace
 
                                     var startInfo = new ProcessStartInfo
                                     {
-                                        FileName = path,
-                                        UseShellExecute = false // Force consistency in behavior between Framework and Core
+                                        FileName = path, UseShellExecute = false // Force consistency in behavior between Framework and Core
                                     };
 
                                     if (!string.IsNullOrWhiteSpace(metadata.ProcessArguments))
@@ -277,6 +276,10 @@ namespace Datadog.Trace
                                 }
                             }
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error occured in keep-live for {Process}.", path);
                     }
                     finally
                     {

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -196,7 +196,7 @@ namespace Datadog.Trace.ClrProfiler
                 catch
                 {
                     // sigh, nothing works, _pretend_ we're in SSI so that we don't crash the app
-                    return false;
+                    return true;
                 }
             }
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -519,17 +519,24 @@ namespace Datadog.Trace.ClrProfiler
                     // TODO: LiveDebugger should be initialized in TracerManagerFactory so it can respond
                     // to changes in ExporterSettings etc.
 
-                    var sw = Stopwatch.StartNew();
-                    var isDiscoverySuccessful = await WaitForDiscoveryService(discoveryService).ConfigureAwait(false);
-                    TelemetryFactory.Metrics.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.DiscoveryService, sw.ElapsedMilliseconds);
-
-                    if (isDiscoverySuccessful)
+                    try
                     {
-                        var liveDebugger = LiveDebuggerFactory.Create(discoveryService, RcmSubscriptionManager.Instance, settings, serviceName, tracer.TracerManager.Telemetry, debuggerSettings, tracer.TracerManager.GitMetadataTagsProvider);
+                        var sw = Stopwatch.StartNew();
+                        var isDiscoverySuccessful = await WaitForDiscoveryService(discoveryService).ConfigureAwait(false);
+                        TelemetryFactory.Metrics.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.DiscoveryService, sw.ElapsedMilliseconds);
 
-                        Log.Debug("Initializing live debugger.");
+                        if (isDiscoverySuccessful)
+                        {
+                            var liveDebugger = LiveDebuggerFactory.Create(discoveryService, RcmSubscriptionManager.Instance, settings, serviceName, tracer.TracerManager.Telemetry, debuggerSettings, tracer.TracerManager.GitMetadataTagsProvider);
 
-                        await InitializeLiveDebugger(liveDebugger).ConfigureAwait(false);
+                            Log.Debug("Initializing live debugger.");
+
+                            await InitializeLiveDebugger(liveDebugger).ConfigureAwait(false);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Error initializing live debugger.");
                     }
                 });
         }

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -153,19 +153,19 @@ namespace Datadog.Trace.ClrProfiler
                 }
 
 #if NETSTANDARD2_0 || NETCOREAPP3_1
-            try
-            {
-                // On .NET Core 2.0-3.0 we see an occasional hang caused by OpenSSL being loaded
-                // while the app is shutting down, which results in flaky tests due to the short-
-                // lived nature of our apps. This appears to be a bug in the runtime (although
-                // we haven't yet confirmed that). Calling the `ToUuid()` method uses an MD5
-                // hash which calls into the native library, triggering the load.
-                _ = string.Empty.ToUUID();
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error triggering eager OpenSSL load");
-            }
+                try
+                {
+                    // On .NET Core 2.0-3.0 we see an occasional hang caused by OpenSSL being loaded
+                    // while the app is shutting down, which results in flaky tests due to the short-
+                    // lived nature of our apps. This appears to be a bug in the runtime (although
+                    // we haven't yet confirmed that). Calling the `ToUuid()` method uses an MD5
+                    // hash which calls into the native library, triggering the load.
+                    _ = string.Empty.ToUUID();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Error triggering eager OpenSSL load");
+                }
 #endif
                 LifetimeManager.Instance.AddShutdownTask(RunShutdown);
 

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -173,17 +173,26 @@ namespace Datadog.Trace.ClrProfiler
 
                 TelemetryFactory.Metrics.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.Total, swTotal.ElapsedMilliseconds);
             }
-            catch (Exception ex) when (IsInSsi())
+            catch (Exception ex)
             {
                 // if we're in SSI we want to be as safe as possible, so catching to avoid the possibility of a crash
                 try
                 {
                     Log.Error(ex, "Error in Datadog.Trace.ClrProfiler.Managed.Loader.Startup.Startup(). Functionality may be impacted.");
+                    return;
                 }
                 catch
                 {
                     // Swallowing any errors here, as something went _very_ wrong, even with logging
+                    // and we 100% don't want to crash in SSI. Outside of SSI we do want to see the crash
+                    // so that it's visible to the user.
+                    if (IsInSsi())
+                    {
+                        return;
+                    }
                 }
+
+                throw;
             }
 
             static bool IsInSsi()

--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -173,9 +173,31 @@ namespace Datadog.Trace.ClrProfiler
 
                 TelemetryFactory.Metrics.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.Total, swTotal.ElapsedMilliseconds);
             }
-            catch
+            catch (Exception ex) when (IsInSsi())
             {
-                // Swallowing any errors here, as something went _very_ wrong, so trying to log might cause issues itself
+                // if we're in SSI we want to be as safe as possible, so catching to avoid the possibility of a crash
+                try
+                {
+                    Log.Error(ex, "Error in Datadog.Trace.ClrProfiler.Managed.Loader.Startup.Startup(). Functionality may be impacted.");
+                }
+                catch
+                {
+                    // Swallowing any errors here, as something went _very_ wrong, even with logging
+                }
+            }
+
+            static bool IsInSsi()
+            {
+                try
+                {
+                    // Not using the ReadEnvironmentVariable method here to avoid logging (which could cause a crash itself)
+                    return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_INJECTION_ENABLED"));
+                }
+                catch
+                {
+                    // sigh, nothing works, _pretend_ we're in SSI so that we don't crash the app
+                    return false;
+                }
             }
         }
 

--- a/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
+++ b/tracer/src/Datadog.Trace/Debugger/ExceptionAutoInstrumentation/ExceptionDebugging.cs
@@ -88,7 +88,8 @@ namespace Datadog.Trace.Debugger.ExceptionAutoInstrumentation
                 snapshotBatchUploader: snapshotBatchUploader,
                 debuggerSettings);
 
-            Task.Run(async () => await _uploader.StartFlushingAsync().ConfigureAwait(false));
+            Task.Run(() => _uploader.StartFlushingAsync())
+                .ContinueWith(t => Log.Error(t.Exception, "Error in flushing task"), TaskContinuationOptions.OnlyOnFaulted);
         }
 
         public static void Report(Span span, Exception exception)

--- a/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
+++ b/tracer/src/Datadog.Trace/RuntimeMetrics/PerformanceCountersListener.cs
@@ -55,6 +55,7 @@ namespace Datadog.Trace.RuntimeMetrics
             // That's because performance counters may rely on wmiApSrv being started,
             // and the windows service manager only allows one service at a time to be starting: https://docs.microsoft.com/en-us/windows/win32/services/service-startup
             _initializationTask = Task.Run(InitializePerformanceCounters);
+            _initializationTask.ContinueWith(t => Log.Error(t.Exception, "Error in performance counter initialization task"), TaskContinuationOptions.OnlyOnFaulted);
         }
 
         public Task WaitForInitialization() => _initializationTask;

--- a/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollectorBase.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Collectors/MetricsTelemetryCollectorBase.cs
@@ -31,6 +31,13 @@ internal abstract partial class MetricsTelemetryCollectorBase
         _aggregationInterval = aggregationInterval;
         _aggregationNotification = aggregationNotification;
         _aggregateTask = Task.Run(AggregateMetricsLoopAsync);
+        _aggregateTask
+           .ContinueWith(
+                t =>
+                {
+                    // There's a complex relationship between metrics and logs initialization, so we don't log anything in this case
+                },
+                TaskContinuationOptions.OnlyOnFaulted);
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/TelemetryController.cs
@@ -81,6 +81,7 @@ internal class TelemetryController : ITelemetryController
         }
 
         _flushTask = Task.Run(PushTelemetryLoopAsync);
+        _flushTask.ContinueWith(t => Log.Error(t.Exception, "Error in telemetry flush task"), TaskContinuationOptions.OnlyOnFaulted);
     }
 
     public void RecordTracerSettings(ImmutableTracerSettings settings, string defaultServiceName)

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -299,36 +299,36 @@ namespace Datadog.Trace
 
         private static async Task WriteDiagnosticLog(TracerManager instance)
         {
-            if (instance._isClosing)
-            {
-                return;
-            }
-
-            string agentError = null;
-            var instanceSettings = instance.Settings;
-
-            // In AAS, the trace agent is deployed alongside the tracer and managed by the tracer
-            // Disable this check as it may hit the trace agent before it is ready to receive requests and give false negatives
-            // Also disable if tracing is not enabled (as likely to be in an environment where agent is not available)
-            if (instanceSettings.TraceEnabledInternal && !instanceSettings.IsRunningInAzureAppService)
-            {
-                try
-                {
-                    var success = await instance.AgentWriter.Ping().ConfigureAwait(false);
-
-                    if (!success)
-                    {
-                        agentError = "An error occurred while sending traces to the agent";
-                    }
-                }
-                catch (Exception ex)
-                {
-                    agentError = ex.Message;
-                }
-            }
-
             try
             {
+                if (instance._isClosing)
+                {
+                    return;
+                }
+
+                string agentError = null;
+                var instanceSettings = instance.Settings;
+
+                // In AAS, the trace agent is deployed alongside the tracer and managed by the tracer
+                // Disable this check as it may hit the trace agent before it is ready to receive requests and give false negatives
+                // Also disable if tracing is not enabled (as likely to be in an environment where agent is not available)
+                if (instanceSettings.TraceEnabledInternal && !instanceSettings.IsRunningInAzureAppService)
+                {
+                    try
+                    {
+                        var success = await instance.AgentWriter.Ping().ConfigureAwait(false);
+
+                        if (!success)
+                        {
+                            agentError = "An error occurred while sending traces to the agent";
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        agentError = ex.Message;
+                    }
+                }
+
                 var stringWriter = new StringWriter();
 
                 using (var writer = new JsonTextWriter(stringWriter))

--- a/tracer/src/Datadog.Trace/Util/Delegates/DelegateInstrumentation.cs
+++ b/tracer/src/Datadog.Trace/Util/Delegates/DelegateInstrumentation.cs
@@ -229,7 +229,7 @@ internal static class DelegateInstrumentation
                 // This method is only called once, so no point saving the logger in the static field forever
                 // If we throw, then _activator will continue to have the default activator which is fine
                 DatadogLogging.GetLoggerFor<ActivatorHelper>()
-                              .Warning(ex, "Error Creating the custom activator for: {Type}", typeof(TCallbacks).FullName);
+                              .Warning(ex, "Error creating the custom activator for: {Type}", typeof(TCallbacks).FullName);
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

- Ensure all "entry points" are guaranteed safe with try-catch
- Ensure all `Task.Run` observe exceptions

## Reason for change

We want to make sure (as best we can) that we don't crash when customer applications are instrumented. This is about the best we can do I think.

`UnobservedTaskException` isn't really a _thing_ in .NET Core AFAICT, and in .NET Framework it requires customers [explicitly turning it on](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.taskscheduler.unobservedtaskexception?view=net-8.0) using

```xml
<configuration>
   <runtime>
      <ThrowUnobservedTaskExceptions enabled="true"/>
   </runtime>
</configuration>
```

but IMO it's still preferable to ensure we wouldn't cause crashes in these cases if we can help it

## Implementation details

- Wraps "entry points" with a try-catch. These are invoked "directly" due to how they're injected or called. e.g.
  - `Datadog.Trace.ClrProfiler.Managed.Loader.Startup.Startup()`
  - `AgentProcessManager.Initialize()`
  - `Instrumentation.Initialize()`
  - (`DiagnosticManager` is already handled)
- Checked places we use `Task.Run` or `TaskFactory.StartNew` and checked that we're either:
  - Wrapping the called code in `try-catch`
  - Calling `await` on the returned `Task`
  - Using `ContinueWith` with at least `OnlyOnFaulted`

## Test coverage

This is all defensive, so just checking that it hasn't introduced regressions (covered by existing tests)

## Other details

As Kevin pointed out, basically _all_ code can throw, so we can't necessarily wrap _everything_, but hopefully this captures _most_ of the "top level" cases that could cause "bubble up" issues for customers