### PR TITLE
Include snapshot diff in snapshot body

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -101,7 +101,7 @@ steps:
 - ${{ if and(eq(parameters.isLinux, true), eq(parameters.isNoop, false)) }}:
   - bash: |
       echo "Verifying snapshot session (fail on mis-match)"
-      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --w '\nGetting a 400 means there is a diff in snapshots. You can diff the files with the artifacts generated. You can also run the tests locally. Follow the doc in /docs/development/CI/RunSmokeTestsLocally\n' --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
+      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail-with-body "http://localhost:8126$(VERIFY_ENDPOINT)"
     displayName: check snapshots
     env:
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}


### PR DESCRIPTION
## Summary of changes

Improve the output when installer snapshot tests fail

## Reason for change

Currently we just show a fixed string, this means we show an actual diff instead

## Implementation details

We already do this for the macos installer tests, this improves it, so that you get something like this:

```bash
curl: (22) The requested URL returned error: 400
At request <Request GET /test/session/snapshot >:
   At snapshot (token='033d5bc0-c2ed-53c6-3ecc-b9d10e43a2b0'):
    - Directory: /Users/runner/work/1/s/tracer/build/smoke_test_snapshots
    - CI mode: 1
    - Trace File: /Users/runner/work/1/s/tracer/build/smoke_test_snapshots/smoke_test_snapshots.json
    - Stats File: /Users/runner/work/1/s/tracer/build/smoke_test_snapshots/smoke_test_snapshots_tracestats.json
    At compare of 1 expected trace(s) to 1 received trace(s):
     At trace 'http.request' (3 spans):
      At snapshot compare of span 'http.request' at position 1 in trace:
       - Expected span:
       {'duration': 184924600,
        'meta': {'component': 'HttpMessageHandler',
                 'http-client-handler-type': 'System.Net.Http.HttpClientHandler',
                 'http.method': 'GET',
                 'http.status_code': '200',
                 'http.url': 'http://localhost:5000/api/values',
                 'out.host': 'localhost',
                 'runtime-id': '11c61d09-16bb-477f-87ab-4f81d656c5ca',
                 'span.kind': 'client'},
        'metrics': {'_dd.top_level': 1.0,
                    '_dd.tracer_kr': 0.0,
                    '_sampling_priority_v1': 1.0,
                    'process_id': 1.0},
        'name': 'http.request',
        'parent_id': 0,
        'resource': 'GET localhost:5000/api/values',
        'service': 'AspNetCoreSmokeTest-http-client',
        'span_id': 1,
        'start': 1652283843057056500,
        'trace_id': 0,
        'type': 'http'}
       - Received span:
       {'duration': 614494000,
        'meta': {'_dd.git.commit.sha': 'a1ae7d806770b5efddb4c0594ca7b35d6d5bd6d0',
                 '_dd.git.repository_url': 'https://github.com/DataDog/dd-trace-dotnet',
                 '_dd.p.dm': '-0',
                 '_dd.p.tid': '66d5e9d300000000',
                 'component': 'HttpMessageHandler',
                 'http-client-handler-type': 'System.Net.Http.HttpClientHandler',
                 'http.method': 'GET',
                 'http.status_code': '200',
                 'http.url': 'http://localhost:5000/api/values',
                 'language': 'dotnet',
                 'out.host': 'localhost',
                 'runtime-id': 'fd0ffe39-9e26-4ca0-b842-00ea612989c1',
                 'span.kind': 'client'},
        'metrics': {'_dd.top_level': 1.0,
                    '_dd.tracer_kr': 0.0,
                    '_sampling_priority_v1': 1.0,
                    'process_id': 5733.0},
        'name': 'http.request',
        'parent_id': 0,
        'resource': 'GET localhost:5000/api/values',
        'service': 'AspNetCoreSmokeTest-http-client',
        'span_id': 1,
        'start': 1725295059820067200,
        'trace_id': 0,
        'type': 'http'}
Span meta value 'language' in received span but is not in the expected span.
```

## Test coverage

It won't fail in this test (hopefully) but we already know this works elsewhere so meh