### PR TITLE
Normalize the environment variable names used by crashtracking

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -187,7 +187,7 @@ void initLibrary(void)
 {
     check_init();
 
-    const char* crashHandlerEnabled = getenv("DD_TRACE_CRASH_HANDLER_ENABLED");
+    const char* crashHandlerEnabled = getenv("DD_CRASHTRACKING_ENABLED");
 
     if (crashHandlerEnabled != NULL)
     {
@@ -204,7 +204,7 @@ void initLibrary(void)
     // If set, set DD_TRACE_CRASH_HANDLER_PASSTHROUGH to indicate dd-dotnet that it should call createdump
     // If not set, set it to 1 so that .NET calls createdump in case of crash
     // (and we will redirect the call to dd-dotnet)
-    const char* crashHandlerEnv = getenv("DD_TRACE_CRASH_HANDLER");
+    const char* crashHandlerEnv = getenv("DD_INTERNAL_CRASHTRACKING_HANDLER");
 
     if (crashHandlerEnv == NULL || crashHandlerEnv[0] == '\0')
     {
@@ -302,7 +302,7 @@ void initLibrary(void)
         if (enableMiniDump != NULL && enableMiniDump[0] == '1')
         {
             // If DOTNET_DbgEnableMiniDump is set, the crash handler should call createdump when done
-            char* passthrough = getenv("DD_TRACE_CRASH_HANDLER_PASSTHROUGH");
+            char* passthrough = getenv("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH");
 
             if (passthrough == NULL || passthrough[0] == '\0')
             {
@@ -311,7 +311,7 @@ void initLibrary(void)
                 //  - dotnet run sets DOTNET_DbgEnableMiniDump=1
                 //  - dotnet then launches the target app
                 //  - the target app thinks DOTNET_DbgEnableMiniDump has been set by the user and enables passthrough
-                setenv("DD_TRACE_CRASH_HANDLER_PASSTHROUGH", "1", 1);
+                setenv("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH", "1", 1);
             }
         }
         else
@@ -320,7 +320,7 @@ void initLibrary(void)
             // but we instruct it to not call createdump afterwards
             setenv("COMPlus_DbgEnableMiniDump", "1", 1);
             setenv("DOTNET_DbgEnableMiniDump", "1", 1);
-            setenv("DD_TRACE_CRASH_HANDLER_PASSTHROUGH", "0", 1);
+            setenv("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH", "0", 1);
         }
 
         originalMiniDumpName = getenv("DOTNET_DbgMiniDumpName");

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -181,12 +181,12 @@ static void check_init();
 
 static char* originalMiniDumpName = NULL;
 static const char* datadogCrashMarker = "datadog_crashtracking";
-#define DD_CRASHTRACKING_ENABLED "DD_CRASHTRACKING_ENABLED";
-#define DD_INTERNAL_CRASHTRACKING_PASSTHROUGH "DD_INTERNAL_CRASHTRACKING_PASSTHROUGH";
-#define DOTNET_DbgEnableMiniDump "DOTNET_DbgEnableMiniDump";
-#define COMPlus_DbgEnableMiniDump "COMPlus_DbgEnableMiniDump";
-#define DOTNET_DbgMiniDumpName "DOTNET_DbgMiniDumpName";
-#define COMPlus_DbgMiniDumpName "COMPlus_DbgMiniDumpName";
+#define DD_CRASHTRACKING_ENABLED "DD_CRASHTRACKING_ENABLED"
+#define DD_INTERNAL_CRASHTRACKING_PASSTHROUGH "DD_INTERNAL_CRASHTRACKING_PASSTHROUGH"
+#define DOTNET_DbgEnableMiniDump "DOTNET_DbgEnableMiniDump"
+#define COMPlus_DbgEnableMiniDump "COMPlus_DbgEnableMiniDump"
+#define DOTNET_DbgMiniDumpName "DOTNET_DbgMiniDumpName"
+#define COMPlus_DbgMiniDumpName "COMPlus_DbgMiniDumpName"
 
 __attribute__((constructor))
 void initLibrary(void)

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -181,13 +181,19 @@ static void check_init();
 
 static char* originalMiniDumpName = NULL;
 static const char* datadogCrashMarker = "datadog_crashtracking";
+#define DD_CRASHTRACKING_ENABLED "DD_CRASHTRACKING_ENABLED";
+#define DD_INTERNAL_CRASHTRACKING_PASSTHROUGH "DD_INTERNAL_CRASHTRACKING_PASSTHROUGH";
+#define DOTNET_DbgEnableMiniDump "DOTNET_DbgEnableMiniDump";
+#define COMPlus_DbgEnableMiniDump "COMPlus_DbgEnableMiniDump";
+#define DOTNET_DbgMiniDumpName "DOTNET_DbgMiniDumpName";
+#define COMPlus_DbgMiniDumpName "COMPlus_DbgMiniDumpName";
 
 __attribute__((constructor))
 void initLibrary(void)
 {
     check_init();
 
-    const char* crashHandlerEnabled = getenv("DD_CRASHTRACKING_ENABLED");
+    const char* crashHandlerEnabled = getenv(DD_CRASHTRACKING_ENABLED);
 
     if (crashHandlerEnabled != NULL)
     {
@@ -281,17 +287,17 @@ void initLibrary(void)
 
     if (crashHandler != NULL && crashHandler[0] != '\0')
     {
-        char* enableMiniDump = getenv("DOTNET_DbgEnableMiniDump");
+        char* enableMiniDump = getenv(DOTNET_DbgEnableMiniDump);
 
         if (enableMiniDump == NULL)
         {
-            enableMiniDump = getenv("COMPlus_DbgEnableMiniDump");
+            enableMiniDump = getenv(COMPlus_DbgEnableMiniDump);
         }
 
         if (enableMiniDump != NULL && enableMiniDump[0] == '1')
         {
             // If DOTNET_DbgEnableMiniDump is set, the crash handler should call createdump when done
-            char* passthrough = getenv("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH");
+            char* passthrough = getenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH);
 
             if (passthrough == NULL || passthrough[0] == '\0')
             {
@@ -300,25 +306,25 @@ void initLibrary(void)
                 //  - dotnet run sets DOTNET_DbgEnableMiniDump=1
                 //  - dotnet then launches the target app
                 //  - the target app thinks DOTNET_DbgEnableMiniDump has been set by the user and enables passthrough
-                setenv("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH", "1", 1);
+                setenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH, "1", 1);
             }
         }
         else
         {
             // If DOTNET_DbgEnableMiniDump is not set, we set it so that the crash handler is called,
             // but we instruct it to not call createdump afterwards
-            setenv("COMPlus_DbgEnableMiniDump", "1", 1);
-            setenv("DOTNET_DbgEnableMiniDump", "1", 1);
-            setenv("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH", "0", 1);
+            setenv(COMPlus_DbgEnableMiniDump, "1", 1);
+            setenv(DOTNET_DbgEnableMiniDump, "1", 1);
+            setenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH, "0", 1);
         }
 
-        originalMiniDumpName = getenv("DOTNET_DbgMiniDumpName");
+        originalMiniDumpName = getenv(DOTNET_DbgMiniDumpName);
         if (originalMiniDumpName == NULL)
         {
-            originalMiniDumpName = getenv("COMPlus_DbgMiniDumpName");
+            originalMiniDumpName = getenv(COMPlus_DbgMiniDumpName);
         }
-        setenv("COMPlus_DbgMiniDumpName", datadogCrashMarker, 1);
-        setenv("DOTNET_DbgMiniDumpName", datadogCrashMarker, 1);
+        setenv(COMPlus_DbgMiniDumpName, datadogCrashMarker, 1);
+        setenv(DOTNET_DbgMiniDumpName, datadogCrashMarker, 1);
     }
 }
 

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -204,9 +204,7 @@ void initLibrary(void)
     // If set, set DD_TRACE_CRASH_HANDLER_PASSTHROUGH to indicate dd-dotnet that it should call createdump
     // If not set, set it to 1 so that .NET calls createdump in case of crash
     // (and we will redirect the call to dd-dotnet)
