### PR TITLE
[build] change agent image source

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -177,7 +177,7 @@ variables:
 resources:
   containers:
   - container: dd_agent
-    image: datadog/agent
+    image: public.ecr.aws/datadog/agent
     ports:
     - 8126:8126
     env:


### PR DESCRIPTION
## Summary of changes

Move from docker's image repository to erc.aws.

## Reason for change

The quotas for unauthenticated users are more generous: 

### erc.aws

```
Rate of unauthenticated image pulls:	Each supported Region: 1 per second
```

https://docs.aws.amazon.com/AmazonECR/latest/public/public-service-quotas.html

### docker

```
Anonymous users:	100 pulls per 6 hours per IP address
```

https://forums.docker.com/t/is-authenticated-user-also-rate-limited-by-ip-address-when-pulling/140031

## Test coverage

it's part of the tests!