### PR TITLE
[Backport][Crashtracking]  Ensure crashtracking does not prevent coredump collection (#5852 -> v2)

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -55,7 +55,7 @@ enum FUNCTION_ID
 // counters: one byte per function
 __thread unsigned long long functions_entered_counter = 0;
 
-__attribute__((visibility("hidden"))) 
+__attribute__((visibility("hidden")))
 atomic_int is_app_crashing = 0;
 
 // this function is called by the profiler
@@ -172,6 +172,9 @@ char* getSubfolder(const char* path)
 
     return subfolder;
 }
+
+static char* originalMiniDumpName = NULL;
+static const char* datadogCrashMarker = "datadog_crashtracking";
 
 __attribute__((constructor))
 void initLibrary(void)
@@ -311,6 +314,14 @@ void initLibrary(void)
             setenv("DOTNET_DbgEnableMiniDump", "1", 1);
             setenv("DD_TRACE_CRASH_HANDLER_PASSTHROUGH", "0", 1);
         }
+
+        originalMiniDumpName = getenv("DOTNET_DbgMiniDumpName");
+        if (originalMiniDumpName == NULL)
+        {
+            originalMiniDumpName = getenv("COMPlus_DbgMiniDumpName");
+        }
+        setenv("COMPlus_DbgMiniDumpName", datadogCrashMarker, 1);
+        setenv("DOTNET_DbgMiniDumpName", datadogCrashMarker, 1);
     }
 }
 
@@ -407,6 +418,35 @@ int dladdr(const void* addr_arg, Dl_info* info)
 /* Function pointers to hold the value of the glibc functions */
 static int (*__real_execve)(const char* pathname, char* const argv[], char* const envp[]) = NULL;
 
+__attribute__((visibility("hidden")))
+int ShouldCallCustomCreatedump(const char* pathname, char* const argv[])
+{
+    if (crashHandler == NULL || pathname == NULL)
+    {
+        return 0;
+    }
+
+    size_t length = strlen(pathname);
+
+    if (length < 11 || strcmp(pathname + length - 11, "/createdump") != 0)
+    {
+        return 0;
+    }
+
+    // datadog_crashtracking is set to identify actual crash to dump generation requests (ex: dotnet-dump)
+    int previousWasNameOpt = 0;
+    for (int i = 0; argv[i] != NULL; i++)
+    {
+        if (previousWasNameOpt != 0 && strncmp(argv[i], datadogCrashMarker, strlen(datadogCrashMarker)) == 0)
+        {
+            return 1;
+        }
+        previousWasNameOpt = strncmp(argv[i], "--name", strlen("--name")) == 0;
+    }
+
+    return 0;
+}
+
 int execve(const char* pathname, char* const argv[], char* const envp[])
 {
     if (__real_execve == NULL)
@@ -414,70 +454,83 @@ int execve(const char* pathname, char* const argv[], char* const envp[])
         __real_execve = dlsym(RTLD_NEXT, "execve");
     }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wtautological-compare"
-    if (crashHandler != NULL && pathname != NULL)
+    int callCustomCreatedump = ShouldCallCustomCreatedump(pathname, argv);
+
+    if (callCustomCreatedump == 0)
     {
-        size_t length = strlen(pathname);
+        return __real_execve(pathname, argv, envp);
+    }
 
