### PR TITLE
[ASM] Avoid reporting unknown matcher WAF errors

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -87,28 +87,13 @@ internal readonly partial struct SecurityCoordinator
             span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             span.SetMetric(Metrics.AppSecWafInitRulesLoaded, security.WafInitResult.LoadedRules);
             span.SetMetric(Metrics.AppSecWafInitRulesErrorCount, security.WafInitResult.FailedToLoadRules);
-            if (security.WafInitResult.HasErrors && !OnlyUnknownMatcherErrors(security.WafInitResult.Errors))
+            if (security.WafInitResult.HasErrors && !Security.OnlyUnknownMatcherErrors(security.WafInitResult.Errors))
             {
                 span.SetTag(Tags.AppSecWafInitRuleErrors, security.WafInitResult.ErrorMessage);
             }
 
             span.SetTag(Tags.AppSecWafVersion, security.DdlibWafVersion);
         }
-    }
-
-    private static bool OnlyUnknownMatcherErrors(IReadOnlyDictionary<string, object> errors)
-    {
-        // if all the errors start with "unknown matcher:", we should not report the error
-        // It will happen if the WAF version used does not support new operators defined in the rules
-        foreach (var error in errors)
-        {
-            if (!error.Key.ToLower().StartsWith("unknown matcher:", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -87,7 +87,7 @@ internal readonly partial struct SecurityCoordinator
             span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             span.SetMetric(Metrics.AppSecWafInitRulesLoaded, security.WafInitResult.LoadedRules);
             span.SetMetric(Metrics.AppSecWafInitRulesErrorCount, security.WafInitResult.FailedToLoadRules);
-            if (security.WafInitResult.HasErrors && !Security.OnlyUnknownMatcherErrors(security.WafInitResult.Errors))
+            if (security.WafInitResult.HasErrors && !Security.HasOnlyUnknownMatcherErrors(security.WafInitResult.Errors))
             {
                 span.SetTag(Tags.AppSecWafInitRuleErrors, security.WafInitResult.ErrorMessage);
             }

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -87,13 +87,28 @@ internal readonly partial struct SecurityCoordinator
             span.Context.TraceContext?.SetSamplingPriority(SamplingPriorityValues.UserKeep, SamplingMechanism.Asm);
             span.SetMetric(Metrics.AppSecWafInitRulesLoaded, security.WafInitResult.LoadedRules);
             span.SetMetric(Metrics.AppSecWafInitRulesErrorCount, security.WafInitResult.FailedToLoadRules);
-            if (security.WafInitResult.HasErrors)
+            if (security.WafInitResult.HasErrors && !OnlyUnknownMatcherErrors(security.WafInitResult.Errors))
             {
                 span.SetTag(Tags.AppSecWafInitRuleErrors, security.WafInitResult.ErrorMessage);
             }
 
             span.SetTag(Tags.AppSecWafVersion, security.DdlibWafVersion);
         }
+    }
+
+    private static bool OnlyUnknownMatcherErrors(IReadOnlyDictionary<string, object> errors)
+    {
+        // if all the errors start with "unknown matcher:", we should not report the error
+        // It will happen if the WAF version used does not support new operators defined in the rules
+        foreach (var error in errors)
+        {
+            if (!error.Key.ToLower().StartsWith("unknown matcher:", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -192,6 +192,11 @@ namespace Datadog.Trace.AppSec
             }
         }
 
+        internal ApplyDetails[] UpdateFromRcmForTest(Dictionary<string, List<RemoteConfiguration>> configsByProduct)
+        {
+            return UpdateFromRcm(configsByProduct, null);
+        }
+
         private ApplyDetails[] UpdateFromRcm(Dictionary<string, List<RemoteConfiguration>> configsByProduct, Dictionary<string, List<RemoteConfigurationPath>>? removedConfigs)
         {
             string? rcmUpdateError = null;
@@ -252,7 +257,7 @@ namespace Datadog.Trace.AppSec
                 productsCount += config.Value.Count;
             }
 
-            bool onlyUnknownMatcherErrors = OnlyUnknownMatcherErrors(updateResult?.Errors);
+            bool onlyUnknownMatcherErrors = string.IsNullOrEmpty(rcmUpdateError) && HasOnlyUnknownMatcherErrors(updateResult?.Errors);
             var applyDetails = new ApplyDetails[productsCount];
             var finalError = rcmUpdateError ?? updateResult?.ErrorMessage;
 
@@ -276,9 +281,9 @@ namespace Datadog.Trace.AppSec
             return applyDetails;
         }
 
-        internal static bool OnlyUnknownMatcherErrors(IReadOnlyDictionary<string, object>? errors)
+        internal static bool HasOnlyUnknownMatcherErrors(IReadOnlyDictionary<string, object>? errors)
         {
-            if (errors is not null)
+            if (errors is not null && errors.Count > 0)
             {
                 // if all the errors start with "unknown matcher:", we should not report the error
                 // It will happen if the WAF version used does not support new operators defined in the rules
@@ -289,9 +294,11 @@ namespace Datadog.Trace.AppSec
                         return false;
                     }
                 }
+
+                return true;
             }
 
-            return true;
+            return false;
         }
 
         internal BlockingAction GetBlockingAction(string[]? requestAcceptHeaders, Dictionary<string, object?>? blockInfo, Dictionary<string, object?>? redirectInfo)

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/rasp-rule-set.json
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/rasp-rule-set.json
@@ -288,6 +288,56 @@
         "stack_trace",
         "block"
       ]
