### PR TITLE
[Version bump] 2.58.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,7 +1,48 @@
 # Datadog .NET Tracer (`dd-trace-dotnet`) Release Notes
 
+## [Release 2.57.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.57.0)
 
+## Summary
 
+- [Tracer] Fixes for potential `NullReferenceException` and native error
+- [Exception Replay] Normalized exception hashing for more fine-grained aggregation
+- [IAST] Hardening of callsites to prevent exception escape
+
+## Changes
+
+### Tracer
+* Disable keep-alive in HttpClientRequestFactory (#5810 -> v2) (#5824)
+* Fix error checking for CallTargetBubbleUpException (#5836 => v2) (#5843)
+* Ensure top-level entry points are wrapped with try-catch (#5838 -> v2) (#5850)
+* Config refactor - Add telemetry to otel config (#5717 -> v2) (#5864)
+* Fix `NullReferenceException` in `HttpClientResponse.GetCharsetEncoding` (#5881 -> v2) (#5887)
+* Fix `NullReferenceException` in ASP.NET Core when `RoutePattern.RawText` is `null` (#5880 -> v2) (#5888)
+
+### ASM
+* [IAST] Broaden AspNet cookies filtering (#5830 -> v2) (#5834)
+* [IAST] Safeguard Insert Before / After aspects with try/catch (#5839 -> v2) (#5849)
+* [IAST] Safeguard Method Replace aspects with try/catch (#5841 -> v2) (#5855)
+* [IAST] Add a mark to the modified instructions in IL dumps (#5854 -> v2) (#5860)
+* [ASM] ensure struct is on the stack before passing to native code (#5886)
+
+### Continuous Profiler
+* [Profiler] Signal-based profiler/Non-Signal-based: prevent deadlock (#5812)
+
+### Debugger
+* [Dynamic Instrumentation] Improved instrumentation matching of symbols received through SymDb (#5829 -> v2) (#5847)
+* [Exception Replay] Normalized exception hashing for more fine-grained aggregation (#5872 -> v2) (#5890)
+
+### Miscellaneous
+* Exclude an SSIS service from auto-tracing (#5813 -> v2) (#5825)
+* [Backport][Crashtracking]  Ensure crashtracking does not prevent coredump collection (#5852 -> v2) (#5863)
+
+### Build / Test
+* Fix builds on release/2.x (#5826)
+* Backport unified pipeline for APM SDKs for SSI artifacts (#5868)
+* Add verification step to create_draft_release to check SSI one-pipeline succeeded (#5865 -> v2) (#5879)
+* Try fix smoke tests (#5889 -> v2) (#5891)
+
+[Changes since 2.56.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.56.0...v2.57.0)
 
 ## [Release 2.56.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.56.0)
 
@@ -33,7 +74,8 @@
 * Package musl assets in linux glibc tar folder (#5801)
 
 
-[Changes since 2.55.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.55.0...v2.56.0)
+[Changes since 2.55.0](https://github.com/DataDog/dd-trace-dotnet/compare/v2.55.0...v2.56.0)
+
 
 ## [Release 2.55.0](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.55.0)
 

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.Linux.ApiWrapper" VERSION 2.57.0)
+project("Datadog.Linux.ApiWrapper" VERSION 2.58.0)
 
 # ******************************************************
 # Compiler options

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.Profiler.Native.Linux" VERSION 2.57.0)
+project("Datadog.Profiler.Native.Linux" VERSION 2.58.0)
 
 option(RUN_ASAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
 option(RUN_UBSAN "Build with Clang Undefined-Behavior Sanitizer" OFF)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
@@ -62,8 +62,8 @@ END
 
 // ------- version info -------------------------------------------------------
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION             2,57,0,0
-PRODUCTVERSION          2,57,0,0
+FILEVERSION             2,58,0,0
+PRODUCTVERSION          2,58,0,0
 FILEFLAGSMASK           VS_FF_PRERELEASE
 FILEOS                  VOS_NT
 FILETYPE                VFT_DLL
@@ -74,12 +74,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog"
             VALUE "FileDescription", "Continuous Profiler for .NET Applications"
-            VALUE "FileVersion", "2.57.0.0"
+            VALUE "FileVersion", "2.58.0.0"
             VALUE "InternalName", "Native Profiler Engine"
             VALUE "LegalCopyright", "(c) Datadog 2020-2022"
             VALUE "OriginalFilename", "Datadog.Profiler.Native.dll"
             VALUE "ProductName", "Continuous Profiler for .NET Applications"
-            VALUE "ProductVersion", "2.57.0.0"
+            VALUE "ProductVersion", "2.58.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-constexpr auto PROFILER_VERSION = "2.57.0";
+constexpr auto PROFILER_VERSION = "2.58.0";

--- a/profiler/src/ProfilerEngine/ProductVersion.props
+++ b/profiler/src/ProfilerEngine/ProductVersion.props
@@ -5,7 +5,7 @@
 
   <!-- * * * * * * * * * * * INPUTS. Update this section EVERY time the component is shipped/released! * * * * * * * * * * *                -->
   <PropertyGroup>
-    <ProductVersion>2.57.0</ProductVersion>
+    <ProductVersion>2.58.0</ProductVersion>
   </PropertyGroup>
   <!-- * * * * * * * * * * * END OF INPUTS.  * * * * * * * * * * *                                                                          -->
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # Project definition
 # ******************************************************
 
-project("Datadog.Trace.ClrProfiler.Native" VERSION 2.57.0)
+project("Datadog.Trace.ClrProfiler.Native" VERSION 2.58.0)
 
 # ******************************************************
 # Environment detection

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -57,8 +57,8 @@ VS_VERSION_INFO VERSIONINFO
 #else
  FILEFLAGS 0x0L
 #endif
- FILEVERSION             2,57,0,0
- PRODUCTVERSION          2,57,0,0
+ FILEVERSION             2,58,0,0
+ PRODUCTVERSION          2,58,0,0
  FILEOS                  VOS_NT
  FILETYPE                VFT_DLL
 BEGIN
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog"
             VALUE "FileDescription", "Native loader for Datadog .NET APM"
-            VALUE "FileVersion", "2.57.0.0"
+            VALUE "FileVersion", "2.58.0.0"
             VALUE "InternalName", "Native loader"
             VALUE "LegalCopyright", "(c) Datadog 2020-2022"
             VALUE "OriginalFilename", "Datadog.Trace.ClrProfiler.Native.dll"
             VALUE "ProductName", "Native loader for Datadog .NET APM"
-            VALUE "ProductVersion", "2.57.0.0"
+            VALUE "ProductVersion", "2.58.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -17,9 +17,9 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>datadog-dotnet-apm-2.57.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
+    <OutputName>datadog-dotnet-apm-2.58.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
-    <DefineConstants>InstallerVersion=2.57.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
+    <DefineConstants>InstallerVersion=2.58.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>$(DefineConstants);Debug</DefineConstants>

--- a/shared/src/native-src/version.h
+++ b/shared/src/native-src/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "2.57.0";
+constexpr auto PROFILER_VERSION = "2.58.0";

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -59,7 +59,7 @@ partial class Build : NukeBuild
     readonly bool IsAlpine = false;
 
     [Parameter("The current version of the source and build")]
-    readonly string Version = "2.57.0";
+    readonly string Version = "2.58.0";
 
     [Parameter("Whether the current build version is a prerelease(for packaging purposes)")]
     readonly bool IsPrerelease = false;

--- a/tracer/build/artifacts/dd-dotnet.sh
+++ b/tracer/build/artifacts/dd-dotnet.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TRACER_VERSION="2.57.0"
+TRACER_VERSION="2.58.0"
 
 # Get the directory of the script
 DIR=$(dirname "$(readlink -f "$0")")

--- a/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.56.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.57.0" />
     <PackageReference Include="log4net" Version="2.0.12" />
     <PackageReference Include="log4net.Ext.Json" Version="2.0.8.3" />
   </ItemGroup>

--- a/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.56.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.57.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.56.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.57.0" />
     <PackageReference Include="NLog" Version="4.0.0" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.56.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.57.0" />
     <PackageReference Include="NLog" Version="4.5.11" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.56.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.57.0" />
     <PackageReference Include="NLog" Version="4.6.7" />
   </ItemGroup>
 

--- a/tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
+++ b/tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Datadog.Trace.Bundle" Version="2.56.0" />
+    <PackageReference Include="Datadog.Trace.Bundle" Version="2.57.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />

--- a/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.10.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=2.56.0
+ARG TRACER_VERSION=2.57.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
+++ b/tracer/samples/ConsoleApp/Alpine3.9.dockerfile
@@ -16,7 +16,7 @@ COPY --from=build /app/out .
 
 # Set up Datadog APM
 RUN apk --no-cache update && apk add curl
-ARG TRACER_VERSION=2.56.0
+ARG TRACER_VERSION=2.57.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -L https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz \

--- a/tracer/samples/ConsoleApp/Debian.dockerfile
+++ b/tracer/samples/ConsoleApp/Debian.dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Set up Datadog APM
-ARG TRACER_VERSION=2.56.0
+ARG TRACER_VERSION=2.57.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb

--- a/tracer/samples/OpenTelemetry/Debian.dockerfile
+++ b/tracer/samples/OpenTelemetry/Debian.dockerfile
@@ -16,7 +16,7 @@ WORKDIR /app
 COPY --from=build /app/out .
 
 # Download the Datadog .NET Tracer
-ARG TRACER_VERSION=2.56.0
+ARG TRACER_VERSION=2.57.0
 RUN mkdir -p /var/log/datadog
 RUN mkdir -p /opt/datadog
 RUN curl -LO https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb

--- a/tracer/samples/WindowsContainer/Dockerfile
+++ b/tracer/samples/WindowsContainer/Dockerfile
@@ -6,7 +6,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:5.0-windowsservercore-ltsc2019 AS base
 WORKDIR /app
 
-ARG TRACER_VERSION=2.56.0
+ARG TRACER_VERSION=2.57.0
 ENV DD_TRACER_VERSION=$TRACER_VERSION
 ENV ASPNETCORE_URLS=http://*.80
 

--- a/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <Title>Datadog CI Visibility - BenchmarkDotNet</Title>
     <Description>BenchmarkDotNet exporter for Datadog CI Visibility</Description>
     <Nullable>enable</Nullable>

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <Title>Datadog APM Auto-instrumentation Assets</Title>
     <Description>Auto-instrumentation assets for Datadog APM</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -6,7 +6,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private const string AssemblyName = "Datadog.Trace, Version=2.57.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb";
+        private const string AssemblyName = "Datadog.Trace, Version=2.58.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb";
         private const string AzureAppServicesKey = "DD_AZURE_APP_SERVICES";
         private const string AasCustomTracingKey = "DD_AAS_ENABLE_CUSTOM_TRACING";
         private const string AasCustomMetricsKey = "DD_AAS_ENABLE_CUSTOM_METRICS";

--- a/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
+++ b/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
   </PropertyGroup>
 
   <!-- For VS testing purposes only, copy all implementation assemblies to the

--- a/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <Title>Datadog APM - OpenTracing</Title>
     <Description>Provides OpenTracing support for Datadog APM</Description>
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <Title>Datadog APM Auto-instrumentation Runner</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <Description>Auto-instrumentation dotnet global tool for Datadog APM</Description>

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <Title>Datadog APM Auto-instrumentation Launcher</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <Description>Auto-instrumentation dotnet tool for Datadog APM</Description>

--- a/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.csproj
+++ b/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <!-- Unconditionally add a prerelease suffix to the package, but keep the rest of the name so we can associate it with the rest of the release -->
     <Version>$(Version)-prerelease</Version>
   </PropertyGroup>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>2.57.0</Version>
+    <Version>2.58.0</Version>
     <Title>Datadog APM</Title>
     <Description>Instrumentation library for Datadog APM.</Description>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace
     internal static class TracerConstants
     {
         public const string Language = "dotnet";
-        public const string AssemblyVersion = "2.57.0.0";
-        public const string ThreePartVersion = "2.57.0";
+        public const string AssemblyVersion = "2.58.0.0";
+        public const string ThreePartVersion = "2.58.0";
     }
 }

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # Project definition
 # ******************************************************
 
-project("Datadog.Tracer.Native" VERSION 2.57.0)
+project("Datadog.Tracer.Native" VERSION 2.58.0)
 
 # ******************************************************
 # Environment detection

--- a/tracer/src/Datadog.Tracer.Native/Resource.rc
+++ b/tracer/src/Datadog.Tracer.Native/Resource.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,57,0,0
- PRODUCTVERSION 2,57,0,0
+ FILEVERSION 2,58,0,0
+ PRODUCTVERSION 2,58,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog, Inc."
             VALUE "FileDescription", "Datadog CLR Profiler"
-            VALUE "FileVersion", "2.57.0.0"
+            VALUE "FileVersion", "2.58.0.0"
             VALUE "InternalName", "Datadog.Tracer.Native.DLL"
             VALUE "LegalCopyright", "Copyright 2017 Datadog, Inc."
             VALUE "OriginalFilename", "Datadog.Tracer.Native.DLL"
             VALUE "ProductName", "Datadog .NET Tracer"
-            VALUE "ProductVersion", "2.57.0"
+            VALUE "ProductVersion", "2.58.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -93,7 +93,7 @@ const shared::WSTRING system_private_corelib_assemblyName = WStr("System.Private
 const shared::WSTRING datadog_trace_clrprofiler_managed_loader_assemblyName = WStr("Datadog.Trace.ClrProfiler.Managed.Loader");
 
 const shared::WSTRING managed_profiler_full_assembly_version =
-    WStr("Datadog.Trace, Version=2.57.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+    WStr("Datadog.Trace, Version=2.58.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
 const shared::WSTRING managed_profiler_name = WStr("Datadog.Trace");
 
@@ -140,7 +140,7 @@ const AssemblyProperty managed_profiler_assembly_property = AssemblyProperty(
                   49,  105, 236, 40,  21,  176, 12, 238, 238, 204, 141, 90,  27,  244, 61,  182, 125, 41,  97,  163,
                   233, 190, 161, 57,  127, 4,   62, 192, 116, 145, 112, 150, 73,  37,  47,  85,  101, 183, 86,  197},
     160, 32772, 1)
-        .WithVersion(2, 57, 0, 0);
+        .WithVersion(2, 58, 0, 0);
 
 } // namespace trace
 

--- a/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
+++ b/tracer/tools/PipelineMonitor/PipelineMonitor.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Datadog.Trace" Version="2.56.0" />
+      <PackageReference Include="Datadog.Trace" Version="2.57.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The following files were found to be modified (as expected)

- [x] docs/CHANGELOG.md
- [x] profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
- [x] profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
- [x] profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
- [x] profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
- [x] profiler/src/ProfilerEngine/ProductVersion.props
- [x] shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
- [x] shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
- [x] shared/src/msi-installer/WindowsInstaller.wixproj
- [x] shared/src/native-src/version.h
- [x] tracer/build/artifacts/dd-dotnet.sh
- [x] tracer/build/_build/Build.cs
- [x] tracer/samples/AutomaticTraceIdInjection/MicrosoftExtensionsExample/MicrosoftExtensionsExample.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/Log4NetExample/Log4NetExample.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/NLog40Example/NLog40Example.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/NLog45Example/NLog45Example.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/NLog46Example/NLog46Example.csproj
- [x] tracer/samples/AutomaticTraceIdInjection/SerilogExample/SerilogExample.csproj
- [x] tracer/samples/ConsoleApp/Alpine3.10.dockerfile
- [x] tracer/samples/ConsoleApp/Alpine3.9.dockerfile
- [x] tracer/samples/ConsoleApp/Debian.dockerfile
- [x] tracer/samples/OpenTelemetry/Debian.dockerfile
- [x] tracer/samples/WindowsContainer/Dockerfile
- [x] tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
- [x] tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
- [x] tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
- [x] tracer/src/Datadog.Trace.Manual/Datadog.Trace.Manual.csproj
- [x] tracer/src/Datadog.Tracer.Native/CMakeLists.txt
- [x] tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
- [x] tracer/src/Datadog.Tracer.Native/Resource.rc
- [x] tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
- [x] tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
- [x] tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
- [x] tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
- [x] tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
- [x] tracer/src/Datadog.Trace/Datadog.Trace.csproj
- [x] tracer/src/Datadog.Trace/TracerConstants.cs
- [x] tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.csproj
- [x] tracer/tools/PipelineMonitor/PipelineMonitor.csproj

@DataDog/apm-dotnet