### PR TITLE
Config refactor - Add telemetry to otel config (#5717 -> v2)

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using System.Xml;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Util;
@@ -405,7 +406,7 @@ namespace Datadog.Trace.Tools.Runner
             configurationSource.AddInternal(new NameValueConfigurationSource(env, ConfigurationOrigins.EnvVars));
             configurationSource.AddInternal(GlobalConfigurationSource.Instance);
 
-            var tracerSettings = new TracerSettings(configurationSource, new ConfigurationTelemetry());
+            var tracerSettings = new TracerSettings(configurationSource, new ConfigurationTelemetry(), new OverrideErrorLog());
             var settings = new ImmutableTracerSettings(tracerSettings, unusedParamNotToUsePublicApi: true);
 
             Log.Debug("Creating DiscoveryService for: {AgentUriInternal}", settings.ExporterInternal.AgentUriInternal);

--- a/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
+++ b/tracer/src/Datadog.Trace/Ci/Configuration/CIVisibilitySettings.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Specialized;
 using System.Threading;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util;
@@ -231,7 +232,7 @@ namespace Datadog.Trace.Ci.Configuration
                                       },
                                       ConfigurationOrigins.Calculated));
 
-            var tracerSettings = new TracerSettings(source, new ConfigurationTelemetry());
+            var tracerSettings = new TracerSettings(source, new ConfigurationTelemetry(), new OverrideErrorLog());
 
             if (Logs)
             {

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationOverrideHandler.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/IConfigurationOverrideHandler.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="IConfigurationOverrideHandler.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+internal interface IConfigurationOverrideHandler
+{
+    bool TryHandleOverrides<T>(
+        string datadogKey,
+        ConfigurationResult<T> datadogConfigResult,
+        string otelKey,
+        ConfigurationResult<T> otelConfigResult,
+        [NotNullWhen(true)] out T? value);
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/OpenTelemetryHelpers.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/OpenTelemetryHelpers.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="OpenTelemetryHelpers.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using Datadog.Trace.Telemetry.Metrics;
+
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry
+{
+    internal static class OpenTelemetryHelpers
+    {
+        public static void GetConfigurationMetricTags(
+                string openTelemetryKey,
+                out MetricTags.OpenTelemetryConfiguration openTelemetryConfig,
+                out MetricTags.DatadogConfiguration datadogConfig)
+        {
+            if (string.Equals(openTelemetryKey, "OTEL_SERVICE_NAME", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.ServiceName;
+                datadogConfig = MetricTags.DatadogConfiguration.Service;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_LOG_LEVEL", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.LogLevel;
+                datadogConfig = MetricTags.DatadogConfiguration.DebugEnabled;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_PROPAGATORS", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.Propagators;
+                datadogConfig = MetricTags.DatadogConfiguration.PropagationStyle;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_TRACES_SAMPLER", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.TracesSampler;
+                datadogConfig = MetricTags.DatadogConfiguration.SampleRate;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_TRACES_SAMPLER_ARG", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.TracesSamplerArg;
+                datadogConfig = MetricTags.DatadogConfiguration.SampleRate;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_TRACES_EXPORTER", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.TracesExporter;
+                datadogConfig = MetricTags.DatadogConfiguration.TraceEnabled;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_METRICS_EXPORTER", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.MetricsExporter;
+                datadogConfig = MetricTags.DatadogConfiguration.RuntimeMetricsEnabled;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_RESOURCE_ATTRIBUTES", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.ResourceAttributes;
+                datadogConfig = MetricTags.DatadogConfiguration.Tags;
+            }
+            else if (string.Equals(openTelemetryKey, "OTEL_SDK_DISABLED", StringComparison.OrdinalIgnoreCase))
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.SdkDisabled;
+                datadogConfig = MetricTags.DatadogConfiguration.OpenTelemetryEnabled;
+            }
+            else
+            {
+                openTelemetryConfig = MetricTags.OpenTelemetryConfiguration.Unknown;
+                datadogConfig = MetricTags.DatadogConfiguration.Unknown;
+            }
+        }
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/OverrideErrorLog.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationSources/Telemetry/OverrideErrorLog.cs
@@ -1,0 +1,137 @@
+﻿// <copyright file="OverrideErrorLog.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
+
+namespace Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+
+/// <summary>
+/// Records cases where configuration was overridden by startup telemetry,
+/// so they can be written once the tracer has been fully initialized
+/// </summary>
+internal sealed class OverrideErrorLog : IConfigurationOverrideHandler
+{
+    private readonly object _lock = new();
+    private List<Action<IDatadogLogger, IMetricsTelemetryCollector>>? _actions;
+
+    public static OverrideErrorLog Instance { get; } = new();
+
+    /// <summary>
+    /// Enqueue an action to be executed
+    /// </summary>
+    public void EnqueueAction(Action<IDatadogLogger, IMetricsTelemetryCollector> action)
+    {
+        lock (_lock)
+        {
+            _actions ??= new();
+            _actions.Add(action);
+        }
+    }
+
+    public void ProcessAndClearActions(IDatadogLogger log, IMetricsTelemetryCollector metrics)
+    {
+        List<Action<IDatadogLogger, IMetricsTelemetryCollector>>? actions;
+
+        lock (_lock)
+        {
+            actions = _actions;
+            _actions = null;
+        }
+
+        if (actions is not null)
+        {
+            foreach (var logAction in actions)
+            {
+                logAction(log, metrics);
+            }
+        }
+    }
+
+    public OverrideErrorLog Clone()
+    {
+        var clone = new OverrideErrorLog();
+        lock (_lock)
+        {
+            clone._actions = _actions?.ToList();
+        }
+
+        return clone;
+    }
+
+    public void LogDuplicateConfiguration(string datadogKey, string otelKey)
+    {
+        EnqueueAction(
+            (log, metrics) =>
+            {
+                log.Warning(
+                    "Both Datadog configuration {DatadogConfiguration} and OpenTelemetry configuration {OpenTelemetryConfiguration} are set. The Datadog configuration will be used.",
+                    datadogKey,
+                    otelKey);
+                OpenTelemetryHelpers.GetConfigurationMetricTags(otelKey, out var openTelemetryConfig, out var datadogConfig);
+                metrics.RecordCountOpenTelemetryConfigHiddenByDatadogConfig(datadogConfig, openTelemetryConfig);
+            });
+    }
+
+    public void LogInvalidConfiguration(string otelKey)
+    {
+        EnqueueAction(
+            (log, metrics) =>
+            {
+                log.Warning("OpenTelemetry configuration {OpenTelemetryConfiguration} is invalid.", otelKey);
+                OpenTelemetryHelpers.GetConfigurationMetricTags(otelKey, out var openTelemetryConfig, out var datadogConfig);
+                metrics.RecordCountOpenTelemetryConfigInvalid(datadogConfig, openTelemetryConfig);
+            });
+    }
+
+    public void LogUnsupportedConfiguration(string otelKey, string otelValue, string replacementValue)
+    {
+        EnqueueAction(
+            (log, _) =>
+            {
+                log.Warning(
+                    "OpenTelemetry configuration {OpenTelemetryConfiguration}={OpenTelemetryValue} is not supported. {ModifiedValue} will be used instead.",
+                    otelKey,
+                    otelValue,
+                    replacementValue);
+            });
+    }
+
+    bool IConfigurationOverrideHandler.TryHandleOverrides<T>(
+        string datadogKey,
+        ConfigurationResult<T> datadogConfigResult,
+        string otelKey,
+        ConfigurationResult<T> otelConfigResult,
+        [NotNullWhen(true)] out T? value)
+        where T : default
+    {
+        if (datadogConfigResult.IsPresent && otelConfigResult.IsPresent)
+        {
+            LogDuplicateConfiguration(datadogKey, otelKey);
+        }
+        else if (otelConfigResult is { IsPresent: true } config)
+        {
+            if (config is { Result: { } openTelemetryValue, IsValid: true })
+            {
+                {
+                    value = openTelemetryValue;
+                    return true;
+                }
+            }
+
+            LogInvalidConfiguration(otelKey);
+        }
+
+        value = default;
+        return false;
+    }
+}

--- a/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/GlobalSettings.cs
@@ -27,7 +27,11 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         /// <param name="telemetry">Records the origin of telemetry values</param>
-        internal GlobalSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
+        /// <param name="overrideHandler">Records any errors </param>
+        internal GlobalSettings(
+            IConfigurationSource source,
+            IConfigurationTelemetry telemetry,
+            IConfigurationOverrideHandler overrideHandler)
         {
             var builder = new ConfigurationBuilder(source, telemetry);
 
@@ -41,7 +45,7 @@ namespace Datadog.Trace.Configuration
             DebugEnabledInternal = builder
                                   .WithKeys(ConfigurationKeys.DebugEnabled)
                                   .AsBoolResult()
-                                  .OverrideWith(in otelConfig, false);
+                                  .OverrideWith(in otelConfig, overrideHandler, false);
 
             DiagnosticSourceEnabled = builder
                                      .WithKeys(ConfigurationKeys.DiagnosticSourceEnabled)
@@ -132,6 +136,6 @@ namespace Datadog.Trace.Configuration
         }
 
         private static GlobalSettings CreateFromDefaultSources()
-            => new(GlobalConfigurationSource.Instance, TelemetryFactory.Config);
+            => new(GlobalConfigurationSource.Instance, TelemetryFactory.Config, OverrideErrorLog.Instance);
     }
 }

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -13,6 +13,7 @@ using System.Linq;
 using System.Text;
 using Datadog.Trace.Ci.Tags;
 using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Logging.DirectSubmission;
@@ -48,7 +49,7 @@ namespace Datadog.Trace.Configuration
         /// <param name="source">The <see cref="IConfigurationSource"/> to use when retrieving configuration values.</param>
         [PublicApi]
         public ImmutableTracerSettings(IConfigurationSource source)
-            : this(new TracerSettings(source, new ConfigurationTelemetry()), true)
+            : this(new TracerSettings(source, new ConfigurationTelemetry(), new OverrideErrorLog()), true)
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.ImmutableTracerSettings_Ctor_Source);
         }
@@ -191,6 +192,8 @@ namespace Datadog.Trace.Configuration
             // but we can't send it to the static collector, as this settings object may never be "activated"
             Telemetry = new ConfigurationTelemetry();
             settings.CollectTelemetry(Telemetry);
+
+            ErrorLog = settings.ErrorLog.Clone();
 
             // Record the final disabled settings values in the telemetry, we can't quite get this information
             // through the IntegrationTelemetryCollector currently so record it here instead
@@ -628,6 +631,11 @@ namespace Datadog.Trace.Configuration
         /// Gets the telemetry that was collected from <see cref="TracerSettings"/> when this instance was built
         /// </summary>
         internal IConfigurationTelemetry Telemetry { get; }
+
+        /// <summary>
+        /// Gets the error logs that were collected from <see cref="TracerSettings"/> when this instance was built
+        /// </summary>
+        internal OverrideErrorLog ErrorLog { get; }
 
         /// <summary>
         /// Gets a value indicating whether remote configuration is potentially available.

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -42,7 +42,7 @@ namespace Datadog.Trace.Configuration
         /// </summary>
         [PublicApi]
         public TracerSettings()