+    },
+    {
+      "id": "rasp-932-400",
+      "name": "New exploit",
+      "enabled": true,
+      "tags": {
+        "type": "new_injection",
+        "category": "vulnerability_trigger",
+        "cwe": "77",
+        "capec": "1000/152/248/88",
+        "confidence": "0",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.sys.shell.cmd"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+
+              {
+                "address": "graphql.server.resolver"
+              }
+            ]
+          },
+          "operator": "new_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
+      ]
     }
   ]
 }

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RASPRcmTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/RASPRcmTests.cs
@@ -1,0 +1,79 @@
+// <copyright file="RASPRcmTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Datadog.Trace.AppSec;
+using Datadog.Trace.Configuration;
+using Datadog.Trace.Configuration.Telemetry;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Datadog.Trace.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+public class RaspRcmTests : SettingsTestsBase
+{
+    [Theory]
+    // New operator
+    [InlineData(false, "{\r\n  \"version\": \"2.2\",\r\n  \"metadata\": {\r\n    \"rules_version\": \"1.10.0\"\r\n  },\r\n\r\n  \"rules\": [\r\n    {\r\n      \"id\": \"rasp-932-400\",\r\n      \"name\": \"New exploit\",\r\n      \"enabled\": true,\r\n      \"tags\": {\r\n        \"type\": \"new_injection\",\r\n        \"category\": \"vulnerability_trigger\",\r\n        \"cwe\": \"77\",\r\n        \"capec\": \"1000/152/248/88\",\r\n        \"confidence\": \"0\",\r\n        \"module\": \"rasp\"\r\n      },\r\n      \"conditions\": [\r\n        {\r\n          \"parameters\": {\r\n            \"resource\": [\r\n              {\r\n                \"address\": \"server.sys.shell.cmd\"\r\n              }\r\n            ],\r\n            \"params\": [\r\n              {\r\n                \"address\": \"server.request.query\"\r\n              },\r\n              {\r\n                \"address\": \"server.request.body\"\r\n              },\r\n              {\r\n                \"address\": \"server.request.path_params\"\r\n              },\r\n              {\r\n                \"address\": \"grpc.server.request.message\"\r\n              },\r\n              {\r\n                \"address\": \"graphql.server.all_resolvers\"\r\n              },\r\n\r\n              {\r\n                \"address\": \"graphql.server.resolver\"\r\n              }\r\n            ]\r\n          },\r\n          \"operator\": \"new_detector\"\r\n        }\r\n      ],\r\n      \"transformers\": [],\r\n      \"on_match\": [\r\n        \"stack_trace\"\r\n      ]\r\n    }\r\n  ]\r\n}")]
+    [InlineData(true, "INVALID")]
+    // Missing key error
+    [InlineData(true, "{\r\n\t\"version\": \"2.2\",\r\n\t\"metadata\": {\r\n\t\t\"rules_version\": \"1.10.0\"\r\n\t},\r\n\t\"rules\": [\r\n\t\t{\r\n\t\t\t\"enabled\": true,\r\n\t\t\t\"tags\": {\r\n\t\t\t\t\"cwe\": \"77\",\r\n\t\t\t\t\"capec\": \"1000/152/248/88\",\r\n\t\t\t\t\"confidence\": \"0\",\r\n\t\t\t\t\"module\": \"rasp\"\r\n\t\t\t}\r\n\t\t}\r\n\t]\r\n}")]
+    public void GivenANewOperator_WhenUpdateFromRcm_NoErrorIsReported(bool errorExpected, string rules)
+    {
+        var remoteConfigValues = CreateRemoteConfigValues(rules);
+        var security = CreateSecurity();
+        var result = security.UpdateFromRcmForTest(remoteConfigValues);
+        result.Length.Should().Be(1);
+
+        if (errorExpected)
+        {
+            AssertHasErrors(result);
+        }
+        else
+        {
+            AssertNoErrors(result);
+        }
+    }
+
+    private static void AssertHasErrors(ApplyDetails[] result)
+    {
+        result[0].Error.Should().NotBeEmpty();
+        result[0].ApplyState.Should().Be(ApplyStates.ERROR);
+    }
+
+    private static AppSec.Security CreateSecurity()
+    {
+        var source = CreateConfigurationSource([(ConfigurationKeys.AppSec.Enabled, "true")]);
+        var settings = new SecuritySettings(source, NullConfigurationTelemetry.Instance);
+        var security = new AppSec.Security(settings);
+        // Set it to true with reflection to avoid all the initialization
+        PropertyInfo propInfo = typeof(AppSec.Security).GetProperty("Enabled", BindingFlags.NonPublic | BindingFlags.Instance);
+        propInfo.SetValue(security, true);
+        security.Enabled.Should().BeTrue();
+        return security;
+    }
+
+    private static Dictionary<string, List<RemoteConfiguration>> CreateRemoteConfigValues(string rules)
+    {
+        var content = Encoding.UTF8.GetBytes(rules);
+        RemoteConfiguration config = new RemoteConfiguration(RemoteConfigurationPath.FromPath("employee/john/doe/smith"), content, content.Length, new Dictionary<string, string>(), 33);
+        var dic = new Dictionary<string, List<RemoteConfiguration>>();
+        dic["ASM_DD"] = (new List<RemoteConfiguration> { config });
+        return dic;
+    }
+
+    private void AssertNoErrors(ApplyDetails[] result)
+    {
+        foreach (var applyDetails in result)
+        {
+            applyDetails.Error.Should().BeNullOrEmpty();
+            applyDetails.ApplyState.Should().Be(ApplyStates.ACKNOWLEDGED);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

The unknown matcher error happens when a new operator is added and it is not supported by the WAF, so sending this particular error is causing a lot of noise because old versions of the WAF will return that error that actually is supported in newer versions. We already write warnings for this situation, but we are also reporting errors that are not actually errors, Which is generating a lot of noise. In particular, we return errors in the remote config operations and we add error tags to the span.

This PR corrects this.

## Reason for change

It was reported and requested.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
