### PR TITLE
[Profiler] Add Callstack::CopyFrom method

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Callstack.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Callstack.cpp
@@ -95,6 +95,6 @@ std::uintptr_t* Callstack::end() const
 
 void Callstack::CopyFrom(Callstack const& other)
 {
-    memcpy(_buffer.begin(), other._buffer.begin(), other._count * sizeof(uintptr_t));
+    memcpy(_buffer.data(), other._buffer.data(), other._count * sizeof(uintptr_t));
     _count = other._count;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Callstack.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Callstack.cpp
@@ -6,6 +6,8 @@
 #include <cassert>
 #include <utility>
 
+#include <string.h>
+
 Callstack::Callstack() :
     Callstack(nullptr)
 {
@@ -89,4 +91,10 @@ std::uintptr_t* Callstack::begin() const
 std::uintptr_t* Callstack::end() const
 {
     return _buffer.data() + _count;
+}
+
+void Callstack::CopyFrom(Callstack const& other)
+{
+    memcpy(_buffer.begin(), other._buffer.begin(), other._count * sizeof(uintptr_t));
+    _count = other._count;
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Callstack.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Callstack.h
@@ -68,6 +68,8 @@ public:
     std::uintptr_t* begin() const;
     std::uintptr_t* end() const;
 
+    void CopyFrom(Callstack const& other);
+
 private:
     shared::pmr::memory_resource* _memoryResource;
     shared::span<std::uintptr_t> _buffer;

--- a/profiler/test/Datadog.Profiler.Native.Tests/CallstackTest.cpp
+++ b/profiler/test/Datadog.Profiler.Native.Tests/CallstackTest.cpp
@@ -79,3 +79,24 @@ TEST(CallstackTest, CheckBufferSetCountApi)
         ASSERT_EQ(ip, expectedIp++);
     }
 }
+
+
+TEST(CallstackTest, CheckCopyFrom)
+{
+    auto p = CallstackProvider(MemoryResourceManager::GetDefault());
+
+    auto s = p.Get();
+
+    for (int i = 0; i < 100; i++)
+    {
+        s.Add(i);
+    }
+
+    ASSERT_EQ(s.Size(), 100);
+
+    auto s2 = p.Get();
+
+    s2.CopyFrom(s);
+    
+    ASSERT_EQ(s, s2);
+}


### PR DESCRIPTION
## Summary of changes
Add `CopyFrom` method.

## Reason for change

This is a first part in an optimization for the walltime. We will need to copy callstacks.

## Implementation details

- Add `CopyFrom` method
## Test coverage
- Add a unit test for it.


## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
