### PR TITLE
init macro benchmarks

### DIFF
--- a/.gitlab/macrobenchmarks.yml
+++ b/.gitlab/macrobenchmarks.yml
@@ -1,0 +1,59 @@
+.macrobenchmarks:
+  stage: macrobenchmarks
+  rules:
+    # - if: $POPULATE_CACHE
+    #   when: never
+    - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
+      when: always
+    - when: manual
+      allow_failure: true
+  tags: ["runner:apm-k8s-same-cpu"]
+  needs: []
+  interruptible: true
+  timeout: 1h
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:dotnet-aspnetcore-4
+  script:
+    - git clone --branch macro/dd-trace-dotnet https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform platform && cd platform
+    - bp-runner bp-runner.yml --debug
+  artifacts:
+    name: "artifacts"
+    when: always
+    paths:
+      - platform/artifacts/
+    expire_in: 3 months
+  variables:
+    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
+
+    ENDPOINT: hello
+
+    K6_OPTIONS_WARMUP_RATE: 30
+    K6_OPTIONS_WARMUP_DURATION: 3m
+    K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s
+    K6_OPTIONS_WARMUP_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_WARMUP_MAX_VUS: 4
+
+    K6_OPTIONS_NORMAL_OPERATION_RATE: 120
+    K6_OPTIONS_NORMAL_OPERATION_DURATION: 7m
+    K6_OPTIONS_NORMAL_OPERATION_GRACEFUL_STOP: 10s
+    K6_OPTIONS_NORMAL_OPERATION_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_NORMAL_OPERATION_MAX_VUS: 4
+
+    K6_OPTIONS_HIGH_LOAD_RATE: 200
+    K6_OPTIONS_HIGH_LOAD_DURATION: 3m
+    K6_OPTIONS_HIGH_LOAD_GRACEFUL_STOP: 10s
+    K6_OPTIONS_HIGH_LOAD_PRE_ALLOCATED_VUS: 4
+    K6_OPTIONS_HIGH_LOAD_MAX_VUS: 4
+
+baseline:
+  extends: .benchmarks
+  variables:
+    DD_SERVICE: "dotnet-aspnetcore"
+    DD_TRACE_DEBUG: "false"
+
+
+only-tracing:
+  extends: .benchmarks
+  variables:
+    DD_TRACE_ENABLED: "true"
+    DD_PROFILING_ENABLED: "false"
+    DD_APPSEC_ENABLED: "false"


### PR DESCRIPTION
## Summary of changes
Adds macrobenchmarks
## Reason for change
Being able to compare impact of commits on main
## Implementation details
https://datadoghq.atlassian.net/wiki/spaces/APMINT/pages/2680356865/How+to+use+Benchmarking+Platform
## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