-            : this(null, new ConfigurationTelemetry())
+            : this(null, new ConfigurationTelemetry(), new OverrideErrorLog())
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_Ctor);
         }
@@ -56,7 +56,7 @@ namespace Datadog.Trace.Configuration
         /// the default sources such as environment variables etc. If <c>false</c>, uses the default values.</param>
         [PublicApi]
         public TracerSettings(bool useDefaultSources)
-            : this(useDefaultSources ? GlobalConfigurationSource.Instance : null, new ConfigurationTelemetry())
+            : this(useDefaultSources ? GlobalConfigurationSource.Instance : null, new ConfigurationTelemetry(), new OverrideErrorLog())
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_Ctor_UseDefaultSources);
         }
@@ -73,16 +73,17 @@ namespace Datadog.Trace.Configuration
         /// </remarks>
         [PublicApi]
         public TracerSettings(IConfigurationSource? source)
-        : this(source, new ConfigurationTelemetry())
+        : this(source, new ConfigurationTelemetry(), new OverrideErrorLog())
         {
             TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_Ctor_Source);
         }
 
-        internal TracerSettings(IConfigurationSource? source, IConfigurationTelemetry telemetry)
+        internal TracerSettings(IConfigurationSource? source, IConfigurationTelemetry telemetry, OverrideErrorLog errorLog)
         {
             var commaSeparator = new[] { ',' };
             source ??= NullConfigurationSource.Instance;
             _telemetry = telemetry;
+            ErrorLog = errorLog;
             var config = new ConfigurationBuilder(source, _telemetry);
 
             GCPFunctionSettings = new ImmutableGCPFunctionSettings(source, _telemetry);
@@ -124,7 +125,7 @@ namespace Datadog.Trace.Configuration
             ServiceNameInternal = config
                                  .WithKeys(ConfigurationKeys.ServiceName, "DD_SERVICE_NAME")
                                  .AsStringResult()
-                                 .OverrideWith(in otelServiceName);
+                                 .OverrideWith(in otelServiceName, ErrorLog);
 
             ServiceVersionInternal = config
                             .WithKeys(ConfigurationKeys.ServiceVersion)
@@ -151,7 +152,7 @@ namespace Datadog.Trace.Configuration
             TraceEnabledInternal = config
                                   .WithKeys(ConfigurationKeys.TraceEnabled)
                                   .AsBoolResult()
-                                  .OverrideWith(in otelTraceEnabled, defaultValue: true);
+                                  .OverrideWith(in otelTraceEnabled, ErrorLog, defaultValue: true);
 
             AppsecStandaloneEnabledInternal = config
                           .WithKeys(ConfigurationKeys.AppsecStandaloneEnabled)
@@ -194,6 +195,7 @@ namespace Datadog.Trace.Configuration
                                 .AsDictionaryResult()
                                 .OverrideWith(
                                      RemapOtelTags(in otelTags),
+                                     ErrorLog,
                                      () => new DefaultResult<IDictionary<string, string>>(new Dictionary<string, string>(), string.Empty))
                                  // Filter out tags with empty keys or empty values, and trim whitespace
                                 .Where(kvp => !string.IsNullOrWhiteSpace(kvp.Key) && !string.IsNullOrWhiteSpace(kvp.Value))
@@ -245,7 +247,7 @@ namespace Datadog.Trace.Configuration
             RuntimeMetricsEnabled = config
                                    .WithKeys(ConfigurationKeys.RuntimeMetricsEnabled)
                                    .AsBoolResult()
-                                   .OverrideWith(in otelRuntimeMetricsEnabled, defaultValue: false);
+                                   .OverrideWith(in otelRuntimeMetricsEnabled, ErrorLog, defaultValue: false);
 
             // We should also be writing telemetry for OTEL_LOGS_EXPORTER similar to OTEL_METRICS_EXPORTER, but we don't have a corresponding Datadog config
             // When we do, we can insert that here
@@ -281,7 +283,7 @@ namespace Datadog.Trace.Configuration
 
             SpanSamplingRules = config.WithKeys(ConfigurationKeys.SpanSamplingRules).AsString();
 
-            GlobalSamplingRateInternal = BuildSampleRate(in config);
+            GlobalSamplingRateInternal = BuildSampleRate(ErrorLog, in config);
 
             // We need to record a default value for configuration reporting
             // However, we need to keep GlobalSamplingRateInternal null because it changes the behavior of the tracer in subtle ways
@@ -366,7 +368,7 @@ namespace Datadog.Trace.Configuration
             IsActivityListenerEnabled = config
                                        .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, "DD_TRACE_ACTIVITY_LISTENER_ENABLED")
                                        .AsBoolResult()
-                                       .OverrideWith(in otelActivityListenerEnabled, defaultValue: false);
+                                       .OverrideWith(in otelActivityListenerEnabled, ErrorLog, defaultValue: false);
 
             OpenTelemetryLegacyOperationNameEnabled = config
                                                      .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryLegacyOperationNameEnabled)
@@ -397,14 +399,14 @@ namespace Datadog.Trace.Configuration
                                     .GetAsClassResult(
                                          validator: injectionValidator, // invalid individual values are rejected later
                                          converter: style => TrimSplitString(style, commaSeparator))
-                                    .OverrideWith(in otelPropagation, getDefaultPropagationHeaders);
+                                    .OverrideWith(in otelPropagation, ErrorLog, getDefaultPropagationHeaders);
 
             PropagationStyleExtract = config
                                      .WithKeys(ConfigurationKeys.PropagationStyleExtract, "DD_PROPAGATION_STYLE_EXTRACT", ConfigurationKeys.PropagationStyle)
                                      .GetAsClassResult(
                                           validator: injectionValidator, // invalid individual values are rejected later
                                           converter: style => TrimSplitString(style, commaSeparator))
-                                     .OverrideWith(in otelPropagation, getDefaultPropagationHeaders);
+                                     .OverrideWith(in otelPropagation, ErrorLog, getDefaultPropagationHeaders);
 
             PropagationExtractFirstOnly = config
                                          .WithKeys(ConfigurationKeys.PropagationExtractFirstOnly)
@@ -505,6 +507,8 @@ namespace Datadog.Trace.Configuration
             // Take a snapshot of the "original" settings, so that we can record any subsequent changes in code
             _initialSettings = new TracerSettingsSnapshot(this);
         }
+
+        internal OverrideErrorLog ErrorLog { get; }
 
 #pragma warning disable SA1624 // Documentation summary should begin with "Gets" - the documentation is primarily for public property
         /// <summary>
@@ -1061,7 +1065,7 @@ namespace Datadog.Trace.Configuration
         }
 
         internal static TracerSettings FromDefaultSourcesInternal()
-            => new(GlobalConfigurationSource.Instance, new ConfigurationTelemetry());
+            => new(GlobalConfigurationSource.Instance, new ConfigurationTelemetry(), new());
 
         /// <summary>
         /// Sets the HTTP status code that should be marked as errors for client integrations.
@@ -1268,7 +1272,7 @@ namespace Datadog.Trace.Configuration
         }
 
         internal static TracerSettings Create(Dictionary<string, object?> settings)
-            => new(new DictionaryConfigurationSource(settings.ToDictionary(x => x.Key, x => x.Value?.ToString()!)), new ConfigurationTelemetry());
+            => new(new DictionaryConfigurationSource(settings.ToDictionary(x => x.Key, x => x.Value?.ToString()!)), new ConfigurationTelemetry(), new());
 
         internal void CollectTelemetry(IConfigurationTelemetry destination)
         {
@@ -1287,9 +1291,9 @@ namespace Datadog.Trace.Configuration
             }
         }
 
-        private static double? BuildSampleRate(in ConfigurationBuilder config)
+        private static double? BuildSampleRate(OverrideErrorLog log, in ConfigurationBuilder config)
         {
-            // The "overriding" is complex, so we can't use the usual `OverrideWith(in )` approach
+            // The "overriding" is complex, so we can't use the usual `OverrideWith()` approach
             var ddSampleRate = config.WithKeys(ConfigurationKeys.GlobalSamplingRate).AsDoubleResult();
             var otelSampleType = config.WithKeys(ConfigurationKeys.OpenTelemetry.TracesSampler).AsStringResult();
             var otelSampleRate = config.WithKeys(ConfigurationKeys.OpenTelemetry.TracesSamplerArg).AsDoubleResult();
@@ -1301,12 +1305,12 @@ namespace Datadog.Trace.Configuration
             {
                 if (otelSampleType.ConfigurationResult.IsPresent)
                 {
-                    // TODO Log to user and report "otel.env.hiding" telemetry metric
+                    log.LogDuplicateConfiguration(ddSampleRate.Key, otelSampleType.Key);
                 }
 
                 if (otelSampleRate.ConfigurationResult.IsPresent)
                 {
-                    // TODO Log to user and report "otel.env.hiding" telemetry metric
+                    log.LogDuplicateConfiguration(ddSampleRate.Key, otelSampleRate.Key);
                 }
             }
             else if (otelSampleType.ConfigurationResult is { IsValid: true, Result: { } samplerName })
@@ -1328,13 +1332,20 @@ namespace Datadog.Trace.Configuration
 
                 if (supportedSamplerName is null)
                 {
-                    // TODO log warning that the OpenTelemetry value is invalid
+                    log.EnqueueAction(
+                        (log, _) =>
+                        {
+                            log.Warning(
+                                "OpenTelemetry configuration {OpenTelemetryConfiguration}={OpenTelemetryValue} is not supported. Using default configuration.",
+                                otelSampleType.Key,
+                                samplerName);
+                        });
                     return ddResult;
                 }
 
                 if (!string.Equals(samplerName, supportedSamplerName, StringComparison.OrdinalIgnoreCase))
                 {
-                    // TODO log warning that the configuration is not supported
+                    log.LogUnsupportedConfiguration(otelSampleType.Key, samplerName, supportedSamplerName);
                 }
 
                 var openTelemetrySampleRateResult = supportedSamplerName switch
@@ -1350,7 +1361,7 @@ namespace Datadog.Trace.Configuration
                     return sampleRateResult;
                 }
 
-                // TODO Log to user and report "otel.env.invalid" telemetry metric
+                log.LogInvalidConfiguration(otelSampleRate.Key);
             }
 
             return ddResult;

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 39;
+    public const int Length = 41;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -41,6 +41,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "otel.env.hiding",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "otel.env.invalid",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry_api.errors",
@@ -90,6 +92,8 @@ internal static partial class CountExtensions
         => metric switch
         {
             Datadog.Trace.Telemetry.Metrics.Count.LogCreated => "general",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "tracers",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "tracers",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry",

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -47,6 +47,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1);
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1);
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 374;
+    private const int CountLength = 554;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -197,10 +197,192 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // telemetry_api.requests, index = 159
+            // otel.env.hiding, index = 159
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // otel.env.invalid, index = 249
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // telemetry_api.requests, index = 339
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
-            // telemetry_api.responses, index = 161
+            // telemetry_api.responses, index = 341
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -245,18 +427,18 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
-            // telemetry_api.errors, index = 205
+            // telemetry_api.errors, index = 385
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
-            // version_conflict_tracers_created, index = 211
+            // version_conflict_tracers_created, index = 391
             new(null),
