### PR TITLE
Add support for alpine on arm64 

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5470,7 +5470,7 @@ stages:
         - template: steps/run-in-docker.yml
           parameters:
             build: true
-            baseImage: debian
+            baseImage: alpine
             command: "CheckSmokeTestsForErrors"
 
 - stage: installer_chiseled_smoke_tests_arm64
@@ -5634,7 +5634,7 @@ stages:
     - template: steps/run-in-docker.yml
       parameters:
         build: true
-        baseImage: debian
+        baseImage: alpine
         command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_smoke_tests_arm64
@@ -5697,81 +5697,8 @@ stages:
     - template: steps/run-in-docker.yml
       parameters:
         build: true
-        baseImage: debian
+        baseImage: alpine
         command: "CheckSmokeTestsForErrors"
-
-- stage: installer_noop_smoke_tests_arm64
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [package_arm64, generate_variables, merge_commit_id]
-  variables:
-    targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
-    targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-  jobs:
-    - template: steps/update-github-status-jobs.yml
-      parameters:
-        jobs: [linux]
-
-    - job: linux
-      timeoutInMinutes: 45 # should take ~15 mins
-      strategy:
-        matrix: $[ stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.installer_noop_smoke_tests_arm64_matrix'] ]
-      variables:
-        smokeTestAppDir: "$(System.DefaultWorkingDirectory)/tracer/test/test-applications/regression/AspNetCoreSmokeTest"
-      pool:
-        name: aws-arm64-auto-scaling
-
-      steps:
-        - template: steps/clone-repo.yml
-          parameters:
-            targetShaId: $(targetShaId)
-            targetBranch: $(targetBranch)
-
-        - task: DownloadPipelineArtifact@2
-          displayName: Download artifacts to smoke test directory
-          inputs:
-            artifact: $(linuxArtifacts)
-            path: $(smokeTestAppDir)/artifacts
-
-        # Run the "normal" noop installer smoke tests 
-        - script: |
-            docker-compose -p $(DockerComposeProjectName) build \
-              --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
-              --build-arg RUNTIME_IMAGE=$(runtimeImage) \
-              --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
-              smoke-tests
-          env:
-            dockerTag: $(dockerTag)
-            DD_LOGGER_DD_API_KEY: $(ddApiKey)
-          displayName: docker-compose build smoke-tests
-          retryCountOnTaskFailure: 3
-
-        - template: steps/run-snapshot-test.yml
-          parameters:
-            target: 'smoke-tests'
-            snapshotPrefix: "smoke_test"
-            isNoop: true
-        
-        # Run the "dd-dotnet" "unsupported tfm" installer smoke tests
-        - script: |
-            echo "Expected installer: $(expectedInstaller)"
-
-            cd tracer/build/artifacts
-            result=$(docker run --rm -v ${PWD}:/app --entrypoint /app/dd-dotnet.sh $(runtimeImage))
-            if [[ "$result" != *"$(expectedInstaller)"* ]]; then
-              echo "Incorrect message. Expected '$(expectedInstaller)', but found:"
-              echo $result
-              exit 1
-            fi
-
-            echo "Received expected response:"
-            echo $result
-
-          displayName: Run artifact test (expecting failure)
-
-        - publish: artifacts/build_data
-          artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
-          condition: succeededOrFailed()
-          continueOnError: true
 
 - stage: nuget_installer_smoke_tests_windows
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -620,6 +620,14 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     dependsOn: []
+    strategy:
+      matrix:
+        arm64:
+          baseImage: debian
+          artifactSuffix: linux-arm64
+        alpine:
+          baseImage: alpine
+          artifactSuffix: linux-musl-arm64
     pool:
       name: aws-arm64-auto-scaling
     workspace:
@@ -633,21 +641,21 @@ stages:
       parameters:
         build: true
         target: builder
-        baseImage: debian
+        baseImage: $(baseImage)
         command: "Clean CompileManagedLoader BuildNativeTracerHome BuildManagedTracerHome ExtractDebugInfoLinux"
         retryCountForRunCommand: 1
 
     - publish: $(monitoringHome)
       displayName: Uploading linux tracer home artifact
-      artifact: linux-tracer-home-linux-arm64
+      artifact: linux-tracer-home-$(artifactSuffix)
 
     - publish: $(System.DefaultWorkingDirectory)
       displayName: Upload working directory after the build
-      artifact: build-linux-arm64-working-directory
+      artifact: build-$(artifactSuffix)-working-directory
 
     - publish: $(symbols)
       displayName: Upload linux tracer symbols
-      artifact: linux-tracer-symbols-linux-arm64
+      artifact: linux-tracer-symbols-$(artifactSuffix)
 
 - stage: build_arm64_profiler
   dependsOn: [merge_commit_id]
@@ -662,6 +670,14 @@ stages:
   - job: build
     timeoutInMinutes: 60 #default value
     dependsOn: []
+    strategy:
+      matrix:
+        arm64:
+          baseImage: debian
+          artifactSuffix: linux-arm64
+        alpine:
+          baseImage: alpine
+          artifactSuffix: linux-musl-arm64
     pool:
       name: aws-arm64-auto-scaling
     workspace:
@@ -675,21 +691,21 @@ stages:
       parameters:
         build: true
         target: builder
-        baseImage: debian
+        baseImage: $(baseImage)
         command: "Clean BuildProfilerHome ExtractDebugInfoLinux"
         retryCountForRunCommand: 1
 
     - publish: $(System.DefaultWorkingDirectory)/profiler/_build
       displayName: Uploading linux profiler output build folder
-      artifact: linux-profiler-binaries-linux-arm64
+      artifact: linux-profiler-binaries-$(artifactSuffix)
 
     - publish: $(monitoringHome)
       displayName: Uploading linux profiler home artifact
-      artifact: linux-profiler-home-linux-arm64
+      artifact: linux-profiler-home-$(artifactSuffix)
 
     - publish: $(symbols)
       displayName: Upload linux profiler symbols
-      artifact: linux-profiler-symbols-linux-arm64
+      artifact: linux-profiler-symbols-$(artifactSuffix)
 
 - stage: build_arm64_universal
   dependsOn: [merge_commit_id]
@@ -744,6 +760,14 @@ stages:
   - job: package
     dependsOn: []
     timeoutInMinutes: 60 #default value
+    strategy:
+      matrix:
+        arm64:
+          baseImage: debian
+          artifactSuffix: linux-arm64
+        alpine:
+          baseImage: alpine
+          artifactSuffix: linux-musl-arm64
     pool:
       name: aws-arm64-auto-scaling
 
@@ -752,27 +776,52 @@ stages:
       parameters:
         targetShaId: $(targetShaId)
         targetBranch: $(targetBranch)
-
+      
+      # Download _both_ musl and glibc if we're building the universal package
+      # but only the musl package if we're building alpine package
     - task: DownloadPipelineArtifact@2
       displayName: Download tracer arm64 native binary
+      condition: eq(variables['artifactSuffix'], 'linux-arm64')
       inputs:
         artifact: linux-tracer-home-linux-arm64
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
       displayName: Download profiler arm64 native binary
+      condition: eq(variables['artifactSuffix'], 'linux-arm64')
       inputs:
         artifact: linux-profiler-home-linux-arm64
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
       displayName: Download dd-dotnet linux-arm64
+      condition: eq(variables['artifactSuffix'], 'linux-arm64')
       inputs:
         artifact: dd-dotnet-linux-arm64
         path: $(monitoringHome)/linux-arm64
 
+    - task: DownloadPipelineArtifact@2
+      displayName: Download tracer linux-musl-arm64 native binary
+      inputs:
+        artifact: linux-tracer-home-linux-musl-arm64
+        path: $(monitoringHome)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download profiler linux-musl-arm64 native binary
+      inputs:
+        artifact: linux-profiler-home-linux-musl-arm64
+        path: $(monitoringHome)
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download dd-dotnet linux-musl-arm64
+      inputs:
+        artifact: dd-dotnet-linux-musl-arm64
+        path: $(monitoringHome)/linux-musl-arm64
+
     - script: |
-        chmod +x $(monitoringHome)/linux-arm64/dd-dotnet
+        chmod +x $(monitoringHome)/linux-musl-arm64/dd-dotnet
+        # don't panic if the file doesn't exist
+        chmod +x $(monitoringHome)/linux-arm64/dd-dotnet | :
       displayName: chmod dd-dotnet
 
     - task: DownloadPipelineArtifact@2
@@ -785,17 +834,17 @@ stages:
       parameters:
         build: true
         target: builder
-        baseImage: debian
+        baseImage: $(baseImage)
         command: "ZipMonitoringHome"
         retryCountForRunCommand: 1
 
     - publish: $(artifacts)/linux-arm64
       displayName: Upload arm64 packages
-      artifact: linux-packages-linux-arm64
+      artifact: linux-packages-$(artifactSuffix)
 
     - publish: $(monitoringHome)
       displayName: Upload arm64 monitoring home
-      artifact: linux-monitoring-home-linux-arm64
+      artifact: linux-monitoring-home-$(artifactSuffix)
 
 - stage: build_macos
   condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'))
@@ -1018,8 +1067,6 @@ stages:
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
-    baseImage: debian
-    artifactSuffix: linux-arm64
     targetFramework: net8.0
   jobs:
   - template: steps/update-github-status-jobs.yml
@@ -1028,6 +1075,14 @@ stages:
 
   - job: linux
     timeoutInMinutes: 60 #default value
+    strategy:
+      matrix:
+        x64:
+          baseImage: debian
+          artifactSuffix: linux-arm64
+        alpine:
+          baseImage: alpine
+          artifactSuffix: linux-musl-arm64
 
     pool:
       name: aws-arm64-auto-scaling
@@ -3382,6 +3437,15 @@ stages:
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
+      displayName: Download alpine arm64 tracer home
+      inputs:
+        artifact: linux-tracer-home-linux-musl-arm64
+        patterns:  |
+          **/*.so
+          **/loader.conf
+        path: $(monitoringHome)
+
+    - task: DownloadPipelineArtifact@2
       displayName: Download osx tracer home
       inputs:
         artifact: macos-tracer-home
@@ -3425,6 +3489,15 @@ stages:
         path: $(monitoringHome)
 
     - task: DownloadPipelineArtifact@2
+      displayName: Download alpine arm64 profiler home
+      inputs:
+        artifact: linux-profiler-home-linux-musl-arm64
+        patterns:  |
+          **/*.so
+          **/loader.conf
+        path: $(monitoringHome)
+
+    - task: DownloadPipelineArtifact@2
       displayName: Download dd-dotnet win-x64
       inputs:
         artifact: dd-dotnet-win-x64
@@ -3449,6 +3522,12 @@ stages:
         path: $(monitoringHome)/linux-arm64
 
     - task: DownloadPipelineArtifact@2
+      displayName: Download dd-dotnet linux-musl-arm64
+      inputs:
+        artifact: dd-dotnet-linux-musl-arm64
+        path: $(monitoringHome)/linux-musl-arm64
+
+    - task: DownloadPipelineArtifact@2
       displayName: Download linux universal artifacts 
       inputs:
         artifact: linux-universal-home-linux-x64
@@ -3465,6 +3544,12 @@ stages:
       inputs:
         artifact: linux-universal-home-linux-arm64
         path: $(monitoringHome)/linux-arm64
+
+    - task: DownloadPipelineArtifact@2
+      displayName: Download linux universal artifacts
+      inputs:
+        artifact: linux-universal-home-linux-arm64
+        path: $(monitoringHome)/linux-musl-arm64
 
     - script: tracer\build.cmd CreateBundleHome BuildBundleNuget BuildRunnerTool PackRunnerToolNuget BuildStandaloneTool BuildBenchmarkNuget
       displayName: Build Bundle, Benchmark NuGet and tools
@@ -3502,6 +3587,10 @@ stages:
     - publish: $(artifacts)/dd-trace-linux-arm64.tar.gz
       displayName: Uploading runner standalone linux-arm64 artifact
       artifact: runner-standalone-linux-arm64
+
+    - publish: $(artifacts)/dd-trace-linux-musl-arm64.tar.gz
+      displayName: Uploading runner standalone linux-musl-arm64 artifact
+      artifact: runner-standalone-linux-musl-arm64
 
     - publish: $(artifacts)/dd-trace-osx-x64.tar.gz
       displayName: Uploading runner standalone osx-x64 artifact

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -828,7 +828,7 @@ stages:
       displayName: Download universal native binaries
       inputs:
         artifact: linux-universal-home-linux-arm64
-        path: $(monitoringHome)/linux-arm64
+        path: $(monitoringHome)/$(artifactSuffix)
 
     - template: steps/run-in-docker.yml
       parameters:
@@ -1377,6 +1377,14 @@ stages:
 
     - job: test
       timeoutInMinutes: 60 #default value
+      strategy:
+        matrix:
+          arm64:
+            baseImage: debian
+            artifactSuffix: linux-arm64
+          alpine:
+            baseImage: alpine
+            artifactSuffix: linux-musl-arm64
       pool:
         name: aws-arm64-auto-scaling
       workspace:
@@ -1388,12 +1396,12 @@ stages:
             targetBranch: $(targetBranch)
         - template: steps/restore-working-directory.yml
           parameters:
-            artifact: build-linux-arm64-working-directory
+            artifact: build-$(artifactSuffix)-working-directory
 
         - template: steps/run-in-docker.yml
           parameters:
             build: true
-            baseImage: debian
+            baseImage: $(baseImage)
             command: "BuildAndRunManagedUnitTests"
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
@@ -2757,6 +2765,7 @@ stages:
 
     - job: Test
       timeoutInMinutes: 60 #default value
+      # TODO: move this to GenerateVariables stage
       strategy:
         matrix: $[stageDependencies.generate_variables.generate_variables_job.outputs['generate_variables_step.integration_tests_linux_arm64_matrix']]
       workspace:
@@ -3714,7 +3723,7 @@ stages:
           artifactSuffix: linux-x64
           poolName: azure-linux-scale-set-2
           targetArch: x64
-        alpine:
+        alpine_x64:
           baseImage: alpine
           artifactSuffix: linux-musl-x64
           poolName: azure-linux-scale-set-2
@@ -3722,6 +3731,11 @@ stages:
         arm64:
           baseImage: debian
           artifactSuffix: linux-arm64
+          poolname: aws-arm64-auto-scaling
+          targetArch: arm64
+        alpine_arm64:
+          baseImage: alpine
+          artifactSuffix: linux-musl-arm64
           poolname: aws-arm64-auto-scaling
           targetArch: arm64
 

--- a/Datadog.Trace.Minimal.slnf
+++ b/Datadog.Trace.Minimal.slnf
@@ -2,7 +2,6 @@
   "solution": {
     "path": "Datadog.Trace.sln",
     "projects": [
-      "tracer\\build\\_build\\_build.csproj",
       "tracer\\src\\Datadog.Trace.ClrProfiler.Managed.Loader\\Datadog.Trace.ClrProfiler.Managed.Loader.csproj",
       "tracer\\src\\Datadog.Tracer.Native\\Datadog.Tracer.Native.DLL.vcxproj",
       "tracer\\src\\Datadog.Tracer.Native\\Datadog.Tracer.Native.vcxproj",

--- a/build/cmake/FindLibunwind.cmake
+++ b/build/cmake/FindLibunwind.cmake
@@ -9,7 +9,7 @@ ExternalProject_Add(libunwind
     INSTALL_COMMAND ""
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -O3\ -g CFLAGS=-fPIC\ -O3\ -g --disable-minidebuginfo --disable-zlibdebuginfo && make -j$(nproc)
+    BUILD_COMMAND autoreconf -i <SOURCE_DIR> && <SOURCE_DIR>/configure CXXFLAGS=-fPIC\ -D_GLIBCXX_USE_CXX11_ABI=0\ -O3\ -g CFLAGS=-fPIC\ -O3\ -g --disable-minidebuginfo --disable-zlibdebuginfo --disable-tests && make -j$(nproc)
     BUILD_ALWAYS false
     BUILD_BYPRODUCTS ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind-${CMAKE_SYSTEM_PROCESSOR}.a
                      ${LIBUNWIND_BINARY_DIR}/src/.libs/libunwind.a

--- a/docs/Datadog.Trace.Bundle/README.md
+++ b/docs/Datadog.Trace.Bundle/README.md
@@ -69,13 +69,14 @@ DD_DOTNET_TRACER_HOME=<APP_DIRECTORY>/datadog
 
 The value for the `<APP_DIRECTORY>` placeholder is the path to the directory containing the application’s .dll files. The value for the `CORECLR_PROFILER_PATH`/`COR_PROFILER_PATH` environment variable varies based on the system where the application is running:
 
-| OPERATING SYSTEM AND PROCESS ARCHITECTURE      | CORECLR_PROFILER_PATH VALUE |
-| ----------- | ----------- |
-| Alpine Linux x64      | <APP_DIRECTORY>/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so       |
-| Linux x64   | <APP_DIRECTORY>/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so        |
-| Linux ARM64      | <APP_DIRECTORY>/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so       |
-| Windows x64   | <APP_DIRECTORY>\datadog\win-x64\Datadog.Trace.ClrProfiler.Native.dll        |
-| Windows x86      | <APP_DIRECTORY>\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll       |
+| OPERATING SYSTEM AND PROCESS ARCHITECTURE | CORECLR_PROFILER_PATH VALUE                                                  |
+|-------------------------------------------|------------------------------------------------------------------------------|
+| Alpine Linux x64                          | <APP_DIRECTORY>/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so   |
+| Linux x64                                 | <APP_DIRECTORY>/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so        |
+| Alpine Linux ARM64                        | <APP_DIRECTORY>/datadog/linux-musl-arm64/Datadog.Trace.ClrProfiler.Native.so |
+| Linux ARM64                               | <APP_DIRECTORY>/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so      |
+| Windows x64                               | <APP_DIRECTORY>\datadog\win-x64\Datadog.Trace.ClrProfiler.Native.dll         |
+| Windows x86                               | <APP_DIRECTORY>\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll         |
 
 For Docker images running on Linux, configure the image to run the createLogPath.sh script:
 

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/EnvironmentHelper.cs
@@ -326,7 +326,8 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 ("win", "x86", _) => "win-x86",
                 ("linux", "x64", false) => "linux-x64",
                 ("linux", "x64", true) => "linux-musl-x64",
-                ("linux", "Arm64", _) => "linux-arm64",
+                ("linux", "Arm64", false) => "linux-arm64",
+                ("linux", "Arm64", true) => "linux-musl-arm64",
                 ("osx", _, _) => "osx-x64",
                 _ => throw new PlatformNotSupportedException()
             };

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/loader.conf
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/loader.conf
@@ -4,6 +4,7 @@ PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x86;.\Datadog.Profiler.Nativ
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-x64;./Datadog.Profiler.Native.so
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-musl-x64;./Datadog.Profiler.Native.so
 PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-arm64;./Datadog.Profiler.Native.so
+PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};linux-musl-arm64;./Datadog.Profiler.Native.so
 
 #Tracer
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-arm64;.\Datadog.Tracer.Native.dll
@@ -12,6 +13,7 @@ TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};win-x86;.\Datadog.Tracer.Native.dl
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-x64;./Datadog.Tracer.Native.so
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-musl-x64;./Datadog.Tracer.Native.so
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-arm64;./Datadog.Tracer.Native.so
+TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};linux-musl-arm64;./Datadog.Tracer.Native.so
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};osx-x64;./Datadog.Tracer.Native.dylib
 TRACER;{50DA5EED-F1ED-B00B-1055-5AFE55A1ADE5};osx-arm64;./Datadog.Tracer.Native.dylib
 

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -901,7 +901,7 @@ partial class Build
 
                 if (isTar)
                 {
-                    var includeMuslArtifacts = !IsAlpine && !IsArm64;
+                    var includeMuslArtifacts = !IsAlpine;
 
                     // On x64, for tar only, we package the linux-musl-x64 target as well, to simplify onboarding
                     PrepareMonitoringHomeLinuxForPackaging(assetsDirectory, arch, ext, muslArch, includeMuslArtifacts);

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -260,6 +260,7 @@ partial class Build : NukeBuild
                 var baseImages = new []
                 {
                     (baseImage: "debian", artifactSuffix: "linux-arm64"),
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-arm64"),
                 };
 
                 var targetFrameworks = GetTestingFrameworks(isArm64: true).Except(new[] { TargetFramework.NET461, TargetFramework.NET462, TargetFramework.NETSTANDARD2_0 });
@@ -1277,7 +1278,7 @@ partial class Build : NukeBuild
             void GenerateIntegrationTestsDebuggerArm64Matrices()
             {
                 var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462, TargetFramework.NETCOREAPP2_1, TargetFramework.NETCOREAPP3_1,  });
