### PR TITLE
[IAST] Add a mark to the modified instructions in IL dumps (#5854 -> v2)

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -3860,21 +3860,6 @@ void CorProfiler::GetAssemblyAndSymbolsBytes(BYTE** pAssemblyArray, int* assembl
 // * ReJIT Methods
 // ***
 
-HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId,
-                                                               BOOL fIsSafeToBlock)
-{
-    if (!is_attached_)
-    {
-        return S_OK;
-    }
-
-    Logger::Debug("ReJITCompilationStarted: [functionId: ", functionId, ", rejitId: ", rejitId,
-                  ", safeToBlock: ", fIsSafeToBlock, "]");
-
-    // we notify the reJIT handler of this event
-    return rejit_handler->NotifyReJITCompilationStarted(functionId, rejitId);
-}
-
 HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdMethodDef methodId,
                                                           ICorProfilerFunctionControl* pFunctionControl)
 {
@@ -3883,22 +3868,10 @@ HRESULT STDMETHODCALLTYPE CorProfiler::GetReJITParameters(ModuleID moduleId, mdM
         return S_OK;
     }
 
-    Logger::Debug("GetReJITParameters: [moduleId: ", moduleId, ", methodId: ", methodId, "]");
+    Logger::Debug("GetReJITParameters: [moduleId: ", moduleId, ", methodId: ", Hex(methodId), "]");
 
     // we notify the reJIT handler of this event and pass the module_metadata.
     return rejit_handler->NotifyReJITParameters(moduleId, methodId, pFunctionControl);
-}
-
-HRESULT STDMETHODCALLTYPE CorProfiler::ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId,
-                                                                HRESULT hrStatus, BOOL fIsSafeToBlock)
-{
-    if (is_attached_ && IsDebugEnabled())
-    {
-        Logger::Debug("ReJITCompilationFinished: [functionId: ", functionId, ", rejitId: ", rejitId,
-                      ", hrStatus: ", hrStatus, ", safeToBlock: ", fIsSafeToBlock, "]");
-    }
-
-    return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CorProfiler::ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId,

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -172,14 +172,8 @@ public:
     // ReJIT Methods
     //
 
-    HRESULT STDMETHODCALLTYPE ReJITCompilationStarted(FunctionID functionId, ReJITID rejitId,
-                                                      BOOL fIsSafeToBlock) override;
-
     HRESULT STDMETHODCALLTYPE GetReJITParameters(ModuleID moduleId, mdMethodDef methodId,
                                                  ICorProfilerFunctionControl* pFunctionControl) override;
-
-    HRESULT STDMETHODCALLTYPE ReJITCompilationFinished(FunctionID functionId, ReJITID rejitId, HRESULT hrStatus,
-                                                       BOOL fIsSafeToBlock) override;
 
     HRESULT STDMETHODCALLTYPE ReJITError(ModuleID moduleId, mdMethodDef methodId, FunctionID functionId,
                                          HRESULT hrStatus) override;

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow.cpp
@@ -671,6 +671,7 @@ HRESULT Dataflow::RewriteMethod(MethodInfo* method, trace::FunctionControlWrappe
             {
                 std::vector<ModuleID> modulesVector = {module->_id};
                 std::vector<mdMethodDef> methodsVector = {method->GetMemberId()}; // methodId
+                trace::Logger::Debug("RewriteMethod: REJIT requested for ", method->GetKey());
                 m_rejitHandler->RequestRejit(modulesVector, methodsVector);
             }
         }

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_aspects.cpp
@@ -485,20 +485,20 @@ namespace iast
                 if (methodRef == 0) { continue; } //Disabled Spot
                 if (instructionToProcess.behavior == AspectBehavior::InsertBefore)
                 {
-                    aspectInstruction = processor->NewILInstr(CEE_CALL, methodRef);
+                    aspectInstruction = processor->NewILInstr(CEE_CALL, methodRef, true);
                     processor->InsertBefore(instructionToProcess.instruction, aspectInstruction);
                 }
                 else if (instructionToProcess.behavior == AspectBehavior::InsertAfter)
                 {
-                    aspectInstruction = processor->NewILInstr(CEE_CALL, methodRef);
+                    aspectInstruction = processor->NewILInstr(CEE_CALL, methodRef, true);
                     auto inserted = processor->InsertAfter(instructionToProcess.instruction, aspectInstruction);
 
                     if (_aspect->_boxParam[instructionToProcess.paramIndex])
                     {
                         // Retrieve type of the valueType in target argument
                         auto paramType = _targetParamTypeToken[instructionToProcess.paramIndex];
-                        processor->InsertBefore(aspectInstruction, processor->NewILInstr(CEE_BOX, paramType));
-                        inserted = processor->InsertAfter(aspectInstruction, processor->NewILInstr(CEE_UNBOX_ANY, paramType));
+                        processor->InsertBefore(aspectInstruction, processor->NewILInstr(CEE_BOX, paramType, true));
+                        inserted = processor->InsertAfter(aspectInstruction, processor->NewILInstr(CEE_UNBOX_ANY, paramType, true));
                     }
 
                     if (instructionToProcess.instruction == instruction)
@@ -525,7 +525,7 @@ namespace iast
                                      paramCount - _aspect->_paramShift[x] - 1)) // Locate param load instruction
                             {
                                 auto paramType = _targetParamTypeToken[x];
-                                processor->InsertAfter(iInfo->_instruction, processor->NewILInstr(CEE_BOX, paramType));
+                                processor->InsertAfter(iInfo->_instruction, processor->NewILInstr(CEE_BOX, paramType, true));
 
                                 // Figure out if param is byref
                                 if (iInfo->IsArgument())
@@ -534,7 +534,7 @@ namespace iast
                                     auto param = sig->_params[iInfo->_instruction->m_Arg32];
                                     if (param->IsByRef())
                                     {
-                                        processor->InsertAfter(iInfo->_instruction, processor->NewILInstr(CEE_LDOBJ, paramType));
+                                        processor->InsertAfter(iInfo->_instruction, processor->NewILInstr(CEE_LDOBJ, paramType, true));
                                     }
                                 }
 

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
@@ -736,7 +736,8 @@ namespace iast
         default:
             break;
         }
