### PR TITLE
Revert "[serverless] No-op AWS Lambda integration on missing API Key"

### DIFF
--- a/docker-compose.serverless.yml
+++ b/docker-compose.serverless.yml
@@ -185,7 +185,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -209,7 +208,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -233,7 +231,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -257,7 +254,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -281,7 +277,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -305,7 +300,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -329,7 +323,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -353,7 +346,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -377,7 +369,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -401,7 +392,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -425,7 +415,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -449,7 +438,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -473,7 +461,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -497,7 +484,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -521,7 +507,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -545,7 +530,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -569,7 +553,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -593,7 +576,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -617,7 +599,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -641,7 +622,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -665,7 +645,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -689,7 +668,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -713,7 +691,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -737,7 +714,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -761,7 +737,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -785,7 +760,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -809,7 +783,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -833,7 +806,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -857,7 +829,6 @@ services:
     - DUMMY_API_HOST=http://serverless-dummy-api:9005
     - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
     - DD_TRACE_DEBUG=1
-    - DD_API_KEY=x
     ports:
     - "8080"
     volumes:
@@ -881,7 +852,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -905,7 +875,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -929,7 +898,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -953,7 +921,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -977,7 +944,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -1001,7 +967,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -1025,7 +990,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -1049,7 +1013,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:
@@ -1073,7 +1036,6 @@ services:
       - DUMMY_API_HOST=http://serverless-dummy-api:9005
       - DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
       - DD_TRACE_DEBUG=1
-      - DD_API_KEY=x
     ports:
       - "8080"
     volumes:

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/HandlerWrapperSetHandlerIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/HandlerWrapperSetHandlerIntegration.cs
@@ -12,9 +12,7 @@ using System.Threading.Tasks;
 using Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.SDK;
 using Datadog.Trace.ClrProfiler.CallTarget;
 using Datadog.Trace.Configuration;
-using Datadog.Trace.Configuration.Telemetry;
 using Datadog.Trace.DuckTyping;
-using Datadog.Trace.Telemetry;
 using Datadog.Trace.Util.Delegates;
 
 namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AWS.Lambda;
@@ -38,7 +36,6 @@ public class HandlerWrapperSetHandlerIntegration
     private const string IntegrationName = nameof(IntegrationId.AwsLambda);
     private static readonly ILambdaExtensionRequest RequestBuilder = new LambdaRequestBuilder();
     private static readonly Async1Callbacks Callbacks = new();
-    private static readonly Lazy<bool> IsApiKeyMissing = new(() => string.IsNullOrEmpty(GetApiKey()));
 
     /// <summary>
     /// OnMethodBegin callback. The input Delegate handler is the customer's handler.
@@ -52,12 +49,6 @@ public class HandlerWrapperSetHandlerIntegration
     /// <returns>CallTarget state value</returns>
     internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, ref Delegate handler)
     {
-        if (IsApiKeyMissing.Value)
-        {
-            LambdaCommon.Log("No API key configured, not calling the Extension", debug: false);
-            return CallTargetState.GetDefault();
-        }
-
         handler = handler.Instrument(Callbacks);
         return CallTargetState.GetDefault();
     }
@@ -69,12 +60,6 @@ public class HandlerWrapperSetHandlerIntegration
         // Reset the offset so that it can be read by the originally intended consumer, i.e. the user defined handler
         payloadStream.Seek(0, SeekOrigin.Begin);
         return result;
-    }
-
-    private static string GetApiKey()
-    {
-        var config = new ConfigurationBuilder(GlobalConfigurationSource.Instance, TelemetryFactory.Config);
-        return config.WithKeys(ConfigurationKeys.ApiKey).AsRedactedString();
     }
 
     private readonly struct Async1Callbacks : IBegin1Callbacks, IReturnAsyncCallback, IReturnCallback


### PR DESCRIPTION
## Summary of changes

This reverts commit 8e63384717cc1a2608815c661c13c65ed94ba965.

## Reason for change

It doesn't account for `DD_API_KEY_SECRET_ARN` or `DD_KMS_API_KEY` which is considered a regression.

## Implementation details

n/a

## Test coverage

Confirmed that it stops working for Lambdas with that configuration

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