-            // unsupported_custom_instrumentation_services, index = 212
+            // unsupported_custom_instrumentation_services, index = 392
             new(null),
-            // direct_log_logs, index = 213
+            // direct_log_logs, index = 393
             new(new[] { "integration_name:datadog" }),
             new(new[] { "integration_name:opentracing" }),
             new(new[] { "integration_name:ciapp" }),
@@ -332,9 +514,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integration_name:directorylistingleak" }),
             new(new[] { "integration_name:sessiontimeout" }),
             new(new[] { "integration_name:datadogtracemanual" }),
-            // direct_log_api.requests, index = 288
+            // direct_log_api.requests, index = 468
             new(null),
-            // direct_log_api.responses, index = 289
+            // direct_log_api.responses, index = 469
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -357,37 +539,37 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors, index = 311
+            // direct_log_api.errors, index = 491
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // waf.init, index = 314
+            // waf.init, index = 494
             new(null),
-            // waf.updates, index = 315
+            // waf.updates, index = 495
             new(null),
-            // waf.requests, index = 316
+            // waf.requests, index = 496
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // waf.input_truncated, index = 321
+            // waf.input_truncated, index = 501
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 324
+            // rasp.rule.eval, index = 504
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 327
+            // rasp.rule.match, index = 507
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 330
+            // rasp.timeout, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // executed.source, index = 333
+            // executed.source, index = 513
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -401,9 +583,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
-            // executed.propagation, index = 346
+            // executed.propagation, index = 526
             new(null),
-            // executed.sink, index = 347
+            // executed.sink, index = 527
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -430,7 +612,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:xss" }),
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
-            // request.tainted, index = 373
+            // request.tainted, index = 553
             new(null),
         };
 
@@ -440,7 +622,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
+        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -551,116 +733,128 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 159 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 249 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
-        var index = 159 + (int)tag;
+        var index = 339 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
-        var index = 161 + ((int)tag1 * 22) + (int)tag2;
+        var index = 341 + ((int)tag1 * 22) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
-        var index = 205 + ((int)tag1 * 3) + (int)tag2;
+        var index = 385 + ((int)tag1 * 3) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[211], increment);
+        Interlocked.Add(ref _buffer.Count[391], increment);
     }
 
     public void RecordCountUnsupportedCustomInstrumentationServices(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[212], increment);
+        Interlocked.Add(ref _buffer.Count[392], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
-        var index = 213 + (int)tag;
+        var index = 393 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[288], increment);
+        Interlocked.Add(ref _buffer.Count[468], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 469 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
-        var index = 311 + (int)tag;
+        var index = 491 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[314], increment);
+        Interlocked.Add(ref _buffer.Count[494], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[315], increment);
+        Interlocked.Add(ref _buffer.Count[495], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
-        var index = 316 + (int)tag;
+        var index = 496 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 321 + (int)tag;
+        var index = 501 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 324 + (int)tag;
+        var index = 504 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 327 + (int)tag;
+        var index = 507 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 330 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 333 + (int)tag;
+        var index = 513 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[346], increment);
+        Interlocked.Add(ref _buffer.Count[526], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 347 + (int)tag;
+        var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[373], increment);
+        Interlocked.Add(ref _buffer.Count[553], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 39;
+    public const int Length = 41;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -41,6 +41,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "otel.env.hiding",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "otel.env.invalid",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry_api.errors",
@@ -90,6 +92,8 @@ internal static partial class CountExtensions
         => metric switch
         {
             Datadog.Trace.Telemetry.Metrics.Count.LogCreated => "general",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "tracers",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "tracers",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry",

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -47,6 +47,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1);
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1);
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 374;
+    private const int CountLength = 554;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -197,10 +197,192 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // telemetry_api.requests, index = 159
+            // otel.env.hiding, index = 159
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // otel.env.invalid, index = 249
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // telemetry_api.requests, index = 339
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
-            // telemetry_api.responses, index = 161
+            // telemetry_api.responses, index = 341
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -245,18 +427,18 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
-            // telemetry_api.errors, index = 205
+            // telemetry_api.errors, index = 385
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
-            // version_conflict_tracers_created, index = 211
+            // version_conflict_tracers_created, index = 391
             new(null),
-            // unsupported_custom_instrumentation_services, index = 212
+            // unsupported_custom_instrumentation_services, index = 392
             new(null),
-            // direct_log_logs, index = 213
+            // direct_log_logs, index = 393
             new(new[] { "integration_name:datadog" }),
             new(new[] { "integration_name:opentracing" }),
             new(new[] { "integration_name:ciapp" }),
@@ -332,9 +514,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integration_name:directorylistingleak" }),
             new(new[] { "integration_name:sessiontimeout" }),
             new(new[] { "integration_name:datadogtracemanual" }),
-            // direct_log_api.requests, index = 288
+            // direct_log_api.requests, index = 468
             new(null),
-            // direct_log_api.responses, index = 289
+            // direct_log_api.responses, index = 469
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -357,37 +539,37 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors, index = 311
+            // direct_log_api.errors, index = 491
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // waf.init, index = 314
+            // waf.init, index = 494
             new(null),
-            // waf.updates, index = 315
+            // waf.updates, index = 495
             new(null),
-            // waf.requests, index = 316
+            // waf.requests, index = 496
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // waf.input_truncated, index = 321
+            // waf.input_truncated, index = 501
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 324
+            // rasp.rule.eval, index = 504
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 327
+            // rasp.rule.match, index = 507
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 330
+            // rasp.timeout, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // executed.source, index = 333
+            // executed.source, index = 513
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -401,9 +583,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
-            // executed.propagation, index = 346
+            // executed.propagation, index = 526
             new(null),
-            // executed.sink, index = 347
+            // executed.sink, index = 527
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -430,7 +612,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:xss" }),
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
-            // request.tainted, index = 373
+            // request.tainted, index = 553
             new(null),
         };
 
@@ -440,7 +622,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
+        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -551,116 +733,128 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 159 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 249 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
-        var index = 159 + (int)tag;
+        var index = 339 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
-        var index = 161 + ((int)tag1 * 22) + (int)tag2;
+        var index = 341 + ((int)tag1 * 22) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
-        var index = 205 + ((int)tag1 * 3) + (int)tag2;
+        var index = 385 + ((int)tag1 * 3) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[211], increment);
+        Interlocked.Add(ref _buffer.Count[391], increment);
     }
 
     public void RecordCountUnsupportedCustomInstrumentationServices(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[212], increment);
+        Interlocked.Add(ref _buffer.Count[392], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
-        var index = 213 + (int)tag;
+        var index = 393 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[288], increment);
+        Interlocked.Add(ref _buffer.Count[468], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 469 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
-        var index = 311 + (int)tag;
+        var index = 491 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[314], increment);
+        Interlocked.Add(ref _buffer.Count[494], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[315], increment);
+        Interlocked.Add(ref _buffer.Count[495], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
-        var index = 316 + (int)tag;
+        var index = 496 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 321 + (int)tag;
+        var index = 501 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 324 + (int)tag;
+        var index = 504 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 327 + (int)tag;
+        var index = 507 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 330 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 333 + (int)tag;
+        var index = 513 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[346], increment);
+        Interlocked.Add(ref _buffer.Count[526], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 347 + (int)tag;
+        var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[373], increment);
+        Interlocked.Add(ref _buffer.Count[553], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 39;
+    public const int Length = 41;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -41,6 +41,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "otel.env.hiding",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "otel.env.invalid",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry_api.errors",
@@ -90,6 +92,8 @@ internal static partial class CountExtensions
         => metric switch
         {
             Datadog.Trace.Telemetry.Metrics.Count.LogCreated => "general",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "tracers",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "tracers",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry",

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -47,6 +47,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1);
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1);
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 374;
+    private const int CountLength = 554;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -197,10 +197,192 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // telemetry_api.requests, index = 159
+            // otel.env.hiding, index = 159
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // otel.env.invalid, index = 249
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // telemetry_api.requests, index = 339
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
-            // telemetry_api.responses, index = 161
+            // telemetry_api.responses, index = 341
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -245,18 +427,18 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
-            // telemetry_api.errors, index = 205
+            // telemetry_api.errors, index = 385
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
-            // version_conflict_tracers_created, index = 211
+            // version_conflict_tracers_created, index = 391
             new(null),
-            // unsupported_custom_instrumentation_services, index = 212
+            // unsupported_custom_instrumentation_services, index = 392
             new(null),
-            // direct_log_logs, index = 213
+            // direct_log_logs, index = 393
             new(new[] { "integration_name:datadog" }),
             new(new[] { "integration_name:opentracing" }),
             new(new[] { "integration_name:ciapp" }),
@@ -332,9 +514,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integration_name:directorylistingleak" }),
             new(new[] { "integration_name:sessiontimeout" }),
             new(new[] { "integration_name:datadogtracemanual" }),
-            // direct_log_api.requests, index = 288
+            // direct_log_api.requests, index = 468
             new(null),
-            // direct_log_api.responses, index = 289
+            // direct_log_api.responses, index = 469
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -357,37 +539,37 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors, index = 311
+            // direct_log_api.errors, index = 491
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // waf.init, index = 314
+            // waf.init, index = 494
             new(null),
-            // waf.updates, index = 315
+            // waf.updates, index = 495
             new(null),
-            // waf.requests, index = 316
+            // waf.requests, index = 496
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // waf.input_truncated, index = 321
+            // waf.input_truncated, index = 501
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 324
+            // rasp.rule.eval, index = 504
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 327
+            // rasp.rule.match, index = 507
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 330
+            // rasp.timeout, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // executed.source, index = 333
+            // executed.source, index = 513
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -401,9 +583,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
-            // executed.propagation, index = 346
+            // executed.propagation, index = 526
             new(null),
-            // executed.sink, index = 347
+            // executed.sink, index = 527
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -430,7 +612,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:xss" }),
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
-            // request.tainted, index = 373
+            // request.tainted, index = 553
             new(null),
         };
 
@@ -440,7 +622,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
+        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -551,116 +733,128 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 159 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 249 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
-        var index = 159 + (int)tag;
+        var index = 339 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
-        var index = 161 + ((int)tag1 * 22) + (int)tag2;
+        var index = 341 + ((int)tag1 * 22) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
-        var index = 205 + ((int)tag1 * 3) + (int)tag2;
+        var index = 385 + ((int)tag1 * 3) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[211], increment);
+        Interlocked.Add(ref _buffer.Count[391], increment);
     }
 
     public void RecordCountUnsupportedCustomInstrumentationServices(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[212], increment);
