### PR TITLE
Protect the connection string tags extractor from an invalid connection string (#5956 -> v2)

### DIFF
--- a/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
+++ b/tracer/src/Datadog.Trace/Util/DbCommandCache.cs
@@ -97,13 +97,23 @@ namespace Datadog.Trace.Util
 
         private static TagsCacheItem ExtractTagsFromConnectionString(string connectionString)
         {
-            // Parse the connection string
-            var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
+            try
+            {
+                // Parse the connection string
+                var builder = new DbConnectionStringBuilder { ConnectionString = connectionString };
 
-            return new TagsCacheItem(
-                dbName: GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog"),
-                dbUser: GetConnectionStringValue(builder, "User ID", "UserID"),
-                outHost: GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"));
+                // Extract the tags
+                return new TagsCacheItem(
+                    dbName: GetConnectionStringValue(builder, "Database", "Initial Catalog", "InitialCatalog"),
+                    dbUser: GetConnectionStringValue(builder, "User ID", "UserID"),
+                    outHost: GetConnectionStringValue(builder, "Server", "Data Source", "DataSource", "Network Address", "NetworkAddress", "Address", "Addr", "Host"));
+            }
+            catch (Exception)
+            {
+                // DbConnectionStringBuilder can throw exceptions if the connection string is invalid
+                // in this case we should not use the connection string and just return default
+                return default;
+            }
         }
 
         private static string? GetConnectionStringValue(DbConnectionStringBuilder builder, params string[] names)


### PR DESCRIPTION
## Summary of changes

This PR fixes an scenario when the connection string could not be parsed by avoiding the exception.

## Reason for change

Seen in Error tracking:

<img width="1127" alt="image"
src="https://github.com/user-attachments/assets/436de8fe-b6b8-43d7-a894-5554bb4e04eb">

## Implementation details

Wrap the method in a try catch block, and return default on that invalid connection string.
The caller method already returns `default` in other cases.

## Test coverage

This is an small fix, I didn't write a test case for this... yet.

## Other details

Backport of https://github.com/DataDog/dd-trace-dotnet/pull/5956