### PR TITLE
[Profiler] Provide the thread id that blocked another thread

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -292,6 +292,18 @@ void ClrEventsParser::ParseContentionEvent(DWORD id, DWORD version, ULONG cbEven
 
         _pContentionListener->OnContention(payload.DurationNs);
     }
+
+    if ((id == EVENT_CONTENTION_START) && (version >= 2))
+    {
+        ContentionStartV2Payload payload{0};
+        ULONG offset = 0;
+        if (!Read<ContentionStartV2Payload>(payload, pEventData, cbEventData, offset))
+        {
+            return;
+        }
+
+        _pContentionListener->SetBlockingThread(payload.LockOwnerThreadID);
+    }
 }
 
 void ClrEventsParser::NotifySuspension(uint64_t timestamp, uint32_t number, uint32_t generation, uint64_t duration)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.h
@@ -130,6 +130,16 @@ struct ContentionStopV1Payload // for .NET Core/ 5+
     double_t DurationNs;       // Duration of the contention (without spinning)
 };
 
+struct ContentionStartV2Payload // for .NET Core/ 5+
+{
+    uint8_t ContentionFlags; // 0 for managed; 1 for native.
+    uint16_t ClrInstanceId;  // Unique ID for the instance of CLR.
+    uintptr_t LockId;
+    uintptr_t AssociatedObjectID;
+    // This is a copy/paste from the CLR, but the LockOwnerThreadID is not a ThreadID but an OS Thread Id
+    uint64_t LockOwnerThreadID;
+};
+
 struct GCStartPayload
 {
     uint32_t Count;
@@ -332,6 +342,7 @@ private:
 private:
     const int EVENT_ALLOCATION_TICK = 10;   // version 4 contains the size + reference
     const int EVENT_CONTENTION_STOP = 91;   // version 1 contains the duration in nanoseconds
+    const int EVENT_CONTENTION_START = 81; // version 2 contains thread id of the threads that owns the lock
 
     // Events emitted during garbage collection lifetime
     // read https://medium.com/criteo-engineering/spying-on-net-garbage-collector-with-net-core-eventpipes-9f2a986d5705?source=friends_link&sk=baf9a7766fb5c7899b781f016803597f

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -51,6 +51,7 @@ public:
     // IContentionListener implementation
     void OnContention(double contentionDurationNs) override;
     void OnContention(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, const std::vector<uintptr_t>& stack) override;
+    void SetBlockingThread(uint64_t osThreadId) override;
 
     // IUpscaleProvider implementation
     UpscalingInfo GetInfo() override;
@@ -58,7 +59,7 @@ public:
 private:
     static std::string GetBucket(double contentionDurationNs);
     static std::vector<SampleValueType> SampleTypeDefinitions;
-    void AddContentionSample(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, const std::vector<uintptr_t>& stack);
+    void AddContentionSample(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, uint64_t blockingThreadId, const std::vector<uintptr_t>& stack);
 
 private:
     static std::vector<uintptr_t> _emptyStack;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1541,11 +1541,12 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ThreadAssignedToOSThread(ThreadID
     dupOsThreadHandle = origOsThreadHandle;
 #endif
 
-#ifdef LINUX
     auto threadInfo = _pManagedThreadList->GetOrCreate(managedThreadId);
     // CurrentThreadInfo relies on the assumption that the native thread calling ThreadAssignedToOSThread/ThreadDestroyed
     // is the same native thread assigned to the managed thread.
     ManagedThreadInfo::CurrentThreadInfo = threadInfo;
+
+#ifdef LINUX
 
     if (_pCpuProfiler != nullptr)
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/IContentionListener.h
@@ -12,4 +12,5 @@ public:
 
     virtual void OnContention(double contentionDurationNs) = 0;
     virtual void OnContention(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, const std::vector<uintptr_t>& stack) = 0;
+    virtual void SetBlockingThread(uint64_t osThreadId) = 0;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.cpp
@@ -45,6 +45,7 @@ ManagedThreadInfo::ManagedThreadInfo(ThreadID clrThreadId, ICorProfilerInfo4* pC
     _isThreadDestroyed{false},
     _traceContextTrackingInfo{},
     _sharedMemoryArea{nullptr},
-    _info{pCorProfilerInfo}
+    _info{pCorProfilerInfo},
+    _blockingThreadId{0}
 {
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -81,6 +81,7 @@ public:
     inline bool IsThreadDestroyed();
     inline bool IsDestroyed();
     inline void SetThreadDestroyed();
+    inline uint64_t SetBlockingThread(uint64_t osThreadId);
 
     inline TraceContextTrackingInfo* GetTraceContextPointer();
     inline std::uint64_t GetLocalRootSpanId() const;
@@ -151,6 +152,7 @@ private:
 #ifdef LINUX
     std::int32_t _timerId;
 #endif
+    uint64_t _blockingThreadId;
 };
 
 std::string ManagedThreadInfo::GetProfileThreadId()
@@ -402,6 +404,11 @@ inline void ManagedThreadInfo::SetThreadDestroyed()
 {
     SemaphoreScope guardedLock(_stackWalkLock);
     _isThreadDestroyed = true;
+}
+
+inline uint64_t ManagedThreadInfo::SetBlockingThread(uint64_t osThreadId)
+{
+    return std::exchange(_blockingThreadId, osThreadId);
 }
 
 inline TraceContextTrackingInfo* ManagedThreadInfo::GetTraceContextPointer()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -12,6 +12,7 @@ public:
     inline static const std::string BucketLabelName = "Duration bucket";
     inline static const std::string RawCountLabelName = "raw count";
     inline static const std::string RawDurationLabelName = "raw duration";
+    inline static const std::string BlockingThreadInfo = "blocking thread";
 
 public:
     RawContentionSample() = default;
@@ -20,7 +21,8 @@ public:
         :
         RawSample(std::move(other)),
         ContentionDuration(other.ContentionDuration),
-        Bucket(std::move(other.Bucket))
+        Bucket(std::move(other.Bucket)),
+        BlockingThread(other.BlockingThread)
     {
     }
 
@@ -31,6 +33,7 @@ public:
             RawSample::operator=(std::move(other));
             ContentionDuration = other.ContentionDuration;
             Bucket = std::move(other.Bucket);
+            BlockingThread = other.BlockingThread;
         }
         return *this;
     }
@@ -46,8 +49,13 @@ public:
         sample->AddNumericLabel(NumericLabel{RawCountLabelName, 1});
         sample->AddNumericLabel(NumericLabel{RawDurationLabelName, static_cast<uint64_t>(ContentionDuration)});
         sample->AddValue(static_cast<std::int64_t>(ContentionDuration), contentionDurationIndex);
+        if (BlockingThread != 0)
+        {
+            sample->AddNumericLabel(NumericLabel{BlockingThreadInfo, BlockingThread});
+        }
     }
 
     double ContentionDuration;
     std::string Bucket;
