### PR TITLE
Fix signature size check in ModifyLocalSig

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/calltarget_tokens.cpp
+++ b/tracer/src/Datadog.Tracer.Native/calltarget_tokens.cpp
@@ -374,7 +374,7 @@ HRESULT CallTargetTokens::ModifyLocalSig(ILRewriter* reWriter, TypeSignature* me
         // should be the callTargetState)
         unsigned temp = 0;
         const auto len = CorSigCompressToken(callTargetStateTypeRef, &temp);
-        if (originalSignatureSize - len > 0)
+        if (originalSignatureSize > len)
         {
             if (originalSignature[originalSignatureSize - len - 1] == ELEMENT_TYPE_VALUETYPE)
             {


### PR DESCRIPTION
## Summary of changes

Fix signature size check in `ModifyLocalSig`.

## Reason for change

Detected by static analysis.

## Implementation details

Because `originalSignatureSize` and `len` are unsigned, their subtraction is unsigned and thus can't be negative.