-                var baseImages = new[] { "debian" };
+                var baseImages = new[] { "debian", "alpine" };
                 var optimizations = new[] { "true", "false" };
 
                 var matrix = new Dictionary<string, object>();

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -471,6 +471,7 @@ partial class Build : NukeBuild
                 (rid: "linux-musl-x64", archiveFormat: ".tar.gz"),
                 (rid: "osx-x64", archiveFormat: ".tar.gz"),
                 (rid: "linux-arm64", archiveFormat: ".tar.gz"),
+                (rid: "linux-musl-arm64", archiveFormat: ".tar.gz"),
             }.Select(x => (x.rid, archive: ArtifactsDirectory / $"dd-trace-{x.rid}{x.archiveFormat}", output: ArtifactsDirectory / "tool" / x.rid))
              .ToArray();
 

--- a/tracer/build/_build/docker/alpine.build.arm64.dockerfile
+++ b/tracer/build/_build/docker/alpine.build.arm64.dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.6
+
+FROM alpine:3.18 as base
+
+RUN apk update \
+        && apk upgrade \
+        && apk add --no-cache \
+        cmake \
+        git \
+        make \
+        alpine-sdk \
+        autoconf \
+        libtool \
+        automake \
+        xz-dev \
+        build-base \
+        python3 \
+        linux-headers \
+        clang16 \
+        clang16-extra-tools

