### PR TITLE
Remove prerelease flag from smoke tests

### DIFF
--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -22,7 +22,7 @@ ARG INSTALL_CMD
 RUN mkdir -p /opt/datadog \
     && mkdir -p /var/log/datadog \
     && mkdir -p /tool \
-    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. --prerelease \
+    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. \
     && rm -rf /app/install
 
 # Set the optional env vars


### PR DESCRIPTION
## Summary of changes

Fix the nuget smoke tests on .NET Core 3.1

## Reason for change

We had to add the prerelease flag to support testing prerelease version of the nuget, but it breaks on 3.1 which doesn't support it. Tried to find a neater way around this but got bored, and just want it to work 😅 

## Implementation details

Remove the flag

## Test coverage

This is the test
