### PR TITLE
[IAST] Safeguard Insert Before / After aspects with try/catch

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BeforeAfterAspectAnalyzer.cs" company="Datadog">
+// <copyright file="BeforeAfterAspectAnalyzer.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -29,7 +29,7 @@ public class BeforeAfterAspectAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// The severity of the diagnostic
     /// </summary>
-    public const DiagnosticSeverity Severity = DiagnosticSeverity.Info;
+    public const DiagnosticSeverity Severity = DiagnosticSeverity.Error;
 
 #pragma warning disable RS2008 // Enable analyzer release tracking for the analyzer project
     private static readonly DiagnosticDescriptor MissingTryCatchRule = new(

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
@@ -135,7 +135,7 @@ public class BeforeAfterAspectAnalyzer : DiagnosticAnalyzer
             isRethrowing = false;
 
             // check that it's catching _everything_
-            hasFilter = catchClause.Filter is not null;
+            hasFilter = catchClause.Filter is not null && catchClause.Filter.FilterExpression is not null && catchClause.Filter.FilterExpression.ToString() != "ex is not BlockException";
             if (hasFilter)
             {
                 // Skipping because we shouldn't be letting anything through

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
@@ -104,9 +104,9 @@ public class BeforeAfterAspectCodeFixProvider : CodeFixProvider
         }
 
         // create the trystatementsyntax with the internals of the method declaration
-        var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
+        var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("global::System.Exception"), SyntaxFactory.Identifier("ex"));
         var logExpression = SyntaxFactory.ExpressionStatement(
-            SyntaxFactory.ParseExpression($$"""Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+            SyntaxFactory.ParseExpression($$"""IastModule.Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
         var returnStatement = paramName is not null
                                   ? SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(paramName))
                                   : SyntaxFactory.ReturnStatement();

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
@@ -104,7 +104,7 @@ public class BeforeAfterAspectCodeFixProvider : CodeFixProvider
         }
 
         // create the trystatementsyntax with the internals of the method declaration
