### PR TITLE
Log to a random file in telemetry forwarder tests

### DIFF
--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -225,7 +225,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var logDir = SetLogDirectory();
             var logFileName = Path.Combine(logDir, $"{Guid.NewGuid()}.txt");
 
-            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper, logFileName);
+            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper);
             Output.WriteLine("Setting forwarder to " + echoApp);
             Output.WriteLine("Logging telemetry to " + logFileName);
 
@@ -256,7 +256,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             var logDir = SetLogDirectory();
             var logFileName = Path.Combine(logDir, $"{Guid.NewGuid()}.txt");
-            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper, logFileName);
+            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper);
             Output.WriteLine("Setting forwarder to " + echoApp);
             Output.WriteLine("Logging telemetry to " + logFileName);
 
@@ -291,7 +291,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
         {
             var logDir = SetLogDirectory();
             var logFileName = Path.Combine(logDir, $"{Guid.NewGuid()}.txt");
-            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper, logFileName);
+            var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper);
             Output.WriteLine("Setting forwarder to " + echoApp);
             Output.WriteLine("Logging telemetry to " + logFileName);
 
@@ -447,7 +447,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             private readonly string _workingDir = Path.Combine(Path.GetTempPath(), Path.GetFileNameWithoutExtension(Path.GetRandomFileName()));
             private string _appPath;
 
-            public string GetAppPath(ITestOutputHelper output, EnvironmentHelper environment, string logFileName)
+            public string GetAppPath(ITestOutputHelper output, EnvironmentHelper environment)
             {
                 if (!string.IsNullOrEmpty(_appPath))
                 {

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -476,7 +476,9 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
                                var data = sb.ToString();
 
                                Console.WriteLine(data);
-                               File.WriteAllText(@"{logFileName}", data);
+
+                               var logFileName = Environment.GetEnvironmentVariable("{WatchFileEnvironmentVariable}");
+                               File.WriteAllText(logFileName, data);
                                """;
                 File.WriteAllText(Path.Combine(_workingDir, "Program.cs"), program);
 

--- a/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/InstrumentationTests.cs
@@ -227,6 +227,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
 
             var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper, logFileName);
             Output.WriteLine("Setting forwarder to " + echoApp);
+            Output.WriteLine("Logging telemetry to " + logFileName);
 
             // indicate we're running in auto-instrumentation, this just needs to be non-null
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
@@ -257,6 +258,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var logFileName = Path.Combine(logDir, $"{Guid.NewGuid()}.txt");
             var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper, logFileName);
             Output.WriteLine("Setting forwarder to " + echoApp);
+            Output.WriteLine("Logging telemetry to " + logFileName);
 
             // indicate we're running in auto-instrumentation, this just needs to be non-null
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");
@@ -291,6 +293,7 @@ namespace Datadog.Trace.ClrProfiler.IntegrationTests
             var logFileName = Path.Combine(logDir, $"{Guid.NewGuid()}.txt");
             var echoApp = _fixture.GetAppPath(Output, EnvironmentHelper, logFileName);
             Output.WriteLine("Setting forwarder to " + echoApp);
+            Output.WriteLine("Logging telemetry to " + logFileName);
 
             // indicate we're running in auto-instrumentation, this just needs to be non-null
             SetEnvironmentVariable("DD_INJECTION_ENABLED", "tracer");


### PR DESCRIPTION
## Summary of changes

Use a random file name for telemetry forwarder tests.

## Reason for change

The tests could find a file left from previous runs and succeed when they should fail.

## Other details
In theory https://github.com/DataDog/dd-trace-dotnet/pull/5950 should already fix the issue by cleaning the log folder, but this adds extra safety (for instance, if running tests without Nuke).