### PR TITLE
Remove dependency of download-single-step-artifacts on build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -79,6 +79,7 @@ download-single-step-artifacts:
   stage: package
   image: registry.ddbuild.io/docker:20.10.13-gbi-focal
   tags: [ "arch:amd64" ]
+  needs: []
   rules:
     - if: $DOTNET_PACKAGE_VERSION
       when: on_success


### PR DESCRIPTION
## Summary of changes
`download-single-step-artifacts` doesn't depend on any other jobs

## Reason for change
With the current pipeline, the download job doesn't start until the `build` job finishes. The `build` job, despite the genericness of the name, is only responsible for building windows artifacts. This can sometimes take dozens of minutes delaying the rest of the pipeline for no reason
