### PR TITLE
Enable ad-hoc memory dumps on Windows x86

### DIFF
--- a/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/MemoryDumpHelper.cs
@@ -18,6 +18,8 @@ namespace Datadog.Trace.TestHelpers
 
         private static IProgress<string> _output;
 
+        private static bool _isCrashMonitoringAvailable = true;
+
         public static bool IsAvailable => _path != null;
 
         public static async Task InitializeAsync(IProgress<string> progress)
@@ -34,7 +36,7 @@ namespace Datadog.Trace.TestHelpers
             if (!EnvironmentTools.IsTestTarget64BitProcess())
             {
                 // We currently have an issue with procdump on x86
-                return;
+                _isCrashMonitoringAvailable = false;
             }
 
             // We don't know if procdump is available, so download it fresh
@@ -60,7 +62,7 @@ namespace Datadog.Trace.TestHelpers
 
         public static Task MonitorCrashes(int pid)
         {
-            if (!EnvironmentTools.IsWindows() || !IsAvailable)
+            if (!EnvironmentTools.IsWindows() || !IsAvailable || !_isCrashMonitoringAvailable)
             {
                 return Task.CompletedTask;
             }
@@ -128,6 +130,7 @@ namespace Datadog.Trace.TestHelpers
         {
             if (!IsAvailable)
             {
+                _output?.Report("Memory dumps not enabled");
                 return false;
             }
 


### PR DESCRIPTION
## Summary of changes

Enable ad-hoc memory dumps on Windows x86.
As part of https://github.com/DataDog/dd-trace-dotnet/pull/5046, I disabled procdump on Windows x86 because it caused issue when monitoring a process. However, by doing so I also disabled "on-demand" memory dumps which _should_ work perfectly fine.

## Reason for change

Needed to investigate mysterious timeouts in dd-dotnet tests.

## Implementation details

Added a `_isCrashMonitoringAvailable` flag to distinguish the two use-cases.