### PR TITLE
Load the tracer/profiler after guardrails checks

### DIFF
--- a/Datadog.Trace.Native.sln
+++ b/Datadog.Trace.Native.sln
@@ -29,6 +29,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Datadog.Trace.ClrProfiler.M
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native", "shared\src\Datadog.Trace.ClrProfiler.Native\Datadog.Trace.ClrProfiler.Native.vcxproj", "{48D12C26-6E63-419C-BFE2-E668E8550613}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Datadog.Trace.ClrProfiler.Native.Tests", "shared\test\Datadog.Trace.ClrProfiler.Native.Tests\Datadog.Trace.ClrProfiler.Native.Tests.vcxproj", "{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -176,6 +178,26 @@ Global
 		{48D12C26-6E63-419C-BFE2-E668E8550613}.Release|x64.Build.0 = Release|x64
 		{48D12C26-6E63-419C-BFE2-E668E8550613}.Release|x86.ActiveCfg = Release|Win32
 		{48D12C26-6E63-419C-BFE2-E668E8550613}.Release|x86.Build.0 = Release|Win32
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|Any CPU.Build.0 = Debug|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|ARM64.Build.0 = Debug|ARM64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|ARM64EC.ActiveCfg = Debug|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|ARM64EC.Build.0 = Debug|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|x64.ActiveCfg = Debug|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|x64.Build.0 = Debug|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|x86.ActiveCfg = Debug|Win32
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Debug|x86.Build.0 = Debug|Win32
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|Any CPU.ActiveCfg = Release|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|Any CPU.Build.0 = Release|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|ARM64.ActiveCfg = Release|ARM64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|ARM64.Build.0 = Release|ARM64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|ARM64EC.ActiveCfg = Release|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|ARM64EC.Build.0 = Release|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|x64.ActiveCfg = Release|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|x64.Build.0 = Release|x64
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|x86.ActiveCfg = Release|Win32
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -188,6 +210,7 @@ Global
 		{6CE95C50-9533-4650-8F11-BCE30908DCDF} = {B9AA20A4-0F9A-47FB-B3BE-A5BDEA42EFF0}
 		{0686E907-996A-4D6D-A685-D9C0F932C405} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
 		{48D12C26-6E63-419C-BFE2-E668E8550613} = {9E5F0022-0A50-40BF-AC6A-C3078585ECAB}
+		{3FCBD2EB-ACBE-4DA1-850F-12BEE08B937B} = {8CEC2042-F11C-49F5-A674-2355793B600A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {160A1D00-1F5B-40F8-A155-621B4459D78F}

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler.cpp
@@ -256,13 +256,25 @@ namespace datadog::shared::nativeloader
         }
 
         //
-        // Get and set profiler pointers
+        // Initialize the dispatcher
         //
         if (m_dispatcher == nullptr)
         {
+            Log::Error("Dispatcher is not set.");
             single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
             return E_FAIL;
         }
+
+        if (FAILED(m_dispatcher->Initialize()))
+        {
+            Log::Error("Error initializing the dispatcher.");
+            single_step_guard_rails.RecordBootstrapError(runtimeInformation, "initialization_error");
+            return E_FAIL;
+        }
+
+        //
+        // Get and set profiler pointers
+        //
         IDynamicInstance* cpInstance = m_dispatcher->GetContinuousProfilerInstance();
         if (cpInstance != nullptr)
         {

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/cor_profiler_class_factory.cpp
@@ -27,13 +27,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerClassFactory::QueryInterface(REFIID riid, v
     {
         *ppvObject = this;
         this->AddRef();
-
-        // We try to load the class factory of all target cor profilers.
-        if (FAILED(m_dispatcher->LoadClassFactory(riid)))
-        {
-            Log::Warn("Error loading all cor profiler class factories.");
-        }
-
+         
         return S_OK;
     }
 
@@ -71,11 +65,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerClassFactory::CreateInstance(IUnknown* pUnk
 
     auto profiler = new datadog::shared::nativeloader::CorProfiler(m_dispatcher);
     HRESULT res = profiler->QueryInterface(riid, ppvObject);
-    if (SUCCEEDED(res))
-    {
-        m_dispatcher->LoadInstance(pUnkOuter, riid);
-    }
-    else
+    if (FAILED(res))
     {
         delete profiler;
     }

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dllmain.cpp
@@ -94,8 +94,7 @@ EXTERN_C BOOL STDMETHODCALLTYPE DllMain(HMODULE hModule, DWORD ul_reason_for_cal
         }
 #endif
 
-        dispatcher = new DynamicDispatcherImpl();
-        dispatcher->LoadConfiguration(GetConfigurationFilePath());
+            dispatcher = new DynamicDispatcherImpl();
 
         // *****************************************************************************************************************
         break;

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -22,8 +22,41 @@ namespace datadog::shared::nativeloader
     DynamicDispatcherImpl::DynamicDispatcherImpl() :
         m_continuousProfilerInstance(nullptr),
         m_tracerInstance(nullptr),
-        m_customInstance(nullptr)
+        m_customInstance(nullptr),
+        m_initialized(false),
+        m_initializationResult(E_NOT_SET)
     {
+    }
+
+    HRESULT DynamicDispatcherImpl::Initialize()
+    {
+        if (m_initialized)
+        {
+            return m_initializationResult;
+        }
+
+        m_initialized = true;
+
+        LoadConfiguration(GetConfigurationFilePath());
+
+        m_initializationResult = LoadClassFactory(IID_IClassFactory);
+
+        if (FAILED(m_initializationResult))
+        {
+            Log::Error("Error loading all cor profiler class factories.");
+            return m_initializationResult;
+        }
+
+        m_initializationResult = LoadInstance();
+
+        if (FAILED(m_initializationResult))
+        {
+            Log::Error("Error loading all cor profiler instances.");
+            return m_initializationResult;
+        }
+
+        m_initializationResult = S_OK;
+        return m_initializationResult;
     }
 
     void DynamicDispatcherImpl::LoadConfiguration(fs::path&& configFilePath)
@@ -201,13 +234,13 @@ namespace datadog::shared::nativeloader
         return GHR;
     }
 
-    HRESULT DynamicDispatcherImpl::LoadInstance(IUnknown* pUnkOuter, REFIID riid)
+    HRESULT DynamicDispatcherImpl::LoadInstance()
     {
         HRESULT GHR = S_OK;
 
         if (m_continuousProfilerInstance != nullptr)
         {
-            HRESULT result = m_continuousProfilerInstance->LoadInstance(pUnkOuter, riid);
+            HRESULT result = m_continuousProfilerInstance->LoadInstance();
             if (FAILED(result))
             {
                 Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
@@ -221,7 +254,7 @@ namespace datadog::shared::nativeloader
 
         if (m_tracerInstance != nullptr)
         {
-            HRESULT result = m_tracerInstance->LoadInstance(pUnkOuter, riid);
+            HRESULT result = m_tracerInstance->LoadInstance();
             if (FAILED(result))
             {
                 Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the tracer instance in: ", m_tracerInstance->GetFilePath());
@@ -234,7 +267,7 @@ namespace datadog::shared::nativeloader
 
         if (m_customInstance != nullptr)
         {
-            HRESULT result = m_customInstance->LoadInstance(pUnkOuter, riid);
+            HRESULT result = m_customInstance->LoadInstance();
             if (FAILED(result))
             {
                 Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the custom instance in: ", m_customInstance->GetFilePath());

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -24,7 +24,7 @@ namespace datadog::shared::nativeloader
         m_tracerInstance(nullptr),
         m_customInstance(nullptr),
         m_initialized(false),
-        m_initializationResult(E_NOT_SET)
+        m_initializationResult(E_UNEXPECTED)
     {
     }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -189,7 +189,8 @@ namespace datadog::shared::nativeloader
 
     HRESULT DynamicDispatcherImpl::LoadClassFactory(REFIID riid)
     {
-        HRESULT GHR = S_OK;
+        // We consider the loading a success if at least one class factory is properly loaded.
+        HRESULT GHR = E_FAIL;
 
         if (m_continuousProfilerInstance != nullptr)
         {
@@ -197,11 +198,19 @@ namespace datadog::shared::nativeloader
             if (FAILED(result))
             {
                 Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load continuous profiler class factory in: ",
-                     m_continuousProfilerInstance->GetFilePath());
+                     m_continuousProfilerInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
                 m_continuousProfilerInstance.release();
-                GHR = result;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
@@ -210,11 +219,20 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_tracerInstance->LoadClassFactory(riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ", m_tracerInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load tracer class factory in: ",
+                    m_tracerInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
                 m_tracerInstance.release();
-                GHR = result;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
@@ -223,11 +241,20 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_customInstance->LoadClassFactory(riid);
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load custom class factory in: ", m_customInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadClassFactory: Error trying to load custom class factory in: ",
+                    m_customInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
                 m_customInstance.release();
-                GHR = result;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
@@ -236,7 +263,8 @@ namespace datadog::shared::nativeloader
 
     HRESULT DynamicDispatcherImpl::LoadInstance()
     {
-        HRESULT GHR = S_OK;
+        // We consider the loading a success if at least one class factory is properly loaded.
+        HRESULT GHR = E_FAIL;
 
         if (m_continuousProfilerInstance != nullptr)
         {
@@ -244,11 +272,19 @@ namespace datadog::shared::nativeloader
             if (FAILED(result))
             {
                 Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the continuous profiler instance in: ",
-                     m_continuousProfilerInstance->GetFilePath());
+                    m_continuousProfilerInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
                 m_continuousProfilerInstance.release();
-                GHR = result;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
@@ -257,11 +293,20 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_tracerInstance->LoadInstance();
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the tracer instance in: ", m_tracerInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the tracer instance in: ",
+                    m_tracerInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
                 m_tracerInstance.release();
-                GHR = result;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 
@@ -270,11 +315,20 @@ namespace datadog::shared::nativeloader
             HRESULT result = m_customInstance->LoadInstance();
             if (FAILED(result))
             {
-                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the custom instance in: ", m_customInstance->GetFilePath());
+                Log::Warn("DynamicDispatcherImpl::LoadInstance: Error trying to load the custom instance in: ",
+                    m_customInstance->GetFilePath(), ", error code: ", result);
 
                 // If we cannot load the class factory we release the instance.
                 m_customInstance.release();
-                GHR = result;
+
+                if (GHR != S_OK)
+                {
+                    GHR = result;
+                }
+            }
+            else
+            {
+                GHR = S_OK;
             }
         }
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
@@ -18,6 +18,9 @@ namespace datadog::shared::nativeloader
     //
     class IDynamicDispatcher
     {
+    protected:
+        virtual void LoadConfiguration(fs::path&& configFilePath) = 0;
+
     public:
         virtual ~IDynamicDispatcher() = default;
         virtual HRESULT Initialize() = 0;
@@ -36,6 +39,7 @@ namespace datadog::shared::nativeloader
         std::unique_ptr<IDynamicInstance> m_continuousProfilerInstance;
         std::unique_ptr<IDynamicInstance> m_tracerInstance;
         std::unique_ptr<IDynamicInstance> m_customInstance;
+        void LoadConfiguration(fs::path&& configFilePath) override;
 
     public:
         DynamicDispatcherImpl();
@@ -46,7 +50,6 @@ namespace datadog::shared::nativeloader
         IDynamicInstance* GetCustomInstance() override;
 
     private:
-        void LoadConfiguration(fs::path&& configFilePath);
         HRESULT LoadClassFactory(REFIID riid);
         HRESULT LoadInstance();
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.h
@@ -20,9 +20,7 @@ namespace datadog::shared::nativeloader
     {
     public:
         virtual ~IDynamicDispatcher() = default;
-        virtual void LoadConfiguration(fs::path&& configFilePath) = 0;
-        virtual HRESULT LoadClassFactory(REFIID riid) = 0;
-        virtual HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) = 0;
+        virtual HRESULT Initialize() = 0;
         virtual HRESULT STDMETHODCALLTYPE DllCanUnloadNow() = 0;
         virtual IDynamicInstance* GetContinuousProfilerInstance() = 0;
         virtual IDynamicInstance* GetTracerInstance() = 0;
@@ -41,13 +39,19 @@ namespace datadog::shared::nativeloader
 
     public:
         DynamicDispatcherImpl();
-        void LoadConfiguration(fs::path&& configFilePath) override;
-        HRESULT LoadClassFactory(REFIID riid) override;
-        HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override;
+        HRESULT Initialize() override;
         HRESULT STDMETHODCALLTYPE DllCanUnloadNow() override;
         IDynamicInstance* GetContinuousProfilerInstance() override;
         IDynamicInstance* GetTracerInstance() override;
         IDynamicInstance* GetCustomInstance() override;
+
+    private:
+        void LoadConfiguration(fs::path&& configFilePath);
+        HRESULT LoadClassFactory(REFIID riid);
+        HRESULT LoadInstance();
+
+        bool m_initialized;
+        HRESULT m_initializationResult;
     };
 
 } // namespace datadog::shared::nativeloader

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.cpp
@@ -65,7 +65,7 @@ namespace datadog::shared::nativeloader
         return res;
     }
 
-    HRESULT DynamicInstanceImpl::LoadInstance(IUnknown* pUnkOuter, REFIID riid)
+    HRESULT DynamicInstanceImpl::LoadInstance()
     {
         Log::Debug("DynamicInstanceImpl::LoadInstance");
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.h
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_instance.h
@@ -20,7 +20,7 @@ namespace datadog::shared::nativeloader
     public:
         virtual ~IDynamicInstance() = default;
         virtual HRESULT LoadClassFactory(REFIID riid) = 0;
-        virtual HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) = 0;
+        virtual HRESULT LoadInstance() = 0;
         virtual HRESULT STDMETHODCALLTYPE DllCanUnloadNow() = 0;
         virtual ICorProfilerCallback10* GetProfilerCallback() = 0;
         virtual std::string GetFilePath() = 0;
@@ -42,7 +42,7 @@ namespace datadog::shared::nativeloader
         DynamicInstanceImpl(const std::string& filePath, const std::string& clsid);
         ~DynamicInstanceImpl() override;
         HRESULT LoadClassFactory(REFIID riid) override;
-        HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override;
+        HRESULT LoadInstance() override;
         HRESULT STDMETHODCALLTYPE DllCanUnloadNow() override;
         ICorProfilerCallback10* GetProfilerCallback() override;
         std::string GetFilePath() override;

--- a/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_dynamic_instance.h
+++ b/shared/test/Datadog.Trace.ClrProfiler.Native.Tests/test_dynamic_instance.h
@@ -34,10 +34,10 @@ public:
         return m_loadClassFactory;
     }
 
-    HRESULT LoadInstance(IUnknown* pUnkOuter, REFIID riid) override
+    HRESULT LoadInstance() override
     {
         if (GetFilePath() != "Test")
-            return DynamicInstanceImpl::LoadInstance(pUnkOuter, riid);
+            return DynamicInstanceImpl::LoadInstance();
         return m_loadInstance;
     }
 


### PR DESCRIPTION
## Summary of changes

Instead of loading the native trace/profiler as soon as the native loader is loaded, wait until we've checked the target runtime/process name.

## Reason for change

When returning an error code from `ICorProfilerCallback::Initialize`, .NET unloads the native loader. However, the native tracer/profiler stay in memory (because .NET is not aware of them). Therefore it makes sense to perform as many checks as possible before actually loading them. Plus that's less work to do in the most common failure cases (blocklisted process).

There are still cases where we're not unloading the native tracer/profiler even though we should (for instance, if their `Initialize` method failed). However they're trickier to get right (we must make sure there's no background thread running, for instance the logger) so I'll leave that for a future PR.

## Implementation details

Moved the `LoadConfiguration`/`LoadClassFactory`/`LoadInstance` methods of the dynamic dispatcher into a single `Initialize` method.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
