### PR TITLE
[CI Visibility] Ensure Datadog.Trace assembly is included in the Datadog.Trace.BenchmarkDotNet package

### DIFF
--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" />
+    <ProjectReference Include="..\Datadog.Trace\Datadog.Trace.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>
@@ -53,4 +53,30 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
+
+  <!--
+    *******************************************************************************************************************
+      WARNING!!!
+     The following snippet ensures that the assemblies from the reference projects (marked with PrivateAssets="All")
+     are copied to the final nuget package
+    *******************************************************************************************************************
+  -->
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
+    <ItemGroup>
+      <!-- Filter out unnecessary files -->
+      <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))"/>
+    </ItemGroup>
+
+    <!-- Print batches for debug purposes -->
+    <Message Text="Batch for .nupkg: ReferenceCopyLocalPaths = @(_ReferenceCopyLocalPaths), ReferenceCopyLocalPaths.DestinationSubDirectory = %(_ReferenceCopyLocalPaths.DestinationSubDirectory) Filename = %(_ReferenceCopyLocalPaths.Filename) Extension = %(_ReferenceCopyLocalPaths.Extension)" Importance="High" Condition="'@(_ReferenceCopyLocalPaths)' != ''" />
+
+    <ItemGroup>
+      <!-- Add file to package with consideration of sub folder. If empty, the root folder is chosen. -->
+      <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)"/>
+    </ItemGroup>
+  </Target>
+  
 </Project>


### PR DESCRIPTION
## Summary of changes

This PR ensures that the `Datadog.Trace` assemblies are included in the `Datadog.Trace.BenchmarkDotNet` nuget package.

## Reason for change

`Datadog.Trace` is required in the `Datadog.Trace.BenchmarkDotnet` integration, and since for v3 we are not publishing this assembly we must include it manually in the `Datadog.Trace.BenchmarkDotnet` package to avoid the following exception when using the BenchmarkDotNet integration
<img width="2040" alt="image" src="https://github.com/user-attachments/assets/2988e2d6-9418-4659-93b6-bd509eef014b">

## Implementation details

We just modified the `csproj` file to make sure we are including all assemblies from ProjectReference with the `PrivateAssets=All` flag

## Test coverage

We need to think about how to test this, no tests are included in this PR.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