+        Interlocked.Add(ref _buffer.Count[392], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
-        var index = 213 + (int)tag;
+        var index = 393 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[288], increment);
+        Interlocked.Add(ref _buffer.Count[468], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 469 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
-        var index = 311 + (int)tag;
+        var index = 491 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[314], increment);
+        Interlocked.Add(ref _buffer.Count[494], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[315], increment);
+        Interlocked.Add(ref _buffer.Count[495], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
-        var index = 316 + (int)tag;
+        var index = 496 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 321 + (int)tag;
+        var index = 501 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 324 + (int)tag;
+        var index = 504 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 327 + (int)tag;
+        var index = 507 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 330 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 333 + (int)tag;
+        var index = 513 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[346], increment);
+        Interlocked.Add(ref _buffer.Count[526], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 347 + (int)tag;
+        var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[373], increment);
+        Interlocked.Add(ref _buffer.Count[553], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CiVisibilityMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class CiVisibilityMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/CountExtensions.g.cs
@@ -12,7 +12,7 @@ internal static partial class CountExtensions
     /// <summary>
     /// The number of separate metrics in the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> metric.
     /// </summary>
-    public const int Length = 39;
+    public const int Length = 41;
 
     /// <summary>
     /// Gets the metric name for the provided metric
@@ -41,6 +41,8 @@ internal static partial class CountExtensions
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiRequests => "stats_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiResponses => "stats_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.StatsApiErrors => "stats_api.errors",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "otel.env.hiding",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "otel.env.invalid",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry_api.requests",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry_api.responses",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry_api.errors",
@@ -90,6 +92,8 @@ internal static partial class CountExtensions
         => metric switch
         {
             Datadog.Trace.Telemetry.Metrics.Count.LogCreated => "general",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigHiddenByDatadogConfig => "tracers",
+            Datadog.Trace.Telemetry.Metrics.Count.OpenTelemetryConfigInvalid => "tracers",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiRequests => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiResponses => "telemetry",
             Datadog.Trace.Telemetry.Metrics.Count.TelemetryApiErrors => "telemetry",

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/IMetricsTelemetryCollector_Count.g.cs
@@ -47,6 +47,10 @@ internal partial interface IMetricsTelemetryCollector
 
     public void RecordCountStatsApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1);
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1);
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1);
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1);

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 374;
+    private const int CountLength = 554;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -197,10 +197,192 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // telemetry_api.requests, index = 159
+            // otel.env.hiding, index = 159
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // otel.env.invalid, index = 249
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_debug", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_runtime_metrics_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_service", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_tags", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_propagation_style", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_sample_rate", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:dd_trace_otel_enabled", "config_opentelemetry:unknown" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_log_level" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_metrics_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_propagators" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_resource_attributes" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_sdk_disabled" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_service_name" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_exporter" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:otel_traces_sampler_arg" }),
+            new(new[] { "config_datadog:unknown", "config_opentelemetry:unknown" }),
+            // telemetry_api.requests, index = 339
             new(new[] { "endpoint:agent" }),
             new(new[] { "endpoint:agentless" }),
-            // telemetry_api.responses, index = 161
+            // telemetry_api.responses, index = 341
             new(new[] { "endpoint:agent", "status_code:200" }),
             new(new[] { "endpoint:agent", "status_code:201" }),
             new(new[] { "endpoint:agent", "status_code:202" }),
@@ -245,18 +427,18 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "endpoint:agentless", "status_code:503" }),
             new(new[] { "endpoint:agentless", "status_code:504" }),
             new(new[] { "endpoint:agentless", "status_code:5xx" }),
-            // telemetry_api.errors, index = 205
+            // telemetry_api.errors, index = 385
             new(new[] { "endpoint:agent", "type:timeout" }),
             new(new[] { "endpoint:agent", "type:network" }),
             new(new[] { "endpoint:agent", "type:status_code" }),
             new(new[] { "endpoint:agentless", "type:timeout" }),
             new(new[] { "endpoint:agentless", "type:network" }),
             new(new[] { "endpoint:agentless", "type:status_code" }),
-            // version_conflict_tracers_created, index = 211
+            // version_conflict_tracers_created, index = 391
             new(null),
-            // unsupported_custom_instrumentation_services, index = 212
+            // unsupported_custom_instrumentation_services, index = 392
             new(null),
-            // direct_log_logs, index = 213
+            // direct_log_logs, index = 393
             new(new[] { "integration_name:datadog" }),
             new(new[] { "integration_name:opentracing" }),
             new(new[] { "integration_name:ciapp" }),
@@ -332,9 +514,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "integration_name:directorylistingleak" }),
             new(new[] { "integration_name:sessiontimeout" }),
             new(new[] { "integration_name:datadogtracemanual" }),
-            // direct_log_api.requests, index = 288
+            // direct_log_api.requests, index = 468
             new(null),
-            // direct_log_api.responses, index = 289
+            // direct_log_api.responses, index = 469
             new(new[] { "status_code:200" }),
             new(new[] { "status_code:201" }),
             new(new[] { "status_code:202" }),
@@ -357,37 +539,37 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "status_code:503" }),
             new(new[] { "status_code:504" }),
             new(new[] { "status_code:5xx" }),
-            // direct_log_api.errors, index = 311
+            // direct_log_api.errors, index = 491
             new(new[] { "type:timeout" }),
             new(new[] { "type:network" }),
             new(new[] { "type:status_code" }),
-            // waf.init, index = 314
+            // waf.init, index = 494
             new(null),
-            // waf.updates, index = 315
+            // waf.updates, index = 495
             new(null),
-            // waf.requests, index = 316
+            // waf.requests, index = 496
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:false", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:true", "request_blocked:true", "waf_timeout:false", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:true", "request_excluded:false" }),
             new(new[] { "waf_version", "rule_triggered:false", "request_blocked:false", "waf_timeout:false", "request_excluded:true" }),
-            // waf.input_truncated, index = 321
+            // waf.input_truncated, index = 501
             new(new[] { "truncation_reason:string_too_long" }),
             new(new[] { "truncation_reason:list_or_map_too_large" }),
             new(new[] { "truncation_reason:object_too_deep" }),
-            // rasp.rule.eval, index = 324
+            // rasp.rule.eval, index = 504
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 327
+            // rasp.rule.match, index = 507
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 330
+            // rasp.timeout, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // executed.source, index = 333
+            // executed.source, index = 513
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -401,9 +583,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.matrix.parameter" }),
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
-            // executed.propagation, index = 346
+            // executed.propagation, index = 526
             new(null),
-            // executed.sink, index = 347
+            // executed.sink, index = 527
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -430,7 +612,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:xss" }),
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
-            // request.tainted, index = 373
+            // request.tainted, index = 553
             new(null),
         };
 
@@ -440,7 +622,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
+        = new int[]{ 4, 75, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 75, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 13, 1, 26, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -551,116 +733,128 @@ internal partial class MetricsTelemetryCollector
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 159 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+        var index = 249 + ((int)tag1 * 10) + (int)tag2;
+        Interlocked.Add(ref _buffer.Count[index], increment);
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
-        var index = 159 + (int)tag;
+        var index = 339 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag2, int increment = 1)
     {
-        var index = 161 + ((int)tag1 * 22) + (int)tag2;
+        var index = 341 + ((int)tag1 * 22) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountTelemetryApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag2, int increment = 1)
     {
-        var index = 205 + ((int)tag1 * 3) + (int)tag2;
+        var index = 385 + ((int)tag1 * 3) + (int)tag2;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountVersionConflictTracerCreated(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[211], increment);
+        Interlocked.Add(ref _buffer.Count[391], increment);
     }
 
     public void RecordCountUnsupportedCustomInstrumentationServices(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[212], increment);