-    // The path to the crash handler is not set, try to deduce it
-    char* crashHandler = NULL;
-    
+    // The path to the crash handler is not set, try to deduce it  
     const char* libraryPath = getLibraryPath();
 
     if (libraryPath != NULL)

--- a/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/LinuxOnly/WrapperLibraryTest.cs
@@ -80,55 +80,5 @@ namespace Datadog.Profiler.IntegrationTests.LinuxOnly
             var lines = File.ReadAllLines(logFile);
             lines.Should().ContainMatch(expectedErrorMessage);
         }
-
-        [TestAppFact("Samples.ExceptionGenerator")]
-        public void RedirectCrashHandler(string appName, string framework, string appAssembly)
-        {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
-
-            runner.Environment.SetVariable("COMPlus_DbgMiniDumpType", string.Empty);
-
-            RegisterCrashHandler(runner);
-
-            using var processHelper = runner.LaunchProcess();
-
-            runner.WaitForExitOrCaptureDump(processHelper.Process, milliseconds: 30_000).Should().BeTrue();
-            processHelper.Drain();
-            processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().MatchRegex(@"createdump [\w\.\/]+createdump \d+")
-                .And.NotContain("Writing minidump");
-        }
-
-        [TestAppFact("Samples.ExceptionGenerator")]
-        public void DontRedirectCrashHandlerIfPathNotSet(string appName, string framework, string appAssembly)
-        {
-            var runner = new TestApplicationRunner(appName, framework, appAssembly, _output, enableTracer: true, commandLine: "--scenario 7");
-
-            // Don't set DD_TRACE_CRASH_HANDLER. In that case, the call to createdump shouldn't be redirected
-            runner.Environment.SetVariable("COMPlus_DbgEnableMiniDump", "1");
-            runner.Environment.SetVariable("COMPlus_DbgMiniDumpName", "/dev/null");
-            runner.Environment.SetVariable("COMPlus_DbgMiniDumpType", string.Empty);
-
-            using var processHelper = runner.LaunchProcess();
-
-            runner.WaitForExitOrCaptureDump(processHelper.Process, milliseconds: 30_000).Should().BeTrue();
-            processHelper.Drain();
-            processHelper.ErrorOutput.Should().Contain("Unhandled exception. System.InvalidOperationException: Task failed successfully");
-            processHelper.StandardOutput.Should().NotMatchRegex(@"createdump [\w\.\/]+createdump \d+")
-                .And.Contain("Writing minidump");
-        }
-
-        private void RegisterCrashHandler(TestApplicationRunner runner)
-        {
-            var crashHandler = "/bin/echo";
-
-            if (!File.Exists(crashHandler))
-            {
-                _output.WriteLine($"Crash handler {crashHandler} does not exist.");
-                throw new FileNotFoundException($"Crash handler {crashHandler} does not exist.");
-            }
-
-            runner.Environment.SetVariable("DD_TRACE_CRASH_HANDLER", crashHandler);
-        }
     }
 }

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -409,7 +409,7 @@ internal class CreatedumpCommand : Command
 
             // Note: if refactoring, make sure to dispose the ClrMD DataTarget before calling createdump,
             // otherwise the calls to ptrace from createdump will fail
