### PR TITLE
Fix incorrect instrumentation for `new TracerSettings(bool)`

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Configuration/TracerSettings/CtorUseDefaultSourcesIntegration.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/ManualInstrumentation/Configuration/TracerSettings/CtorUseDefaultSourcesIntegration.cs
@@ -27,7 +27,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.ManualInstrumentation.Co
 [EditorBrowsable(EditorBrowsableState.Never)]
 public class CtorUseDefaultSourcesIntegration
 {
-    internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance)
+    internal static CallTargetState OnMethodBegin<TTarget>(TTarget instance, bool useDefaultSources)
     {
         TelemetryFactory.Metrics.Record(PublicApiUsage.TracerSettings_Ctor_UseDefaultSources);
         return CallTargetState.GetDefault();


### PR DESCRIPTION
## Summary of changes

Fix bug in v3 instrumentation of `new TracerSettings(bool useDefaultSources)`

## Reason for change

We were missing a parameter in the instrumentation

## Implementation details

Add the missing parameter

## Test coverage

We don't have a good coverage for this and I'm not sure the best way to catch it in the future tbh 🤔 Typically we catch these when developing integrations. 

I guess in this case the best way is to call every API and check for the side effects, but that also feels like a lot of work, so inclined to just YOLO it unless others think it's worth the effort