-        if (length >= 11 && strcmp(pathname + length - 11, "/createdump") == 0)
+    is_app_crashing = 1;
+    // Execute the alternative crash handler, and prepend "createdump" to the arguments
+
+    // Count the number of arguments (the list ends with a null pointer)
+    int argc = 0;
+    while (argv[argc++] != NULL);
+
+    // We add two arguments: the path to dd-dotnet, and "createdump"
+    char** newArgv = malloc((argc + 2) * sizeof(char*));
+
+    // By convention, argv[0] contains the name of the executable
+    // Insert createdump as the first actual argument
+    newArgv[0] = crashHandler;
+    newArgv[1] = "createdump";
+
+    // Copy the remaining arguments and replace datadog_crashtracking by the original name if needed
+    size_t idx = 0;
+    size_t new_idx = 2;
+    while (argv[idx] != NULL)
+    {
+        if (strncmp(argv[idx], "--name", strlen("--name")) == 0)
         {
-            is_app_crashing = 1;
-            // Execute the alternative crash handler, and prepend "createdump" to the arguments
-
-            // Count the number of arguments (the list ends with a null pointer)
-            int argc = 0;
-            while (argv[argc++] != NULL);
-
-            // We add two arguments: the path to dd-dotnet, and "createdump"
-            char** newArgv = malloc((argc + 2) * sizeof(char*));
-
-            // By convention, argv[0] contains the name of the executable
-            // Insert createdump as the first actual argument
-            newArgv[0] = crashHandler;
-            newArgv[1] = "createdump";
-
-            // Copy the remaining arguments
-            memcpy(newArgv + 2, argv, sizeof(char*) * argc);
-
-            size_t envp_count;
-            for (envp_count = 0; envp[envp_count]; ++envp_count);
-            char** new_envp = malloc((envp_count + 1) * sizeof(char*)); // +1 for NULL terminator
-
-            int index = 0;
-
-            for (size_t i = 0; i < envp_count; ++i) {
-                if (strncmp(envp[i], "LD_PRELOAD=", strlen("LD_PRELOAD=")) == 0) {
-                    continue;
-                }
-
-                if (strncmp(envp[i], "CORECLR_ENABLE_PROFILING=", strlen("CORECLR_ENABLE_PROFILING=")) == 0) {
-                    continue;
-                }
-
-                if (strncmp(envp[i], "DOTNET_DbgEnableMiniDump=", strlen("DOTNET_DbgEnableMiniDump=")) == 0) {
-                    continue;
-                }
-
-                if (strncmp(envp[i], "COMPlus_DbgEnableMiniDump=", strlen("COMPlus_DbgEnableMiniDump=")) == 0) {
-                    continue;
-                }
-
-                new_envp[index++] = envp[i];
+            if (originalMiniDumpName != NULL)
+            {
+                newArgv[new_idx++] = "--name";
+                newArgv[new_idx++] = originalMiniDumpName; // no need to check for datadog_crashtracking, this was done in ShouldCallOurOwnCreatedump
             }
-            new_envp[index] = NULL; // NULL terminate the array
 
-            int result = __real_execve(crashHandler, newArgv, new_envp);
-
-            free(newArgv);
-            free(new_envp);
-
-            return result;
+            idx += 2;
+        }
+        else
+        {
+            newArgv[new_idx++] = argv[idx++];
         }
     }
-#pragma clang diagnostic pop
+    newArgv[new_idx] = NULL;  // NULL terminate the array
 
-    return __real_execve(pathname, argv, envp);
+    size_t envp_count;
+    for (envp_count = 0; envp[envp_count]; ++envp_count);
+    char** new_envp = malloc((envp_count + 1) * sizeof(char*)); // +1 for NULL terminator
+
+    int index = 0;
+
+    for (size_t i = 0; i < envp_count; ++i) {
+        if (strncmp(envp[i], "LD_PRELOAD=", strlen("LD_PRELOAD=")) == 0) {
+            continue;
+        }
+
+        if (strncmp(envp[i], "CORECLR_ENABLE_PROFILING=", strlen("CORECLR_ENABLE_PROFILING=")) == 0) {
+            continue;
+        }
+
+        if (strncmp(envp[i], "DOTNET_DbgEnableMiniDump=", strlen("DOTNET_DbgEnableMiniDump=")) == 0) {
+            continue;
+        }
+
+        if (strncmp(envp[i], "COMPlus_DbgEnableMiniDump=", strlen("COMPlus_DbgEnableMiniDump=")) == 0) {
+            continue;
+        }
+
+        new_envp[index++] = envp[i];
+    }
+    new_envp[index] = NULL; // NULL terminate the array
+
+    int result = __real_execve(crashHandler, newArgv, new_envp);
+
+    free(newArgv);
+    free(new_envp);
+
+    return result;
 }
 
 #ifdef DD_ALPINE


### PR DESCRIPTION
## Summary of changes

This PR allows to take coredump using `dotnet-dump` (other external tool)  even if the crashtracker is enabled.

## Reason for change

Recently, a customer reported impossibility to take coredump using `dotnet-dump`. 

## Implementation details

- Set `COMPlus_DbgMiniDumpName` to `datadog_crashtracking`. So we have marker when coredump collection is triggered from the inside of the process. And save the previous value.
- Check if we should call our custom `createdump`-like tool by searching for `datadog_crashtracking` in the command-line.
- If `datadog_crashtracking` not present, just call the real `createdump`
- Otherwise, create a new set of command-line argument with the old value of `DOTNET_DbgMiniDumpName/COMPlus_DbgMiniDumpName` for `--name` (or do not add anything if there was no previous value)
- Call our `createdump`-like tool. (like before)

## Test coverage
- Tested locally: 
using `dotnet-dump`: coredump was correctly created
a crash with `COMPlus_DbgEnableMiniDump/DOTNET_DbgEnableMiniDump` set to 0: no coredump
a crash with `COMPlus_DbgEnableMiniDump/DOTNET_DbgEnableMiniDump` set to 1: a coredump was correctly created. 

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
