### PR TITLE
Fix GRPC integration

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Grpc/GrpcDotNet/GrpcAspNetCoreServer/GrpcDotNetServerCommon.cs
@@ -28,8 +28,24 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Grpc.GrpcDotNet.GrpcAspN
                 return null;
             }
 
+            // Check if the current handler has the MethodInvoker property
+            MethodStruct method;
+            if (instance.TryDuckCast<ServerCallHandlerBaseStruct>(out var handlerWithMethodInvoker))
+            {
+                // The current handler has the MethodInvoker property (this is the case for >= 2.27.0 versions)
+                method = handlerWithMethodInvoker.MethodInvoker.Method;
+            }
+            else if (instance.TryDuckCast<ServerMethodInvokerBaseStruct>(out var methodInvoker))
+            {
+                // The current handler has the Method property (this is the case for < 2.27.0 versions)
+                method = methodInvoker.Method;
+            }
+            else
+            {
+                return null;
+            }
+
             Scope? scope = null;
-            var method = instance.DuckCast<ServerCallHandlerBaseStruct>().MethodInvoker.Method;
             try
             {
                 var tags = new GrpcServerTags();


### PR DESCRIPTION
## Summary of changes

This PR fixes the current GRPC integration.

## Reason for change

The following error has been seen in the Error tracking product: 
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/294999f2-8106-429b-b381-d70fc57ff17c">

## Implementation details

Instead of calling `DuckCast` directly that can throw, we use `TryDuckCast` to check if we can use the ducktype struct before.
