### PR TITLE
[ASM] ensure struct is on the stack before passing to native code

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Waf.cs
@@ -127,7 +127,8 @@ namespace Datadog.Trace.AppSec.Waf
             var diagnosticsValue = new DdwafObjectStruct { Type = DDWAF_OBJ_TYPE.DDWAF_OBJ_MAP };
             try
             {
-                var newHandle = _wafLibraryInvoker.Update(_wafHandle, ref updateData.ResultDdwafObject, ref diagnosticsValue);
+                var updateObject = updateData.ResultDdwafObject;
+                var newHandle = _wafLibraryInvoker.Update(_wafHandle, ref updateObject, ref diagnosticsValue);
                 if (newHandle != IntPtr.Zero)
                 {
                     var oldHandle = _wafHandle;

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/Encoder.cs
@@ -690,7 +690,7 @@ namespace Datadog.Trace.AppSec.WafEncoding
                 _result = result;
             }
 
-            public ref DdwafObjectStruct ResultDdwafObject => ref _result;
+            public DdwafObjectStruct ResultDdwafObject => _result;
 
             public void Dispose()
             {

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/EncoderLegacy.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/EncoderLegacy.cs
@@ -334,7 +334,7 @@ internal class EncoderLegacy : IEncoder
             _wafLibraryInvoker = wafLibraryInvoker;
         }
 
-        public ref DdwafObjectStruct ResultDdwafObject => ref _resultDdwafObject;
+        public DdwafObjectStruct ResultDdwafObject => _resultDdwafObject;
 
         public void Dispose() => _wafLibraryInvoker.ObjectFree(ref _resultDdwafObject);
     }

--- a/tracer/src/Datadog.Trace/AppSec/WafEncoding/IEncodeResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/WafEncoding/IEncodeResult.cs
@@ -10,5 +10,5 @@ namespace Datadog.Trace.AppSec.WafEncoding;
 
 internal interface IEncodeResult : IDisposable
 {
-    public ref DdwafObjectStruct ResultDdwafObject { get; }
+    public DdwafObjectStruct ResultDdwafObject { get; }
 }


### PR DESCRIPTION
## Summary of changes

Some crashes where reported where the stack trace showed the error occurred in the WAF, with the call starting in `Waf.UpdateWafAndDispose`. A review of this method spotted that a pointer to a struct stored in a object field was being passed to the WAF. This meant the GC might move the object, which could potentially lead to a crash.