+        Interlocked.Add(ref _buffer.Count[392], increment);
     }
 
     public void RecordCountDirectLogLogs(Datadog.Trace.Telemetry.Metrics.MetricTags.IntegrationName tag, int increment = 1)
     {
-        var index = 213 + (int)tag;
+        var index = 393 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiRequests(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[288], increment);
+        Interlocked.Add(ref _buffer.Count[468], increment);
     }
 
     public void RecordCountDirectLogApiResponses(Datadog.Trace.Telemetry.Metrics.MetricTags.StatusCode tag, int increment = 1)
     {
-        var index = 289 + (int)tag;
+        var index = 469 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountDirectLogApiErrors(Datadog.Trace.Telemetry.Metrics.MetricTags.ApiError tag, int increment = 1)
     {
-        var index = 311 + (int)tag;
+        var index = 491 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountWafInit(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[314], increment);
+        Interlocked.Add(ref _buffer.Count[494], increment);
     }
 
     public void RecordCountWafUpdates(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[315], increment);
+        Interlocked.Add(ref _buffer.Count[495], increment);
     }
 
     public void RecordCountWafRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.WafAnalysis tag, int increment = 1)
     {
-        var index = 316 + (int)tag;
+        var index = 496 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountInputTruncated(Datadog.Trace.Telemetry.Metrics.MetricTags.TruncationReason tag, int increment = 1)
     {
-        var index = 321 + (int)tag;
+        var index = 501 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleEval(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 324 + (int)tag;
+        var index = 504 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 327 + (int)tag;
+        var index = 507 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 330 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 333 + (int)tag;
+        var index = 513 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[346], increment);
+        Interlocked.Add(ref _buffer.Count[526], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 347 + (int)tag;
+        var index = 527 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[373], increment);
+        Interlocked.Add(ref _buffer.Count[553], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/NullMetricsTelemetryCollector_Count.g.cs
@@ -88,6 +88,14 @@ internal partial class NullMetricsTelemetryCollector
     {
     }
 
+    public void RecordCountOpenTelemetryConfigHiddenByDatadogConfig(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
+    public void RecordCountOpenTelemetryConfigInvalid(Datadog.Trace.Telemetry.Metrics.MetricTags.DatadogConfiguration tag1, Datadog.Trace.Telemetry.Metrics.MetricTags.OpenTelemetryConfiguration tag2, int increment = 1)
+    {
+    }
+
     public void RecordCountTelemetryApiRequests(Datadog.Trace.Telemetry.Metrics.MetricTags.TelemetryEndpoint tag, int increment = 1)
     {
     }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/Count.cs
@@ -115,6 +115,16 @@ internal enum Count
     /// The number of requests sent to the api endpoint in the agent that errored, tagged by the error type (e.g. `type:timeout`, `type:network`, `type:status_code`)
     /// </summary>
     [TelemetryMetric<MetricTags.ApiError>("stats_api.errors")] StatsApiErrors,
+
+    /// <summary>
+    /// The number of times a Datadog configuration is set while a corresponding OpenTelemetry configuration is set.
+    /// </summary>
+    [TelemetryMetric<MetricTags.DatadogConfiguration, MetricTags.OpenTelemetryConfiguration>("otel.env.hiding", isCommon: true, NS.Tracer)] OpenTelemetryConfigHiddenByDatadogConfig,
+
+    /// <summary>
+    /// The number of times an OpenTelemetry configuration has a mapping to a Datadog configuration but it cannot be mapped correctly.
+    /// </summary>
+    [TelemetryMetric<MetricTags.DatadogConfiguration, MetricTags.OpenTelemetryConfiguration>("otel.env.invalid", isCommon: true, NS.Tracer)] OpenTelemetryConfigInvalid,
 #endregion
 #region Telemetry Namespace
 

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -116,6 +116,33 @@ internal static class MetricTags
         [Description("type:status_code")] StatusCode,
     }
 
+    internal enum DatadogConfiguration
+    {
+        [Description("config_datadog:dd_trace_debug")] DebugEnabled,
+        [Description("config_datadog:dd_runtime_metrics_enabled")] RuntimeMetricsEnabled,
+        [Description("config_datadog:dd_service")] Service,
+        [Description("config_datadog:dd_tags")] Tags,
+        [Description("config_datadog:dd_trace_enabled")] TraceEnabled,
+        [Description("config_datadog:dd_trace_propagation_style")] PropagationStyle,
+        [Description("config_datadog:dd_trace_sample_rate")] SampleRate,
+        [Description("config_datadog:dd_trace_otel_enabled")] OpenTelemetryEnabled,
+        [Description("config_datadog:unknown")] Unknown,
+    }
+
+    internal enum OpenTelemetryConfiguration
+    {
+        [Description("config_opentelemetry:otel_log_level")] LogLevel,
+        [Description("config_opentelemetry:otel_metrics_exporter")] MetricsExporter,
+        [Description("config_opentelemetry:otel_propagators")] Propagators,
+        [Description("config_opentelemetry:otel_resource_attributes")] ResourceAttributes,
+        [Description("config_opentelemetry:otel_sdk_disabled")] SdkDisabled,
+        [Description("config_opentelemetry:otel_service_name")] ServiceName,
+        [Description("config_opentelemetry:otel_traces_exporter")] TracesExporter,
+        [Description("config_opentelemetry:otel_traces_sampler")] TracesSampler,
+        [Description("config_opentelemetry:otel_traces_sampler_arg")] TracesSamplerArg,
+        [Description("config_opentelemetry:unknown")] Unknown,
+    }
+
     internal enum PartialFlushReason
     {
         [Description("reason:large_trace")] LargeTrace,

--- a/tracer/src/Datadog.Trace/TracerManager.cs
+++ b/tracer/src/Datadog.Trace/TracerManager.cs
@@ -15,6 +15,7 @@ using Datadog.Trace.AppSec;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.ClrProfiler.ServerlessInstrumentation;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Schema;
 using Datadog.Trace.ContinuousProfiler;
 using Datadog.Trace.DataStreamsMonitoring;
@@ -573,6 +574,9 @@ namespace Datadog.Trace
                 }
 
                 Log.Information("DATADOG TRACER CONFIGURATION - {Configuration}", stringWriter.ToString());
+
+                OverrideErrorLog.Instance.ProcessAndClearActions(Log, TelemetryFactory.Metrics); // global errors, only logged once
+                instanceSettings.ErrorLog.ProcessAndClearActions(Log, TelemetryFactory.Metrics); // global errors, only logged once
             }
             catch (Exception ex)
             {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Helpers/TelemetryHelperTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
@@ -59,7 +60,7 @@ public class TelemetryHelperTests
 
         collector.IntegrationRunning(IntegrationId.Kafka);
         collector.IntegrationGeneratedSpan(IntegrationId.Msmq);
-        var tracerSettings = new TracerSettings(null, NullConfigurationTelemetry.Instance)
+        var tracerSettings = new TracerSettings(null, NullConfigurationTelemetry.Instance, new OverrideErrorLog())
         {
             DisabledIntegrationNames = new HashSet<string> { nameof(IntegrationId.Kafka), nameof(IntegrationId.Msmq) }
         };
@@ -128,7 +129,7 @@ public class TelemetryHelperTests
             { ConfigurationKeys.AppSec.ScaEnabled, "1" },
         });
 
-        _ = new ImmutableTracerSettings(new TracerSettings(config, collector));
+        _ = new ImmutableTracerSettings(new TracerSettings(config, collector, new OverrideErrorLog()));
 
         telemetryData.Add(BuildTelemetryData(null, collector.GetData()));
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
@@ -153,7 +154,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 { ConfigurationKeys.DbmPropagationMode, dbmMode }
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
+            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
             await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
@@ -175,7 +176,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 { ConfigurationKeys.DbmPropagationMode, dbmMode }
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
+            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
             await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using (var scope = CreateDbCommandScope(tracer, command))
@@ -211,7 +212,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 { ConfigurationKeys.DbmPropagationMode, dbmMode }
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
+            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
             await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);
@@ -233,7 +234,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
                 { ConfigurationKeys.DbmPropagationMode, "disabled" }
             };
             IConfigurationSource source = new NameValueConfigurationSource(collection);
-            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance);
+            var tracerSettings = new TracerSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
             await using var tracer = TracerHelper.CreateWithFakeAgent(tracerSettings);
 
             using var scope = CreateDbCommandScope(tracer, command);

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/StandaloneASMBillingTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/StandaloneASMBillingTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Generic;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Security.Unit.Tests.Iast;
 using Xunit;
@@ -20,7 +21,7 @@ public class StandaloneASMBillingTests
         {
             { ConfigurationKeys.AppsecStandaloneEnabled, true }
         });
-        var tracerSettings = new TracerSettings(settings, NullConfigurationTelemetry.Instance);
+        var tracerSettings = new TracerSettings(settings, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
         Assert.True(tracerSettings.AppsecStandaloneEnabledInternal);
     }
 
@@ -32,7 +33,7 @@ public class StandaloneASMBillingTests
             { ConfigurationKeys.AppsecStandaloneEnabled, true },
             { ConfigurationKeys.StatsComputationEnabled, true }
         });
-        var tracerSettings = new TracerSettings(settings, NullConfigurationTelemetry.Instance);
+        var tracerSettings = new TracerSettings(settings, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
 
         // Should ignore the configuration set by the customer
         Assert.False(tracerSettings.StatsComputationEnabled);

--- a/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/LogSettingsHelper.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Logging.DirectSubmission;
 using Datadog.Trace.Logging.DirectSubmission.Formatting;
 
@@ -13,7 +14,7 @@ namespace Datadog.Trace.TestHelpers
     internal class LogSettingsHelper
     {
         public static LogFormatter GetFormatter() => new(
-            new ImmutableTracerSettings(new TracerSettings(null, Configuration.Telemetry.NullConfigurationTelemetry.Instance)),
+            new ImmutableTracerSettings(new TracerSettings(null, Configuration.Telemetry.NullConfigurationTelemetry.Instance, new OverrideErrorLog())),
             GetValidSettings(),
             aasSettings: null,
             serviceName: "MyTestService",

--- a/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/ConfigurationSourceTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
 using FluentAssertions;
@@ -247,7 +248,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             foreach (var (settingGetter, expectedValue) in GetGlobalDefaultTestData())
             {
-                var settings = new GlobalSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance);
+                var settings = new GlobalSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
                 object actualValue = settingGetter(settings);
                 Assert.Equal(expectedValue, actualValue);
             }
@@ -260,7 +261,7 @@ namespace Datadog.Trace.Tests.Configuration
             {
                 var collection = new NameValueCollection { { key, value } };
                 IConfigurationSource source = new NameValueConfigurationSource(collection);
-                var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
+                var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
                 object actualValue = settingGetter(settings);
                 Assert.Equal(expectedValue, actualValue);
             }
@@ -275,7 +276,7 @@ namespace Datadog.Trace.Tests.Configuration
 
                 // save original value so we can restore later
                 Environment.SetEnvironmentVariable(key, value, EnvironmentVariableTarget.Process);
-                var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
+                var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
 
                 object actualValue = settingGetter(settings);
                 Assert.Equal(expectedValue, actualValue);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/GlobalSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/GlobalSettingsTests.cs
@@ -4,7 +4,11 @@
 // </copyright>
 
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Xunit;
@@ -18,31 +22,33 @@ namespace Datadog.Trace.Tests.Configuration
         public void DebugEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DebugEnabled, value));
-            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
+            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
 
             settings.DebugEnabled.Should().Be(expected);
         }
 
         [Theory]
