### PR TITLE
Use a native logger for critical failures in the loader

### DIFF
--- a/shared/src/native-src/string.cpp
+++ b/shared/src/native-src/string.cpp
@@ -32,16 +32,16 @@ namespace shared {
 #ifdef _WIN32
         if (nbChars == 0) return std::string();
 
-        char tmpStr[tmp_buffer_size] = { 0 };
+        char tmpStr[tmp_buffer_size] = {0};
         int size_needed =
-            WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, &tmpStr[0], tmp_buffer_size, nullptr, nullptr);
+            WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) nbChars, &tmpStr[0], tmp_buffer_size, nullptr, nullptr);
         if (size_needed < tmp_buffer_size)
         {
             return std::string(tmpStr, size_needed);
         }
 
         std::string strTo(size_needed, 0);
-        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, &strTo[0], size_needed, nullptr, nullptr);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) nbChars, &strTo[0], size_needed, nullptr, nullptr);
         return strTo;
 #else
         std::u16string ustr(reinterpret_cast<const char16_t*>(wstr), nbChars);
@@ -68,7 +68,7 @@ namespace shared {
 #ifdef _WIN32
         if (str.empty()) return std::wstring();
 
-        wchar_t tmpStr[tmp_buffer_size] = { 0 };
+        wchar_t tmpStr[tmp_buffer_size] = {0};
         int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &tmpStr[0], tmp_buffer_size);
         if (size_needed < tmp_buffer_size) {
             return std::wstring(tmpStr, size_needed);
@@ -135,12 +135,12 @@ namespace shared {
         return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
     }
 
-    bool StartsWith(const std::string& str, const std::string& prefix)
+    bool StartsWith(const std::string &str, const std::string &prefix)
     {
         return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
     }
 
-    bool StartsWith(const WSTRING& str, const WSTRING& prefix)
+    bool StartsWith(const WSTRING &str, const WSTRING &prefix)
     {
         return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
     }

--- a/shared/src/native-src/string.cpp
+++ b/shared/src/native-src/string.cpp
@@ -33,15 +33,19 @@ namespace shared {
         if (nbChars == 0) return std::string();
 
         char tmpStr[tmp_buffer_size] = {0};
-        int size_needed =
+        int charsWritten =
             WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) nbChars, &tmpStr[0], tmp_buffer_size, nullptr, nullptr);
-        if (size_needed < tmp_buffer_size)
+
+        if (charsWritten < tmp_buffer_size && charsWritten != 0)
         {
-            return std::string(tmpStr, size_needed);
+            return std::string(tmpStr, charsWritten);
         }
 
-        std::string strTo(size_needed, 0);
-        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) nbChars, &strTo[0], size_needed, nullptr, nullptr);
+        // Get the actual size needed
+        auto sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, nullptr, 0, nullptr, nullptr);
+
+        std::string strTo(sizeNeeded, 0);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) nbChars, &strTo[0], sizeNeeded, nullptr, nullptr);
         return strTo;
 #else
         std::u16string ustr(reinterpret_cast<const char16_t*>(wstr), nbChars);

--- a/shared/src/native-src/string.cpp
+++ b/shared/src/native-src/string.cpp
@@ -32,20 +32,16 @@ namespace shared {
 #ifdef _WIN32
         if (nbChars == 0) return std::string();
 
-        char tmpStr[tmp_buffer_size] = {0};
-        int charsWritten =
-            WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) nbChars, &tmpStr[0], tmp_buffer_size, nullptr, nullptr);
-
-        if (charsWritten < tmp_buffer_size && charsWritten != 0)
+        char tmpStr[tmp_buffer_size] = { 0 };
+        int size_needed =
+            WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, &tmpStr[0], tmp_buffer_size, nullptr, nullptr);
+        if (size_needed < tmp_buffer_size)
         {
-            return std::string(tmpStr, charsWritten);
+            return std::string(tmpStr, size_needed);
         }
 
-        // Get the actual size needed
-        auto sizeNeeded = WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, nullptr, 0, nullptr, nullptr);
-
-        std::string strTo(sizeNeeded, 0);
-        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int) nbChars, &strTo[0], sizeNeeded, nullptr, nullptr);
+        std::string strTo(size_needed, 0);
+        WideCharToMultiByte(CP_UTF8, 0, &wstr[0], (int)nbChars, &strTo[0], size_needed, nullptr, nullptr);
         return strTo;
 #else
         std::u16string ustr(reinterpret_cast<const char16_t*>(wstr), nbChars);
