### PR TITLE
Fix `NullReferenceException` in `HttpClientResponse.GetCharsetEncoding` (#5881 -> v2)

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -50,7 +50,6 @@ src/Datadog.Trace/Agent/IAgentWriter.cs
 src/Datadog.Trace/Agent/IApi.cs
 src/Datadog.Trace/Agent/IApiRequest.cs
 src/Datadog.Trace/Agent/IApiRequestFactory.cs
-src/Datadog.Trace/Agent/IApiResponse.cs
 src/Datadog.Trace/Agent/IApiResponseTelemetryExtensions.cs
 src/Datadog.Trace/Agent/IKeepRateCalculator.cs
 src/Datadog.Trace/Agent/IStatsAggregator.cs
@@ -272,13 +271,10 @@ src/Datadog.Trace/Agent/TraceSamplers/PrioritySampler.cs
 src/Datadog.Trace/Agent/TraceSamplers/RareSampler.cs
 src/Datadog.Trace/Agent/Transports/ApiWebRequest.cs
 src/Datadog.Trace/Agent/Transports/ApiWebRequestFactory.cs
-src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
 src/Datadog.Trace/Agent/Transports/HttpClientRequest.cs
 src/Datadog.Trace/Agent/Transports/HttpClientRequestFactory.cs
-src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
 src/Datadog.Trace/Agent/Transports/HttpStreamRequest.cs
 src/Datadog.Trace/Agent/Transports/HttpStreamRequestFactory.cs
-src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
 src/Datadog.Trace/Agent/Transports/MimeTypes.cs
 src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
 src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs

--- a/tracer/src/Datadog.Trace/Agent/IApiResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/IApiResponse.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -23,14 +25,14 @@ namespace Datadog.Trace.Agent
         /// <summary>
         /// Gets the "raw" content-type header, which may contain additional information like charset or boundary.
         /// </summary>
-        string ContentTypeHeader { get; }
+        string? ContentTypeHeader { get; }
 
         /// <summary>
         /// Gets the "raw" content-encoding header, which may contain multiple values
         /// </summary>
-        string ContentEncodingHeader { get; }
+        string? ContentEncodingHeader { get; }
 
-        string GetHeader(string headerName);
+        string? GetHeader(string headerName);
 
         Encoding GetCharsetEncoding();
 
@@ -50,9 +52,9 @@ namespace Datadog.Trace.Agent
             return await reader.ReadToEndAsync().ConfigureAwait(false);
         }
 