-        [InlineData("true", "info", true)]
-        [InlineData("true", "debug", true)]
-        [InlineData("false", "info", false)]
-        [InlineData("false", "debug", false)]
-        [InlineData("A", "info", false)]
-        [InlineData("A", "debug", false)]
-        [InlineData(null, "info", false)]
-        [InlineData(null, "debug", true)]
-        [InlineData("", "info", false)]
-        [InlineData("", "debug", false)]
-        public void OtelLogLevelDebugSetsDebugEnabled(string value, string otelValue, bool expected)
+        [InlineData("true", "info", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("true", "debug", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("false", "info", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("false", "debug", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("A", "info", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("A", "debug", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData(null, "info", false, (int)Count.OpenTelemetryConfigInvalid)]
+        [InlineData(null, "debug", true, null)]
+        [InlineData("", "info", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("", "debug", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        public void OtelLogLevelDebugSetsDebugEnabled(string value, string otelValue, bool expected, int? metric)
         {
             const string otelKey = ConfigurationKeys.OpenTelemetry.LogLevel;
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.DebugEnabled, value),
                 (otelKey, otelValue));
-            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
+            var errorLog = new OverrideErrorLog();
+            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance, errorLog);
 
             settings.DebugEnabled.Should().Be(expected);
+            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.LogLevel.ToLowerInvariant(), ConfigurationKeys.DebugEnabled.ToLowerInvariant());
         }
 
         [Theory]
@@ -50,7 +56,7 @@ namespace Datadog.Trace.Tests.Configuration
         public void DiagnosticSourceEnabled(string value, bool expected)
         {
             var source = CreateConfigurationSource((ConfigurationKeys.DiagnosticSourceEnabled, value));
-            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance);
+            var settings = new GlobalSettings(source, NullConfigurationTelemetry.Instance, new OverrideErrorLog());
 
             settings.DiagnosticSourceEnabled.Should().Be(expected);
         }

--- a/tracer/test/Datadog.Trace.Tests/Configuration/MsmqTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/MsmqTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Datadog.Trace.Agent;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.Msmq;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Sampling;
 using FluentAssertions;
@@ -31,7 +32,7 @@ namespace Datadog.Trace.Tests.Configuration
             var schemaVersion = (SchemaVersion)schemaVersionObject;
             var configSourceMock = new Mock<IConfigurationSource>();
             configSourceMock.Setup(c => c.GetString(It.Is<string>(s => s.Equals(ConfigurationKeys.MetadataSchemaVersion)))).Returns(schemaVersion.ToString());
-            var settings = new TracerSettings(configSourceMock.Object, new ConfigurationTelemetry());
+            var settings = new TracerSettings(configSourceMock.Object, new ConfigurationTelemetry(), new OverrideErrorLog());
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ITraceSampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/OverrideErrorLogExtensions.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/OverrideErrorLogExtensions.cs
@@ -1,0 +1,53 @@
+// <copyright file="OverrideErrorLogExtensions.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Linq;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
+using Datadog.Trace.Logging;
+using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
+using FluentAssertions;
+using MetricDefinition = (Datadog.Trace.Telemetry.Metrics.Count? Metric, string OtelSetting, string DdSetting);
+
+namespace Datadog.Trace.Tests.Configuration;
+
+internal static class OverrideErrorLogExtensions
+{
+    public static void ShouldHaveExpectedOtelMetric(this OverrideErrorLog errorLog, int? metric, string otelSetting, string ddSetting)
+        => errorLog.ShouldHaveExpectedOtelMetric(metric.HasValue ? (Count?)metric.Value : null, otelSetting, ddSetting);
+
+    public static void ShouldHaveExpectedOtelMetric(this OverrideErrorLog errorLog, Count? metric, string otelSetting, string ddSetting)
+        => errorLog.ShouldHaveExpectedOtelMetric((metric, otelSetting, ddSetting));
+
+    public static void ShouldHaveExpectedOtelMetric(this OverrideErrorLog errorLog, IEnumerable<MetricDefinition> metric)
+        => errorLog.ShouldHaveExpectedOtelMetric([..metric]);
+
+    private static void ShouldHaveExpectedOtelMetric(this OverrideErrorLog errorLog, params MetricDefinition[] expectedMetrics)
+    {
+        var telemetry = new MetricsTelemetryCollector();
+        errorLog.ProcessAndClearActions(DatadogSerilogLogger.NullLogger, telemetry);
+        telemetry.AggregateMetrics();
+
+        var actual = telemetry.GetMetrics().Metrics;
+        var expected = expectedMetrics
+                      .Where(x => x.Metric.HasValue)
+                      .Select(metric => new
+                       {
+                           Metric = metric.Metric.Value.GetName(),
+                           Tags = new[] { $"config_datadog:{metric.DdSetting}", $"config_opentelemetry:{metric.OtelSetting}" },
+                       })
+                      .ToList();
+
+        if (expected.Count == 0)
+        {
+            actual.Should().BeNullOrEmpty();
+        }
+        else
+        {
+            actual.Should().BeEquivalentTo(expected);
+        }
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/RabbitMQTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/RabbitMQTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Datadog.Trace.Agent;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.RabbitMQ;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Sampling;
 using FluentAssertions;
@@ -31,7 +32,7 @@ namespace Datadog.Trace.Tests.Configuration
             var schemaVersion = (SchemaVersion)schemaVersionObject;
             var configSourceMock = new Mock<IConfigurationSource>();
             configSourceMock.Setup(c => c.GetString(It.Is<string>(s => s.Equals(ConfigurationKeys.MetadataSchemaVersion)))).Returns(schemaVersion.ToString());
-            var settings = new TracerSettings(configSourceMock.Object, new ConfigurationTelemetry());
+            var settings = new TracerSettings(configSourceMock.Object, new ConfigurationTelemetry(), new OverrideErrorLog());
             var writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ITraceSampler>();
             var tracer = new Tracer(settings, writerMock.Object, samplerMock.Object, scopeManager: null, statsd: null);

--- a/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/TracerSettingsTests.cs
@@ -10,11 +10,13 @@ using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.Agent;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.ExtensionMethods;
 using Datadog.Trace.Sampling;
 using Datadog.Trace.Tagging;
 using Datadog.Trace.Telemetry;
+using Datadog.Trace.Telemetry.Metrics;
 using Datadog.Trace.TestHelpers;
 using FluentAssertions;
 using Moq;
@@ -112,16 +114,16 @@ namespace Datadog.Trace.Tests.Configuration
         }
 
         [Theory]
-        [InlineData("", null, true)]
-        [InlineData("", "random", true)]
-        [InlineData("", "none", true)]
-        [InlineData("1", null, true)]
-        [InlineData("1", "none", true)]
-        [InlineData("0", "random", false)]
-        [InlineData("0", "none", false)]
-        [InlineData(null, "random", true)]
-        [InlineData(null, "none", false)]
-        public void TraceEnabled(string value, string otelValue, bool areTracesEnabled)
+        [InlineData("", null, true, null)]
+        [InlineData("", "random", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("", "none", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("1", null, true, null)]
+        [InlineData("1", "none", true, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("0", "random", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData("0", "none", false, (int)Count.OpenTelemetryConfigHiddenByDatadogConfig)]
+        [InlineData(null, "random", true, (int)Count.OpenTelemetryConfigInvalid)]
+        [InlineData(null, "none", false, null)]
+        public void TraceEnabled(string value, string otelValue, bool areTracesEnabled, int? metric)
         {
             var settings = new NameValueCollection
             {
@@ -129,9 +131,11 @@ namespace Datadog.Trace.Tests.Configuration
                 { ConfigurationKeys.OpenTelemetry.TracesExporter, otelValue },
             };
 
-            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings));
+            var errorLog = new OverrideErrorLog();
+            var tracerSettings = new TracerSettings(new NameValueConfigurationSource(settings), NullConfigurationTelemetry.Instance, errorLog);
 
             Assert.Equal(areTracesEnabled, tracerSettings.TraceEnabled);
+            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.TracesExporter.ToLowerInvariant(), ConfigurationKeys.TraceEnabled.ToLowerInvariant());
 
             _writerMock.Invocations.Clear();
 
@@ -273,9 +277,16 @@ namespace Datadog.Trace.Tests.Configuration
             const string otelKey = ConfigurationKeys.OpenTelemetry.ServiceName;
 
             var source = CreateConfigurationSource((ConfigurationKeys.ServiceName, value), (legacyServiceName, legacyValue), (otelKey, otelValue));
-            var settings = new TracerSettings(source);
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
 
             settings.ServiceName.Should().Be(expected);
+            Count? metric = otelValue switch
+            {
+                "ignored_otel" => Count.OpenTelemetryConfigHiddenByDatadogConfig,
+                _ => null,
+            };
+            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.ServiceName.ToLowerInvariant(), ConfigurationKeys.ServiceName.ToLowerInvariant());
         }
 
         [Theory]
@@ -490,22 +501,35 @@ namespace Datadog.Trace.Tests.Configuration
         [Theory]
         [InlineData("true", "none", true)]
         [InlineData("true", "random", true)]
+        [InlineData("true", null, true)]
         [InlineData("false", "none", false)]
         [InlineData("false", "random", false)]
+        [InlineData("false", null, false)]
         [InlineData("A", "none", false)]
         [InlineData("A", "random", false)]
         [InlineData("", "none", false)]
         [InlineData("", "random", false)]
         [InlineData(null, "none", false)]
         [InlineData(null, "random", false)]
+        [InlineData(null, null, false)]
         public void RuntimeMetricsEnabled(string value, string otelValue, bool expected)
         {
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.RuntimeMetricsEnabled, value),
                 (ConfigurationKeys.OpenTelemetry.MetricsExporter, otelValue));
-            var settings = new TracerSettings(source);
+
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
 
             settings.RuntimeMetricsEnabled.Should().Be(expected);
+            Count? metric = (value, otelValue) switch
+            {
+                (null, "random") => Count.OpenTelemetryConfigInvalid,
+                (not null, not null) => Count.OpenTelemetryConfigHiddenByDatadogConfig,
+                _ => null,
+            };
+
+            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.MetricsExporter.ToLowerInvariant(), ConfigurationKeys.RuntimeMetricsEnabled.ToLowerInvariant());
         }
 
         [Theory]
@@ -534,7 +558,7 @@ namespace Datadog.Trace.Tests.Configuration
         {
             var source = CreateConfigurationSource((ConfigurationKeys.CustomSamplingRulesFormat, value));
             var telemetry = new ConfigurationTelemetry();
-            var settings = new TracerSettings(source, telemetry);
+            var settings = new TracerSettings(source, telemetry, new());
 
             // verify setting
             settings.CustomSamplingRulesFormat.Should().Be(expected);
@@ -602,15 +626,51 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData(null, "always_on", null, 1.0d)]
         [InlineData(null, "parentbased_always_off", null, 0.0d)]
         [InlineData(null, "always_off", null, 0.0d)]
+        [InlineData(null, "traceidratio", "invalid", null)]
+        [InlineData(null, "parentbased_always_on", "invalid", 1.0d)]
+        [InlineData(null, "always_on", "invalid", 1.0d)]
+        [InlineData(null, "parentbased_always_off", "invalid", 0.0d)]
+        [InlineData(null, "always_off", "invalid", 0.0d)]
+        [InlineData(null, "invalid", null, null)]
+        [InlineData(null, "invalid", "invalid", null)]
         public void GlobalSamplingRate(string value, string otelSampler, string otelSampleRate, double? expected)
         {
             var source = CreateConfigurationSource(
                 (ConfigurationKeys.GlobalSamplingRate, value),
                 (ConfigurationKeys.OpenTelemetry.TracesSampler, otelSampler),
                 (ConfigurationKeys.OpenTelemetry.TracesSamplerArg, otelSampleRate));
-            var settings = new TracerSettings(source);
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
 
+            // confirm the logs/metrics
             settings.GlobalSamplingRate.Should().Be(expected);
+            var metrics = new List<(Count?, string, string)>();
+
+            if (value is not null)
+            {
+                // hidden metrics
+                if (otelSampler is not null)
+                {
+                    metrics.Add((Count.OpenTelemetryConfigHiddenByDatadogConfig, ConfigurationKeys.OpenTelemetry.TracesSampler.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
+                }
+
+                if (otelSampleRate is not null)
+                {
+                    metrics.Add((Count.OpenTelemetryConfigHiddenByDatadogConfig, ConfigurationKeys.OpenTelemetry.TracesSamplerArg.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
+                }
+            }
+            else if (otelSampler is "invalid")
+            {
+                // we _don't_ report this one as invalid, and it "prevents" reporting the invalid arg
+            }
+            else if (otelSampler is "traceidratio" or "parentbased_traceidratio"
+                  && otelSampleRate is "invalid" or null)
+            {
+                // we _only_ report this one if we need to use it
+                metrics.Add((Count.OpenTelemetryConfigInvalid, ConfigurationKeys.OpenTelemetry.TracesSamplerArg.ToLowerInvariant(), ConfigurationKeys.GlobalSamplingRate.ToLowerInvariant()));
+            }
+
+            errorLog.ShouldHaveExpectedOtelMetric(metrics.ToArray());
         }
 
         [Theory]
@@ -775,9 +835,19 @@ namespace Datadog.Trace.Tests.Configuration
             const string otelKey = ConfigurationKeys.OpenTelemetry.SdkDisabled;
 
             var source = CreateConfigurationSource((ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, value), (fallbackKey, fallbackValue), (otelKey, otelValue));
-            var settings = new TracerSettings(source);
+            var errorLog = new OverrideErrorLog();
+            var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
 
             settings.IsActivityListenerEnabled.Should().Be(expected);
+            Count? metric = (value ?? fallbackValue, otelValue?.ToLower()) switch
+            {
+                (null, "true") => null,
+                (null, _) => Count.OpenTelemetryConfigInvalid,
+                (not null, not null) => Count.OpenTelemetryConfigHiddenByDatadogConfig,
+                _ => null,
+            };
+
+            errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.SdkDisabled.ToLowerInvariant(), ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled.ToLowerInvariant());
         }
 
         [Theory]
@@ -789,6 +859,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData(null, null, null, "tracecontext", new[] { "tracecontext" })]
         [InlineData(null, null, null, "tracecontext,b3,b3multi", new[] { "tracecontext", "b3 single header", "b3multi" })]
         [InlineData(null, null, null, null, new[] { "Datadog", "tracecontext" })]
+        [InlineData(null, null, null, ",", new[] { "Datadog", "tracecontext" })]
         public void PropagationStyleInject(string value, string legacyValue, string fallbackValue, string otelValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_INJECT";
@@ -803,9 +874,19 @@ namespace Datadog.Trace.Tests.Configuration
                     (otelKey, otelValue),
                     (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isActivityListenerEnabled ? "1" : "0"));
 
-                var settings = new TracerSettings(source);
+                var errorLog = new OverrideErrorLog();
+                var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
 
                 settings.PropagationStyleInject.Should().BeEquivalentTo(expected);
+
+                Count? metric = (value ?? legacyValue ?? fallbackValue, otelValue) switch
+                {
+                    (null, ",") => Count.OpenTelemetryConfigInvalid,
+                    (not null, not null) => Count.OpenTelemetryConfigHiddenByDatadogConfig,
+                    _ => null,
+                };
+
+                errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.Propagators.ToLowerInvariant(), ConfigurationKeys.PropagationStyle.ToLowerInvariant());
             }
         }
 