--- a/tracer/build/_build/docker/alpine.dockerfile
+++ b/tracer/build/_build/docker/alpine.dockerfile
@@ -1,4 +1,4 @@
-﻿FROM gleocadie/alpine-clang16 as base
+﻿FROM andrewlockdd/alpine-clang:1.0 as base
 ARG DOTNETSDK_VERSION
 
 ENV \
@@ -79,15 +79,18 @@ WORKDIR /project
 
 FROM base as tester
 
-# Install .NET Core runtimes using install script
+# Install .NET Core runtimes using install script (don't install 2.1 on ARM64, because it's not available)
 COPY ./bootstrap/dotnet-install.sh .
-RUN ./dotnet-install.sh --runtime aspnetcore --channel 2.1 --install-dir /usr/share/dotnet --no-path \
+RUN if [ "$(uname -m)" != "aarch64" ]; then \
+        ./dotnet-install.sh --runtime aspnetcore --channel 2.1 --install-dir /usr/share/dotnet --no-path; \
+    fi \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.0 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 3.1 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 5.0 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 6.0 --install-dir /usr/share/dotnet --no-path \
     && ./dotnet-install.sh --runtime aspnetcore --channel 7.0 --install-dir /usr/share/dotnet --no-path \
     && rm dotnet-install.sh
