### PR TITLE
Ignore `StyleCop.Analyzers` in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       - "area:dependabot"
     ignore:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
+      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
       - dependency-name: "*" # Ignore patches for all integrations
         update-types: ["version-update:semver-patch"]
   # Src libraries
@@ -38,6 +39,8 @@ updates:
       # Lock Microsoft.Build.Framework for widest compatibility when instrumenting builds
       - dependency-name: "Microsoft.Build.Framework"
 
+      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
+
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.OpenTracing"
     schedule:
@@ -58,6 +61,8 @@ updates:
       # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
+
+      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
       ### End Datadog.Trace.csproj ignored dependencies
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
@@ -79,4 +84,6 @@ updates:
       # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
+
+      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
       ### End Datadog.Trace.csproj ignored dependencies


### PR DESCRIPTION
## Summary of changes

Adds `StyleCope.Analyzers` to the ignored dependencies within Dependabot.

## Reason for change

I've been looking into why it seemed that Dependabot wasn't creating PRs and found several issues in the logs:

```
`.../NuGet.targets(169,5): error : '[1.2.0-beta.*]' is not a valid version string. [...]`
```

This was repeated throughout all of the Dependabot logs and doesn't _appear_ to cause the run to loudly fail, but appears to cause it to silently fail. This version comes from here: https://github.com/DataDog/dd-trace-dotnet/blob/master/tracer/Directory.Build.props#L20

I attempted to replicate this issue and have had no luck. But I think it is fine to just try to ignore this package as it is a floating version anyway and will automatically update (and only applies to the editor).

## Implementation details

Added the package to the ignore list.

## Test coverage

- Attempted to debug this locally with MSBuild tasks to parse versions (which seemed fine) and with dependabot

## Other details

I don't think there is a way to manually run this file until it is merged.

There is another issue that may or may not be related with `InlineIL.Fody` and the `SourceGenerators` project, but want to fix this one first as it is in all of them.
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
