### PR TITLE
Fix branch selection in version bump PR

### DIFF
--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -25,9 +25,8 @@ jobs:
         run: |
           if( "${{ github.event.release.tag_name}}".StartsWith("v1.")) {
             echo "::set-output name=ref::release/1.x"
-          # TODO: Uncomment the following once we cut the release/2.x branch and merge v3
-          # } elseif("${{ github.event.release.tag_name}}".StartsWith("v2.")) {
-            # echo "::set-output name=ref::release/2.x"
+          } elseif("${{ github.event.release.tag_name}}".StartsWith("v2.")) {
+            echo "::set-output name=ref::release/2.x"
           } else {
             echo "::set-output name=ref::master"
           }


### PR DESCRIPTION
## Summary of changes

Fixes the version-bump PR for release/2.x versions

## Reason for change

Fix the version selector

## Implementation details

Uncomment the bit that should already have been uncommented. This is already fixed on master, and tbh, I don't really know _why_ it's automatically running the version of the action that lives on the release/2.x branch, but here we are.

## Test coverage

Not possible
