### PR TITLE
[Profiler] Contention profiling: add blocking thread name

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ContentionProvider.h
@@ -59,7 +59,7 @@ public:
 private:
     static std::string GetBucket(double contentionDurationNs);
     static std::vector<SampleValueType> SampleTypeDefinitions;
-    void AddContentionSample(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, uint64_t blockingThreadId, const std::vector<uintptr_t>& stack);
+    void AddContentionSample(uint64_t timestamp, uint32_t threadId, double contentionDurationNs, uint64_t blockingThreadId, shared::WSTRING blockingThreadName, const std::vector<uintptr_t>& stack);
 
 private:
     static std::vector<uintptr_t> _emptyStack;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -81,7 +81,7 @@ public:
     inline bool IsThreadDestroyed();
     inline bool IsDestroyed();
     inline void SetThreadDestroyed();
-    inline uint64_t SetBlockingThread(uint64_t osThreadId);
+    inline std::pair<uint64_t, shared::WSTRING> SetBlockingThread(uint64_t osThreadId, shared::WSTRING name);
 
     inline TraceContextTrackingInfo* GetTraceContextPointer();
     inline std::uint64_t GetLocalRootSpanId() const;
@@ -153,6 +153,7 @@ private:
     std::int32_t _timerId;
 #endif
     uint64_t _blockingThreadId;
+    shared::WSTRING _blockingThreadName;
 };
 
 std::string ManagedThreadInfo::GetProfileThreadId()
@@ -406,9 +407,11 @@ inline void ManagedThreadInfo::SetThreadDestroyed()
     _isThreadDestroyed = true;
 }
 
-inline uint64_t ManagedThreadInfo::SetBlockingThread(uint64_t osThreadId)
+inline std::pair<uint64_t, shared::WSTRING> ManagedThreadInfo::SetBlockingThread(uint64_t osThreadId, shared::WSTRING name)
 {
-    return std::exchange(_blockingThreadId, osThreadId);
+    auto oldId = std::exchange(_blockingThreadId, osThreadId);
+    auto oldName = std::exchange(_blockingThreadName, std::move(name));
+    return {oldId, oldName};
 }
 
 inline TraceContextTrackingInfo* ManagedThreadInfo::GetTraceContextPointer()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/RawContentionSample.h
@@ -12,7 +12,8 @@ public:
     inline static const std::string BucketLabelName = "Duration bucket";
     inline static const std::string RawCountLabelName = "raw count";
     inline static const std::string RawDurationLabelName = "raw duration";
-    inline static const std::string BlockingThreadInfo = "blocking thread";
+    inline static const std::string BlockingThreadIdLabelName = "blocking thread id";
+    inline static const std::string BlockingThreadNameLabelName = "blocking thread name";
 
 public:
     RawContentionSample() = default;
@@ -22,7 +23,8 @@ public:
         RawSample(std::move(other)),
         ContentionDuration(other.ContentionDuration),
         Bucket(std::move(other.Bucket)),
-        BlockingThread(other.BlockingThread)
+        BlockingThreadId(other.BlockingThreadId),
+        BlockingThreadName(std::move(other.BlockingThreadName))
     {
     }
 
@@ -33,7 +35,8 @@ public:
             RawSample::operator=(std::move(other));
             ContentionDuration = other.ContentionDuration;
             Bucket = std::move(other.Bucket);
-            BlockingThread = other.BlockingThread;
+            BlockingThreadId = other.BlockingThreadId;
+            BlockingThreadName = std::move(other.BlockingThreadName);
         }
         return *this;
     }
@@ -49,13 +52,15 @@ public:
         sample->AddNumericLabel(NumericLabel{RawCountLabelName, 1});
         sample->AddNumericLabel(NumericLabel{RawDurationLabelName, static_cast<uint64_t>(ContentionDuration)});
         sample->AddValue(static_cast<std::int64_t>(ContentionDuration), contentionDurationIndex);
-        if (BlockingThread != 0)
+        if (BlockingThreadId != 0)
         {
-            sample->AddNumericLabel(NumericLabel{BlockingThreadInfo, BlockingThread});
+            sample->AddNumericLabel(NumericLabel{BlockingThreadIdLabelName, BlockingThreadId});
+            sample->AddLabel(Label{BlockingThreadNameLabelName, shared::ToString(BlockingThreadName)});
         }
     }
 
     double ContentionDuration;
     std::string Bucket;
-    uint64_t BlockingThread;
+    uint64_t BlockingThreadId;
+    shared::WSTRING BlockingThreadName;
 };

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Contention/ContentionProfilerTest.cs
@@ -90,15 +90,19 @@ namespace Datadog.Profiler.IntegrationTests.Contention
             var threadIds = SamplesHelper.GetThreadIds(pprofDir);
             // get samples with lock-count value set and blocking thread info
             var contentionSamples = SamplesHelper.GetSamples(pprofDir, "lock-count")
-                .Where(e => e.Labels.Any(x => x.Name == "blocking thread"));
+                .Where(e => e.Labels.Any(x => x.Name == "blocking thread id"));
 
             contentionSamples.Should().NotBeEmpty();
 
             foreach (var (_, labels, _) in contentionSamples)
             {
-                var label = labels.FirstOrDefault(l => l.Name == "blocking thread");
-                label.Name.Should().NotBeNullOrWhiteSpace();
-                threadIds.Should().Contain(int.Parse(label.Value), $"Unknown blocking thread id {label.Value}");
+                var blockingThreadIdLabel = labels.FirstOrDefault(l => l.Name == "blocking thread id");
+                blockingThreadIdLabel.Name.Should().NotBeNullOrWhiteSpace();
+                threadIds.Should().Contain(int.Parse(blockingThreadIdLabel.Value), $"Unknown blocking thread id {blockingThreadIdLabel.Value}");
+
+                var blockingThreadNameLabel = labels.FirstOrDefault(l => l.Name == "blocking thread name");
+                blockingThreadIdLabel.Name.Should().NotBeNullOrWhiteSpace();
+                blockingThreadIdLabel.Value.Should().NotBeNullOrWhiteSpace();
             }
         }
     }


### PR DESCRIPTION
## Summary of changes

Add the `blocking thread name` as tag on sample.

## Reason for change
In a previous [PR](https://github.com/DataDog/dd-trace-dotnet/pull/5959), we provide the `blocking thread id` only. The backend would need the name to display something useful.

## Implementation details

Add and propagate the blocking thread name.

## Test coverage

Update the current test.
## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
