### PR TITLE
Fix bug in verification stage of release

### DIFF
--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -1155,7 +1155,7 @@ partial class Build
                 
                 if(new Version(Version).Major < 3)
                 {
-                    image = $"ghcr.io/datadog/dd-trace-dotnet/dd-lib-dotnet:{CommitSha}-musl";
+                    image = $"{image}-musl";
                     VerifyDockerImageExists(image);
                 }
 


### PR DESCRIPTION
## Summary of changes

Fix bug in pre-release validation stage

## Reason for change

There was a bug where we were using the wrong image during the musl validation

## Implementation details

It was looking for `dd-lib-dotnet` instead of `dd-lib-dotnet-init`

## Test coverage

We'll see if it works next time

## Other details

Needs backporting to v2 (only runs there, but makes sense to fix on master too)