### PR TITLE
[Crashtracking] Fix the handling of COMPlus_DbgMiniDumpName

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -220,7 +220,7 @@ void initLibrary(void)
     char* passthrough = getenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH);
 
     originalMiniDumpName = getenv(DOTNET_DbgMiniDumpName);
-    if (originalMiniDumpName == NULL)
+    if (originalMiniDumpName == NULL || strncmp(originalMiniDumpName, datadogCrashMarker, strlen(datadogCrashMarker)) == 0)
     {
         originalMiniDumpName = getenv(COMPlus_DbgMiniDumpName);
     }

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -49,12 +49,16 @@ public abstract class ConsoleTestHelper : ToolTestHelper
         return (executable, args);
     }
 
-    protected async Task<ProcessHelper> StartConsole(EnvironmentHelper environmentHelper, bool enableProfiler, string args, params (string Key, string Value)[] environmentVariables)
+    protected Task<ProcessHelper> StartConsole(EnvironmentHelper environmentHelper, bool enableProfiler, string args, params (string Key, string Value)[] environmentVariables)
     {
         var (executable, baseArgs) = PrepareSampleApp(environmentHelper);
-
         args = $"{baseArgs} {args}";
 
+        return StartConsole(executable, args, environmentHelper, enableProfiler, environmentVariables);
+    }
+
+    protected async Task<ProcessHelper> StartConsole(string executable, string args, EnvironmentHelper environmentHelper, bool enableProfiler, params (string Key, string Value)[] environmentVariables)
+    {
         var processStart = new ProcessStartInfo(executable, args) { UseShellExecute = false, RedirectStandardError = true, RedirectStandardOutput = true };
 
         MockTracerAgent? agent = null;

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -112,14 +112,14 @@ public class CreatedumpTests : ConsoleTestHelper
         var (executable, args) = PrepareSampleApp(EnvironmentHelper);
 
         var bashScript = $"""
-                         #!/usr/bin/bash
+                         #!/bin/bash
                          {executable} {args} crash-datadog
                          """;
 
         using var bashFile = new TemporaryFile();
         bashFile.SetContent(bashScript);
 
-        using var helper = await StartConsole("/usr/bin/bash", bashFile.Path, EnvironmentHelper, false, environment);
+        using var helper = await StartConsole("/bin/bash", bashFile.Path, EnvironmentHelper, false, environment);
 
         await helper.Task;
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -111,11 +111,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         var (executable, args) = PrepareSampleApp(EnvironmentHelper);
 
-        var bashScript = $"""
-                         #!/bin/bash
-                         {executable} {args} crash-datadog
-                         """;
-
+        var bashScript = $"#!/bin/bash\n{executable} {args} crash-datadog\n"
         using var bashFile = new TemporaryFile();
         bashFile.SetContent(bashScript);
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -111,7 +111,7 @@ public class CreatedumpTests : ConsoleTestHelper
 
         var (executable, args) = PrepareSampleApp(EnvironmentHelper);
 
-        var bashScript = $"#!/bin/bash\n{executable} {args} crash-datadog\n"
+        var bashScript = $"#!/bin/bash\n{executable} {args} crash-datadog\n";
         using var bashFile = new TemporaryFile();
         bashFile.SetContent(bashScript);
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests;
 
 public class CreatedumpTests : ConsoleTestHelper
 {
-    private const string CreatedumpExpectedOutput = "Writing minidump";
+    private const string CreatedumpExpectedOutput = "Writing minidump with heap to file /dev/null";
     private const string CrashReportExpectedOutput = "The crash may have been caused by automatic instrumentation";
 
     public CreatedumpTests(ITestOutputHelper output)
@@ -92,6 +92,45 @@ public class CreatedumpTests : ConsoleTestHelper
         {
             helper.StandardOutput.Should().NotContain(CreatedumpExpectedOutput);
         }
+    }
+
+    [SkippableFact]
+    public async Task BashScript()
+    {
+        // This tests the case when an app is called through a bash script
+        // This scenario has unique challenges because:
+        //   - The COMPlus_DbgMiniDumpName environment variable that we override is then inherited by the child
+        //   - Bash overrides the getenv/setenv functions, which cause some unexpected behaviors
+
+        SkipOn.Platform(SkipOn.PlatformValue.Windows);
+        SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
+        using var reportFile = new TemporaryFile();
+
+        (string, string)[] environment = [LdPreloadConfig, .. CreatedumpConfig, CrashReportConfig(reportFile)];
+
+        var (executable, args) = PrepareSampleApp(EnvironmentHelper);
+
+        var bashScript = $"""
+                         #!/usr/bin/bash
+                         {executable} {args} crash-datadog
+                         """;
+
+        using var bashFile = new TemporaryFile();
+        bashFile.SetContent(bashScript);
+
+        using var helper = await StartConsole("/usr/bin/bash", bashFile.Path, EnvironmentHelper, false, environment);
+
+        await helper.Task;
+
+        using var assertionScope = new AssertionScope();
+        assertionScope.AddReportable("stdout", helper.StandardOutput);
+        assertionScope.AddReportable("stderr", helper.ErrorOutput);
+
+        helper.StandardOutput.Should().Contain(CrashReportExpectedOutput);
+        File.Exists(reportFile.Path).Should().BeTrue();
+
+        helper.StandardOutput.Should().Contain(CreatedumpExpectedOutput);
     }
 
     [SkippableTheory]
@@ -482,6 +521,8 @@ public class CreatedumpTests : ConsoleTestHelper
         public string Url => $"file:/{Path}";
 
         public string GetContent() => File.ReadAllText(Path);
+
+        public void SetContent(string content) => File.WriteAllText(Path, content);
 
         public void Dispose()
         {


### PR DESCRIPTION
## Summary of changes

To distinguish the case when createdump is called because of a crash vs a call from `dotnet-dump`, we store a dummy value in `COMPlus_DbgMiniDumpName`: https://github.com/DataDog/dd-trace-dotnet/pull/5852

However, this becomes a problem when the process spawns a child process, as it inherits the dummy `COMPlus_DbgMiniDumpName` and we lose the original value.

To get around that, this PR saves the original value in `DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME` so the children can retrieve it.

## Reason for change

This prevents the crash dump to be generated when launching the app from a bash script when `LD_PRELOAD` is set globally.

## Implementation details

We discovered that bash provides its own version of the `getenv`/`setenv` functions, which leads to some unexpected behavior. To get around that, we use `dlsym` to fetch the original libc functions.

## Test coverage

Added a test with a sample app launched from a bash script.