### PR TITLE
Don't include the Datadog.Trace.BenchmarkDotNet NuGet in the release artifacts

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -3912,11 +3912,13 @@ stages:
             artifact: bundle-nuget-package
             path: $(Build.ArtifactStagingDirectory)
 
-        - task: DownloadPipelineArtifact@2
-          displayName: Download benchmark nuget package
-          inputs:
-            artifact: benchmark-nuget-package
-            path: $(Build.ArtifactStagingDirectory)
+#        Don't include the Datadog.Trace.BenchmarkDotNet package in the release artifacts
+#        as it currently doesn't work with v3.
+#        - task: DownloadPipelineArtifact@2
+#          displayName: Download benchmark nuget package
+#          inputs:
+#            artifact: benchmark-nuget-package
+#            path: $(Build.ArtifactStagingDirectory)
 
         # runner tool
         - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
## Summary of changes

Exclude the `Datadog.Trace.BenchmarkDotNet` NuGet package from the v3 release artifacts

## Reason for change

The v3 version of Datadog.Trace.BenchmarkDotNet requires custom-only instrumentation... which doesn't work in v3. Rather than ship something which breaks at runtime, we'll hold off shipping this for now, and figure out our solution later. The v2 version continues to work, the package is not heavily used, and it shouldn't be used with auto-instrumentation anyway, so this seems like the best short-term solution.

## Implementation details

Remove the NuGet from the release artifacts.

## Test coverage

For this build I'll check that it's not in the release artifacts. Otherwise there's nothing else to do.

## Other Details

Favouring this over https://github.com/DataDog/dd-trace-dotnet/pull/5953 for now to avoid any future issues with mixing version conflict stuff