### PR TITLE
Add an `IsManualInstrumentationOnly` flag to Datadog.Trace.Manual

### DIFF
--- a/tracer/src/Datadog.Trace.Manual/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace.Manual/ClrProfiler/Instrumentation.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="Instrumentation.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using Datadog.Trace.SourceGenerators;
+
+namespace Datadog.Trace.ClrProfiler;
+
+internal class Instrumentation
+{
+    /// <summary>
+    /// Gets whether automatic instrumentation is attached.
+    /// Rewritten by the tracer to return false if automatic instrumentation is enabled.
+    /// </summary>
+    [Instrumented]
+    public static bool IsManualInstrumentationOnly() => true;
+}

--- a/tracer/src/Datadog.Trace.Manual/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace.Manual/ClrProfiler/Instrumentation.cs
@@ -13,6 +13,6 @@ internal class Instrumentation
     /// Gets whether automatic instrumentation is attached.
     /// Rewritten by the tracer to return false if automatic instrumentation is enabled.
     /// </summary>
-    [Instrumented]
+    // [Instrumented] This is auto-rewritten, not instrumented with calltarget
     public static bool IsManualInstrumentationOnly() => true;
 }

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -988,7 +988,7 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
 
             const auto& assemblyVersion = assemblyImport.version.str();
 