@@ -818,6 +899,7 @@ namespace Datadog.Trace.Tests.Configuration
         [InlineData(null, null, null, "tracecontext", new[] { "tracecontext" })]
         [InlineData(null, null, null, "tracecontext,b3,b3multi", new[] { "tracecontext", "b3 single header", "b3multi" })]
         [InlineData(null, null, null, null, new[] { "Datadog", "tracecontext" })]
+        [InlineData(null, null, null, ",", new[] { "Datadog", "tracecontext" })]
         public void PropagationStyleExtract(string value, string legacyValue, string fallbackValue, string otelValue, string[] expected)
         {
             const string legacyKey = "DD_PROPAGATION_STYLE_EXTRACT";
@@ -832,9 +914,19 @@ namespace Datadog.Trace.Tests.Configuration
                     (otelKey, otelValue),
                     (ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, isActivityListenerEnabled ? "1" : "0"));
 
-                var settings = new TracerSettings(source);
+                var errorLog = new OverrideErrorLog();
+                var settings = new TracerSettings(source, NullConfigurationTelemetry.Instance, errorLog);
 
                 settings.PropagationStyleExtract.Should().BeEquivalentTo(expected);
+
+                Count? metric = (value ?? legacyValue ?? fallbackValue, otelValue) switch
+                {
+                    (null, ",") => Count.OpenTelemetryConfigInvalid,
+                    (not null, not null) => Count.OpenTelemetryConfigHiddenByDatadogConfig,
+                    _ => null,
+                };
+
+                errorLog.ShouldHaveExpectedOtelMetric(metric, ConfigurationKeys.OpenTelemetry.Propagators.ToLowerInvariant(), ConfigurationKeys.PropagationStyle.ToLowerInvariant());
             }
         }
 

--- a/tracer/test/Datadog.Trace.Tests/SpanTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/SpanTests.cs
@@ -30,14 +30,11 @@ namespace Datadog.Trace.Tests
         {
             _output = output;
 
-            var settings = new TracerSettings(
-                new NameValueConfigurationSource(
-                    new NameValueCollection
-                    {
-                        { ConfigurationKeys.PeerServiceDefaultsEnabled, "true" },
-                        { ConfigurationKeys.PeerServiceNameMappings, "a-peer-service:a-remmaped-peer-service" }
-                    }),
-                new ConfigurationTelemetry());
+            var settings = TracerSettings.Create(new()
+            {
+                { ConfigurationKeys.PeerServiceDefaultsEnabled, "true" },
+                { ConfigurationKeys.PeerServiceNameMappings, "a-peer-service:a-remmaped-peer-service" }
+            });
 
             _writerMock = new Mock<IAgentWriter>();
             var samplerMock = new Mock<ITraceSampler>();

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ApplicationTelemetryCollectorTests.cs
@@ -5,6 +5,7 @@
 
 using System.Collections.Specialized;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.PlatformHelpers;
 using Datadog.Trace.Telemetry;
@@ -34,7 +35,8 @@ public class ApplicationTelemetryCollectorTests
                     { ConfigurationKeys.GitCommitSha, "mySha" },
                     { ConfigurationKeys.GitRepositoryUrl, "https://github.com/gitOrg/gitRepo" },
                 }),
-            configurationTelemetry);
+            configurationTelemetry,
+            new OverrideErrorLog());
 
         var collector = new ApplicationTelemetryCollector();
 
@@ -76,7 +78,8 @@ public class ApplicationTelemetryCollectorTests
                     { ConfigurationKeys.Environment, env },
                     { ConfigurationKeys.ServiceVersion, serviceVersion },
                 }),
-            configurationTelemetry);
+            configurationTelemetry,
+            new OverrideErrorLog());
 
         var collector = new ApplicationTelemetryCollector();
 
@@ -120,7 +123,8 @@ public class ApplicationTelemetryCollectorTests
                     { ConfigurationKeys.GitCommitSha, "mySha" },
                     { ConfigurationKeys.GitRepositoryUrl, "https://github.com/gitOrg/gitRepo" },
                 }),
-            configurationTelemetry);
+            configurationTelemetry,
+            new OverrideErrorLog());
 
         var collector = new ApplicationTelemetryCollector();
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/ConfigurationTelemetryCollectorTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Specialized;
 using System.Linq;
 using Datadog.Trace.AppSec;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.Telemetry;
@@ -37,7 +38,8 @@ public class ConfigurationTelemetryCollectorTests
         var settings1 = new TracerSettings(
             new NameValueConfigurationSource(
                 new NameValueCollection { { ConfigurationKeys.ServiceVersion, "1.2.3" } }),
-            collector);
+            collector,
+            new OverrideErrorLog());
 
         collector.HasChanges().Should().BeTrue();
         GetLatestValueFromConfig(collector.GetData(), ConfigurationKeys.ServiceVersion).Should().Be("1.2.3");
@@ -46,7 +48,8 @@ public class ConfigurationTelemetryCollectorTests
         var settings2 = new TracerSettings(
             new NameValueConfigurationSource(
                 new NameValueCollection { { ConfigurationKeys.ServiceVersion, "2.0.0" } }),
-            collector);
+            collector,
+            new OverrideErrorLog());
 
         collector.HasChanges().Should().BeTrue();
         GetLatestValueFromConfig(collector.GetData(), ConfigurationKeys.ServiceVersion).Should().Be("2.0.0");
@@ -63,7 +66,8 @@ public class ConfigurationTelemetryCollectorTests
         var settings1 = new TracerSettings(
             new NameValueConfigurationSource(
                 new NameValueCollection { { ConfigurationKeys.ServiceVersion, "1.2.3" } }),
-            secondary);
+            secondary,
+            new OverrideErrorLog());
 
         secondary.HasChanges().Should().BeTrue();
         collector.HasChanges().Should().BeFalse();
@@ -72,7 +76,8 @@ public class ConfigurationTelemetryCollectorTests
         var settings2 = new TracerSettings(
             new NameValueConfigurationSource(
                 new NameValueCollection { { ConfigurationKeys.ServiceVersion, "2.0.0" } }),
-            collector);
+            collector,
+            new OverrideErrorLog());
 
         collector.HasChanges().Should().BeTrue();
 
@@ -136,7 +141,7 @@ public class ConfigurationTelemetryCollectorTests
             config.Add(ConfigurationKeys.ApiKey, "SomeValue");
         }
 
-        var settings = new ImmutableTracerSettings(new TracerSettings(new NameValueConfigurationSource(config), collector));
+        var settings = new ImmutableTracerSettings(new TracerSettings(new NameValueConfigurationSource(config), collector, new OverrideErrorLog()));
 
         var data = collector.GetData();
 
@@ -162,7 +167,7 @@ public class ConfigurationTelemetryCollectorTests
     {
         var collector = new ConfigurationTelemetry();
 
-        _ = new TracerSettings(new NameValueConfigurationSource(new NameValueCollection { { ConfigurationKeys.ServiceVersion, "1.2.3" } }), collector);
+        _ = new TracerSettings(new NameValueConfigurationSource(new NameValueCollection { { ConfigurationKeys.ServiceVersion, "1.2.3" } }), collector, new OverrideErrorLog());
 
         collector.Clear();
         collector.GetData().Should().BeNull();
@@ -173,7 +178,7 @@ public class ConfigurationTelemetryCollectorTests
     {
         var collector = new ConfigurationTelemetry();
 
-        var s = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, collector));
+        var s = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, collector, new OverrideErrorLog()));
 
         GetLatestValueFromConfig(collector.GetData(), ConfigTelemetryData.NativeTracerVersion).Should().Be("None");
     }
@@ -191,7 +196,7 @@ public class ConfigurationTelemetryCollectorTests
             { ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, activityListenerEnabled },
         };
 
-        _ = new ImmutableTracerSettings(new TracerSettings(new NameValueConfigurationSource(config), collector));
+        _ = new ImmutableTracerSettings(new TracerSettings(new NameValueConfigurationSource(config), collector, new OverrideErrorLog()));
 
         var data = collector.GetData();
 
@@ -220,7 +225,7 @@ public class ConfigurationTelemetryCollectorTests
         var collector = new ConfigurationTelemetry();
         var source = new NameValueConfigurationSource(new NameValueCollection());
 
-        _ = new ImmutableTracerSettings(new TracerSettings(source, collector));
+        _ = new ImmutableTracerSettings(new TracerSettings(source, collector, new OverrideErrorLog()));
         _ = new SecuritySettings(source, collector);
 
         var data = collector.GetData();
@@ -263,7 +268,7 @@ public class ConfigurationTelemetryCollectorTests
             const string serviceName = "my-tests";
             const string serviceVersion = "1.2.3";
             var collector = new ConfigurationTelemetry();
-            var s = new TracerSettings(NullConfigurationSource.Instance, collector)
+            var s = new TracerSettings(NullConfigurationSource.Instance, collector, new OverrideErrorLog())
             {
                 ServiceName = serviceName,
                 Environment = env,

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Collectors/MetricsTelemetryCollectorTests.cs
@@ -7,6 +7,7 @@ using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.Telemetry.Metrics;
 using FluentAssertions;
@@ -86,6 +87,13 @@ public class MetricsTelemetryCollectorTests
     [InlineData("1.2.3")]
     public async Task AllMetricsAreReturned_ForMetricsTelemetryCollector(string wafVersion)
     {
+        static void IncrementOpenTelemetryConfigMetrics(MetricsTelemetryCollector collector, string openTelemetryKey)
+        {
+            OpenTelemetryHelpers.GetConfigurationMetricTags(openTelemetryKey, out var openTelemetryConfig, out var datadogConfig);
+            collector.RecordCountOpenTelemetryConfigHiddenByDatadogConfig(datadogConfig, openTelemetryConfig);
+            collector.RecordCountOpenTelemetryConfigInvalid(datadogConfig, openTelemetryConfig);
+        }
+
         var collector = new MetricsTelemetryCollector(Timeout.InfiniteTimeSpan);
         collector.Record(PublicApiUsage.Tracer_Configure);
         collector.Record(PublicApiUsage.Tracer_Configure);
@@ -104,6 +112,17 @@ public class MetricsTelemetryCollectorTests
         collector.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.Total, 23);
         collector.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.Total, 46);
         collector.RecordDistributionSharedInitTime(MetricTags.InitializationComponent.Managed, 52);
