### PR TITLE
[IAST] Safeguard Insert Before / After aspects with try/catch (#5839 -> v2)

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectAnalyzer.cs
@@ -1,0 +1,176 @@
+// <copyright file="BeforeAfterAspectAnalyzer.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+
+/// <summary>
+/// An analyzer that analyzers aspects that use [AspectMethodInsertAfter] and [AspectMethodInsertBefore]
+/// for example, and checks that they are all wrapped in a try-catch block. These methods should never throw
+/// so they should always have a try-catch block around them.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class BeforeAfterAspectAnalyzer : DiagnosticAnalyzer
+{
+    /// <summary>
+    /// The diagnostic ID displayed in error messages
+    /// </summary>
+    public const string DiagnosticId = "DD0004";
+
+    /// <summary>
+    /// The severity of the diagnostic
+    /// </summary>
+    public const DiagnosticSeverity Severity = DiagnosticSeverity.Error;
+
+#pragma warning disable RS2008 // Enable analyzer release tracking for the analyzer project
+    private static readonly DiagnosticDescriptor MissingTryCatchRule = new(
+        DiagnosticId,
+        title: "Aspect is missing try-catch block",
+        messageFormat: "Aspect method bodies should contain a try-catch block at the top level",
+        category: "Reliability",
+        defaultSeverity: Severity,
+        isEnabledByDefault: true,
+        description: "[AspectMethodInsertBefore] and [AspectMethodInsertAfter] Aspects should guarantee safety if possible. Please wrap the aspect in a try-catch block.");
+#pragma warning restore RS2008
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(MissingTryCatchRule);
+
+    /// <inheritdoc />
+    public override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        // Consider registering other actions that act on syntax instead of or in addition to symbols
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/Analyzer%20Actions%20Semantics.md for more information
+        context.RegisterSyntaxNodeAction(AnalyseMethod, SyntaxKind.MethodDeclaration);
+    }
+
+    private void AnalyseMethod(SyntaxNodeAnalysisContext context)
+    {
+        // assume that generated code is safe, so bail out for perf reasons
+        if (context.IsGeneratedCode || context.Node is not MethodDeclarationSyntax methodDeclaration)
+        {
+            return;
+        }
+
+        var attributes = methodDeclaration.AttributeLists;
+        if (!attributes.Any())
+        {
+            // no attributes, let's just bail
+            return;
+        }
+
+        var hasAspectAttribute = false;
+        foreach (var attributeList in attributes)
+        {
+            foreach (var attribute in attributeList.Attributes)
+            {
+                var name = attribute.Name.ToString();
+                if (name is "AspectMethodInsertBefore" or "AspectMethodInsertAfter"
+                    or "AspectMethodInsertBeforeAttribute" or "AspectMethodInsertAfterAttribute")
+                {
+                    hasAspectAttribute = true;
+                    break;
+                }
+            }
+        }
+
+        if (!hasAspectAttribute)
+        {
+            // not an aspect
+            return;
+        }
+
+        var bodyBlock = methodDeclaration.Body;
+        if (bodyBlock is null)
+        {
+            // If we don't have a bodyBlock, it's probably a lambda or expression bodied member
+            // These can't have try catch blocks, so we should bail out
+            var location = methodDeclaration.ExpressionBody?.GetLocation() ?? methodDeclaration.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, location));
+            return;
+        }
+
+        // first statement should be a try-catch block
+        if (!bodyBlock.Statements.Any())
+        {
+            // ignore this case, for now, if there's nothing in there, it's safe, and we don't want to hassle users too soon
+            return;
+        }
+
+        if (bodyBlock.Statements.Count != 1)
+        {
+            // oops, you should have a try block here, and it should be the only child
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        if (bodyBlock.Statements[0] is not TryStatementSyntax tryCatchStatement)
+        {
+            // oops, you should have a try block here
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, bodyBlock.GetLocation()));
+            return;
+        }
+
+        CatchClauseSyntax? catchClause = null;
+        var hasFilter = false;
+        var isSystemException = false;
+        var isRethrowing = false;
+
+        foreach (var catchSyntax in tryCatchStatement.Catches)
+        {
+            catchClause = catchSyntax;
+            isSystemException = false;
+            isRethrowing = false;
+
+            // check that it's catching _everything_
+            hasFilter = catchClause.Filter is not null && catchClause.Filter.FilterExpression is not null && catchClause.Filter.FilterExpression.ToString() != "ex is not BlockException";
+            if (hasFilter)
+            {
+                // Skipping because we shouldn't be letting anything through
+                continue;
+            }
+
+            var exceptionTypeName = catchSyntax.Declaration?.Type is { } exceptionType
+                                        ? context.SemanticModel.GetSymbolInfo(exceptionType).Symbol?.ToString()
+                                        : null;
+            isSystemException = exceptionTypeName is null or "System.Exception";
+            if (!isSystemException)
+            {
+                // skipping because it's not broad enough
+                continue;
+            }
+
+            // final requirement, must not be rethrowing
+            foreach (var statement in catchSyntax.Block.Statements)
+            {
+                if (statement is ThrowStatementSyntax)
+                {
+                    isRethrowing = true;
+                    break;
+                }
+            }
+
+            // if we get here, we know one of the loops is all good, so we can break
+            break;
+        }
+
+        if (catchClause is null || hasFilter || !isSystemException || isRethrowing)
+        {
+            // oops, no good
+            var location = catchClause?.GetLocation() ?? tryCatchStatement.GetLocation();
+            context.ReportDiagnostic(Diagnostic.Create(MissingTryCatchRule, location));
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
+++ b/tracer/src/Datadog.Trace.Tools.Analyzers/AspectAnalyzers/BeforeAfterAspectCodeFixProvider.cs
@@ -1,0 +1,150 @@
+﻿// <copyright file="BeforeAfterAspectCodeFixProvider.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.ThreadAbortAnalyzer;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+
+/// <summary>
+/// A CodeFixProvider for the <see cref="ThreadAbortAnalyzer"/>
+/// </summary>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(BeforeAfterAspectCodeFixProvider))]
+[Shared]
+public class BeforeAfterAspectCodeFixProvider : CodeFixProvider
+{
+    /// <inheritdoc />
+    public sealed override ImmutableArray<string> FixableDiagnosticIds
+    {
+        get => ImmutableArray.Create(BeforeAfterAspectAnalyzer.DiagnosticId);
+    }
+
+    /// <inheritdoc />
+    public sealed override FixAllProvider GetFixAllProvider()
+    {
+        // See https://github.com/dotnet/roslyn/blob/master/docs/analyzers/FixAllProvider.md for more information on Fix All Providers
+        return WellKnownFixAllProviders.BatchFixer;
+    }
+
+    /// <inheritdoc />
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+        var diagnostic = context.Diagnostics.First();
+        var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+        // Find the methodDeclaration identified by the diagnostic.
+        var methodDeclaration = root?.FindToken(diagnosticSpan.Start)
+                                    .Parent
+                                    ?.AncestorsAndSelf()
+                                    .OfType<MethodDeclarationSyntax>()
+                                    .First();
+
+        if (methodDeclaration is null)
+        {
+            return;
+        }
+
+        // Register a code action that will invoke the fix.
+        context.RegisterCodeFix(
+            CodeAction.Create(
+                title: "Wrap aspect with exception handler",
+                createChangedDocument: c => AddTryCatch(context.Document, methodDeclaration, c),
+                equivalenceKey: nameof(BeforeAfterAspectCodeFixProvider)),
+            diagnostic);
+    }
+
+    private async Task<Document> AddTryCatch(Document document, MethodDeclarationSyntax methodDeclaration, CancellationToken cancellationToken)
+    {
+        var paramName = methodDeclaration.ParameterList.Parameters.FirstOrDefault()?.Identifier.Text;
+        var blockSyntax = methodDeclaration.Body ?? CreateBasicBlock(methodDeclaration.ExpressionBody) ?? null;
+        if (blockSyntax is null)
+        {
+            // weirdness, bail out
+            return document;
+        }
+
+        var parentType = methodDeclaration.AncestorsAndSelf()
+                                        .FirstOrDefault(x => x is TypeDeclarationSyntax or RecordDeclarationSyntax or StructDeclarationSyntax);
+
+        var typeName = parentType switch
+        {
+            StructDeclarationSyntax t => t.Identifier.Text,
+            RecordDeclarationSyntax t => t.Identifier.Text,
+            TypeDeclarationSyntax t => t.Identifier.Text,
+            _ => "UNKNOWN",
+        };
+
+        var methodName = methodDeclaration.Identifier.Text;
+
+        // check if we already have a try catch
+        TryStatementSyntax tryCatch;
+        if (blockSyntax.Statements.Count == 1 && blockSyntax.Statements[0] is TryStatementSyntax tryStatementSyntax)
+        {
+            tryCatch = tryStatementSyntax;
+        }
+        else
+        {
+            tryCatch = SyntaxFactory.TryStatement().WithBlock(blockSyntax);
+        }
+
+        // create the trystatementsyntax with the internals of the method declaration
+        var catchDeclaration = SyntaxFactory.CatchDeclaration(SyntaxFactory.IdentifierName("Exception"), SyntaxFactory.Identifier("ex"));
+        var logExpression = SyntaxFactory.ExpressionStatement(
+            SyntaxFactory.ParseExpression($$"""IastModule.Log.Error(ex, $"Error invoking {nameof({{typeName}})}.{nameof({{methodName}})}")"""));
+        var returnStatement = paramName is not null
+                                  ? SyntaxFactory.ReturnStatement(SyntaxFactory.IdentifierName(paramName))
+                                  : SyntaxFactory.ReturnStatement();
+        var syntaxList = SyntaxFactory.List(new StatementSyntax[] { logExpression, returnStatement });
+
+        var catchSyntax = SyntaxFactory.CatchClause()
+                                       .WithDeclaration(catchDeclaration)
+                                       .WithBlock(SyntaxFactory.Block(syntaxList));
+
+        var updatedTryCatch = tryCatch.AddCatches(catchSyntax);
+        var newBlock = SyntaxFactory.Block(updatedTryCatch)
+                                    .WithAdditionalAnnotations(Formatter.Annotation);
+
+        // remove the expression body if we have one
+        var newMethodDeclaration = methodDeclaration.ExpressionBody is not null
+                                       ? methodDeclaration
+                                        .WithExpressionBody(null)
+                                        .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None))
+                                       : methodDeclaration;
+
+        newMethodDeclaration = newMethodDeclaration.WithBody(newBlock);
+
+        // replace the syntax and return updated document
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        root = root!.ReplaceNode(methodDeclaration, newMethodDeclaration);
+        return document.WithSyntaxRoot(root);
+    }
+
+    private BlockSyntax? CreateBasicBlock(ArrowExpressionClauseSyntax? expressionBodyExpression)
+    {
+        if (expressionBodyExpression is null)
+        {
+            return null;
+        }
+
+        return SyntaxFactory.Block()
+                            .WithStatements(
+                                 SyntaxFactory.SingletonList<StatementSyntax>(
+                                     SyntaxFactory.ReturnStatement(expressionBodyExpression.Expression)));
+    }
+}

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Http/HttpResponseAspect.cs
@@ -25,6 +25,14 @@ public class HttpResponseAspect
     [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String,System.Boolean)", 1)]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/AspNetCore.Mvc/ControllerBaseAspect.cs