-            Logger::Info("ModuleLoadFinished: ", manual_instrumentation_name, " v", assemblyVersion, " - Fix PInvoke maps");
+            Logger::Info("ModuleLoadFinished: ", manual_instrumentation_name, " v", assemblyVersion, " - RewriteIsManualInstrumentationOnly");
 
             // Rewrite Instrumentation.IsManualInstrumentationOnly()
             RewriteIsManualInstrumentationOnly(module_metadata, module_id);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -956,6 +956,44 @@ HRESULT CorProfiler::TryRejitModule(ModuleID module_id, std::vector<ModuleID>& m
     }
     else
     {
+        // Datadog.Trace.Manual is _mostly_ treated as a third-party assembly,
+        // but we do some rewriting to support manual-only scenarios
+        // If/when we go with v3 part deux, we will need to update this to
+        // also rewrite to support version mismatch via IDistributedTracer
+        if (module_info.assembly.name == manual_instrumentation_name)
+        {
+            // Rewrite key methods for version mismatch + 
+            ComPtr<IUnknown> metadata_interfaces;
+            auto hr = this->info_->GetModuleMetaData(module_id, ofRead | ofWrite, IID_IMetaDataImport2,
+                                                     metadata_interfaces.GetAddressOf());
+
+            if (FAILED(hr))
+            {
+                Logger::Warn("ModuleLoadFinished failed to get metadata interface for ", module_id, " ",
+                             module_info.assembly.name);
+                return S_OK;
+            }
+
+            const auto& metadata_import = metadata_interfaces.As<IMetaDataImport2>(IID_IMetaDataImport);
+            const auto& metadata_emit = metadata_interfaces.As<IMetaDataEmit2>(IID_IMetaDataEmit);
+            const auto& assembly_import = metadata_interfaces.As<IMetaDataAssemblyImport>(IID_IMetaDataAssemblyImport);
+            const auto& assembly_emit = metadata_interfaces.As<IMetaDataAssemblyEmit>(IID_IMetaDataAssemblyEmit);
+
+            // NOTE: I'm not entirely comfortable that we're passing corAssemblyProperty in here...
+            // but I don't know if I _should_ worry, or if we can avoid it 
+            const auto& module_metadata =
+                ModuleMetadata(metadata_import, metadata_emit, assembly_import, assembly_emit, module_info.assembly.name,
+                               module_info.assembly.app_domain_id, &corAssemblyProperty, false, false);
+            const auto& assemblyImport = GetAssemblyImportMetadata(assembly_import);
+
+            const auto& assemblyVersion = assemblyImport.version.str();
+
+            Logger::Info("ModuleLoadFinished: ", manual_instrumentation_name, " v", assemblyVersion, " - Fix PInvoke maps");
+
+            // Rewrite Instrumentation.IsManualInstrumentationOnly()
+            RewriteIsManualInstrumentationOnly(module_metadata, module_id);
+        }
+
         modules.push_back(module_id);
 
         bool searchForTraceAttribute = trace_annotations_enabled;
@@ -2637,6 +2675,68 @@ HRESULT CorProfiler::RewriteForTelemetry(const ModuleMetadata& module_metadata, 
     {
         Logger::Info(GetILCodes("After -> Instrumentation.GetNativeTracerVersion(). ", &methodRewriter,
                                 GetFunctionInfo(module_metadata.metadata_import, getNativeTracerVersionMethodDef),
+                                module_metadata.metadata_import));
+    }
+
+    return hr;
+}
+
+HRESULT CorProfiler::RewriteIsManualInstrumentationOnly(const ModuleMetadata& module_metadata, ModuleID module_id)
+{
+    //
+    // *** Get Instrumentation TypeDef
+    //
+    mdTypeDef instrumentationTypeDef;
+    HRESULT hr = module_metadata.metadata_import->FindTypeDefByName(instrumentation_type_name.c_str(),
+                                                                    mdTokenNil, &instrumentationTypeDef);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting IsManualInstrumentationOnly on getting Instrumentation TypeDef");
+        return hr;
+    }
+
+    //
+    // *** IsManualInstrumentationOnly MethodDef ***
+    //
+    constexpr COR_SIGNATURE isAutoEnabledSignature[] = {IMAGE_CEE_CS_CALLCONV_DEFAULT, 0, ELEMENT_TYPE_BOOLEAN};
+    mdMethodDef isAutoEnabledMethodDef;
+    hr = module_metadata.metadata_import->FindMethod(instrumentationTypeDef, WStr("IsManualInstrumentationOnly"),
+                                                     isAutoEnabledSignature, 3, &isAutoEnabledMethodDef);
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting IsManualInstrumentationOnly on getting IsManualInstrumentationOnly MethodDef");
+        return hr;
+    }
+
+    ILRewriter methodRewriter(this->info_, nullptr, module_id, isAutoEnabledMethodDef);
+    methodRewriter.InitializeTiny();
+
+    // Modify method from this:
+    // IL_0000: ldc.i4.1
+    // IL_0001: ret
+    //
+    // to this:
+    // IL_0000: ldc.i4.0
+    // IL_0001: ret
+    ILRewriterWrapper wrapper(&methodRewriter);
+    wrapper.SetILPosition(methodRewriter.GetILList()->m_pNext);
+    wrapper.LoadInt32(0);
+    wrapper.Return();
+
+    hr = methodRewriter.Export();
+
+    if (FAILED(hr))
+    {
+        Logger::Warn("Error rewriting Instrumentation.IsManualInstrumentationOnly() => false");
+        return hr;
+    }
+
+    Logger::Info("Rewriting Instrumentation.IsManualInstrumentationOnly() => false");
+
+    if (IsDumpILRewriteEnabled())
+    {
+        Logger::Info(GetILCodes("After -> Instrumentation.IsManualInstrumentationOnly(). ", &methodRewriter,
+                                GetFunctionInfo(module_metadata.metadata_import, isAutoEnabledMethodDef),
                                 module_metadata.metadata_import));
     }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -122,6 +122,7 @@ private:
                            const ComPtr<IMetaDataImport2>& metadata_import);
     HRESULT RewriteForDistributedTracing(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT RewriteForTelemetry(const ModuleMetadata& module_metadata, ModuleID module_id);
+    HRESULT RewriteIsManualInstrumentationOnly(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT EmitDistributedTracerTargetMethod(const ModuleMetadata& module_metadata, ModuleID module_id);
     HRESULT TryRejitModule(ModuleID module_id, std::vector<ModuleID>& modules);
     static bool TypeNameMatchesTraceAttribute(WCHAR type_name[], DWORD type_name_len);

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -96,6 +96,7 @@ const shared::WSTRING managed_profiler_full_assembly_version =
     WStr("Datadog.Trace, Version=3.1.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
 const shared::WSTRING managed_profiler_name = WStr("Datadog.Trace");
+const shared::WSTRING manual_instrumentation_name = WStr("Datadog.Trace.Manual");
 
 const shared::WSTRING nonwindows_nativemethods_type = WStr("Datadog.Trace.ClrProfiler.NativeMethods+NonWindows");
 const shared::WSTRING windows_nativemethods_type = WStr("Datadog.Trace.ClrProfiler.NativeMethods+Windows");

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/ManualInstrumentationTests.cs
@@ -25,6 +25,7 @@ public class ManualInstrumentationTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ManualAndAutomatic()
     {
+        SetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED", "1");
         const int expectedSpans = 36;
         using var telemetry = this.ConfigureTelemetry();
         using var agent = EnvironmentHelper.GetMockAgent();
@@ -43,6 +44,7 @@ public class ManualInstrumentationTests : TestHelper
     [Trait("RunOnWindows", "True")]
     public async Task ManualOnly()
     {
+        SetEnvironmentVariable("AUTO_INSTRUMENT_ENABLED", "0");
         EnvironmentHelper.SetAutomaticInstrumentation(false);
         // with automatic instrumentation disabled, we don't expect _any_ spans
         using var telemetry = this.ConfigureTelemetry();


### PR DESCRIPTION
## Summary of changes

Adds a `IsManualInstrumentationOnly()` method to the manual library, and rewrites it when we're doing automatic instrumentation

## Reason for change

For some scenarios we're considering (e.g. v3 part deux) we need to know from inside the manual library whether we're auto-instrumenting. This is a relatively simple approach to achieve it. 

## Implementation details

Mostly copied C++ rewriting code that we're already doing, and tweaked it for our use case

## Test coverage

Added a check to the manualinstrumentation tests that the flag behaves as expected (`true` when no auto instrumentation, `false` if we have auto instrumentation)

## Other details

For part deux we'll need to do more rewriting, but there shouldn't be any harm in doing the rewriting in this PR regardless of what happens with that