+
+        // Record OpenTelemetry => Datadog configuration error metrics
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_SERVICE_NAME");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_LOG_LEVEL");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_PROPAGATORS");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_TRACES_SAMPLER");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_TRACES_SAMPLER_ARG");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_TRACES_EXPORTER");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_METRICS_EXPORTER");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_RESOURCE_ATTRIBUTES");
+        IncrementOpenTelemetryConfigMetrics(collector, "OTEL_SDK_DISABLED");
 
         // These aren't applicable in non-ci visibility
         collector.RecordCountCIVisibilityITRSkipped(MetricTags.CIVisibilityTestingEventType.Test, 123);
@@ -289,6 +308,168 @@ public class MetricsTelemetryCollectorTests
                 Tags = (string[])null,
                 Common = false,
                 Namespace = (string)null,
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_service_name", "config_datadog:dd_service" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_service_name", "config_datadog:dd_service" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_log_level", "config_datadog:dd_trace_debug" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_log_level", "config_datadog:dd_trace_debug" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_propagators", "config_datadog:dd_trace_propagation_style" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_propagators", "config_datadog:dd_trace_propagation_style" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_traces_sampler", "config_datadog:dd_trace_sample_rate" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_traces_sampler", "config_datadog:dd_trace_sample_rate" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_traces_sampler_arg", "config_datadog:dd_trace_sample_rate" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_traces_sampler_arg", "config_datadog:dd_trace_sample_rate" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_traces_exporter", "config_datadog:dd_trace_enabled" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_traces_exporter", "config_datadog:dd_trace_enabled" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_metrics_exporter", "config_datadog:dd_runtime_metrics_enabled" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_metrics_exporter", "config_datadog:dd_runtime_metrics_enabled" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_resource_attributes", "config_datadog:dd_tags" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_resource_attributes", "config_datadog:dd_tags" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigHiddenByDatadogConfig.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_sdk_disabled", "config_datadog:dd_trace_otel_enabled" },
+                Common = true,
+                Namespace = "tracers",
+            },
+            new
+            {
+                Metric = Count.OpenTelemetryConfigInvalid.GetName(),
+                Points = new[] { new { Value = 1 } },
+                Type = TelemetryMetricType.Count,
+                Tags = new[] { "config_opentelemetry:otel_sdk_disabled", "config_datadog:dd_trace_otel_enabled" },
+                Common = true,
+                Namespace = "tracers",
             },
         });
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/Metrics/common_metrics.json
@@ -37,6 +37,38 @@
       "send_to_user": false,
       "user_tags": []
     },
+    "otel.env.hiding": {
+      "tags": [
+        "config_datadog",
+        "config_opentelemetry"
+      ],
+      "metric_type": "count",
+      "data_type": "configuration keys",
+      "description": "The number of Opentelemetry configuration keys, configured and supported, but overridden by its counterpart Datadog Configuration key, tagged by Datadog configuration key and Opentelemetry configuration key",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "otel.env.invalid": {
+      "tags": [
+        "config_datadog",
+        "config_opentelemetry"
+      ],
+      "metric_type": "count",
+      "data_type": "configuration keys",
+      "description": "The number of configured supported Opentelemetry configuration keys that we fail to map its value to the Datadog form, tagged by Datadog configuration key and Opentelemetry configuration key",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "otel.env.unsupported": {
+      "tags": [
+        "config_opentelemetry"
+      ],
+      "metric_type": "count",
+      "data_type": "configuration keys",
+      "description": "The number of unsupported (not having a mapping with any Datadog configuration key) configured Opentelemetry Configuration keys, tagged by Opentelemetry configuration key",
+      "send_to_user": false,
+      "user_tags": []
+    },
     "spans_created": {
       "tags": [
         "integration_name"
@@ -314,28 +346,100 @@
       "send_to_user": false,
       "user_tags": []
     },
+    "inject.success": {
+      "tags": [
+        "language",
+        "version",
+        "injector_version",
+        "platform",
+        "injecter_version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of successful injections of APM libraries",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "inject.skip": {
+      "tags": [
+        "language",
+        "version",
+        "injector_version",
+        "injecter_version",
+        "platform",
+        "reason"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of skipped injections of APM libraries",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "inject.error": {
+      "tags": [
+        "language",
+        "version",
+        "injector_version",
+        "injecter_version",
+        "platform",
+        "reason"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of erroneous injections of APM libraries",
+      "send_to_user": false,
+      "user_tags": []
+    },
     "host_lib_injection.success": {
       "tags": [
         "language",
         "version",
+        "injector_version",
         "injecter_version"
       ],
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of successful host lib injection",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "host_lib_injection.failure": {
       "tags": [
         "language",
         "version",
+        "injector_version",
         "injecter_version"
       ],
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of failed host lib injection",
-      "send_to_user": true,
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "k8s_lib_injection.success": {
+      "tags": [
+        "language",
+        "version",
+        "injector_version",
+        "injecter_version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of successful k8s lib injection",
+      "send_to_user": false,
+      "user_tags": []
+    },
+    "k8s_lib_injection.failure": {
+      "tags": [
+        "language",
+        "version",
+        "injector_version",
+        "injecter_version"
+      ],
+      "metric_type": "count",
+      "data_type": "requests",
+      "description": "Number of failed host k8s injection",
+      "send_to_user": false,
       "user_tags": []
     },
     "docker_lib_injection.success": {
@@ -346,7 +450,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of successful docker lib injection",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "docker_lib_injection.failure": {
@@ -357,7 +461,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of failed docker lib injection",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "library_entrypoint.abort": {
@@ -369,7 +473,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of injections aborted at library entrypoint due to checks not passing",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "library_entrypoint.abort.runtime": {
@@ -380,7 +484,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of injections aborted at library entrypoint due to runtime version not supported",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "library_entrypoint.abort.integration": {
@@ -393,7 +497,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of injections aborted at library entrypoint due to integration version not supported",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "library_entrypoint.error": {
@@ -407,7 +511,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of injections aborted at library entrypoint due to an error",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "library_entrypoint.complete": {
@@ -419,7 +523,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of successful library entrypoint injections",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "entry.process.running.1s": {
@@ -430,7 +534,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of injections that are still running after 1s",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "entry.process.running.5s": {
@@ -441,7 +545,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of injections that are still running after 5s",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "entry.process.running.10s": {
@@ -452,7 +556,7 @@
       "metric_type": "count",
       "data_type": "requests",
       "description": "Number of injections that are still running after 10s",
-      "send_to_user": true,
+      "send_to_user": false,
       "user_tags": []
     },
     "exporter_fallback": {

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/TelemetryFactoryTests.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.ClrProfiler;
 using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.ConfigurationSources.Telemetry;
 using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.Telemetry;
 using Datadog.Trace.TestHelpers;
@@ -27,7 +28,7 @@ public class TelemetryFactoryTests
     public void TelemetryFactory_DisabledIfTelemetryIsDisabled()
     {
         var factory = TelemetryFactory.CreateFactory();
-        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog()));
         var settings = new TelemetrySettings(
             telemetryEnabled: false, // explicitly disabled
             configurationError: null,
@@ -47,7 +48,7 @@ public class TelemetryFactoryTests
     public void TelemetryFactory_DisabledIfNoTransports()
     {
         var factory = TelemetryFactory.CreateFactory();
-        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog()));
         var settings = new TelemetrySettings(
             telemetryEnabled: true,
             configurationError: null,
@@ -71,7 +72,7 @@ public class TelemetryFactoryTests
         TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
 
         var factory = TelemetryFactory.CreateFactory();
-        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog()));
         var settings = new TelemetrySettings(
             telemetryEnabled: true,
             configurationError: null,
@@ -96,7 +97,7 @@ public class TelemetryFactoryTests
         TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
 
         var factory = TelemetryFactory.CreateFactory();
-        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog()));
         var settings = new TelemetrySettings(
             telemetryEnabled: true,
             configurationError: null,
@@ -121,7 +122,7 @@ public class TelemetryFactoryTests
         TelemetryFactory.SetMetricsForTesting(metricsTelemetryCollector);
 
         var factory = TelemetryFactory.CreateFactory();
-        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog()));
         var settings = new TelemetrySettings(
             telemetryEnabled: true,
             configurationError: null,
@@ -146,7 +147,7 @@ public class TelemetryFactoryTests
         TelemetryFactory.SetMetricsForTesting(metricsTelemetryCollector);
 
         var factory = TelemetryFactory.CreateFactory();
-        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog()));
         var settings = new TelemetrySettings(
             telemetryEnabled: true,
             configurationError: null,
@@ -175,7 +176,7 @@ public class TelemetryFactoryTests
         TelemetryFactory.SetMetricsForTesting(new MetricsTelemetryCollector());
 
         var factory = TelemetryFactory.CreateFactory();
-        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance));
+        var tracerSettings = new ImmutableTracerSettings(new TracerSettings(NullConfigurationSource.Instance, NullConfigurationTelemetry.Instance, new OverrideErrorLog()));
         var settings = new TelemetrySettings(
             telemetryEnabled: true,
             configurationError: null,


### PR DESCRIPTION
## Summary of changes

Records logs and metrics for when otel config is overriden by datadog config, or when it's invalid

## Reason for change

This was originally part of https://github.com/DataDog/dd-trace-dotnet/pull/5661, but wasn't possible due to concerns with the fact `ConfigurationBuilder` is used in critical "startup" paths for the tracer, so can result in recursion if we're not careful.

## Implementation details

The crux of the implementation is that we "store" error and metrics for writing at the point we know it's safe. This is _similar_ to what we already do for configuration telemetry. 

(Technically I think we _Could_ directly access the `TelemetryFactory.Metrics`, but this is "safer", and makes it easier to test we're sending the right metrics

## Test coverage

Added unit tests to all of the existing settings tests where we override configuration to confirm that it works as expected

## Other details

The metrics etc are all ported from https://github.com/DataDog/dd-trace-dotnet/pull/5661, but there are currently some issues with the proposed values:

- [x] The metrics aren't added to the intake yet, so need updating there (and copying here)
- [x] The tag names aren't "valid" for standard telemetry metrics, they should be lowercase, and shouldn't use `.`. I would suggest changing these to be lowercase and replacing `.` with `_`, but either way this should happen after they've been OK'd in the intake.

Original PR:
- https://github.com/DataDog/dd-trace-dotnet/pull/5717
