### PR TITLE
[IAST] Move analyzers init to an explicit call (#5920 -> v2)

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/Instrumentation.cs
@@ -131,6 +131,8 @@ namespace Datadog.Trace.ClrProfiler
                             {
                                 Log.Debug("Enabling Iast call target category");
                                 category |= InstrumentationCategory.Iast;
+
+                                Iast.Iast.Instance.InitAnalyzers();
                             }
 
                             if (raspEnabled)
@@ -500,6 +502,7 @@ namespace Datadog.Trace.ClrProfiler
             }
             else
             {
+                Iast.Iast.Instance.InitAnalyzers();
                 InitializeInstrumentationsLegacy(InstrumentationCategory.Iast, sw);
             }
         }

--- a/tracer/src/Datadog.Trace/Iast/Iast.cs
+++ b/tracer/src/Datadog.Trace/Iast/Iast.cs
@@ -40,11 +40,6 @@ internal class Iast
     internal Iast(IastSettings settings = null)
     {
         _settings = settings ?? IastSettings.FromDefaultSources();
-        if (_settings.Enabled)
-        {
-            HardcodedSecretsAnalyzer.Initialize(TimeSpan.FromMilliseconds(_settings.RegexTimeout));
-        }
-
         _overheadController = new OverheadController(_settings.MaxConcurrentRequests, _settings.RequestSampling);
     }
 
@@ -66,6 +61,14 @@ internal class Iast
                 _instance = value;
                 _globalInstanceInitialized = true;
             }
+        }
+    }
+
+    internal void InitAnalyzers()
+    {
+        if (_settings.Enabled)
+        {
+            HardcodedSecretsAnalyzer.Initialize(TimeSpan.FromMilliseconds(_settings.RegexTimeout));
         }
     }
 }


### PR DESCRIPTION
## Summary of changes
Make IAST analyzers initialization explicit, and call it only in `Instrumentation.Initialize` to avoid multiple instances scenarios

## Reason for change
A crash under these circumstances has been detected

## Implementation details
Move IAST analyzers init inside `Instrumentation.Initialize` only to make sure they are initialized only once

## Test coverage

## Other details
Backport of https://github.com/DataDog/dd-trace-dotnet/pull/5920