### PR TITLE
Display the crash tests stdout live

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -146,8 +146,11 @@ steps:
 # Run crash tests
 - ${{ if and(eq(parameters.isLinux, true), eq(parameters.isNoop, false)) }}:
   - bash: |
-      LOGS=$(${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
-      echo $LOGS
+      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }} | while IFS= read -r line
+      do
+        echo "$line"  # Output the log line to stdout in real-time
+        LOGS+="$line"$'\n'  # Capture each line into LOGS variable
+      done
 
       # check logs for evidence of crash detection in the output
       expected="The crash may have been caused by automatic instrumentation"

--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -146,11 +146,12 @@ steps:
 # Run crash tests
 - ${{ if and(eq(parameters.isLinux, true), eq(parameters.isNoop, false)) }}:
   - bash: |
-      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }} | while IFS= read -r line
+      LOGS=""
+      while IFS= read -r line
       do
         echo "$line"  # Output the log line to stdout in real-time
         LOGS+="$line"$'\n'  # Capture each line into LOGS variable
-      done
+      done < <(${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) run -e dockerTag=$(dockerTag) -e CRASH_APP_ON_STARTUP=1 -e COMPlus_DbgEnableMiniDump=0 ${{ parameters.target }})
 
       # check logs for evidence of crash detection in the output
       expected="The crash may have been caused by automatic instrumentation"


### PR DESCRIPTION
## Summary of changes

In the crashtracking installer smoke-tests, display the output as it comes instead of all at once when it finishes.

## Reason for change

The job sometimes hangs. When it happens, it gets killed after the timeout elapses, and we see no output because the command didn't complete.

## Implementation details

Bash.