-            if (Environment.GetEnvironmentVariable("DD_TRACE_CRASH_HANDLER_PASSTHROUGH") == "1")
+            if (Environment.GetEnvironmentVariable("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH") == "1")
             {
                 if (allArguments.Length > 0)
                 {
@@ -547,7 +547,7 @@ internal class CreatedumpCommand : Command
 
         try
         {
-            var outputFile = Environment.GetEnvironmentVariable("DD_TRACE_CRASH_OUTPUT");
+            var outputFile = Environment.GetEnvironmentVariable("DD_INTERNAL_CRASHTRACKING_OUTPUT");
 
             if (!string.IsNullOrEmpty(outputFile))
             {

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -64,14 +64,14 @@ public class CreatedumpTests : ConsoleTestHelper
         // If it wasn't set, then we set it so that dd-dotnet will be invoked in case of crash.
         // If a child dotnet process is spawned, we may then mistakenly think that COMPlus_DbgEnableMiniDump
         // was set from the environment, even though it was set by us. To prevent that, we set the
-        // DD_TRACE_CRASH_HANDLER_PASSTHROUGH environment variable, which codifies the result of the
+        // DD_INTERNAL_CRASHTRACKING_PASSTHROUGH environment variable, which codifies the result of the
         // "was COMPlus_DbgEnableMiniDump set?" check.
 
         SkipOn.Platform(SkipOn.PlatformValue.MacOs);
 
         using var reportFile = new TemporaryFile();
 
-        (string, string)[] args = [LdPreloadConfig, .. CreatedumpConfig, ("DD_TRACE_CRASH_HANDLER_PASSTHROUGH", passthrough), CrashReportConfig(reportFile)];
+        (string, string)[] args = [LdPreloadConfig, .. CreatedumpConfig, ("DD_INTERNAL_CRASHTRACKING_PASSTHROUGH", passthrough), CrashReportConfig(reportFile)];
 
         using var helper = await StartConsoleWithArgs("crash-datadog", false, args);
 
@@ -103,7 +103,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         using var reportFile = new TemporaryFile();
 
-        (string, string)[] args = [LdPreloadConfig, ("DD_TRACE_CRASH_HANDLER_ENABLED", "0")];
+        (string, string)[] args = [LdPreloadConfig, ("DD_CRASHTRACKING_ENABLED", "0")];
 
         if (enableCrashDumps)
         {
@@ -444,7 +444,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
     private static (string Key, string Value) CrashReportConfig(TemporaryFile reportFile)
     {
-        return ("DD_TRACE_CRASH_OUTPUT", reportFile.Url);
+        return ("DD_INTERNAL_CRASHTRACKING_OUTPUT", reportFile.Url);
     }
 
     private static void CopyDirectory(string source, string destination)


### PR DESCRIPTION
## Summary of changes

Normalize the environment variable names used by crashtracking.

`DD_CRASHTRACKING_*`: environment variables expected to be set by the customers. Currently:
 - `DD_CRASHTRACKING_ENABLED`: enables or disables crashtracking (default: enabled)

`DD_INTERNAL_CRASHTRACKING_*`: environment variables used by the tracer infrastructure and/or tests. Currently:
 - `DD_INTERNAL_CRASHTRACKING_PASSTHROUGH`: automatically set to decide whether the real createdump should be called or not
 - `DD_INTERNAL_CRASHTRACKING_OUTPUT`: save the crash report to a file instead of using telemetry

## Reason for change

Now that other languages are implementing the feature, it's important to have consistent names.

## Implementation details

`DD_TRACE_CRASH_HANDLER` is not needed anymore, removed it.
Removed the profiler tests that relied on `DD_TRACE_CRASH_HANDLER` (they're not needed now that we have crashtracking tests).

## Test coverage

The existing tests were updated. 