-        auto res = "IL" + Hex(instruction->m_offset) + " : " + _instructionNames[instruction->m_opcode] + " " + argument;
+        auto sep = instruction->IsDirty() ? "*: " : " : ";
+        auto res = "IL" + Hex(instruction->m_offset) + sep + _instructionNames[instruction->m_opcode] + " " + argument;
         return res;
     }
 
@@ -787,7 +788,6 @@ namespace iast
             for (ILInstr* instruction = _body->GetILList()->m_pNext; instruction != _body->GetILList(); instruction = instruction->m_pNext)
             {
                 if (instruction->m_opcode == CEE_SWITCH_ARG) { continue; }
-                bool written = false;
                 EHClause* exitBlock = nullptr;
                 auto hs = Get<ILInstr*, std::vector<EHClause*>>(handlers, instruction);
                 if (hs != nullptr)
@@ -826,7 +826,7 @@ namespace iast
                         }
                     }
                 }
-                if (!written) { trace::Logger::Info(indent, ToString(_body, instruction)); } // Write current instruction
+                trace::Logger::Info(indent, ToString(_body, instruction)); // Write current instruction
                 if (instruction->m_opcode == CEE_ENDFILTER || instruction->m_opcode == CEE_ENDFINALLY || instruction->m_opcode == CEE_LEAVE || instruction->m_opcode == CEE_LEAVE_S)
                 {
                     if (nesting.size() > 0)

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_rewriter.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_rewriter.cpp
@@ -412,7 +412,7 @@ namespace iast
     }
 
 
-    ILInstr* ILRewriter::NewILInstr(OPCODE opcode, ULONG32 arg)
+    ILInstr* ILRewriter::NewILInstr(OPCODE opcode, ULONG32 arg, bool isNew)
     {
         //m_bDirty = true;
         m_nInstrs++;
@@ -421,6 +421,7 @@ namespace iast
         res->m_opcode = opcode;
         res->m_Arg32 = arg;
         res->m_originalArg64 = res->m_Arg64;
+        res->m_isNew = isNew;
         return res;
     }
 

--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_rewriter.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_rewriter.h
@@ -28,6 +28,7 @@ namespace iast
 
         unsigned        m_opcode;
         unsigned        m_offset;
+        bool            m_isNew;
 
         union
         {
@@ -45,7 +46,7 @@ namespace iast
             INT32       m_originalArg32;
             INT64       m_originalArg64;
         };
-        inline bool IsNew() { return m_offset == -1; }
+        inline bool IsNew() { return m_isNew; }
         inline bool IsDirty() { return IsNew() || m_Arg64 != m_originalArg64; }
         inline int GetLine() { return (IsNew() && m_pNext) ? m_pNext->GetLine() : -((int)m_offset); }
     };
@@ -104,7 +105,7 @@ namespace iast
         //void SetDirty();
         HRESULT Import();
         HRESULT Import(LPCBYTE pMethodIL);
-        ILInstr* NewILInstr(OPCODE opcode = CEE_COUNT, ULONG32 arg = 0);
+        ILInstr* NewILInstr(OPCODE opcode = CEE_COUNT, ULONG32 arg = 0, bool isNew = false);
         ILInstr* InsertBefore(ILInstr* pWhere, ILInstr* pWhat, bool updateReferences = true);
         ILInstr* InsertAfter(ILInstr* pWhere, ILInstr* pWhat, bool updateReferences = true);
         HRESULT Export();

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.cpp
@@ -414,11 +414,6 @@ HRESULT RejitHandler::NotifyReJITParameters(ModuleID moduleId, mdMethodDef metho
     return functionControl.ApplyChanges(pFunctionControl);
 }
 
-HRESULT RejitHandler::NotifyReJITCompilationStarted(FunctionID functionId, ReJITID rejitId)
-{
-    return S_OK;
-}
-
 ICorProfilerInfo7* RejitHandler::GetCorProfilerInfo()
 {
     return m_profilerInfo;

--- a/tracer/src/Datadog.Tracer.Native/rejit_handler.h
+++ b/tracer/src/Datadog.Tracer.Native/rejit_handler.h
@@ -134,8 +134,7 @@ public:
 
     HRESULT NotifyReJITParameters(ModuleID moduleId, mdMethodDef methodId,
                                   ICorProfilerFunctionControl* pFunctionControl);
-    static HRESULT NotifyReJITCompilationStarted(FunctionID functionId, ReJITID rejitId);
-
+ 
     ICorProfilerInfo7* GetCorProfilerInfo();
 
     void SetCorAssemblyProfiler(AssemblyProperty* pCorAssemblyProfiler);


### PR DESCRIPTION
## Summary of changes
Add a marker * after the IL instruction OFFSET in Dataflow IL dumps


![image](https://github.com/user-attachments/assets/6cd6c007-5e48-4ce8-99a0-6b1d1d00d24e)

Also, some not used code and useless logs have been removed

## Reason for change
Sometimes modified instructions were difficult to locate in dumps present in the logs.

## Implementation details
Identified new instructions with a flag instead of relaying on a negative offset as before, as this was lost in `rejit` situations