@@ -31,6 +31,14 @@ public class ControllerBaseAspect
     [AspectMethodInsertBefore("Microsoft.AspNetCore.Mvc.ControllerBase::LocalRedirectPermanentPreserveMethod(System.String)")]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(ControllerBaseAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/BsonAspect.cs
@@ -28,7 +28,15 @@ public class BsonAspect
     [AspectMethodInsertBefore("MongoDB.Bson.IO.JsonReader::.ctor(System.String)")]
     public static object AnalyzeJsonString(string json)
     {
-        IastModule.OnNoSqlMongoDbQuery(json, IntegrationId.MongoDb);
-        return json;
+        try
+        {
+            IastModule.OnNoSqlMongoDbQuery(json, IntegrationId.MongoDb);
+            return json;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(BsonAspect)}.{nameof(AnalyzeJsonString)}");
+            return json;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/MongoDB/MongoDatabaseAspect.cs
@@ -31,13 +31,13 @@ public class MongoDatabaseAspect
     [AspectMethodInsertBefore("MongoDB.Driver.IMongoCollectionExtensions::FindAsync(MongoDB.Driver.IMongoCollection`1<!!0>,MongoDB.Driver.FilterDefinition`1<!!0>,MongoDB.Driver.FindOptions`2<!!0,!!0>,System.Threading.CancellationToken)", 2)]
     public static object? AnalyzeCommand(object? command)
     {
-        if (command == null || !Iast.Instance.Settings.Enabled)
-        {
-            return command;
-        }
-
         try
         {
+            if (command == null || !Iast.Instance.Settings.Enabled)
+            {
+                return command;
+            }
+
             var commandType = command.GetType().Name;
             switch (commandType)
             {
@@ -50,12 +50,13 @@ public class MongoDatabaseAspect
                     MongoDbHelper.AnalyzeJsonCommand(command);
                     break;
             }
-        }
-        catch (Exception ex)
-        {
-            Log.Warning(ex, "Failed to analyze the command");
-        }
 
-        return command;
+            return command;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Warning(ex, $"Error invoking {nameof(MongoDatabaseAspect)}.{nameof(AnalyzeCommand)}");
+            return command;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/NHibernate/ISessionAspect.cs
@@ -5,11 +5,10 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast.Dataflow;
-using static Datadog.Trace.Configuration.ConfigurationKeys;
 
 namespace Datadog.Trace.Iast.Aspects.NHibernate;
 
@@ -28,7 +27,15 @@ public class ISessionAspect
     [AspectMethodInsertBefore("NHibernate.ISession::CreateSQLQuery(System.String)", 0)]
     public static object AnalyzeQuery(string query)
     {
-        VulnerabilitiesModule.OnSqlQuery(query, IntegrationId.NHibernate);
-        return query;
+        try
+        {
+            VulnerabilitiesModule.OnSqlQuery(query, IntegrationId.NHibernate);
+            return query;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(ISessionAspect)}.{nameof(AnalyzeQuery)}");
+            return query;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectoryEntryAspect.cs
@@ -26,11 +26,19 @@ public partial class DirectoryEntryAspect
     [AspectMethodInsertBefore("System.DirectoryServices.DirectoryEntry::.ctor(System.String,System.String,System.String,System.DirectoryServices.AuthenticationTypes)", 3)]
     public static object Init(string path)
     {
-        if (!string.IsNullOrEmpty(path) && path.ToLower().StartsWith("ldap"))
+        try
         {
-            IastModule.OnLdapInjection(path);
-        }
+            if (!string.IsNullOrEmpty(path) && path.ToLower().StartsWith("ldap"))
+            {
+                IastModule.OnLdapInjection(path);
+            }
 
-        return path;
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryEntryAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/DirectorySearcherAspect.cs
@@ -30,7 +30,15 @@ public partial class DirectorySearcherAspect
     [AspectMethodInsertBefore("System.DirectoryServices.DirectorySearcher::.ctor(System.DirectoryServices.DirectoryEntry,System.String,System.String[],System.DirectoryServices.SearchScope)", 2)]
     public static object Init(string path)
     {
-        IastModule.OnLdapInjection(path);
-        return path;
+        try
+        {
+            IastModule.OnLdapInjection(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectorySearcherAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/PrincipalContextAspect.cs
@@ -28,7 +28,15 @@ public partial class PrincipalContextAspect
     [AspectMethodInsertBefore("System.DirectoryServices.AccountManagement.PrincipalContext::.ctor(System.DirectoryServices.AccountManagement.ContextType,System.String,System.String,System.DirectoryServices.AccountManagement.ContextOptions,System.String,System.String)", 3)]
     public static object Init(string path)
     {
-        IastModule.OnLdapInjection(path);
-        return path;
+        try
+        {
+            IastModule.OnLdapInjection(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(PrincipalContextAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.DirectoryServices/SearchRequestAspect.cs
@@ -23,11 +23,19 @@ public partial class SearchRequestAspect
     [AspectMethodInsertBefore("System.DirectoryServices.Protocols.SearchRequest::set_Filter(System.Object)")]
     public static object Init(object path)
     {
-        if (path is string pathString)
+        try
         {
-            IastModule.OnLdapInjection(pathString);
-        }
+            if (path is string pathString)
+            {
+                IastModule.OnLdapInjection(pathString);
+            }
 
-        return path;
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SearchRequestAspect)}.{nameof(Init)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -75,7 +75,15 @@ public class DirectoryAspect
     [AspectMethodInsertBefore("System.IO.Directory::SetCurrentDirectory(System.String)")]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/DirectoryInfoAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -60,7 +60,15 @@ public class DirectoryInfoAspect
 #endif
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(DirectoryInfoAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileAspect.cs
@@ -7,7 +7,6 @@
 
 using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -104,7 +103,15 @@ public class FileAspect
     [AspectMethodInsertBefore("System.IO.File::Replace(System.String,System.String,System.String,System.Boolean)", new int[] { 1, 2, 3 })]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(FileAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileInfoAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -33,7 +33,15 @@ public class FileInfoAspect
     [AspectMethodInsertBefore("System.IO.FileInfo::Replace(System.String,System.String,System.Boolean)", new int[] { 1, 2 })]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(FileInfoAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/FileStreamAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -37,7 +37,15 @@ public class FileStreamAspect
 #endif
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(FileStreamAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamReaderAspect.cs
@@ -5,8 +5,8 @@
 
 #nullable enable
 
+using System;
 using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rasp;
 using Datadog.Trace.Iast.Dataflow;
 
 namespace Datadog.Trace.Iast.Aspects;
@@ -33,7 +33,15 @@ public class StreamReaderAspect
 #endif
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(StreamReaderAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.IO/StreamWriterAspect.cs
@@ -32,7 +32,15 @@ public class StreamWriterAspect
     [AspectMethodInsertBefore("System.IO.StreamWriter::.ctor(System.String,System.Boolean,System.Text.Encoding,System.Int32)", 3)]
     public static string ReviewPath(string path)
     {
-        VulnerabilitiesModule.OnPathTraversal(path);
-        return path;
+        try
+        {
+            VulnerabilitiesModule.OnPathTraversal(path);
+            return path;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(StreamWriterAspect)}.{nameof(ReviewPath)}");
+            return path;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/HttpClientAspect.cs
@@ -54,8 +54,16 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::DeleteAsync(System.String,System.Threading.CancellationToken)", 1)]
     public static string Review(string parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter);
+            return parameter;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -88,8 +96,20 @@ public class HttpClientAspect
     [AspectMethodInsertBefore("System.Net.Http.HttpClient::set_BaseAddress(System.Uri)")]
     public static Uri ReviewUri(Uri parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-        return parameter;
+        try
+        {
+            if (parameter is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+            }
+
+            return parameter!;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewUri)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -111,26 +131,43 @@ public class HttpClientAspect
 #if !NETFRAMEWORK
     public static object ReviewHttpRequestMessage(HttpRequestMessage parameter)
     {
-        var uri = parameter.RequestUri;
-
-        if (uri is not null)
+        try
         {
-            VulnerabilitiesModule.OnSSRF(uri.OriginalString);
-        }
+            if (parameter is not null && parameter.RequestUri is not null && parameter.RequestUri.OriginalString is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(parameter.RequestUri.OriginalString);
+            }
 
-        return parameter;
+            return parameter!;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            return parameter;
+        }
     }
 #else
     public static object ReviewHttpRequestMessage(object parameter)
     {
-        var uri = parameter.DuckCast<ClrProfiler.AutoInstrumentation.AspNet.IHttpRequestMessage>()?.RequestUri;
-
-        if (uri is not null)
+        try
         {
-            VulnerabilitiesModule.OnSSRF(uri.OriginalString);
-        }
+            if (parameter is not null)
+            {
+                var uri = parameter.DuckCast<ClrProfiler.AutoInstrumentation.AspNet.IHttpRequestMessage>()?.RequestUri;
 
-        return parameter;
+                if (uri is not null)
+                {
+                    VulnerabilitiesModule.OnSSRF(uri.OriginalString);
+                }
+            }
+
+            return parameter!;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpClientAspect)}.{nameof(ReviewHttpRequestMessage)}");
+            return parameter;
+        }
     }
 #endif
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebClientAspect.cs
@@ -53,8 +53,20 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::set_BaseAddress(System.String)")]
     public static object Review(string parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter);
-        return parameter;
+        try
+        {
+            if (parameter is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(parameter);
+            }
+
+            return parameter!;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -115,7 +127,19 @@ public class WebClientAspect
     [AspectMethodInsertBefore("System.Net.WebClient::UploadValuesTaskAsync(System.Uri,System.String,System.Collections.Specialized.NameValueCollection)", 2)]
     public static object ReviewUri(Uri parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-        return parameter;
+        try
+        {
+            if (parameter is not null && parameter.OriginalString is not null)
+            {
+                VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+            }
+
+            return parameter!;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebClientAspect)}.{nameof(ReviewUri)}");
+            return parameter;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Net/WebRequestAspect.cs
@@ -26,8 +26,16 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.String)")]
     public static object Review(string parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter);
+            return parameter;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 
     /// <summary>
@@ -40,7 +48,15 @@ public class WebRequestAspect
     [AspectMethodInsertBefore("System.Net.WebRequest::CreateHttp(System.Uri)")]
     public static object Review(Uri parameter)
     {
-        VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
-        return parameter;
+        try
+        {
+            VulnerabilitiesModule.OnSSRF(parameter.OriginalString);
+            return parameter;
+        }
+        catch (Exception ex) when (ex is not BlockException)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(WebRequestAspect)}.{nameof(Review)}");
+            return parameter;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/ActivatorAspect.cs
@@ -38,7 +38,15 @@ public class ActivatorAspect
     [AspectMethodInsertBefore("System.Activator::CreateComInstanceFrom(System.String,System.String,System.Byte[],System.Configuration.Assemblies.AssemblyHashAlgorithm)", 3, 2)]
     public static string ReflectionInjectionParam(string param)
     {
-        IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
-        return param;
+        try
+        {
+            IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
+            return param;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(ActivatorAspect)}.{nameof(ReflectionInjectionParam)}");
+            return param;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/AssemblyAspect.cs
@@ -30,7 +30,15 @@ public class AssemblyAspect
     [AspectMethodInsertBefore("System.Reflection.AssemblyName::.ctor(System.String)", 0)]
     public static string ReflectionAssemblyInjection(string assemblyString)
     {
-        IastModule.OnReflectionInjection(assemblyString, IntegrationId.ReflectionInjection);
-        return assemblyString;
+        try
+        {
+            IastModule.OnReflectionInjection(assemblyString, IntegrationId.ReflectionInjection);
+            return assemblyString;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(AssemblyAspect)}.{nameof(ReflectionAssemblyInjection)}");
+            return assemblyString;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Reflection/TypeAspect.cs
@@ -43,7 +43,15 @@ public class TypeAspect
     [AspectMethodInsertBefore("System.Type::InvokeMember(System.String,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object,System.Object[],System.Reflection.ParameterModifier[],System.Globalization.CultureInfo,System.String[])", 7)]
     public static string ReflectionInjectionParam(string param)
     {
-        IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
-        return param;
+        try
+        {
+            IastModule.OnReflectionInjection(param, IntegrationId.ReflectionInjection);
+            return param;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(TypeAspect)}.{nameof(ReflectionInjectionParam)}");
+            return param;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/HashAlgorithmAspect.cs
@@ -39,13 +39,13 @@ public class HashAlgorithmAspect
         {
             var scope = HashAlgorithmIntegrationCommon.CreateScope(target);
             scope?.Dispose();
+            return target;
         }
-        catch (Exception ex)
+        catch (global::System.Exception ex)
         {
-            Log.Error(ex, "Error in HashAlgorithmAspect.");
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HashAlgorithmAspect)}.{nameof(ComputeHash)}");
+            return target;
         }
-
-        return target;
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Security.Cryptography/SymmetricAlgorithmAspect.cs
@@ -113,8 +113,16 @@ public class SymmetricAlgorithmAspect
     [AspectMethodInsertAfter($"System.Security.Cryptography.Aes::Create({ClrNames.String})")]
     public static SymmetricAlgorithm Create(SymmetricAlgorithm target)
     {
-        ProcessCipherClassCreation(target);
-        return target;
+        try
+        {
+            ProcessCipherClassCreation(target);
+            return target;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SymmetricAlgorithmAspect)}.{nameof(Create)}");
+            return target;
+        }
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.Mvc/HttpControllerAspect.cs
@@ -25,6 +25,14 @@ public class HttpControllerAspect
     [AspectMethodInsertBefore("System.Web.Mvc.Controller::RedirectPermanent(System.String)")]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpControllerAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/HttpSessionStateBaseAspect.cs
@@ -29,12 +29,20 @@ public class HttpSessionStateBaseAspect
     [AspectMethodInsertBefore("System.Web.HttpSessionStateBase::Remove(System.String)", 0)]
     public static object Add(object value)
     {
-        if (value is string valueStr)
+        try
         {
-            IastModule.OnTrustBoundaryViolation(valueStr);
-        }
+            if (value is string valueStr)
+            {
+                IastModule.OnTrustBoundaryViolation(valueStr);
+            }
 
-        return value;
+            return value;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpSessionStateBaseAspect)}.{nameof(Add)}");
+            return value;
+        }
     }
 }
 

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web.SessionState/SessionExtensionsAspect.cs
@@ -32,12 +32,20 @@ public class SessionExtensionsAspect
     [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.SessionExtensions::SetInt32(Microsoft.AspNetCore.Http.ISession,System.String,System.Int32)", 1)]
     public static string ReviewTbv(string value)
     {
-        if (value != null)
+        try
         {
-            IastModule.OnTrustBoundaryViolation(value);
-        }
+            if (value != null)
+            {
+                IastModule.OnTrustBoundaryViolation(value);
+            }
 
-        return value;
+            return value;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SessionExtensionsAspect)}.{nameof(ReviewTbv)}");
+            return value;
+        }
     }
 }
 #endif

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Web/HttpResponseAspect.cs
@@ -26,6 +26,14 @@ public class HttpResponseAspect
     [AspectMethodInsertBefore("System.Web.HttpResponse::RedirectPermanent(System.String,System.Boolean)", 1)]
     public static string? Redirect(string? url)
     {
-        return IastModule.OnUnvalidatedRedirect(url);
+        try
+        {
+            return IastModule.OnUnvalidatedRedirect(url);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(HttpResponseAspect)}.{nameof(Redirect)}");
+            return url;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/SystemXmlAspect.cs
@@ -33,7 +33,15 @@ public class SystemXmlAspect
     [AspectMethodInsertBefore("System.Xml.XPath.XPathNavigator::Select(System.String,System.Xml.IXmlNamespaceResolver)", 1)]
     public static string ReviewPath(string xpath)
     {
-        IastModule.OnXpathInjection(xpath);
-        return xpath;
+        try
+        {
+            IastModule.OnXpathInjection(xpath);
+            return xpath;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(SystemXmlAspect)}.{nameof(ReviewPath)}");
+            return xpath;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System.Xml/XPathExtensionAspect.cs
@@ -28,7 +28,15 @@ public class XPathExtensionAspect
     [AspectMethodInsertBefore("System.Xml.XPath.Extensions::XPathSelectElements(System.Xml.Linq.XNode,System.String,System.Xml.IXmlNamespaceResolver)", 1)]
     public static string ReviewPath(string xpath)
     {
-        IastModule.OnXpathInjection(xpath);
-        return xpath;
+        try
+        {
+            IastModule.OnXpathInjection(xpath);
+            return xpath;
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(XPathExtensionAspect)}.{nameof(ReviewPath)}");
+            return xpath;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
+++ b/tracer/src/Datadog.Trace/Iast/Aspects/System/RandomAspect.cs
@@ -24,6 +24,14 @@ public class RandomAspect
     [AspectMethodInsertAfter("System.Random::.ctor(System.Int32)")]
     public static void Init()
     {
-        IastModule.OnWeakRandomness(_evidenceValue);
+        try
+        {
+            IastModule.OnWeakRandomness(_evidenceValue);
+        }
+        catch (global::System.Exception ex)
+        {
+            IastModule.Log.Error(ex, $"Error invoking {nameof(RandomAspect)}.{nameof(Init)}");
+            return;
+        }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -46,10 +47,11 @@ internal static partial class IastModule
     private const string OperationNameXss = "xss";
     private const string OperationNameSessionTimeout = "session_timeout";
     private const string ReferrerHeaderName = "Referrer";
-    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(IastModule));
+    internal static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(IastModule));
     private static readonly Lazy<EvidenceRedactor?> EvidenceRedactorLazy;
     private static readonly Func<TaintedObject, bool> Always = (x) => true;
     private static IastSettings iastSettings = Iast.Instance.Settings;
+    private static ConcurrentDictionary<string, Exception> errors = new ConcurrentDictionary<string, Exception>();
 
     static IastModule()
     {
@@ -108,13 +110,13 @@ internal static partial class IastModule
             return true;
         }
 
-        if (!Iast.Instance.Settings.Enabled)
-        {
-            return IastModuleResponse.Empty;
-        }
-
         try
         {
+            if (!Iast.Instance.Settings.Enabled)
+            {
+                return IastModuleResponse.Empty;
+            }
+
             OnExecutedSinkTelemetry(IastInstrumentedSinks.UnvalidatedRedirect);
             return GetScope(evidence, integrationId, VulnerabilityTypeName.UnvalidatedRedirect, OperationNameUnvalidatedRedirect, HasInvalidOrigin);
         }
@@ -127,13 +129,13 @@ internal static partial class IastModule
 
     internal static IastModuleResponse OnTrustBoundaryViolation(string name)
     {
-        if (!Iast.Instance.Settings.Enabled)
-        {
-            return IastModuleResponse.Empty;
-        }
-
         try
         {
+            if (!Iast.Instance.Settings.Enabled)
+            {
+                return IastModuleResponse.Empty;
+            }
+
             OnExecutedSinkTelemetry(IastInstrumentedSinks.TrustBoundaryViolation);
             return GetScope(name, IntegrationId.TrustBoundaryViolation, VulnerabilityTypeName.TrustBoundaryViolation, OperationNameTrustBoundaryViolation, Always);
         }
@@ -146,13 +148,13 @@ internal static partial class IastModule
 
     internal static IastModuleResponse OnLdapInjection(string evidence)
     {
-        if (!Iast.Instance.Settings.Enabled)
-        {
-            return IastModuleResponse.Empty;
-        }
-
         try
         {
+            if (!Iast.Instance.Settings.Enabled)
+            {
+                return IastModuleResponse.Empty;
+            }
+
             OnExecutedSinkTelemetry(IastInstrumentedSinks.LdapInjection);
             return GetScope(evidence, IntegrationId.Ldap, VulnerabilityTypeName.LdapInjection, OperationNameLdapInjection, Always);
         }

--- a/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Analyzers.Tests/AspectAnalyzers/BeforeAfterAspectAnalyzerTests.cs
@@ -1,0 +1,324 @@
+// <copyright file="BeforeAfterAspectAnalyzerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Threading.Tasks;
+using Datadog.Trace.Tools.Analyzers.AspectAnalyzers;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Testing;
+using Xunit;
+using Verifier = Microsoft.CodeAnalysis.CSharp.Testing.XUnit.CodeFixVerifier<
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.BeforeAfterAspectAnalyzer,
+    Datadog.Trace.Tools.Analyzers.AspectAnalyzers.BeforeAfterAspectCodeFixProvider>;
+
+namespace Datadog.Trace.Tools.Analyzers.Tests.AspectAnalyzers;
+
+public class BeforeAfterAspectAnalyzerTests
+{
+    private const string DiagnosticId = BeforeAfterAspectAnalyzer.DiagnosticId;
+    private const DiagnosticSeverity Severity = BeforeAfterAspectAnalyzer.Severity;
+
+    // No diagnostics expected to show up
+    [Fact]
+    public async Task EmptySourceShouldNotHaveDiagnostics()
+    {
+        var test = string.Empty;
+
+        await Verifier.VerifyAnalyzerAsync(test);
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagMethodWithoutAttributes()
+    {
+        var method =
+            """
+            string TestMethod(string myParam)
+            {
+                // does something
+                return myParam;
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagMethodWithTryCatch()
+    {
+        var method =
+            """
+            [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            string TestMethod(string myParam)
+            {
+                try
+                {
+                    // does something
+                    return myParam;
+                }
+                catch (Exception ex)
+                {
+                    // the contents don't actually matter here
+                    return myParam;
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagMethodWithTryCatchAndBlockExceptionFilter()
+    {
+        var method =
+            """
+            [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            string TestMethod(string myParam)
+            {
+                try
+                {
+                    // does something
+                    return myParam;
+                }
+                catch (Exception ex) when (ex is not BlockException)
+                {
+                    // the contents don't actually matter here
+                    return myParam;
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldNotFlagEmptyMethod()
+    {
+        var method =
+            """
+            [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+            void TestMethod(string myParam)
+            {
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(GetTestCode(method));
+    }
+
+    [Fact]
+    public async Task ShouldFlagExpressionBodiedMember()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:=> myParam|};
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodWithoutTryCatch()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {|#0:{
+                        // does something
+                        return myParam;
+                    }|}
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodWithDerivedException()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        {|#0:catch (SystemException ex)
+                        {
+                            return myParam;
+                        }|}
+                    }
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        catch (SystemException ex)
+                        {
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    [Fact]
+    public async Task ShouldFlagMethodWithFilter()
+    {
+        var method =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        {|#0:catch (Exception ex) when (ex.Message == "test")
+                        {
+                            return myParam;
+                        }|}
+                    }
+            """;
+
+        var fixedMethod =
+            """
+                    [AspectMethodInsertBefore("Microsoft.AspNetCore.Http.HttpResponse::Redirect(System.String)")]
+                    string TestMethod(string myParam)
+                    {
+                        try
+                        {
+                            // does something
+                            return myParam;
+                        }
+                        catch (Exception ex) when (ex.Message == "test")
+                        {
+                            return myParam;
+                        }
+                        catch (Exception ex)
+                        {
+                            IastModule.Log.Error(ex, $"Error invoking {nameof(TestClass)}.{nameof(TestMethod)}");
+                            return myParam;
+                        }
+                    }
+            """;
+
+        var expected = new DiagnosticResult(DiagnosticId, Severity).WithLocation(0);
+        var code = GetTestCode(method);
+        var fix = GetTestCode(fixedMethod);
+        await Verifier.VerifyCodeFixAsync(code, expected, fix);
+    }
+
+    private static string GetTestCode(string testFragment)
+        =>
+            $$"""
+              using System;
+              using System.Collections.Generic;
+              using System.Linq;
+              using System.Text;
+              using System.Threading;
+              using System.Threading.Tasks;
+              using System.Diagnostics;
+
+              namespace ConsoleApplication1
+              {
+                  class TestClass
+                  {
+                      private static readonly IDatadogLogger Log = new DatadogLogging();
+
+              {{testFragment}}
+                  }
+              
+                  [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = true)]
+                  internal abstract class AspectAttribute : Attribute { } 
+              
+                  internal sealed class AspectMethodInsertBeforeAttribute : AspectAttribute
+                  {
+                      public AspectMethodInsertBeforeAttribute(string targetMethod) { }
+                  }
+
+                  internal sealed class AspectMethodInsertAfterAttribute : AspectAttribute { }
+                  
+                  interface IDatadogLogger
+                  {
+                      void Error(Exception? exception, string messageTemplate);
+                  }
+                  
+                  class DatadogLogging : IDatadogLogger
+                  {
+                      public void Error(Exception? exception, string messageTemplate) { }
+                  }
+
+                  static class IastModule
+                  {
+                      public static readonly IDatadogLogger Log = new DatadogLogging();
+                  }
+
+                  class BlockException : Exception
+                  {
+                  }
+              }
+              """;
+}

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SSRF/WebClientTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SSRF/WebClientTests.cs
@@ -22,7 +22,7 @@ public class WebClientTests : SSRFTests
     [Fact]
     public void GivenAWebClient_WhenDownloadData_Exception()
     {
-        Assert.Throws<NullReferenceException>(() => webclient.DownloadData((Uri) null));
+        Assert.Throws<ArgumentNullException>(() => webclient.DownloadData((Uri) null));
     }
 
     // Testing [AspectMethodInsertBefore("System.Net.WebClient::DownloadDataAsync(System.Uri)")]


### PR DESCRIPTION
## Summary of changes
Covered all `InsertBefore` / `InsertAfter` aspects with try catch clauses to ensure no crash will bubble up to client, following new analyzer rules.

## Reason for change
SSI will make the tracer enabled for a lot more of services when available. We must ensure we do not break any of them, and if so, that we provide a fast answer.

## Implementation details
Apply analyzer suggestions adding a try / catch clause in all `InsertBefore` / `InsertAfter` aspects

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
