### PR TITLE
[serverless] No-op AWS Lambda integration on missing API Key (#5900 - v2)

### DIFF
--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -185,6 +185,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -208,6 +209,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -231,6 +233,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -254,6 +257,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -277,6 +281,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -300,6 +305,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -323,6 +329,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -346,6 +353,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -369,6 +377,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -392,6 +401,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -415,6 +425,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -438,6 +449,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -461,6 +473,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -484,6 +497,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -507,6 +521,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -530,6 +545,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -553,6 +569,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -576,6 +593,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -599,6 +617,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -622,6 +641,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -645,6 +665,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -668,6 +689,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -691,6 +713,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -714,6 +737,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -737,6 +761,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -760,6 +785,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -783,6 +809,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -806,6 +833,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -829,6 +857,7 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
+    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -852,6 +881,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -875,6 +905,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -898,6 +929,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -921,6 +953,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -944,6 +977,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -967,6 +1001,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -990,6 +1025,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -1013,6 +1049,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -1036,6 +1073,7 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
+      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:


### PR DESCRIPTION
## Summary of changes

Verifies that an API key is set in order to call the Lambda Extension.

## Reason for change

It would not crash the customers, but it logs errors that should be avoided and handled better by not doing the operation.

## Implementation details

Just created an API key getter in order to then check if the API is missing.

## Test coverage

Tested manually on AWS Lambda.
<img width="1486" alt="Screenshot 2024-08-14 at 9 00 16 PM" src="https://github.com/user-attachments/assets/7a993627-3b68-4ef1-9960-3d69890a8f56">

## Other details

Backport of #5900