+
 
 # Copy the build project in and build it
 COPY *.csproj *.props *.targets /build/

--- a/tracer/build/artifacts/dd-dotnet.sh
+++ b/tracer/build/artifacts/dd-dotnet.sh
@@ -50,8 +50,8 @@ if contains_word "$DISTRO_ID" "alpine"; then
         DD_DOTNET_PATH="$DIR/linux-musl-x64/dd-dotnet"
         EXPECTED_PACKAGE="datadog-dotnet-apm-${TRACER_VERSION}-musl.tar.gz"
     elif [ "$ARCH" = "aarch64" ]; then
-        echo "Alpine ARM64 is not supported."
-        exit 1
+	      DD_DOTNET_PATH="$DIR/linux-musl-arm64/dd-dotnet"
+        EXPECTED_PACKAGE="datadog-dotnet-apm-${TRACER_VERSION}.arm64.tar.gz"
     else
         echo "Unsupported architecture: $ARCH"
         exit 1

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -33,7 +33,7 @@
         <OutputPath>bin\$(Configuration)\Console</OutputPath>
         <PublishDir Condition="'$(PublishDir)' == '' ">bin\$(Configuration)\Console\publish\$(RuntimeIdentifier)</PublishDir>
         <AssemblyName>dd-trace</AssemblyName>
