### PR TITLE
Fix gitlab build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,17 +22,17 @@ build:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
-    - if (Test-Path artifacts) { remove-item -recurse -force artifacts }
+    - if (Test-Path artifacts-out) { remove-item -recurse -force artifacts-out }
     - docker run --rm -m 8192M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e ENABLE_MULTIPROCESSOR_COMPILATION=false -e WINDOWS_BUILDER=true -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e NUGET_CERT_REVOCATION_MODE=offline registry.ddbuild.io/images/mirror/datadog/dd-trace-dotnet-docker-build:latest
-    - mkdir artifacts
-    - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts
+    - mkdir artifacts-out
+    - xcopy /e/s build-out\${CI_JOB_ID}\*.* artifacts-out
     - remove-item -recurse -force build-out\${CI_JOB_ID}
     - get-childitem build-out
-    - get-childitem artifacts
+    - get-childitem artifacts-out
   artifacts:
     expire_in: 2 weeks
     paths:
-    - artifacts
+    - artifacts-out
 
 publish:
   only:
@@ -60,7 +60,7 @@ publish:
       do {
           try {
               # The grants option at the end is used to allow public access on the files we upload as the acls only aren't enough.
-              aws s3 cp artifacts/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+              aws s3 cp artifacts-out/ s3://dd-windowsfilter/builds/tracer/${CI_COMMIT_SHA} --recursive --region us-east-1 --exclude "*" --include "*.zip" --include "*.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
               If ($LASTEXITCODE -eq 0) { 
                 return
               }

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,11 +14,6 @@ variables:
     description: "Used by the package stage when triggered manually"
 
 build:
-  only:
-    - master
-    - main
-    - /^hotfix.*$/
-    - /^release.*$/
   except:
     variables:
       - $DEPLOY_TO_REL_ENV == "true"


### PR DESCRIPTION
## Summary of changes

- Fixes the gitlab build that I broke by merging #5744
- Runs the build on every push

## Reason for change

I broke the build on master. It's happened one too many times, so changed this to _always_ do the build (i.e. in builds too). Seeing as that's what we're doing for one pipeline now anyway, doesn't make much sense to _not_ do it for the main build too IMO.

## Implementation details

- Removed the `only`
- Fixed the folder conflict in the gitlab job

Yes, we could probably do something tidier, no I couldn't be bothered right now 😅 

## Test coverage

This is the test - if it builds, we should be good 🤞 

## Other details

Docker on Windows in GitLab is so slow 😅 
