### PR TITLE
Need to freeze/unfreeze _all_ PRs

### DIFF
--- a/.github/actions/code-freeze/action.yml
+++ b/.github/actions/code-freeze/action.yml
@@ -23,7 +23,6 @@ runs:
         owner: DataDog
         repo: dd-trace-dotnet
         state: open
-        base: master
         per_page: 25
         page: ${{inputs.page_number}}
       env:


### PR DESCRIPTION
## Summary of changes

Removes the "master" filter on the freeze/unfreeze action

## Reason for change

Wasn't able to unfreeze PRs to `release/2.x` that were created when a code-freeze was in place

## Implementation details

Removed the `master` base requirement

## Test coverage

Ran a test [here](https://github.com/DataDog/dd-trace-dotnet/actions/runs/10401227237/job/28803320889) and it worked