-        var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("global::System.Exception"), SyntaxFactory.Identifier("ex"));
+        var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
         var logExpression = SyntaxFactory.ExpressionStatement(
             SyntaxFactory.ParseExpression($$"""IastModule.Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
         var returnStatement = paramName is not null

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
@@ -25,6 +25,14 @@ public class HttpResponseAspect
     [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String,System.Boolean)", 1)]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
@@ -31,6 +31,14 @@ public class ControllerBaseAspect
     [AspectMethodInsertBefore("Microsoft.AspNetCore.Mvc.ControllerBase::LocalRedirectPermanentPreserveMethod(System.String)")]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(ControllerBaseAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -29,12 +29,20 @@ public class EntityCommandAspect
     [AspectMethodInsertBefore("System.Data.Entity.Core.EntityClient.EntityCommand::ExecuteReaderAsync(System.Data.CommandBehavior)", 1)]
     public static object ReviewSqlCommand(object command)
     {
-        if (command is DbCommand dbCommand)
+        try
         {
-            var commandText = dbCommand.CommandText;
-            VulnerabilitiesModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
-        }
+            if (command is DbCommand dbCommand)
+            {
+                var commandText = dbCommand.CommandText;
+                VulnerabilitiesModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
+            }
 
-        return command;
+            return command;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(EntityCommandAspect)}.{nameof(ReviewSqlCommand)}");
+            return command;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFramework/EntityCommandAspect.cs
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Data.Common;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -39,7 +39,7 @@ public class EntityCommandAspect
 
             return command;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(EntityCommandAspect)}.{nameof(ReviewSqlCommand)}");
             return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -37,7 +37,7 @@ public class EntityFrameworkCoreAspect
             VulnerabilitiesModule.OnSqlQuery(sqlAsString, IntegrationId.SqlClient);
             return sqlAsString;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(EntityFrameworkCoreAspect)}.{nameof(ReviewSqlString)}");
             return sqlAsString;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/EntityFrameworkCore/EntityFrameworkCoreAspect.cs
@@ -32,8 +32,16 @@ public class EntityFrameworkCoreAspect
     [AspectMethodInsertBefore("Microsoft.EntityFrameworkCore.RelationalQueryableExtensions::FromSqlRaw(Microsoft.EntityFrameworkCore.DbSet`1<!!0>,System.String,System.Object[])", 1)]
     public static object ReviewSqlString(string sqlAsString)
     {
-        VulnerabilitiesModule.OnSqlQuery(sqlAsString, IntegrationId.SqlClient);
-        return sqlAsString;
+        try
+        {
+            VulnerabilitiesModule.OnSqlQuery(sqlAsString, IntegrationId.SqlClient);
+            return sqlAsString;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(EntityFrameworkCoreAspect)}.{nameof(ReviewSqlString)}");
+            return sqlAsString;
+        }
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
@@ -28,7 +28,15 @@ public class BsonAspect
     [AspectMethodInsertBefore("MongoDB.Bson.IO.JsonReader::.ctor(System.String)")]
     public static object AnalyzeJsonString(string json)
     {
-        IastModule.OnNoSqlMongoDbQuery(json, IntegrationId.MongoDb);
-        return json;
+        try
+        {
+            IastModule.OnNoSqlMongoDbQuery(json, IntegrationId.MongoDb);
+            return json;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(BsonAspect)}.{nameof(AnalyzeJsonString)}");
+            return json;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
@@ -31,13 +31,13 @@ public class MongoDatabaseAspect
     [AspectMethodInsertBefore("MongoDB.Driver.IMongoCollectionExtensions::FindAsync(MongoDB.Driver.IMongoCollection`1<!!0>,MongoDB.Driver.FilterDefinition`1<!!0>,MongoDB.Driver.FindOptions`2<!!0,!!0>,System.Threading.CancellationToken)", 2)]
     public static object? AnalyzeCommand(object? command)
     {
-        if (command == null || !Iast.Instance.Settings.Enabled)
-        {
-            return command;
-        }
-
         try
         {
+            if (command == null || !Iast.Instance.Settings.Enabled)
+            {
+                return command;
+            }
+
             var commandType = command.GetType().Name;
             switch (commandType)
             {
@@ -50,12 +50,13 @@ public class MongoDatabaseAspect
                     MongoDbHelper.AnalyzeJsonCommand(command);
                     break;
             }
-        }
-        catch (Exception ex)
-        {
-            Log.Warning(ex, "Failed to analyze the command");
-        }
 
-        return command;
+            return command;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Warning(ex, $"Error invoking {nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
+            return command;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -5,11 +5,10 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
-using static Datadog.Trace.Configuration.ConfigurationKeys;
 
 namespace Datadog.Trace.Iast.Aspects.NHibernate;
 
@@ -33,7 +32,7 @@ public class ISessionAspect
             VulnerabilitiesModule.OnSqlQuery(query, IntegrationId.NHibernate);
             return query;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
             return query;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -28,7 +28,15 @@ public class ISessionAspect
     [AspectMethodInsertBefore("NHibernate.ISession::CreateSQLQuery(System.String)", 0)]
     public static object AnalyzeQuery(string query)
     {
-        VulnerabilitiesModule.OnSqlQuery(query, IntegrationId.NHibernate);
-        return query;
+        try
+        {
+            VulnerabilitiesModule.OnSqlQuery(query, IntegrationId.NHibernate);
+            return query;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
+            return query;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -3,9 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System;
 using System.Data.Common;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
 
@@ -38,7 +38,7 @@ public class DbCommandAspect
 
             return command;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(DbCommandAspect)}.{nameof(ReviewExecuteNonQuery)}");
             return command;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Data.Common/DbCommandAspect.cs
@@ -28,12 +28,20 @@ public class DbCommandAspect
     [AspectMethodInsertBefore("System.Data.Common.DbCommand::ExecuteNonQueryAsync()")]
     public static object ReviewExecuteNonQuery(object command)
     {
-        if (command is DbCommand entityCommand && command.GetType().Name == "EntityCommand")
+        try
         {
-            var commandText = entityCommand.CommandText;
-            VulnerabilitiesModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
-        }
+            if (command is DbCommand entityCommand && command.GetType().Name == "EntityCommand")
+            {
+                var commandText = entityCommand.CommandText;
+                VulnerabilitiesModule.OnSqlQuery(commandText, IntegrationId.SqlClient);
+            }
 
-        return command;
+            return command;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DbCommandAspect)}.{nameof(ReviewExecuteNonQuery)}");
+            return command;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
@@ -26,11 +26,19 @@ public partial class DirectoryEntryAspect
     [AspectMethodInsertBefore("System.DirectoryServices.DirectoryEntry::.ctor(System.String,System.String,System.String,System.DirectoryServices.AuthenticationTypes)", 3)]
     public static object Init(string path)
     {
-        if (!string.IsNullOrEmpty(path) && path.ToLower().StartsWith("ldap"))
+        try
         {
-            IastModule.OnLdapInjection(path);
-        }
+            if (!string.IsNullOrEmpty(path) && path.ToLower().StartsWith("ldap"))
+            {
+                IastModule.OnLdapInjection(path);
+            }
 
-        return path;
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryEntryAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
@@ -30,7 +30,15 @@ public partial class DirectorySearcherAspect
     [AspectMethodInsertBefore("System.DirectoryServices.DirectorySearcher::.ctor(System.DirectoryServices.DirectoryEntry,System.String,System.String[],System.DirectoryServices.SearchScope)", 2)]
     public static object Init(string path)
     {
-        IastModule.OnLdapInjection(path);
-        return path;
+        try
+        {
+            IastModule.OnLdapInjection(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectorySearcherAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
@@ -28,7 +28,15 @@ public partial class PrincipalContextAspect
     [AspectMethodInsertBefore("System.DirectoryServices.AccountManagement.PrincipalContext::.ctor(System.DirectoryServices.AccountManagement.ContextType,System.String,System.String,System.DirectoryServices.AccountManagement.ContextOptions,System.String,System.String)", 3)]
     public static object Init(string path)
     {
-        IastModule.OnLdapInjection(path);
-        return path;
+        try
+        {
+            IastModule.OnLdapInjection(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(PrincipalContextAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
@@ -23,11 +23,19 @@ public partial class SearchRequestAspect
     [AspectMethodInsertBefore("System.DirectoryServices.Protocols.SearchRequest::set_Filter(System.Object)")]
     public static object Init(object path)
     {
-        if (path is string pathString)
+        try
         {
-            IastModule.OnLdapInjection(pathString);
-        }
+            if (path is string pathString)
+            {
+                IastModule.OnLdapInjection(pathString);
+            }
 
-        return path;
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SearchRequestAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -80,7 +80,7 @@ public class DirectoryAspect
             VulnerabilitiesModule.OnPathTraversal(path);
             return path;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
             return path;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -75,7 +75,15 @@ public class DirectoryAspect
     [AspectMethodInsertBefore("System.IO.Directory::SetCurrentDirectory(System.String)")]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -65,7 +65,7 @@ public class DirectoryInfoAspect
             VulnerabilitiesModule.OnPathTraversal(path);
             return path;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
             return path;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -60,7 +60,15 @@ public class DirectoryInfoAspect
 #endif
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -7,7 +7,6 @@
 
 using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -109,7 +108,7 @@ public class FileAspect
             VulnerabilitiesModule.OnPathTraversal(path);
             return path;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPath)}");
             return path;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -104,7 +104,15 @@ public class FileAspect
     [AspectMethodInsertBefore("System.IO.File::Replace(System.String,System.String,System.String,System.Boolean)", new int[] { 1, 2, 3 })]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -33,7 +33,15 @@ public class FileInfoAspect
     [AspectMethodInsertBefore("System.IO.FileInfo::Replace(System.String,System.String,System.Boolean)", new int[] { 1, 2 })]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -38,7 +38,7 @@ public class FileInfoAspect
             VulnerabilitiesModule.OnPathTraversal(path);
             return path;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
             return path;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -42,7 +42,7 @@ public class FileStreamAspect
             VulnerabilitiesModule.OnPathTraversal(path);
             return path;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
             return path;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -37,7 +37,15 @@ public class FileStreamAspect
 #endif
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -38,7 +38,7 @@ public class StreamReaderAspect
             VulnerabilitiesModule.OnPathTraversal(path);
             return path;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
             return path;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -33,7 +33,15 @@ public class StreamReaderAspect
 #endif
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
@@ -32,7 +32,15 @@ public class StreamWriterAspect
     [AspectMethodInsertBefore("System.IO.StreamWriter::.ctor(System.String,System.Boolean,System.Text.Encoding,System.Int32)", 3)]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(StreamWriterAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -98,8 +98,11 @@ public class HttpClientAspect
     {
         try
         {
-            VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-            return parameter;
+            if (parameter is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+                return parameter;
+            }
         }
         catch (Exception ex) when (ex is not BlockException)
         {
@@ -129,14 +132,12 @@ public class HttpClientAspect
     {
         try
         {
-            var uri = parameter.RequestUri;
-
-            if (uri is not null)
+            if (parameter is not null && parameter.RequestUri is not null && parameter.RequestUri.OriginalString is not null)
             {
-                VulnerabilitiesModule.OnSSRF(uri.OriginalString);
+                VulnerabilitiesModule.OnSSRF(parameter.RequestUri.OriginalString);
             }
 
-            return parameter;
+            return parameter!;
         }
         catch (Exception ex) when (ex is not BlockException)
         {
@@ -149,14 +150,17 @@ public class HttpClientAspect
     {
         try
         {
-            var uri = parameter.DuckCast<ClrProfiler.AutoInstrumentation.AspNet.IHttpRequestMessage>()?.RequestUri;
-
-            if (uri is not null)
+            if (parameter is not null)
             {
-                VulnerabilitiesModule.OnSSRF(uri.OriginalString);
+                var uri = parameter.DuckCast<ClrProfiler.AutoInstrumentation.AspNet.IHttpRequestMessage>()?.RequestUri;
+
+                if (uri is not null)
+                {
+                    VulnerabilitiesModule.OnSSRF(uri.OriginalString);
+                }
             }
 
-            return parameter;
+            return parameter!;
         }
         catch (Exception ex) when (ex is not BlockException)
         {

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -54,8 +54,16 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::DeleteAsync(System.String,System.Threading.CancellationToken)", 1)]
     public static string Review(string parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter);
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -88,8 +96,16 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::set_BaseAddress(System.Uri)")]
     public static Uri ReviewUri(Uri parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -111,26 +127,42 @@ public class HttpClientAspect
 #if !NETFRAMEWORK
     public static object ReviewHttpRequestMessage(HttpRequestMessage parameter)
     {
-        var uri = parameter.RequestUri;
-
-        if (uri is not null)
+        try
         {
-            VulnerabilitiesModule.OnSSRF(uri.OriginalString);
-        }
+            var uri = parameter.RequestUri;
 
-        return parameter;
+            if (uri is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(uri.OriginalString);
+            }
+
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            return parameter;
+        }
     }
 #else
     public static object ReviewHttpRequestMessage(object parameter)
     {
-        var uri = parameter.DuckCast<ClrProfiler.AutoInstrumentation.AspNet.IHttpRequestMessage>()?.RequestUri;
-
-        if (uri is not null)
+        try
         {
-            VulnerabilitiesModule.OnSSRF(uri.OriginalString);
-        }
+            var uri = parameter.DuckCast<ClrProfiler.AutoInstrumentation.AspNet.IHttpRequestMessage>()?.RequestUri;
 
-        return parameter;
+            if (uri is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(uri.OriginalString);
+            }
+
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            return parameter;
+        }
     }
 #endif
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -101,8 +101,9 @@ public class HttpClientAspect
             if (parameter is not null)
             {
                 VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-                return parameter;
             }
+
+            return parameter!;
         }
         catch (Exception ex) when (ex is not BlockException)
         {

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -59,7 +59,7 @@ public class HttpClientAspect
             VulnerabilitiesModule.OnSSRF(parameter);
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(Review)}");
             return parameter;
@@ -101,7 +101,7 @@ public class HttpClientAspect
             VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
             return parameter;
@@ -138,7 +138,7 @@ public class HttpClientAspect
 
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
             return parameter;
@@ -158,7 +158,7 @@ public class HttpClientAspect
 
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
             return parameter;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -53,8 +53,16 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::set_BaseAddress(System.String)")]
     public static object Review(string parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter);
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -115,7 +123,15 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::UploadValuesTaskAsync(System.Uri,System.String,System.Collections.Specialized.NameValueCollection)", 2)]
     public static object ReviewUri(Uri parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(ReviewUri)}");
+            return parameter;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -58,7 +58,7 @@ public class WebClientAspect
             VulnerabilitiesModule.OnSSRF(parameter);
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(Review)}");
             return parameter;
@@ -128,7 +128,7 @@ public class WebClientAspect
             VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(ReviewUri)}");
             return parameter;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -55,8 +55,12 @@ public class WebClientAspect
     {
         try
         {
-            VulnerabilitiesModule.OnSSRF(parameter);
-            return parameter;
+            if (parameter is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(parameter);
+            }
+
+            return parameter!;
         }
         catch (Exception ex) when (ex is not BlockException)
         {
@@ -125,8 +129,12 @@ public class WebClientAspect
     {
         try
         {
-            VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-            return parameter;
+            if (parameter is not null && parameter.OriginalString is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+            }
+
+            return parameter!;
         }
         catch (Exception ex) when (ex is not BlockException)
         {

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -26,8 +26,16 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.String)")]
     public static object Review(string parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter);
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -40,7 +48,15 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.Uri)")]
     public static object Review(Uri parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+            return parameter;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -31,7 +31,7 @@ public class WebRequestAspect
             VulnerabilitiesModule.OnSSRF(parameter);
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
             return parameter;
@@ -53,7 +53,7 @@ public class WebRequestAspect
             VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
             return parameter;
         }
-        catch (global::System.Exception ex)
+        catch (Exception ex) when (ex is not BlockException)
         {
             IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
             return parameter;

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
@@ -38,7 +38,15 @@ public class ActivatorAspect
     [AspectMethodInsertBefore("System.Activator::CreateComInstanceFrom(System.String,System.String,System.Byte[],System.Configuration.Assemblies.AssemblyHashAlgorithm)", 3, 2)]
     public static string ReflectionInjectionParam(string param)
     {
-        IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
-        return param;
+        try
+        {
+            IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
+            return param;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(ActivatorAspect)}.{nameof(ReflectionInjectionParam)}");
+            return param;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
@@ -30,7 +30,15 @@ public class AssemblyAspect
     [AspectMethodInsertBefore("System.Reflection.AssemblyName::.ctor(System.String)", 0)]
     public static string ReflectionAssemblyInjection(string assemblyString)
     {
-        IastModule.OnReflectionInjection(assemblyString, IntegrationId.ReflectionInjection);
-        return assemblyString;
+        try
+        {
+            IastModule.OnReflectionInjection(assemblyString, IntegrationId.ReflectionInjection);
+            return assemblyString;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(AssemblyAspect)}.{nameof(ReflectionAssemblyInjection)}");
+            return assemblyString;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
@@ -43,7 +43,15 @@ public class TypeAspect
     [AspectMethodInsertBefore("System.Type::InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])", 7)]
     public static string ReflectionInjectionParam(string param)
     {
-        IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
-        return param;
+        try
+        {
+            IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
+            return param;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(TypeAspect)}.{nameof(ReflectionInjectionParam)}");
+            return param;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
@@ -39,13 +39,13 @@ public class HashAlgorithmAspect
         {
             var scope = HashAlgorithmIntegrationCommon.CreateScope(target);
             scope?.Dispose();
+            return target;
         }
-        catch (Exception ex)
+        catch (global::System.Exception ex)
         {
-            Log.Error(ex, "Error in HashAlgorithmAspect.");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HashAlgorithmAspect)}.{nameof(ComputeHash)}");
+            return target;
         }
-
-        return target;
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
@@ -113,8 +113,16 @@ public class SymmetricAlgorithmAspect
     [AspectMethodInsertAfter($"System.Security.Cryptography.Aes::Create({ClrNames.String})")]
     public static SymmetricAlgorithm Create(SymmetricAlgorithm target)
     {
-        ProcessCipherClassCreation(target);
-        return target;
+        try
+        {
+            ProcessCipherClassCreation(target);
+            return target;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(Create)}");
+            return target;
+        }
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
@@ -25,6 +25,14 @@ public class HttpControllerAspect
     [AspectMethodInsertBefore("System.Web.Mvc.Controller::RedirectPermanent(System.String)")]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpControllerAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
@@ -29,12 +29,20 @@ public class HttpSessionStateBaseAspect
     [AspectMethodInsertBefore("System.Web.HttpSessionStateBase::Remove(System.String)", 0)]
     public static object Add(object value)
     {
-        if (value is string valueStr)
+        try
         {
-            IastModule.OnTrustBoundaryViolation(valueStr);
-        }
+            if (value is string valueStr)
+            {
+                IastModule.OnTrustBoundaryViolation(valueStr);
+            }
 
-        return value;
+            return value;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpSessionStateBaseAspect)}.{nameof(Add)}");
+            return value;
+        }
     }
 }
 

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
@@ -32,12 +32,20 @@ public class SessionExtensionsAspect
     [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.SessionExtensions::SetInt32(Microsoft.AspNetCore.Http.ISession,System.String,System.Int32)", 1)]
     public static string ReviewTbv(string value)
     {
-        if (value != null)
+        try
         {
-            IastModule.OnTrustBoundaryViolation(value);
-        }
+            if (value != null)
+            {
+                IastModule.OnTrustBoundaryViolation(value);
+            }
 
-        return value;
+            return value;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SessionExtensionsAspect)}.{nameof(ReviewTbv)}");
+            return value;
+        }
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
@@ -26,6 +26,14 @@ public class HttpResponseAspect
     [AspectMethodInsertBefore("System.Web.HttpResponse::RedirectPermanent(System.String,System.Boolean)", 1)]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
@@ -33,7 +33,15 @@ public class SystemXmlAspect
     [AspectMethodInsertBefore("System.Xml.XPath.XPathNavigator::Select(System.String,System.Xml.IXmlNamespaceResolver)", 1)]
     public static string ReviewPath(string xpath)
     {
-        IastModule.OnXpathInjection(xpath);
-        return xpath;
+        try
+        {
+            IastModule.OnXpathInjection(xpath);
+            return xpath;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SystemXmlAspect)}.{nameof(ReviewPath)}");
+            return xpath;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
@@ -28,7 +28,15 @@ public class XPathExtensionAspect
     [AspectMethodInsertBefore("System.Xml.XPath.Extensions::XPathSelectElements(System.Xml.Linq.XNode,System.String,System.Xml.IXmlNamespaceResolver)", 1)]
     public static string ReviewPath(string xpath)
     {
-        IastModule.OnXpathInjection(xpath);
-        return xpath;
+        try
+        {
+            IastModule.OnXpathInjection(xpath);
+            return xpath;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(XPathExtensionAspect)}.{nameof(ReviewPath)}");
+            return xpath;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
@@ -24,6 +24,14 @@ public class RandomAspect
     [AspectMethodInsertAfter("System.Random::.ctor(System.Int32)")]
     public static void Init()
     {
-        IastModule.OnWeakRandomness(_evidenceValue);
+        try
+        {
+            IastModule.OnWeakRandomness(_evidenceValue);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(RandomAspect)}.{nameof(Init)}");
+            return;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -46,10 +47,11 @@ internal static partial class IastModule
     private const string OperationNameXss = "xss";
     private const string OperationNameSessionTimeout = "session_timeout";
     private const string ReferrerHeaderName = "Referrer";
-    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(IastModule));
+    internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(IastModule));
     private static readonly Lazy<EvidenceRedactor?> EvidenceRedactorLazy;
     private static readonly Func<TaintedObject, bool> Always = (x) => true;
     private static IastSettings iastSettings = Iast.Instance.Settings;
+    private static ConcurrentDictionary<string, Exception> errors = new ConcurrentDictionary<string, Exception>();
 
     static IastModule()
     {
@@ -108,13 +110,13 @@ internal static partial class IastModule
             return true;
         }
 
-        if (!Iast.Instance.Settings.Enabled)
-        {
-            return IastModuleResponse.Empty;
-        }
-
         try
         {
+            if (!Iast.Instance.Settings.Enabled)
+            {
+                return IastModuleResponse.Empty;
+            }
+
             OnExecutedSinkTelemetry(IastInstrumentedSinks.UnvalidatedRedirect);
             return GetScope(evidence, integrationId, VulnerabilityTypeName.UnvalidatedRedirect, OperationNameUnvalidatedRedirect, HasInvalidOrigin);
         }
@@ -127,13 +129,13 @@ internal static partial class IastModule
 
     internal static IastModuleResponse OnTrustBoundaryViolation(string name)
     {
-        if (!Iast.Instance.Settings.Enabled)
-        {
-            return IastModuleResponse.Empty;
-        }
-
         try
         {
+            if (!Iast.Instance.Settings.Enabled)
+            {
+                return IastModuleResponse.Empty;
+            }
+
             OnExecutedSinkTelemetry(IastInstrumentedSinks.TrustBoundaryViolation);
             return GetScope(name, IntegrationId.TrustBoundaryViolation, VulnerabilityTypeName.TrustBoundaryViolation, OperationNameTrustBoundaryViolation, Always);
         }
@@ -146,13 +148,13 @@ internal static partial class IastModule
 
     internal static IastModuleResponse OnLdapInjection(string evidence)
     {
-        if (!Iast.Instance.Settings.Enabled)
-        {
-            return IastModuleResponse.Empty;
-        }
-
         try
         {
+            if (!Iast.Instance.Settings.Enabled)
+            {
+                return IastModuleResponse.Empty;
+            }
+
             OnExecutedSinkTelemetry(IastInstrumentedSinks.LdapInjection);
             return GetScope(evidence, IntegrationId.Ldap, VulnerabilityTypeName.LdapInjection, OperationNameLdapInjection, Always);
         }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="BeforeAfterAspectAnalyzerTests.cs" company="Datadog">
+// <copyright file="BeforeAfterAspectAnalyzerTests.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -102,7 +102,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -139,7 +139,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -187,7 +187,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -235,7 +235,7 @@ public class BeforeAfterAspectAnalyzerTests
                         }
                         catch (Exception ex)
                         {
-                            Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
                             return myParam;
                         }
                     }
@@ -285,6 +285,11 @@ public class BeforeAfterAspectAnalyzerTests
                   class DatadogLogging : IDatadogLogger
                   {
                       public void Error(Exception? exception, string messageTemplate) { }
+                  }
+
+                  static class IastModule
+                  {
+                      public static readonly IDatadogLogger Log = new DatadogLogging();
                   }
               }
               """;

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -68,6 +68,30 @@ public class BeforeAfterAspectAnalyzerTests
     }
 
     [Fact]
+    public async Task ShouldNotFlagMethodWithTryCatchAndBlockExceptionFilter()
+    {
+        var method =
+            """
+            [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            string TestMethod(string myParam)
+            {
+                try
+                {
+                    // does something
+                    return myParam;
+                }
+                catch (Exception ex) when (ex is not BlockException)
+                {
+                    // the contents don't actually matter here
+                    return myParam;
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
     public async Task ShouldNotFlagEmptyMethod()
     {
         var method =
@@ -290,6 +314,10 @@ public class BeforeAfterAspectAnalyzerTests
                   static class IastModule
                   {
                       public static readonly IDatadogLogger Log = new DatadogLogging();
+                  }
+
+                  class BlockException : Exception
+                  {
                   }
               }
               """;

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SSRF/WebClientTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SSRF/WebClientTests.cs
@@ -22,7 +22,7 @@ public class WebClientTests : SSRFTests
     [Fact]
     public void GivenAWebClient_WhenDownloadData_Exception()
     {
-        Assert.Throws<NullReferenceException>(() => webclient.DownloadData((Uri) null));
+        Assert.Throws<ArgumentNullException>(() => webclient.DownloadData((Uri) null));
     }
 
     // Testing [AspectMethodInsertBefore("System.Net.WebClient::DownloadDataAsync(System.Uri)")]


### PR DESCRIPTION
## Summary of changes
Covered all `InsertBefore` / `InsertAfter` aspects with try catch clauses to ensure no crash will bubble up to client, following new analyzer rules.

## Reason for change
SSI will make the tracer enabled for a lot more of services when available. We must ensure we do not break any of them, and if so, that we provide a fast answer.

## Implementation details
Apply analyzer suggestions adding a try / catch clause in all `InsertBefore` / `InsertAfter` aspects

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
