### PR TITLE
Fix `NullReferenceException` in ASP.NET Core when `RoutePattern.RawText` is `null`

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -118,13 +118,11 @@ src/Datadog.Trace/Debugger/ILineProbeResolver.cs
 src/Datadog.Trace/Debugger/LiveDebugger.cs
 src/Datadog.Trace/Debugger/ProbeLocationType.cs
 src/Datadog.Trace/DiagnosticListeners/AspNetCoreDiagnosticObserver.cs
-src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
 src/Datadog.Trace/DiagnosticListeners/DiagnosticManager.cs
 src/Datadog.Trace/DiagnosticListeners/DiagnosticObserver.cs
 src/Datadog.Trace/DiagnosticListeners/EndpointFeatureProxy.cs
 src/Datadog.Trace/DiagnosticListeners/IDiagnosticManager.cs
 src/Datadog.Trace/DiagnosticListeners/RouteEndpoint.cs
-src/Datadog.Trace/DiagnosticListeners/RoutePattern.cs
 src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
 src/Datadog.Trace/DogStatsd/StatsdExtensions.cs
 src/Datadog.Trace/DogStatsd/TracerMetricNames.cs

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/AspNetCoreResourceNameHelper.cs
@@ -2,6 +2,9 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
+
+#nullable enable
+
 #if !NETFRAMEWORK
 
 using System;
@@ -18,15 +21,15 @@ internal class AspNetCoreResourceNameHelper
     internal static string SimplifyRoutePattern(
         RoutePattern routePattern,
         RouteValueDictionary routeValueDictionary,
-        string areaName,
-        string controllerName,
-        string actionName,
+        string? areaName,
+        string? controllerName,
+        string? actionName,
         bool expandRouteParameters)
     {
-        var maxSize = routePattern.RawText.Length
-                    + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName.Length - 4, 0)) // "area".Length
-                    + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName.Length - 10, 0)) // "controller".Length
-                    + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName.Length - 6, 0)) // "action".Length
+        var maxSize = (routePattern.RawText?.Length ?? 0)
+                    + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName!.Length - 4, 0)) // "area".Length
+                    + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName!.Length - 10, 0)) // "controller".Length
+                    + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName!.Length - 6, 0)) // "action".Length
                     + 1; // '/' prefix
 
         var sb = StringBuilderCache.Acquire(maxSize);
@@ -129,15 +132,15 @@ internal class AspNetCoreResourceNameHelper
     internal static string SimplifyRouteTemplate(
         RouteTemplate routePattern,
         RouteValueDictionary routeValueDictionary,
-        string areaName,
-        string controllerName,
-        string actionName,
+        string? areaName,
+        string? controllerName,
+        string? actionName,
         bool expandRouteParameters)
     {
-        var maxSize = routePattern.TemplateText.Length
-                    + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName.Length - 4, 0)) // "area".Length
-                    + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName.Length - 10, 0)) // "controller".Length
-                    + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName.Length - 6, 0)) // "action".Length
+        var maxSize = (routePattern.TemplateText?.Length ?? 0)
+                    + (string.IsNullOrEmpty(areaName) ? 0 : Math.Max(areaName!.Length - 4, 0)) // "area".Length
+                    + (string.IsNullOrEmpty(controllerName) ? 0 : Math.Max(controllerName!.Length - 10, 0)) // "controller".Length
+                    + (string.IsNullOrEmpty(actionName) ? 0 : Math.Max(actionName!.Length - 6, 0)) // "action".Length
                     + 1; // '/' prefix
 
         var sb = StringBuilderCache.Acquire(maxSize);
@@ -228,7 +231,7 @@ internal class AspNetCoreResourceNameHelper
         return string.IsNullOrEmpty(simplifiedRoute) ? "/" : simplifiedRoute.ToLowerInvariant();
     }
 
-    private static bool IsIdentifierSegment(object value, [NotNullWhen(false)] out string valueAsString)
+    private static bool IsIdentifierSegment(object? value, [NotNullWhen(true)] out string? valueAsString)
     {
         valueAsString = value as string ?? value?.ToString();
         if (valueAsString is null)

--- a/tracer/src/Datadog.Trace/DiagnosticListeners/RoutePattern.cs
+++ b/tracer/src/Datadog.Trace/DiagnosticListeners/RoutePattern.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System.Collections;
 using Datadog.Trace.DuckTyping;
 
@@ -22,6 +24,6 @@ namespace Datadog.Trace.DiagnosticListeners
         /// <summary>
         /// Gets the RoutePattern.RawText
         /// </summary>
-        public string RawText;
+        public string? RawText;
     }
 }


### PR DESCRIPTION
## Summary of changes

Fix `NullReferenceException` in aspnetcore handler

## Reason for change

`RoutePattern.RawText` can be null

## Implementation details

Add `#nullable enable` annotation to the duck type, and `AspNetCoreResourceNameHelper` and follow the errors.

## Test coverage

Covered by existing in general, hard to reproduce this specific bug


<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
