### PR TITLE
Prevent the native loader from being unloaded while sending telemetry

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/single_step_guard_rails.cpp
@@ -5,7 +5,6 @@
 #include "EnvironmentVariables.h"
 #include "single_step_guard_rails.h"
 #include "process_helper.h"
-#include "exported_functions.h"
 
 #ifdef _WIN32
 #include <Windows.h>
@@ -298,7 +297,7 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
 
     // GetModuleHandleEx increments the reference count if called without GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT
     if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
-        (LPCWSTR)&GetRuntimeId, &handle))
+        (LPCWSTR)&datadog::shared::nativeloader::CorProfiler::GetRuntimeId, &handle))
     {
         handle = 0;
     }
@@ -307,7 +306,7 @@ void SingleStepGuardRails::SendTelemetry(const std::string& runtimeName, const s
     // Use dlopen to increment the reference count of the module
     void* handle = 0;
     Dl_info info;
-    if (dladdr((void*)&GetRuntimeId, &info))
+    if (dladdr((void*)&datadog::shared::nativeloader::CorProfiler::GetRuntimeId, &info))
     {
         handle = dlopen(info.dli_fname, RTLD_LAZY);
     }


### PR DESCRIPTION
## Summary of changes

Prevent the native loader from being unloaded while sending telemetry.

## Reason for change

We send telemetry when we decide not to instrument a process (for instance because of an EOL runtime). To send the telemetry, we spawn the telemetry forwarder. This is done in a background thread to avoid blocking the startup of the process. However, .NET unloads the profiler when the `CorProfilerInfo::Initialize` method returns, even if the background thread is still running, causing a segfault.

## Implementation details

We increment the reference count of the module to prevent it from being unloaded by the .NET runtime.

Two different implementations:
 - On Windows, we use `GetModuleHandleEx` to increment the reference count. Then, when we're done sending the telemetry, we use `FreeLibraryAndExitThread` to safely unload the module.
 - On Linux, we use `dlopen` to increment the reference count. Unfortunately there is no safe way to unload the module from within itself, so we keep it in memory.

If for some reason we failed to increment the reference count, we give up on sending telemetry.

## Test coverage

`OnEolFrameworkInSsi_WhenForwarderPathExists_CallsForwarderWithExpectedTelemetry` segfaults on 3.0 without this change.
