### PR TITLE
Timeit bump and fixes

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
@@ -15,10 +15,10 @@
       "name": "CallTarget\u002BInlining\u002BNGEN"
     }
   ],
-  "processName": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net462\\Samples.FakeDbCommand.exe",
+  "processName": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.FakeDbCommand\\release_net462\\Samples.FakeDbCommand.exe",
   "processArguments": "no-wait",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net462",
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.FakeDbCommand\\release_net462",
   "environmentVariables": {
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -18,7 +18,7 @@
   "processName": "dotnet",
   "processArguments": ".\\Samples.FakeDbCommand.dll no-wait",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\net6.0",
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.FakeDbCommand\\release_net6.0",
   "environmentVariables": {
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -18,7 +18,7 @@
   "processName": "dotnet",
   "processArguments": ".\\Samples.FakeDbCommand.dll no-wait",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.FakeDbCommand\\bin\\Release\\netcoreapp3.1",
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.FakeDbCommand\\release_netcoreapp3.1",
   "environmentVariables": {
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net60.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.1.14
+dotnet tool update -g timeitsharp --version 0.1.19
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
@@ -15,9 +15,9 @@
       "name": "CallTarget\u002BInlining\u002BNGEN"
     }
   ],
-  "processName": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.HttpMessageHandler\\bin\\Release\\net462\\Samples.HttpMessageHandler.exe",
+  "processName": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.HttpMessageHandler\\release_net462\\Samples.HttpMessageHandler.exe",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.HttpMessageHandler\\bin\\Release\\net462",
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.HttpMessageHandler\\release_net462",
   "environmentVariables": {
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -18,7 +18,7 @@
   "processName": "dotnet",
   "processArguments": ".\\Samples.HttpMessageHandler.dll",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.HttpMessageHandler\\bin\\Release\\net6.0",
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.HttpMessageHandler\\release_net6.0",
   "environmentVariables": {
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -18,7 +18,7 @@
   "processName": "dotnet",
   "processArguments": ".\\Samples.HttpMessageHandler.dll",
   "processTimeout": 15,
-  "workingDirectory": "$(CWD)\\..\\..\\..\\test\\test-applications\\integrations\\Samples.HttpMessageHandler\\bin\\Release\\netcoreapp3.1",
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.HttpMessageHandler\\release_netcoreapp3.1",
   "environmentVariables": {
     "CORECLR_ENABLE_PROFILING": "1",
     "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net60.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.1.14
+dotnet tool update -g timeitsharp --version 0.1.19
 
 echo *********************
 echo .NET Framework 4.6.1


### PR DESCRIPTION
## Summary of changes

This PR fixes the Execution Benchmark job, by changing the Samples path to the new artifact folder. It also bumps the timeit version.

## Reason for change

Currently we are not collecting Execution Benchmark data.
