### PR TITLE
Fix debugger arm64 alpine tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2960,7 +2960,7 @@ stages:
 
         - template: steps/restore-working-directory.yml
           parameters:
-            artifact: build-linux-arm64-working-directory
+            artifact: build-$(artifactSuffix)-working-directory
 
         - template: steps/run-in-docker.yml
           parameters:
@@ -2970,9 +2970,9 @@ stages:
             apiKey: $(DD_LOGGER_DD_API_KEY)
 
         - task: DownloadPipelineArtifact@2
-          displayName: Download arm64 monitoring home
+          displayName: Download $(artifactSuffix) monitoring home
           inputs:
-            artifact: linux-monitoring-home-linux-arm64
+            artifact: linux-monitoring-home-$(artifactSuffix)
             path: $(monitoringHome)
 
         - script: |

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -1277,13 +1277,17 @@ partial class Build : NukeBuild
             void GenerateIntegrationTestsDebuggerArm64Matrices()
             {
                 var targetFrameworks = TestingFrameworksDebugger.Except(new[] { TargetFramework.NET462, TargetFramework.NETCOREAPP2_1, TargetFramework.NETCOREAPP3_1,  });
-                var baseImages = new[] { "debian", "alpine" };
+                var baseImages = new []
+                {
+                    (baseImage: "debian", artifactSuffix: "linux-arm64"),
+                    (baseImage: "alpine", artifactSuffix: "linux-musl-arm64"),
+                };
                 var optimizations = new[] { "true", "false" };
 
                 var matrix = new Dictionary<string, object>();
                 foreach (var framework in targetFrameworks)
                 {
-                    foreach (var baseImage in baseImages)
+                    foreach (var (baseImage, artifactSuffix) in baseImages)
                     {
                         foreach (var optimize in optimizations)
                         {
@@ -1293,6 +1297,7 @@ partial class Build : NukeBuild
                                            publishTargetFramework = framework,
                                            baseImage = baseImage,
                                            optimize = optimize,
+                                           artifactSuffix = artifactSuffix,
                                        });
                         }
                     }


### PR DESCRIPTION
## Summary of changes

Fixes the debugger alpine tests that were broken by #5933 

## Reason for change

The debugger tests were broken, but because that PR didn't run the debugger tests by default, we didn't notice.

## Implementation details

Download the correct artifacts in arm64 alpine