+    uint64_t BlockingThread;
 };

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -3,7 +3,10 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
 // </copyright>
 
+using System;
+using System.Linq;
 using Datadog.Profiler.IntegrationTests.Helpers;
+using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -34,6 +37,11 @@ namespace Datadog.Profiler.IntegrationTests.Contention
             // only contention profiler enabled so should only see the 2 related values per sample
             SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 2);
             Assert.True(SamplesHelper.IsLabelPresent(runner.Environment.PprofDir, "raw duration"));
+
+            if (framework == "net8.0")
+            {
+                AssertBlockingThreadLabel(runner.Environment.PprofDir);
+            }
         }
 
         [TestAppFact("Samples.Computer01", new[] { "net6.0", "net7.0", "net8.0" })]
@@ -54,6 +62,11 @@ namespace Datadog.Profiler.IntegrationTests.Contention
             // only contention profiler enabled so should see 2 value per sample
             SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 2);
             Assert.NotEqual(0, SamplesHelper.GetSamplesCount(runner.Environment.PprofDir));
+
+            if (framework == "net8.0")
+            {
+                AssertBlockingThreadLabel(runner.Environment.PprofDir);
+            }
         }
 
         [TestAppFact("Samples.Computer01", new[] { "net6.0", "net7.0", "net8.0" })]
@@ -70,6 +83,23 @@ namespace Datadog.Profiler.IntegrationTests.Contention
 
             // only walltime profiler enabled so should see 1 value per sample
             SamplesHelper.CheckSamplesValueCount(runner.Environment.PprofDir, 1);
+        }
+
+        private static void AssertBlockingThreadLabel(string pprofDir)
+        {
+            var threadIds = SamplesHelper.GetThreadIds(pprofDir);
+            // get samples with lock-count value set and blocking thread info
+            var contentionSamples = SamplesHelper.GetSamples(pprofDir, "lock-count")
+                .Where(e => e.Labels.Any(x => x.Name == "blocking thread"));
+
+            contentionSamples.Should().NotBeEmpty();
+
+            foreach (var (_, labels, _) in contentionSamples)
+            {
+                var label = labels.FirstOrDefault(l => l.Name == "blocking thread");
+                label.Name.Should().NotBeNullOrWhiteSpace();
+                threadIds.Should().Contain(int.Parse(label.Value), $"Unknown blocking thread id {label.Value}");
+            }
         }
     }
 }

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/PprofHelper.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Helpers/PprofHelper.cs
@@ -37,6 +37,15 @@ namespace Datadog.Profiler.IntegrationTests.Helpers
                 });
         }
 
+        public static string[] SampleType(this Perftools.Profiles.Profile profile)
+        {
+            return profile.SampleType.Select(
+                sampleType =>
+                {
+                    return profile.StringTable[(int)sampleType.Type];
+                }).ToArray();
+        }
+
         public static StackTrace StackTrace(this Perftools.Profiles.Sample sample, Profile profile)
         {
             return new StackTrace(


### PR DESCRIPTION
## Summary of changes

Provides the thread id of that owns a lock object.

## Reason for change

New feature.

## Implementation details

The ContentionStart event contains information about the contented lock and the thread that owns it. Remember the OS Thread Id of the thread that owns the lock object and use it when creating a sample.

## Test coverage
Add asserts on the existing tests.
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
