### PR TITLE
[CONTSEC-1501] Comment the action that uploads SARIF to Datadog

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,12 +81,12 @@ jobs:
         input: ../results/csharp.sarif
         output: ../results/csharp.sarif
 
-    - name: Upload sarif file
-      run: |
-        datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
-      env:
-        DD_API_KEY: '${{ secrets.DD_STAGING_API_KEY }}'
+    # - name: Upload sarif file
+    #   run: |
+    #     datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
+    #     datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
+    #   env:
+    #     DD_API_KEY: '${{ secrets.DD_STAGING_API_KEY }}'
 
   tracer:
     name: Analyze Tracer
@@ -158,9 +158,9 @@ jobs:
         input: ../results/csharp.sarif
         output: ../results/csharp.sarif
 
-    - name: Upload sarif file
-      run: |
-        datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
-        datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
-      env:
-        DD_API_KEY: '${{ secrets.DD_STAGING_API_KEY }}'
+    # - name: Upload sarif file
+    #   run: |
+    #     datadog-ci sarif upload ../results/cpp.sarif --service dd-trace-dotnet
+    #     datadog-ci sarif upload ../results/csharp.sarif --service dd-trace-dotnet
+    #   env:
+    #     DD_API_KEY: '${{ secrets.DD_STAGING_API_KEY }}'


### PR DESCRIPTION

## Summary of changes
Commenting out the action that uploads SARIF to Datadog until the issue (`Datadog does not like the SARIF report that is being uploaded for csharp.`) gets resolved.
## Reason for change
The action `advanced-security/filter-sarif@v1` is altering the SARIF fields when filtering the results which is not getting supported by Datadog when uploading.
## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
