### PR TITLE
Add `linux-musl-arm64` standalone `dd-trace` to the v3 release artifacts

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4059,6 +4059,13 @@ stages:
             patterns: "*.tar.gz"
             path: $(Build.ArtifactStagingDirectory)
 
+        - task: DownloadPipelineArtifact@2
+          displayName: Download standalone dotnet tool linux-musl-arm64
+          inputs:
+            artifact: runner-standalone-linux-musl-arm64
+            patterns: "*.tar.gz"
+            path: $(Build.ArtifactStagingDirectory)
+
         # release artifacts
         - publish: "$(Build.ArtifactStagingDirectory)"
           displayName: Publish release artifacts


### PR DESCRIPTION
## Summary of changes

Includes the alpine arm64 standalone runner in the release artifacts

## Reason for change

We include standalone artifacts for dd-trace for win-x64, linux-x64, linux-arm64, linux-musl-x64. Now we have linux-musl-arm64 too, which is required for customers troubleshooting alpine arm64 issues.

## Implementation details

Just include it in the release automatically, we already build it. I manually added it to the 3.2.0 release.

## Test coverage

Nope, we'll just need to check the next release to make sure it's there