@@ -72,7 +68,7 @@ namespace shared {
 #ifdef _WIN32
         if (str.empty()) return std::wstring();
 
-        wchar_t tmpStr[tmp_buffer_size] = {0};
+        wchar_t tmpStr[tmp_buffer_size] = { 0 };
         int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &tmpStr[0], tmp_buffer_size);
         if (size_needed < tmp_buffer_size) {
             return std::wstring(tmpStr, size_needed);
@@ -139,12 +135,12 @@ namespace shared {
         return str.size() >= suffix.size() && str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
     }
 
-    bool StartsWith(const std::string &str, const std::string &prefix)
+    bool StartsWith(const std::string& str, const std::string& prefix)
     {
         return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
     }
 
-    bool StartsWith(const WSTRING &str, const WSTRING &prefix)
+    bool StartsWith(const WSTRING& str, const WSTRING& prefix)
     {
         return str.size() >= prefix.size() && str.compare(0, prefix.size(), prefix) == 0;
     }

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -74,7 +74,6 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
             }
             catch (Exception ex)
             {
-                // if we're in SSI we want to be as safe as possible, so catching to avoid the possibility of a crash
                 try
                 {
                     StartupLogger.Log(ex, "Error in Datadog.Trace.ClrProfiler.Managed.Loader.Startup.Startup(). Functionality may be impacted.");
@@ -82,30 +81,11 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
                 }
                 catch
                 {
-                    // Swallowing any errors here, as something went _very_ wrong, even with logging
-                    // and we 100% don't want to crash in SSI. Outside of SSI we do want to see the crash
-                    // so that it's visible to the user.
-                    if (IsInSsi())
-                    {
-                        return;
-                    }
+                    // Nothing to do here.
                 }
 
+                // If the logger fails, throw the original exception. The profiler emits code to log it.
                 throw;
-            }
-
-            static bool IsInSsi()
-            {
-                try
-                {
-                    // Not using the ReadEnvironmentVariable method here to avoid logging (which could cause a crash itself)
-                    return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DD_INJECTION_ENABLED"));
-                }
-                catch
-                {
-                    // sigh, nothing works, _pretend_ we're in SSI so that we don't crash the app
-                    return true;
-                }
             }
         }
 

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.cpp
@@ -1,7 +1,5 @@
 #include "cor_profiler.h"
 
-#include <iostream>
-
 #include "corhlpr.h"
 #include <corprof.h>
 #include <string>
@@ -3854,6 +3852,17 @@ HRESULT CorProfiler::GenerateVoidILStartupMethod(const ModuleID module_id, mdMet
     rewriterWrapper_void.CreateInstr(CEE_LEAVE_S, returnInstr);
 
     // Step 7) Catch block
+    // catch (Exception ex)
+    // {
+    //      var message = "An error occured in the managed loader: " + ex.ToString();
+    //      var chars = message.ToCharArray();
+    // 
+    //      fixed (char* p = chars)
+    //      {
+    //          var nativeLog = (delegate* unmanaged<int, IntPtr, int, void>)0xFFFFFFFF; // Replaced with the actual address
+    //          nativeLog(3, p, chars.Length);
+    //      }
+    // }
     auto catchBegin = rewriterWrapper_void.CallMember(object_to_string_member_ref, true);
     rewriterWrapper_void.StLocal(6);
     rewriterWrapper_void.LoadStr(error_token);

--- a/tracer/src/Datadog.Tracer.Native/cor_profiler.h
+++ b/tracer/src/Datadog.Tracer.Native/cor_profiler.h
@@ -115,6 +115,7 @@ private:
     static void RewritingPInvokeMaps(const ModuleMetadata& module_metadata, const shared::WSTRING& rewrite_reason,
                                      const shared::WSTRING& nativemethods_type_name,
                                      const shared::WSTRING& library_path = shared::WSTRING());
+    static void __stdcall NativeLog(int32_t level, const WCHAR* message, int32_t length);
     bool GetIntegrationTypeRef(ModuleMetadata& module_metadata, ModuleID module_id,
                                const IntegrationDefinition& integration_definition, mdTypeRef& integration_type_ref);
     bool ProfilerAssemblyIsLoadedIntoAppDomain(AppDomainID app_domain_id);

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.cpp
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.cpp
@@ -375,6 +375,24 @@ ILInstr* ILRewriterWrapper::CreateInstr(unsigned opCode) const
     return pNewInstr;
 }
 
+ILInstr* ILRewriterWrapper::CreateInstr(unsigned opCode, uint32_t arg) const
+{
+    ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
+    pNewInstr->m_opcode = opCode;
+    pNewInstr->m_Arg32 = arg;
+    m_ILRewriter->InsertBefore(m_ILInstr, pNewInstr);
+    return pNewInstr;
+}
+
+ILInstr* ILRewriterWrapper::CreateInstr(unsigned opCode, ILInstr* target) const
+{
+    ILInstr* pNewInstr = m_ILRewriter->NewILInstr();
+    pNewInstr->m_opcode = opCode;
+    pNewInstr->m_pTarget = target;
+    m_ILRewriter->InsertBefore(m_ILInstr, pNewInstr);
+    return pNewInstr;
+}
+
 ILInstr* ILRewriterWrapper::InitObj(mdTypeRef type_ref) const
 {
     ILInstr* pNewInstr = m_ILRewriter->NewILInstr();

--- a/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.h
+++ b/tracer/src/Datadog.Tracer.Native/il_rewriter_wrapper.h
@@ -47,6 +47,8 @@ public:
     ILInstr* EndFinally() const;
 
     ILInstr* CreateInstr(unsigned opCode) const;
+    ILInstr* CreateInstr(unsigned opCode, uint32_t arg) const;
+    ILInstr* CreateInstr(unsigned opCode, ILInstr* target) const;
     ILInstr* InitObj(mdTypeRef type_ref) const;
 };
 


### PR DESCRIPTION
## Summary of changes

Wrap the call to the managed loader in a try/catch, and use a native logger to log the exception if any.

## Reason for change

There's already a try/catch in the managed loader, but in some situations we can fail before even getting there (if jitting the method failed, for instance because of a trimmed runtime). Also, the managed loader logger can fail.

## Implementation details

This PR adds a try/catch in the code emitted to load the managed loader. In the catch clause, we call a native logging function, with a direct unmanaged `calli` call to its address.

Because we have now this outer catch block, I removed the `IsInSsi` logic which isn't needed anymore.
