### PR TITLE
Ensure we clean log files before testing with Nuke

### DIFF
--- a/tracer/build/_build/Build.ExplorationTests.cs
+++ b/tracer/build/_build/Build.ExplorationTests.cs
@@ -138,7 +138,7 @@ partial class Build
                .After(Clean, BuildTracerHome, BuildNativeLoader, SetUpExplorationTests)
                .Executes(() =>
                 {
-                    FileSystemTasks.EnsureExistingDirectory(TestLogsDirectory);
+                    FileSystemTasks.EnsureCleanDirectory(TestLogsDirectory);
                     try
                     {
                         var envVariables = GetEnvironmentVariables();

--- a/tracer/build/_build/Build.Steps.Debugger.cs
+++ b/tracer/build/_build/Build.Steps.Debugger.cs
@@ -98,7 +98,7 @@ partial class Build
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
             EnsureResultsDirectory(DebuggerIntegrationTests);
 
             try

--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -1066,7 +1066,7 @@ partial class Build
         .After(CompileManagedUnitTests)
         .Executes(() =>
         {
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
 
             var testProjects = TracerDirectory.GlobFiles("test/**/*.Tests.csproj")
                 .Select(x => Solution.GetProject(x))
@@ -1450,7 +1450,7 @@ partial class Build
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
 
@@ -1545,7 +1545,7 @@ partial class Build
         {
             var isDebugRun = IsDebugRun();
             var project = Solution.GetProject(Projects.ClrProfilerIntegrationTests);
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
             EnsureResultsDirectory(project);
 
             try
@@ -1586,7 +1586,7 @@ partial class Build
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
 
             try
@@ -1940,7 +1940,7 @@ partial class Build
         {
             var project = Solution.GetProject(Projects.DdTraceIntegrationTests);
 
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
             EnsureResultsDirectory(project);
 
             try
@@ -1973,7 +1973,7 @@ partial class Build
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
 
@@ -2054,7 +2054,7 @@ partial class Build
         .Executes(() =>
         {
             var isDebugRun = IsDebugRun();
-            EnsureExistingDirectory(TestLogsDirectory);
+            EnsureCleanDirectory(TestLogsDirectory);
             ParallelIntegrationTests.ForEach(EnsureResultsDirectory);
             ClrProfilerIntegrationTests.ForEach(EnsureResultsDirectory);
 


### PR DESCRIPTION
## Summary of changes

Cleans the log file directory before running tests

## Reason for change

Some tests assert on the presence/absence of log files. Tests should handle cleaning up before they run, but this is a stop gap.

## Implementation details

Clean the test logs directory before running the tests

## Test coverage

This is the test
