### PR TITLE
[Crashtracking] Keep mangled name in case of error

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.cpp
@@ -214,6 +214,7 @@ std::vector<StackFrame> CrashReportingLinux::GetThreadFrames(int32_t tid, Resolv
             if (result == 0)
             {
                 stackFrame.method = std::string(methodData.symbolName);
+                hasName = true;
 
                 auto demangleResult = ddog_demangle(libdatadog::FfiHelper::StringToCharSlice(stackFrame.method), DDOG_PROF_DEMANGLE_OPTIONS_COMPLETE);
 
@@ -224,8 +225,7 @@ std::vector<StackFrame> CrashReportingLinux::GetThreadFrames(int32_t tid, Resolv
 
                     if (stringWrapper.message.len > 0)
                     {
-                        stackFrame.method = std::string((char*)stringWrapper.message.ptr, stringWrapper.message.len);
-                        hasName = true;
+                        stackFrame.method = std::string((char*)stringWrapper.message.ptr, stringWrapper.message.len);                        
                     }
                 }
             }


### PR DESCRIPTION
## Summary of changes

If libdatadog failed to demangle a symbol name, keep the mangled name.

## Reason for change

That was an oversight. It's better to have a mangled name than no name at all.

## Implementation details

Moved a boolean around.

## Test coverage

There are no tests because I don't know why it would fail to begin with.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
