### PR TITLE
Run installer tests with libgcc added to the alpine package

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4974,6 +4974,7 @@ stages:
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
           --build-arg INSTALL_CMD="$(installCmd)" \
+          --build-arg $ADDITIONAL_INSTALL="$(additionalInstall)" \
           smoke-tests
       env:
         dockerTag: $(dockerTag)
@@ -5433,6 +5434,7 @@ stages:
               --build-arg RUNTIME_IMAGE=$(runtimeImage) \
               --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
               --build-arg INSTALL_CMD="$(installCmd)" \
+              --build-arg $ADDITIONAL_INSTALL="$(additionalInstall)" \
               smoke-tests
           env:
             dockerTag: $(dockerTag)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -883,6 +883,7 @@ services:
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
         # - INSTALL_CMD=
+        # - ADDITIONAL_INSTALL=
     image: dd-trace-dotnet/${dockerTag:-not-set}-tester
     volumes:
     - ./:/project

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -501,6 +501,28 @@ partial class Build : NukeBuild
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
                     );
 
+                    // Alpine tests with the default package with glibc compat installed
+                    AddToLinuxSmokeTestsMatrix(
+                        matrix,
+                        "alpine_libgcc",
+                        new SmokeTestImage[]
+                        {
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.18"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.16"),
+                            new (publishFramework: TargetFramework.NET5_0, "5.0-alpine3.14"),
+                            new (publishFramework: TargetFramework.NETCOREAPP3_1, "3.1-alpine3.14"),
+                        },
+                        // currently we direct customers to the musl-specific package in the command line.
+                        // Should we update this to point to the default artifact instead?
+                        installer: "datadog-dotnet-apm*-musl.tar.gz", // used by the dd-dotnet checks to direct customers to the right place
+                        additionalInstall: "apk add gcompat", // add the glibc compatibility library
+                        installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*.tar.gz",
+                        linuxArtifacts: "linux-packages-linux-x64", // these are what we download
+                        runtimeId: "linux-musl-x64", // used by the dd-dotnet checks to direct customers to the right place
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
                     // Alpine tests with the musl-specific package
                     AddToLinuxSmokeTestsMatrix(
                         matrix,
@@ -687,6 +709,28 @@ partial class Build : NukeBuild
                         dockerName: "mcr.microsoft.com/dotnet/aspnet"
                     );
 
+                    // Alpine tests with the default package
+                    AddToLinuxSmokeTestsMatrix(
+                        matrix,
+                        "alpine_libgcc",
+                        new SmokeTestImage[]
+                        {
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.20"),
+                            new (publishFramework: TargetFramework.NET8_0, "8.0-alpine3.19-composite"),
+                            new (publishFramework: TargetFramework.NET7_0, "7.0-alpine3.18"),
+                            new (publishFramework: TargetFramework.NET6_0, "6.0-alpine3.18"),
+                            // runtimes on earlier alpine versions aren't provided by MS
+                        },
+                        // currently we direct customers to the musl-specific package in the command line.
+                        // Should we update this to point to the default artifact instead?
+                        installer: "datadog-dotnet-apm*.arm64.tar.gz", // used by the dd-dotnet checks to direct customers to the right place
+                        additionalInstall: "apk add gcompat", // add the glibc compatibility library
+                        installCmd: "tar -C /opt/datadog -xzf ./datadog-dotnet-apm*.tar.gz",
+                        linuxArtifacts: "linux-packages-linux-arm64", // these are what we download
+                        runtimeId: "linux-musl-arm64", // used by the dd-dotnet checks to direct customers to the right place
+                        dockerName: "mcr.microsoft.com/dotnet/aspnet"
+                    );
+
                     Logger.Information($"Installer smoke tests matrix");
                     Logger.Information(JsonConvert.SerializeObject(matrix, Formatting.Indented));
                     AzurePipelines.Instance.SetOutputVariable("installer_smoke_tests_arm64_matrix", JsonConvert.SerializeObject(matrix, Formatting.None));
@@ -724,7 +768,8 @@ partial class Build : NukeBuild
                     string installCmd,
                     string linuxArtifacts,
                     string runtimeId,
-                    string dockerName
+                    string dockerName,
+                    string additionalInstall = ""
                 )
                 {
                     foreach (var image in images)
@@ -741,7 +786,8 @@ partial class Build : NukeBuild
                                 publishFramework = image.PublishFramework,
                                 linuxArtifacts = linuxArtifacts,
                                 runCrashTest = image.RunCrashTest ? "true" : "false",
-                                runtimeImage = $"{dockerName}:{image.RuntimeTag}"
+                                runtimeImage = $"{dockerName}:{image.RuntimeTag}",
+                                additionalInstall = additionalInstall
                             });
                     }
                 }

--- a/tracer/build/_build/docker/smoke.dockerfile
+++ b/tracer/build/_build/docker/smoke.dockerfile
@@ -19,11 +19,14 @@ WORKDIR /app
 COPY --from=builder /src/artifacts /app/install
 
 ARG INSTALL_CMD
+# A simple non-install command to simplify the RUN command below
+ARG ADDITIONAL_INSTALL="ls /var/log/datadog"
 RUN mkdir -p /opt/datadog \
     && mkdir -p /var/log/datadog \
     && cd /app/install \
     && $INSTALL_CMD \
-    && rm -rf /app/install
+    && rm -rf /app/install \
+    && $ADDITIONAL_INSTALL
 
 # Set the required env vars
 ENV CORECLR_ENABLE_PROFILING=1


### PR DESCRIPTION
## Summary of changes

Runs additional installer tests for alpine where the glibc compatibility package is installed

## Reason for change

It's possible to run glibc libraries on alpine if you use the compatibility layer. We don't _need_ these and generally won't "notice" they're there, but we should check that it doesn't cause any issues for us

## Implementation details

Add additional smokes tests that add the compatibility package to the alpine container

## Test coverage

Just added a few smoke tests, to make sure we don't hit any obvious issues

## Other details

Will also backport these to v2