### PR TITLE
Fix musl tags for dd-lib-dotnet-init image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,6 +131,7 @@ publish-lib-init-pinned-tags-musl:
   needs: [ generate-lib-init-pinned-tag-values-musl ]
   variables:
     IMG_SOURCES: $GHCR_BASE/$LIB_INJECTION_NAME:${CI_COMMIT_SHA}-musl
+    IMG_DESTINATIONS: $IMG_DESTINATIONS_musl
 
 onboarding_tests_installer:
   parallel:


### PR DESCRIPTION
## Summary of changes
Musl tags generated from `generate-lib-init-pinned-tag-values-musl` have an `_musl` suffix. This PR ensures that the pinning job uses the correct variable.

