### PR TITLE
Catch exceptions when trying to shutdown IIS

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers.AutoInstrumentation/IisFixture.cs
@@ -48,8 +48,15 @@ namespace Datadog.Trace.TestHelpers
         {
             if (IisExpress.Process != null && ShutdownPath != null)
             {
-                var request = WebRequest.CreateHttp($"http://localhost:{HttpPort}{ShutdownPath}");
-                request.GetResponse().Close();
+                try
+                {
+                    var request = WebRequest.CreateHttp($"http://localhost:{HttpPort}{ShutdownPath}");
+                    request.GetResponse().Close();
+                }
+                catch
+                {
+                    // Ignore
+                }
             }
 
             Agent?.Dispose();


### PR DESCRIPTION
## Summary of changes

Catch exceptions when sending a shutdown request to IIS.

## Reason for change

To shutdown IIS, we first send a request to the web app to ask it to exit gracefully, and then we kill the IIS Express process. But if for some reason an exception is thrown when sending the request, we wouldn't get to the killing part.

