### PR TITLE
Pin `StyleCop.Analzyers` to latest pre-release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
       - "area:dependabot"
     ignore:
       - dependency-name: "MessagePack" # Locked at a version that supports our net452 build target
-      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
       - dependency-name: "*" # Ignore patches for all integrations
         update-types: ["version-update:semver-patch"]
   # Src libraries
@@ -39,8 +38,6 @@ updates:
       # Lock Microsoft.Build.Framework for widest compatibility when instrumenting builds
       - dependency-name: "Microsoft.Build.Framework"
 
-      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
-
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.OpenTracing"
     schedule:
@@ -61,8 +58,6 @@ updates:
       # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
-
-      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
       ### End Datadog.Trace.csproj ignored dependencies
   - package-ecosystem: "nuget"
     directory: "/tracer/src/Datadog.Trace.BenchmarkDotNet"
@@ -84,6 +79,4 @@ updates:
       # DuckTyping libraries are kept at the lowest supported version for compatibility on netstandard2.0
       - dependency-name: "System.Reflection.Emit"
       - dependency-name: "System.Reflection.Emit.Lightweight"
-
-      - dependency-name: "StyleCop.Analyzers" # floating version is being used and it seemed to break dependabot (for some reason)
       ### End Datadog.Trace.csproj ignored dependencies

--- a/profiler/Directory.Build.props
+++ b/profiler/Directory.Build.props
@@ -172,7 +172,7 @@
 
     <!-- StyleCop -->
     <ItemGroup Condition=" '$(MSBuildProjectExtension)' == '.csproj' And '$(MSBuildProjectName)' != 'Website-AspNet' ">
-        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.*" PrivateAssets="all" />
+        <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
         <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
         <Compile Include="$(MSBuildThisFileDirectory)\src\GlobalSuppressions.cs" Link="GlobalSuppressions.solution.cs" />
     </ItemGroup>

--- a/tracer/Directory.Build.props
+++ b/tracer/Directory.Build.props
@@ -17,7 +17,7 @@
 
   <!-- StyleCop -->
   <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.*" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="all" />
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" Link="stylecop.json" />
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" Link="GlobalSuppressions.solution.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Summary of changes

:sorry:

Pins `StyleCop.Analyzers` to the latest prerelease instead of a floating version.
Reverts ignoring `StyleCop.Analyzers` in Dependabot because that did nothing.

## Reason for change

Dependabot still struggling with ` error : '[1.2.0-beta.*]' is not a valid version string`

## Implementation details

Updated both locations of `StyleCop.Analzyer` to the latest pre-release
Dependabot will attempt to update this package again

## Test coverage

- Nothing

## Other details
If this doesn't fix it I'll find a better way to update/test this without having to PR and merge to run dependabot.
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