-        public static async Task<T> ReadAsTypeAsync<T>(this IApiResponse apiResponse)
+        public static async Task<T?> ReadAsTypeAsync<T>(this IApiResponse apiResponse)
         {
-            InitiallyBufferedStream bufferedStream = null;
+            InitiallyBufferedStream? bufferedStream = null;
             try
             {
                 var stream = await apiResponse.GetStreamAsync().ConfigureAwait(false);
@@ -103,7 +105,7 @@ namespace Datadog.Trace.Agent
         /// <param name="contentTypeHeader">The raw content-type header, for example <c>"application/json;charset=utf-8"</c></param>
         /// <returns>The encoding associated with the charset, or <see cref="EncodingHelpers.Utf8NoBom"/> if the content-type header was not provided,
         /// if the charset was not provided, or if the charset was not recognized</returns>
-        public static Encoding GetCharsetEncoding(string contentTypeHeader)
+        public static Encoding GetCharsetEncoding(string? contentTypeHeader)
         {
             // special casing application/json because it's so common
             if (string.IsNullOrEmpty(contentTypeHeader)
@@ -114,7 +116,7 @@ namespace Datadog.Trace.Agent
             }
 
             // text/plain; charset=utf-8; boundary=foo
-            foreach (var pair in contentTypeHeader.SplitIntoSpans(';'))
+            foreach (var pair in contentTypeHeader!.SplitIntoSpans(';'))
             {
                 var parts = pair.AsSpan();
                 var index = parts.IndexOf('=');
@@ -143,14 +145,14 @@ namespace Datadog.Trace.Agent
             return EncodingHelpers.Utf8NoBom;
         }
 
-        public static ContentEncodingType GetContentEncodingType(string contentEncodingHeader)
+        public static ContentEncodingType GetContentEncodingType(string? contentEncodingHeader)
         {
             if (string.IsNullOrEmpty(contentEncodingHeader))
             {
                 return ContentEncodingType.None;
             }
 
-            if (contentEncodingHeader.Contains(","))
+            if (contentEncodingHeader!.Contains(","))
             {
                 return ContentEncodingType.Multiple;
             }

--- a/tracer/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/ApiWebResponse.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
 using System.IO;
 using System.Net;
@@ -24,11 +26,11 @@ namespace Datadog.Trace.Agent.Transports
 
         public long ContentLength => _response.ContentLength;
 
-        public string ContentTypeHeader => _response.ContentType;
+        public string? ContentTypeHeader => _response.ContentType;
 
-        public string ContentEncodingHeader => _response.ContentEncoding;
+        public string? ContentEncodingHeader => _response.ContentEncoding;
 
-        public string GetHeader(string headerName) => _response.Headers[headerName];
+        public string? GetHeader(string headerName) => _response.Headers[headerName];
 
         public Encoding GetCharsetEncoding() => ApiResponseExtensions.GetCharsetEncoding(ContentTypeHeader);
 

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpClientResponse.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 #if NETCOREAPP
 using System.IO;
 using System.Linq;
@@ -26,9 +28,9 @@ namespace Datadog.Trace.Agent.Transports
 
         public long ContentLength => _response.Content.Headers.ContentLength ?? -1;
 
-        public string ContentEncodingHeader => string.Join(',', _response.Content.Headers.ContentEncoding);
+        public string? ContentEncodingHeader => string.Join(',', _response.Content.Headers.ContentEncoding);
 
-        public string ContentTypeHeader => _response.Content.Headers.ContentType?.ToString();
+        public string? ContentTypeHeader => _response.Content.Headers.ContentType?.ToString();
 
         public ContentEncodingType GetContentEncodingType() =>
             _response.Content.Headers.ContentEncoding.Count switch
@@ -40,7 +42,7 @@ namespace Datadog.Trace.Agent.Transports
 
         public Encoding GetCharsetEncoding()
         {
-            var charset = _response.Content.Headers.ContentType.CharSet;
+            var charset = _response.Content.Headers.ContentType?.CharSet;
             if (string.IsNullOrEmpty(charset))
             {
                 return EncodingHelpers.Utf8NoBom;
@@ -61,7 +63,7 @@ namespace Datadog.Trace.Agent.Transports
             _response.Dispose();
         }
 
-        public string GetHeader(string headerName)
+        public string? GetHeader(string headerName)
         {
             if (_response.Headers.TryGetValues(headerName, out var headers))
             {

--- a/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
+++ b/tracer/src/Datadog.Trace/Agent/Transports/HttpStreamResponse.cs
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -28,9 +30,9 @@ namespace Datadog.Trace.Agent.Transports
 
         public long ContentLength { get; }
 
-        public string ContentTypeHeader => _headers.GetValue("Content-Type");
+        public string? ContentTypeHeader => _headers.GetValue("Content-Type");
 
-        public string ContentEncodingHeader => _headers.GetValue("Content-Encoding");
+        public string? ContentEncodingHeader => _headers.GetValue("Content-Encoding");
 
         public Stream ResponseStream { get; }
 
@@ -38,7 +40,7 @@ namespace Datadog.Trace.Agent.Transports
         {
         }
 
-        public string GetHeader(string headerName) => _headers.GetValue(headerName);
+        public string? GetHeader(string headerName) => _headers.GetValue(headerName);
 
         public Encoding GetCharsetEncoding() => _encoding;
 

--- a/tracer/src/Datadog.Trace/Util/EncodingHelpers.cs
+++ b/tracer/src/Datadog.Trace/Util/EncodingHelpers.cs
@@ -6,9 +6,9 @@
 #nullable enable
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Datadog.Trace.Logging;
-using Datadog.Trace.VendoredMicrosoftCode.System.Diagnostics.CodeAnalysis;
 
 namespace Datadog.Trace.Util;
 


### PR DESCRIPTION
## Summary of changes

Fixes a `NullReferenceException` that occurred on some responses in .NET 6+

## Reason for change

We were getting null reference exceptions in some cases

## Implementation details

Fix the NRE, and add some more `#nullable enable`

## Test coverage

Should probably have some :awkward-monkey: