### PR TITLE
[IAST] Cookie filter implementation

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Iast.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Iast.cs
@@ -103,6 +103,12 @@ namespace Datadog.Trace.Configuration
             /// Default value is 1
             /// </summary>
             public const string DataBaseRowsToTaint = "DD_IAST_DB_ROWS_TO_TAINT";
+
+            /// <summary>
+            /// Configuration key for number of rows to taint on each Db query in IAST.
+            /// Default value is 1
+            /// </summary>
+            public const string CookieFilterRegex = "DD_IAST_COOKIE_FILTER_PATTERN";
         }
     }
 }

--- a/tracer/src/Datadog.Trace/Iast/CookieAnalyzer.cs
+++ b/tracer/src/Datadog.Trace/Iast/CookieAnalyzer.cs
@@ -6,8 +6,10 @@
 #nullable enable
 
 using System;
+using System.Text.RegularExpressions;
 using Datadog.Trace.Configuration;
 using Datadog.Trace.Iast;
+using Datadog.Trace.Iast.Settings;
 using Datadog.Trace.Logging;
 #if !NETFRAMEWORK
 using Microsoft.AspNetCore.Http;
@@ -18,12 +20,44 @@ using System.Web;
 
 namespace Datadog.Trace.Iast;
 
-internal static class CookieAnalyzer
+internal class CookieAnalyzer
 {
+    private static readonly Lazy<CookieAnalyzer> Instance = new Lazy<CookieAnalyzer>();
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(CookieAnalyzer));
+    private readonly Regex? _cookieFilterRegex = null;
+
+    public CookieAnalyzer()
+        : this(Iast.Instance.Settings)
+    {
+    }
+
+    internal CookieAnalyzer(IastSettings settings)
+        : this(settings.Enabled, settings.CookieFilterRegex, settings.RegexTimeout)
+    {
+    }
+
+    internal CookieAnalyzer(bool iastEnabled, string pattern, double timeoutMilliSeconds)
+    {
+        if (iastEnabled && !string.IsNullOrEmpty(pattern))
+        {
+            var timeout = TimeSpan.FromMilliseconds(timeoutMilliSeconds);
+            if (timeout.TotalMilliseconds == 0)
+            {
+                timeout = Regex.InfiniteMatchTimeout;
+            }
+
+            var options = RegexOptions.IgnoreCase | RegexOptions.Compiled;
+            _cookieFilterRegex = new(pattern, options, timeout);
+        }
+    }
 
 #if NETFRAMEWORK
     public static void AnalyzeCookies(HttpCookieCollection cookies, IntegrationId integrationId)
+    {
+        Instance.Value.AnalyzeCookieCollection(cookies, integrationId);
+    }
+
+    public void AnalyzeCookieCollection(HttpCookieCollection cookies, IntegrationId integrationId)
     {
         try
         {
@@ -38,7 +72,7 @@ internal static class CookieAnalyzer
         }
     }
 
-    private static void ReportVulnerabilities(IntegrationId integrationId, HttpCookie cookie)
+    private void ReportVulnerabilities(IntegrationId integrationId, HttpCookie cookie)
     {
         if (cookie.Values.Count == 0)
         {
@@ -54,25 +88,33 @@ internal static class CookieAnalyzer
             return;
         }
 
+        bool isFiltered = IsFiltered(name);
+
         string? samesiteCookie = cookie.Values["SameSite"];
         if (samesiteCookie?.Equals("Strict", System.StringComparison.InvariantCultureIgnoreCase) is not true)
         {
-            IastModule.OnNoSamesiteCookie(integrationId, name);
+            IastModule.OnNoSamesiteCookie(integrationId, name, isFiltered);
         }
 
         if (!cookie.HttpOnly)
         {
-            IastModule.OnNoHttpOnlyCookie(integrationId, name);
+            IastModule.OnNoHttpOnlyCookie(integrationId, name, isFiltered);
         }
 
         if (!cookie.Secure)
         {
-            IastModule.OnInsecureCookie(integrationId, name);
+            IastModule.OnInsecureCookie(integrationId, name, isFiltered);
         }
     }
 #else
     // Extract the cookie information of a request from a IHeaderDictionary
-    public static void AnalyzeCookies(IHeaderDictionary headers, IntegrationId integrationId)
+
+    public static void AnalyzeCookies(IHeaderDictionary cookies, IntegrationId integrationId)
+    {
+        Instance.Value.AnalyzeCookieCollection(cookies, integrationId);
+    }
+
+    public void AnalyzeCookieCollection(IHeaderDictionary headers, IntegrationId integrationId)
     {
         try
         {
@@ -92,7 +134,7 @@ internal static class CookieAnalyzer
         }
     }
 
-    private static void AnalyzeCookie(string cookieHeaderValue, IntegrationId integrationId)
+    private void AnalyzeCookie(string cookieHeaderValue, IntegrationId integrationId)
     {
         if (!IsExcluded(cookieHeaderValue))
         {
@@ -103,7 +145,7 @@ internal static class CookieAnalyzer
         }
     }
 
-    private static void ReportVulnerabilities(IntegrationId integrationId, SetCookieHeaderValue cookie)
+    private void ReportVulnerabilities(IntegrationId integrationId, SetCookieHeaderValue cookie)
     {
         var name = cookie.Name.ToString();
         var value = cookie.Value.ToString();
@@ -114,26 +156,32 @@ internal static class CookieAnalyzer
             return;
         }
 
+        bool isFiltered = IsFiltered(name);
+
         if (cookie.SameSite != Microsoft.Net.Http.Headers.SameSiteMode.Strict)
         {
-            IastModule.OnNoSamesiteCookie(integrationId, name);
+            IastModule.OnNoSamesiteCookie(integrationId, name, isFiltered);
         }
 
         if (!cookie.HttpOnly)
         {
-            IastModule.OnNoHttpOnlyCookie(integrationId, name);
+            IastModule.OnNoHttpOnlyCookie(integrationId, name, isFiltered);
         }
 
         if (!cookie.Secure)
         {
-            IastModule.OnInsecureCookie(integrationId, name);
+            IastModule.OnInsecureCookie(integrationId, name, isFiltered);
         }
     }
 
-    private static bool IsExcluded(string cookieName)
+    internal bool IsExcluded(string cookieName)
     {
         return string.IsNullOrWhiteSpace(cookieName) || cookieName.StartsWith(".AspNetCore.", StringComparison.OrdinalIgnoreCase);
     }
-
 #endif
+
+    internal bool IsFiltered(string cookieName)
+    {
+        return _cookieFilterRegex?.IsMatch(cookieName) ?? false;
+    }
 }

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -357,7 +357,13 @@ internal static partial class IastModule
         }
     }
 
-    public static IastModuleResponse OnInsecureCookie(IntegrationId integrationId, string cookieName)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static int GetCookieHash(string vulnerability, string cookieName, bool isFiltered)
+    {
+        return (vulnerability.ToString() + ":" + (isFiltered ? "Filtered" : cookieName)).GetStaticHashCode();
+    }
+
+    public static IastModuleResponse OnInsecureCookie(IntegrationId integrationId, string cookieName, bool isFiltered)
     {
         if (!Iast.Instance.Settings.Enabled)
         {
@@ -366,10 +372,10 @@ internal static partial class IastModule
 
         OnExecutedSinkTelemetry(IastInstrumentedSinks.InsecureCookie);
         // We provide a hash value for the vulnerability instead of calculating one, following the agreed conventions
-        return AddWebVulnerability(cookieName, integrationId, VulnerabilityTypeName.InsecureCookie, (VulnerabilityTypeName.InsecureCookie.ToString() + ":" + cookieName).GetStaticHashCode());
+        return AddWebVulnerability(cookieName, integrationId, VulnerabilityTypeName.InsecureCookie, GetCookieHash(VulnerabilityTypeName.InsecureCookie, cookieName, isFiltered));
     }
 
-    public static IastModuleResponse OnNoHttpOnlyCookie(IntegrationId integrationId, string cookieName)
+    public static IastModuleResponse OnNoHttpOnlyCookie(IntegrationId integrationId, string cookieName, bool isFiltered)
     {
         if (!Iast.Instance.Settings.Enabled)
         {
@@ -378,10 +384,10 @@ internal static partial class IastModule
 
         OnExecutedSinkTelemetry(IastInstrumentedSinks.NoHttpOnlyCookie);
         // We provide a hash value for the vulnerability instead of calculating one, following the agreed conventions
-        return AddWebVulnerability(cookieName, integrationId, VulnerabilityTypeName.NoHttpOnlyCookie, (VulnerabilityTypeName.NoHttpOnlyCookie.ToString() + ":" + cookieName).GetStaticHashCode());
+        return AddWebVulnerability(cookieName, integrationId, VulnerabilityTypeName.NoHttpOnlyCookie, GetCookieHash(VulnerabilityTypeName.NoHttpOnlyCookie, cookieName, isFiltered));
     }
 
-    public static IastModuleResponse OnNoSamesiteCookie(IntegrationId integrationId, string cookieName)
+    public static IastModuleResponse OnNoSamesiteCookie(IntegrationId integrationId, string cookieName, bool isFiltered)
     {
         if (!Iast.Instance.Settings.Enabled)
         {
@@ -390,7 +396,7 @@ internal static partial class IastModule
 
         OnExecutedSinkTelemetry(IastInstrumentedSinks.NoSameSiteCookie);
         // We provide a hash value for the vulnerability instead of calculating one, following the agreed conventions
-        return AddWebVulnerability(cookieName, integrationId, VulnerabilityTypeName.NoSameSiteCookie, (VulnerabilityTypeName.NoSameSiteCookie.ToString() + ":" + cookieName).GetStaticHashCode());
+        return AddWebVulnerability(cookieName, integrationId, VulnerabilityTypeName.NoSameSiteCookie, GetCookieHash(VulnerabilityTypeName.NoSameSiteCookie, cookieName, isFiltered));
     }
 
     public static void OnHardcodedSecret(Vulnerability vulnerability)

--- a/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
+++ b/tracer/src/Datadog.Trace/Iast/Settings/IastSettings.cs
@@ -34,6 +34,11 @@ internal class IastSettings
     /// </summary>
     internal const string DefaultRedactionValuesRegex = @"(?i)(?:bearer\s+[a-z0-9\._\-]+|glpat-[\w\-]{20}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L][\w=\-]+\.ey[I-L][\w=\-]+(?:\.[\w.+/=\-]+)?|(?:[\-]{5}BEGIN[a-z\s]+PRIVATE\sKEY[\-]{5}[^\-]+[\-]{5}END[a-z\s]+PRIVATE\sKEY[\-]{5}|ssh-rsa\s*[a-z0-9/\.+]{100,})|[\w\.-]+@[a-zA-Z\d\.-]+\.[a-zA-Z]{2,})";
 
+    /// <summary>
+    /// Default values readaction regex if none specified via env DD_IAST_REDACTION_VALUES_REGEXP
+    /// </summary>
+    internal const string DefaultCookieFilterRegex = @".{20,}";
+
     public IastSettings(IConfigurationSource source, IConfigurationTelemetry telemetry)
     {
         var config = new ConfigurationBuilder(source, telemetry);
@@ -95,6 +100,10 @@ internal class IastSettings
             .WithKeys(ConfigurationKeys.Iast.DataBaseRowsToTaint)
             .AsInt32(DataBaseRowsToTaintDefault, x => x >= 0)
             .Value;
+
+        CookieFilterRegex = config
+            .WithKeys(ConfigurationKeys.Iast.CookieFilterRegex)
+            .AsString(DefaultCookieFilterRegex);
     }
 
     public bool Enabled { get; set; }
@@ -130,6 +139,8 @@ internal class IastSettings
     public int TruncationMaxValueLength { get; }
 
     public int DataBaseRowsToTaint { get; }
+
+    public string CookieFilterRegex { get; }
 
     public static IastSettings FromDefaultSources()
     {

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/CookieAnalyzerTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/CookieAnalyzerTests.cs
@@ -1,0 +1,72 @@
+// <copyright file="CookieAnalyzerTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using Bogus;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Iast;
+using Datadog.Trace.Iast.Settings;
+using Datadog.Trace.Logging;
+using Datadog.Trace.TestHelpers;
+using Datadog.Trace.Util.Http.QueryStringObfuscation;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Datadog.Trace.Tests.Util.Http
+{
+    [Collection(nameof(EvidenceRedactorTests))]
+    public class CookieAnalyzerTests
+    {
+        private const double Timeout = 10_000;
+
+        [Theory]
+        [InlineData("TestCookie", false)]
+        [InlineData("TestCookie.0123456789", true)]
+        [InlineData(".AspNetCore.", false)]
+        [InlineData(".AspNetCore.Whatever", true)]
+        [InlineData(".AspNetCore.0123456789abcdefghi", true)]
+
+        public void WithDefaultConfigCookieIsFiltered(string pattern, bool mustFilter)
+        {
+            var cookieAnalyzer = new CookieAnalyzer(true, IastSettings.DefaultCookieFilterRegex, 5000); // Default settings
+
+            cookieAnalyzer.IsFiltered(pattern).Should().Be(mustFilter);
+        }
+
+        [Theory]
+        [InlineData("TestCookie", false)]
+        [InlineData("TestCookie.0123456789", true)]
+        [InlineData(".AspNetCore.", false)]
+        [InlineData(".AspNetCore.Whatever", false)]
+        [InlineData(".AspNetCore.0123456789abcdefghi", false)]
+        [InlineData(".Other.0123456789", true)]
+
+        public void WithCustomConfigCookieIsFiltered(string pattern, bool mustFilter)
+        {
+            var cookieAnalyzer = new CookieAnalyzer(true, @"TestCookie\..*|\.Other\..*", 5000);
+
+            cookieAnalyzer.IsFiltered(pattern).Should().Be(mustFilter);
+        }
+
+#if !NETFRAMEWORK
+
+        [Theory]
+        [InlineData("TestCookie", false)]
+        [InlineData("TestCookie.0123456789", false)]
+        [InlineData(".AspNetCore.", true)]
+        [InlineData(".AspNetCore.Whatever", true)]
+        [InlineData(".AspNetCore.0123456789abcdefghi", true)]
+        public void CookieIsExcluded(string pattern, bool mustExclude)
+        {
+            var cookieAnalyzer = new CookieAnalyzer(); // Default settings
+
+            cookieAnalyzer.IsExcluded(pattern).Should().Be(mustExclude);
+        }
+#endif
+    }
+}

--- a/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Configuration/Telemetry/ConfigurationBuilderTests.cs
@@ -176,7 +176,7 @@ public class ConfigurationBuilderTests
                     },
                     { } i => new List<Entry>
                     {
-                        Entry.String(Key, i.ToString(), ConfigurationOrigins.Code, error: null),
+                        Entry.String(Key, Convert.ToString(i, CultureInfo.InvariantCulture), ConfigurationOrigins.Code, error: null),
                     },
                 };
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -516,6 +516,7 @@
   "DD_IAST_TELEMETRY_VERBOSITY": "iast_telemetry_verbosity",
   "DD_IAST_TRUNCATION_MAX_VALUE_LENGTH": "iast_truncation_max_value_length",
   "DD_IAST_DB_ROWS_TO_TAINT": "iast_db_rows_to_taint",
+  "DD_IAST_COOKIE_FILTER_PATTERN": "iast_cookie_filter_pattern",
   "DD_TRACE_STARTUP_LOGS": "trace_startup_logs_enabled",
   "DD_MAX_LOGFILE_SIZE": "trace_log_file_max_size",
   "DD_TRACE_LOGGING_RATE": "trace_log_rate",


### PR DESCRIPTION
## Summary of changes
Filter Cookie vulnerabilities by configurable regex as described in this [RFC](https://docs.google.com/document/d/1LLilcVkA1godL5sXuEoMlPFTT-hEF-8f-seGnx_CIvc/edit)

## Reason for change
Sometimes, randomly generated cookies could cause an infinite number of cookie related vulnerabilities

## Implementation details
Read `DD_IAST_COOKIE_FILTER_PATTERN` env var and apply it to cookie name. If matches, the vulnerability hash will be fixed (`vuln:Filtered`), effectively grouping all these vulnerabilities.

## Test coverage
Added unit tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