-        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-musl-x64;osx-x64;linux-arm64</RuntimeIdentifiers>
+        <RuntimeIdentifiers>win-x64;win-x86;linux-x64;linux-musl-x64;osx-x64;linux-arm64;linux-musl-arm64</RuntimeIdentifiers>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
         <PublishTrimmed>true</PublishTrimmed>
         <SelfContained>true</SelfContained>
@@ -105,6 +105,11 @@
         </Content>
 
         <Content Condition="'$(RuntimeIdentifier)' != 'linux-arm64'" Update="..\Datadog.Trace.Bundle\home\linux-arm64\*.*">
+          <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+          <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </Content>
+
+        <Content Condition="'$(RuntimeIdentifier)' != 'linux-musl-arm64'" Update="..\Datadog.Trace.Bundle\home\linux-musl-arm64\*.*">
           <CopyToOutputDirectory>Never</CopyToOutputDirectory>
           <CopyToPublishDirectory>Never</CopyToPublishDirectory>
         </Content>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Utils.cs
@@ -563,9 +563,10 @@ namespace Datadog.Trace.Tools.Runner
                 }
                 else if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
                 {
-                    tracerProfiler64 = FileExists(Path.Combine(tracerHome, "linux-arm64", "Datadog.Trace.ClrProfiler.Native.so"));
+                    var archFolder = IsAlpine() ? "linux-musl-arm64" : "linux-arm64";
+                    tracerProfiler64 = FileExists(Path.Combine(tracerHome, archFolder, "Datadog.Trace.ClrProfiler.Native.so"));
                     tracerProfilerArm64 = tracerProfiler64;
-                    ldPreload = FileExists(Path.Combine(tracerHome, "linux-arm64", "Datadog.Linux.ApiWrapper.x64.so"));
+                    ldPreload = FileExists(Path.Combine(tracerHome, archFolder, "Datadog.Linux.ApiWrapper.x64.so"));
                 }
                 else
                 {

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -438,7 +438,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             }
             else if (osArchitecture == Architecture.Arm64)
             {
-                archFolder = "linux-arm64";
+                archFolder = Utils.IsAlpine() ? "linux-musl-arm64" : "linux-arm64";
             }
             else
             {
@@ -626,6 +626,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
             {
                 "/datadog/linux-musl-x64/Datadog.Trace.ClrProfiler.Native.so",
                 "/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so",
+                "/datadog/linux-musl-arm64/Datadog.Trace.ClrProfiler.Native.so",
                 "/datadog/linux-arm64/Datadog.Trace.ClrProfiler.Native.so",
                 "\\datadog\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
                 "\\datadog\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll"

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Utils.cs
@@ -102,9 +102,10 @@ internal class Utils
             }
             else if (RuntimeInformation.OSArchitecture == Architecture.Arm64)
             {
-                tracerProfiler64 = FileExists(Path.Combine(tracerHome, "linux-arm64", "Datadog.Trace.ClrProfiler.Native.so"));
+                var archFolder = IsAlpine() ? "linux-musl-arm64" : "linux-arm64";
+                tracerProfiler64 = FileExists(Path.Combine(tracerHome, archFolder, "Datadog.Trace.ClrProfiler.Native.so"));
                 tracerProfilerArm64 = tracerProfiler64;
-                ldPreload = FileExists(Path.Combine(tracerHome, "linux-arm64", "Datadog.Linux.ApiWrapper.x64.so"));
+                ldPreload = FileExists(Path.Combine(tracerHome, archFolder, "Datadog.Linux.ApiWrapper.x64.so"));
             }
             else
             {

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/LibraryLocationHelper.cs
@@ -183,7 +183,7 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
                 OSPlatformName.MacOS => new[] { $"osx" },
                 OSPlatformName.Windows => new[] { $"win-{fwk.ProcessArchitecture}" },
                 OSPlatformName.Linux => fwk.ProcessArchitecture == ProcessArchitecture.Arm64
-                                            ? new[] { "linux-arm64" }
+                                            ? new[] { "linux-arm64", "linux-musl-arm64" }
                                             : new[] { "linux-x64", "linux-musl-x64" },
                 _ => null, // unsupported
             };

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -496,7 +496,8 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                 var rid = (EnvironmentTools.GetOS(), EnvironmentTools.GetPlatform(), EnvironmentHelper.IsAlpine()) switch
                 {
                     ("win", _, _) => "win-x64",
-                    ("linux", "Arm64", _) => "linux-arm64",
+                    ("linux", "Arm64", false) => "linux-arm64",
+                    ("linux", "Arm64", true) => "linux-musl-arm64",
                     ("linux", "X64", false) => "linux-x64",
                     ("linux", "X64", true) => "linux-musl-x64",
                     ("osx", "X64", _) => "osx-x64",

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/IAST/IastInstrumentationUnitTests.cs
@@ -307,14 +307,12 @@ public class IastInstrumentationUnitTests : TestHelper
 #else
             if (!EnvironmentTools.IsWindows())
             {
-                if (RuntimeInformation.ProcessArchitecture == Architecture.Arm64)
+                arguments += (RuntimeInformation.ProcessArchitecture == Architecture.Arm64, EnvironmentHelper.IsAlpine()) switch
                 {
-                    arguments += " --TestCaseFilter:\"(Category!=ArmUnsupported)&(Category!=LinuxUnsupported)\"";
-                }
-                else
-                {
-                    arguments += " --TestCaseFilter:\"Category!=LinuxUnsupported\"";
-                }
+                    (true, false) => @" --TestCaseFilter:""(Category!=ArmUnsupported)&(Category!=LinuxUnsupported)""",
+                    (true, true) => @" --TestCaseFilter:""(Category!=ArmUnsupported)&(Category!=AlpineArmUnsupported)&(Category!=LinuxUnsupported)""",
+                    _ => @" --TestCaseFilter:""Category!=LinuxUnsupported""",
+                };
             }
 #endif
             SetEnvironmentVariable(ConfigurationKeys.CIVisibility.Enabled, "0"); // without this key, ci visibility is enabled for the samples, which we don't really want

--- a/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
+++ b/tracer/test/Datadog.Trace.TestHelpers/EnvironmentHelper.cs
@@ -128,7 +128,8 @@ namespace Datadog.Trace.TestHelpers
             {
                 ("win", _, "X64", _) => ("dll", "win-x64"),
                 ("win", _, "X86", _) => ("dll", "win-x86"),
-                ("linux", "Arm64", _, _) => ("so", "linux-arm64"),
+                ("linux", "Arm64", _, false) => ("so", "linux-arm64"),
+                ("linux", "Arm64", _, true) => ("so", "linux-musl-arm64"),
                 ("linux", "X64", _, false) => ("so", "linux-x64"),
                 ("linux", "X64", _, true) => ("so", "linux-musl-x64"),
                 ("osx", _, _, _) => ("dylib", "osx"),

--- a/tracer/test/Datadog.Trace.Tests/FrameworkDescriptionTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/FrameworkDescriptionTests.cs
@@ -46,9 +46,12 @@ public class FrameworkDescriptionTests
         SkipOn.Platform(Windows);
         SkipOn.Platform(MacOs);
 
-        var expectedOs = EnvironmentHelper.IsAlpine()
-                             ? "Alpine Linux v3.14"
-                             : "Debian GNU/Linux 10 (buster)";
+        var expectedOs = (EnvironmentHelper.IsAlpine(), RuntimeInformation.OSArchitecture) switch
+        {
+            (true, Architecture.Arm64) => "Alpine Linux v3.18",
+            (true, Architecture.X64) => "Alpine Linux v3.14",
+            _ => "Debian GNU/Linux 10 (buster)",
+        };
 
         var description = FrameworkDescription.Create();
         var arch = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64" : "x64";

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ToolTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ToolTestHelper.cs
@@ -55,6 +55,7 @@ public abstract class ToolTestHelper : TestHelper
         };
 
         var executable = Path.Combine(EnvironmentHelper.MonitoringHome, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dd-dotnet.cmd" : "dd-dotnet.sh");
+        Output.WriteLine($"{executable} {arguments}");
 
         var processStart = new ProcessStartInfo(executable, arguments)
         {

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ToolTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Checks/ToolTestHelper.cs
@@ -48,7 +48,8 @@ public abstract class ToolTestHelper : TestHelper
         var rid = (EnvironmentTools.GetOS(), EnvironmentTools.GetPlatform(), EnvironmentHelper.IsAlpine()) switch
         {
             ("win", _, _) => "win-x64",
-            ("linux", "Arm64", _) => "linux-arm64",
+            ("linux", "Arm64", false) => "linux-arm64",
+            ("linux", "Arm64", true) => "linux-musl-arm64",
             ("linux", "X64", false) => "linux-x64",
             ("linux", "X64", true) => "linux-musl-x64",
             _ => throw new PlatformNotSupportedException()

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Utils.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/Utils.cs
@@ -26,7 +26,7 @@ public static class Utils
 
         if (FrameworkDescription.Instance.ProcessArchitecture == ProcessArchitecture.Arm64)
         {
-            archFolder = "linux-arm64";
+            archFolder = IsAlpine() ? "linux-musl-arm64" : "linux-arm64";
         }
         else
         {
@@ -42,7 +42,8 @@ public static class Utils
         var rid = (EnvironmentTools.GetOS(), EnvironmentTools.GetPlatform(), EnvironmentHelper.IsAlpine()) switch
         {
             ("win", _, _) => "win-x64",
-            ("linux", "Arm64", _) => "linux-arm64",
+            ("linux", "Arm64", false) => "linux-arm64",
+            ("linux", "Arm64", true) => "linux-musl-arm64",
             ("linux", "X64", false) => "linux-x64",
             ("linux", "X64", true) => "linux-musl-x64",
             _ => throw new PlatformNotSupportedException()

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -33,6 +33,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
     private const string CorProfilerPath32Key = "CORECLR_PROFILER_PATH_32";
     private const string CorProfilerPath64Key = "CORECLR_PROFILER_PATH_64";
     private const string CorEnableKey = "CORECLR_ENABLE_PROFILING";
+    private const string LogDirectoryKey = "DD_TRACE_LOG_DIRECTORY";
 
     private static readonly string ProfilerPath = EnvironmentHelper.GetNativeLoaderPath();
 
@@ -243,6 +244,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
         using var helper = await StartConsole(
                                enableProfiler: true,
                                ("DD_PROFILING_ENABLED", "1"),
+                               (LogDirectoryKey, this.LogDirectory),
                                ("LD_PRELOAD", apiWrapperPath));
         var processInfo = ProcessInfo.GetProcessInfo(helper.Process.Id);
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.IntegrationTests/Checks/ProcessBasicChecksTests.cs
@@ -232,7 +232,7 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
 
         if (FrameworkDescription.Instance.ProcessArchitecture == ProcessArchitecture.Arm64)
         {
-            archFolder = "linux-arm64";
+            archFolder = Utils.IsAlpine() ? "linux-musl-arm64" : "linux-arm64";
         }
         else
         {
@@ -471,7 +471,8 @@ public class ProcessBasicChecksTests : ConsoleTestHelper
             {
                 ("win", _, "X64", _) => ("dll", "win-x64"),
                 ("win", _, "X86", _) => ("dll", "win-x86"),
-                ("linux", "Arm64", _, _) => ("so", "linux-arm64"),
+                ("linux", "Arm64", _, false) => ("so", "linux-arm64"),
+                ("linux", "Arm64", _, true) => ("so", "linux-musl-arm64"),
                 ("linux", "X64", _, false) => ("so", "linux-x64"),
                 ("linux", "X64", _, true) => ("so", "linux-musl-x64"),
                 ("osx", _, _, _) => ("dylib", "osx"),

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreSqliteTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/EFCoreSqliteTests.cs
@@ -5,6 +5,9 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 
+#if !NET6_0_OR_GREATER
+[Xunit.Trait("Category", "AlpineArmUnsupported")] // sqlite isn't supported in .NET 5 on Alpine
+#endif
 public class EFCoreSqliteTests : EFCoreBaseTests
 {
     public EFCoreSqliteTests()

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/MicrosoftSqLiteTests.cs
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/Vulnerabilities/SqlInjection/MicrosoftSqLiteTests.cs
@@ -6,6 +6,9 @@ using Xunit;
 
 namespace Samples.InstrumentedTests.Iast.Vulnerabilities.SqlInjection;
 
+#if !NET6_0_OR_GREATER
+[Trait("Category", "AlpineArmUnsupported")] // sqlite isn't supported in .NET 5 on Alpine
+#endif
 public class MicrosoftSqLiteTests : InstrumentationTestsBase, IDisposable
 {
     protected static string ScalarCommandUnsafe;

--- a/tracer/test/test-applications/integrations/Samples.InstrumentedTests/generaterunsettings.sh
+++ b/tracer/test/test-applications/integrations/Samples.InstrumentedTests/generaterunsettings.sh
@@ -13,13 +13,16 @@ echo FILE $FILE
 echo SOLUTIONFOLDER $SOLUTIONFOLDER
 
 if [[ "$ARCH" == *"aarch64"* ]]; then
-  BIN_FOLDER="linux-arm64"
+    case $DISTRIBUTION in
+    *"Alpine"*) echo Alpine; BIN_FOLDER="linux-musl-arm64";;
+    *) echo Linux; BIN_FOLDER="linux-arm64";;
+    esac
   else
 	  case $DISTRIBUTION in 
 		*"Ubuntu"*) echo Ubuntu; BIN_FOLDER="linux-x64";;
 		*"Alpine"*) echo Alpine; BIN_FOLDER="linux-musl-x64";;
 		*) echo Linux; BIN_FOLDER="linux-x64";;
-	  esac 
+	  esac
 fi
 
 # Check for macos


### PR DESCRIPTION
## Summary of changes

Adds support for the tracer on alpine on ARM64

## Reason for change

We currently support x64 on glibc/alpine but only glibc on arm64. This closes that matrix which makes it easier to understand

## Implementation details

There's several layers, but at a high level
- Anywhere where we detect platform, make sure to include `linux-musl-arm64` as well as `linux-arm64`
- Build the tracer + profiler on alpine arm64

There were several difficulties
- The ruby-based fpm bundler we use doesn't work on alpine arm64, hence #5905 
- I couldn't get our existing alpine.build.dockerfile to compile on arm64 (where we currently compile llvm/clang16 on alpine14).
  - To work around it, created a separate alpine.build.arm64.dockerfile image which uses alpine:18 (the first version that includes clang16) as the base.
  - Obviously this gives us different requirements in arm64, but I think that's fine because a) this is a new feature b) we already have differences on the glibc requirements for arm64 c) We only support .NET 5+ anyway on arm64 (.NET 6 really given .NET 5 is mostly gone) and they ship alpine:18 images for .NET 6+
  - I created a multi arch base image from the two base images ([as some bloke with a blog describes here](https://andrewlock.net/combining-multiple-docker-images-into-a-multi-arch-image/))
- I had difficulty compiling the profiler on arm64 initially (we require it for some crash tracking functionality), as we were getting `undefined reference to `_Uaarch64_get_accessors_int'` when trying to compile libunwind. @gleocadie tracked it down to [this issue](https://github.com/libunwind/libunwind/issues/788), and fixed it by just not building the libunwind tests 🙇‍♂️ 
- The sqlite IAST instrumentation tests on alpine arm64 were failing in .NET 5. I _think_ that's because the sqlite package we're using there doesn't support it (which makes sense) so just disabled the tests for that scenario. They pass in .NET 6+ so I'm not worried about it.
- Removed the "noop" smoke tests stage (there's nothing to run in it currently)
- We can't even install .NET Core 2.1 using the dotnet install script on alpine arm64, so bailing out. We can probably bail out of more too, but that's not _necessary_ so haven't done it yet.

There's still one outstanding issue I can't get my head around, on _debian x64_ (i.e. not something that should have changed) The `OnEolFrameworkInSsi_WhenForwarderPathExists_CallsForwarderWithExpectedTelemetry` tests is failing by crashing. It's bizarre, I can't figure it out, if anyone has any ideas, please let me know 😅 

## Test coverage

I've run full installer + full TFM tests [here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=162869&view=results) 🤞 

## Other details

Stacked on 
- https://github.com/DataDog/dd-trace-dotnet/pull/5770
- https://github.com/DataDog/dd-trace-dotnet/pull/5905

as they both change key parts of the build + will mean we need to rebuild the VMs

Fixes #3850
