### PR TITLE
Remove the xml and pdb files from the linux packages

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -988,6 +988,9 @@ partial class Build
                 EnsureCleanDirectory(assetsDirectory);
                 CopyDirectoryRecursively(MonitoringHomeDirectory, assetsDirectory, DirectoryExistsPolicy.Merge);
 
+                // remove the XML files and pdb files from the package - they take up space and aren't needed
+                assetsDirectory.GlobFiles("**/*.xml", "**/*.pdb").ForEach(DeleteFile);
+
                 if (!includeMuslArtifacts && !IsAlpine)
                 {
                     // Remove the linux-musl-x64 folder entirely if we don't need it


### PR DESCRIPTION
## Summary of changes

Remove the xml and pdb files from the linux packages

## Reason for change

They're not actually used for anything, and just increase the size of artifacts

## Implementation details

Remove the xml and pdb files just before packaging

## Test coverage

File size changes previous -> now:
- `linux-x64` deb/rpm : 21MB -> 19MB compressed
- `linux-x64` tar : 30MB -> 25MB compressed
- `linux-musl-x64` tar : 22MB -> 17MB compressed
- `linux-arm64` deb/rpm : 21MB -> 18MB compressed
- `linux-arm64` tar : 28MB -> 24MB compressed

Uncompressed changes are much bigger because we have pretty much 3 copies of each file so e.g. 84MB vs 58MB

## Other details

For simplicity, stacked on: 
- https://github.com/DataDog/dd-trace-dotnet/pull/5933

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
