### PR TITLE
Fix 2.x smoke test and installer tests

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -97,7 +97,7 @@ steps:
 - ${{ if eq(parameters.isLinux, true) }}:
   - bash: |
       echo "Verifying snapshot session (fail on mis-match)"
-      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --w '\nGetting a 400 means there is a diff in snapshots. You can diff the files with the artifacts generated. You can also run the tests locally. Follow the doc in /docs/development/CI/RunSmokeTestsLocally\n' --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
+      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail-with-body "http://localhost:8126$(VERIFY_ENDPOINT)"
     displayName: check snapshots
     env:
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5916,7 +5916,13 @@ stages:
           failOnStderr: true
 
         - script: |
-            dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --add-source $(smokeTestAppDir)/artifacts/.
+            # to force it to use our local package only, we have to create a custom config, and tell the tool to use that
+            echo '<?xml version="1.0" encoding="utf-8"?><configuration><packageSources><clear /><add key="local" value="'"$(smokeTestAppDir)/artifacts/."'" /></packageSources></configuration>' > nuget.config
+
+            dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --configfile ./nuget.config
+
+            # remove the config afterwards to avoid interfering with anything else
+            rm nuget.config
           displayName: Install tracer
 
         - script: |

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -5912,8 +5912,9 @@ stages:
 
         - script: |
             # to force it to use our local package only, we have to create a custom config, and tell the tool to use that
-            echo '<?xml version="1.0" encoding="utf-8"?><configuration><packageSources><clear /><add key="local" value="'"$(smokeTestAppDir)/artifacts/."'" /></packageSources></configuration>' > nuget.config
-
+            dotnet new nuget.config
+            dotnet nuget disable source nuget
+            dotnet nuget add source "$(smokeTestAppDir)/artifacts/."
             dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --configfile ./nuget.config
 
             # remove the config afterwards to avoid interfering with anything else

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4640,7 +4640,12 @@ stages:
             versionSpec: '3.12'
         displayName: Install python 3.12
 
-      - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
+      - script: |
+          # force using a commit just before https://github.com/DataDog/system-tests/pull/2962, which was adapted for v3 
+          git init
+          git remote add origin https://github.com/DataDog/system-tests.git
+          git fetch --depth 1 origin 3415a681860ef3c2e9376aae4befc791431e94d2
+          git checkout FETCH_HEAD
         displayName: Get system tests repo
 
       - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4928,8 +4928,8 @@ stages:
         command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_nuget_smoke_tests_linux
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
+#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -4958,6 +4958,11 @@ stages:
       inputs:
         artifact: runner-dotnet-tool
         path: $(smokeTestAppDir)/artifacts
+        buildType: 'specific'
+        project: 'dd-trace-dotnet'
+        definition: 54
+        buildVersionToDownload: 'specific'
+        pipelineId: 163290
 
     - script: |
         mkdir -p tracer/build_data/snapshots
@@ -5841,8 +5846,8 @@ stages:
       displayName: CheckSmokeTestsForErrors
 
 - stage: dotnet_tool_nuget_smoke_tests_macos
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
+#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -5877,6 +5882,11 @@ stages:
           inputs:
             artifact: runner-dotnet-tool
             path: $(smokeTestAppDir)/artifacts
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'specific'
+            pipelineId: 163290
 
         - script: |
             mkdir -p tracer/build_data/snapshots

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4928,8 +4928,8 @@ stages:
         command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_nuget_smoke_tests_linux
-#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [generate_variables, merge_commit_id]
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -4958,11 +4958,6 @@ stages:
       inputs:
         artifact: runner-dotnet-tool
         path: $(smokeTestAppDir)/artifacts
-        buildType: 'specific'
-        project: 'dd-trace-dotnet'
-        definition: 54
-        buildVersionToDownload: 'specific'
-        pipelineId: 163290
 
     - script: |
         mkdir -p tracer/build_data/snapshots
@@ -5846,8 +5841,8 @@ stages:
       displayName: CheckSmokeTestsForErrors
 
 - stage: dotnet_tool_nuget_smoke_tests_macos
-#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [generate_variables, merge_commit_id]
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -5882,11 +5877,6 @@ stages:
           inputs:
             artifact: runner-dotnet-tool
             path: $(smokeTestAppDir)/artifacts
-            buildType: 'specific'
-            project: 'dd-trace-dotnet'
-            definition: 54
-            buildVersionToDownload: 'specific'
-            pipelineId: 163290
 
         - script: |
             mkdir -p tracer/build_data/snapshots

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -22,7 +22,9 @@ ARG INSTALL_CMD
 RUN mkdir -p /opt/datadog \
     && mkdir -p /var/log/datadog \
     && mkdir -p /tool \
-    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. \
+    && echo '<?xml version="1.0" encoding="utf-8"?><configuration><packageSources><clear /><add key="local" value="/app/install/." /></packageSources></configuration>' > nuget.config \
+    && dotnet tool install dd-trace --tool-path /tool --configfile ./nuget.config \
+    && rm ./nuget.config \
     && rm -rf /app/install
 
 # Set the optional env vars

--- a/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
@@ -8,14 +8,14 @@ FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
-# do an initial restore
-RUN dotnet restore "AspNetCoreSmokeTest.csproj"
-
-# install the package
-RUN dotnet add package "Datadog.Trace.Bundle" --source /src/artifacts
-
 ARG PUBLISH_FRAMEWORK
-RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet new nuget.config \
+    && dotnet nuget disable source nuget \
+    && dotnet nuget add source "/src/artifacts" \
+    && dotnet add package "Datadog.Trace.Bundle" \
+    && rm nuget.config \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
 FROM $RUNTIME_IMAGE AS publish
 

--- a/tracer/build/_build/docker/smoke.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dockerfile
@@ -8,14 +8,14 @@ FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
-# do an initial restore
-RUN dotnet restore "AspNetCoreSmokeTest.csproj"
-
-# install the package
-RUN dotnet add package "Datadog.Trace.Bundle" --source /src/artifacts
-
 ARG PUBLISH_FRAMEWORK
-RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet new nuget.config \
+    && dotnet nuget disable source nuget \
+    && dotnet nuget add source "/src/artifacts" \
+    && dotnet add package "Datadog.Trace.Bundle" \
+    && rm nuget.config \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
 FROM $RUNTIME_IMAGE AS publish
 

--- a/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
@@ -13,8 +13,11 @@ COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
 ARG PUBLISH_FRAMEWORK
 RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet new nuget.config \
+    && dotnet nuget disable source nuget \
     && dotnet nuget add source "c:\src\artifacts" \
     && dotnet add package "Datadog.Trace.Bundle" \
+    && rm nuget.config \
     && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o "c:\src\publish"
 
 FROM $RUNTIME_IMAGE AS publish-msi

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -13,8 +13,11 @@ COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
 ARG PUBLISH_FRAMEWORK
 RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet new nuget.config \
+    && dotnet nuget disable source nuget \
     && dotnet nuget add source "c:\src\artifacts" \
     && dotnet add package "Datadog.Trace.Bundle" \
+    && rm nuget.config \
     && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o "c:\src\publish"
 
 FROM $RUNTIME_IMAGE AS publish-msi


### PR DESCRIPTION
## Summary of changes

- Fix nuget/dd-trace installer tests in 2.x branch
- Pin system tests in 2.x branch

## Reason for change

The code we were using to install the "local" builds of the NuGet packages added the local source. However the dotnet restore was looking in both the local and nuget.org sources, and installing the highest version it found. That worked fine until we released 3.2.0 publicly and expect to install 2.59.0 of the local build.

For system-tests, we had to change how things work to support v3 (https://github.com/DataDog/system-tests/pull/2962), but unfortunately that breaks for v2.

## Implementation details

Explicitly create a new NuGet.config, disable the nuget.org source, and add our local source instead, install the tool/add the package, then remove the config.

For system tests, just pinning to the specific commit prior to the v3 PR being merged. 

## Test coverage

Running [a full installer run here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=163495&view=results)

## Other details

Another way around this would be to explicitly set the version when we do the install. We should potentially do that in a follow up PR, but it would require a lot more effort, and it might be better to move the entire setup to Nuke if we're taking that approach

This PR also contains a backport of 
- https://github.com/DataDog/dd-trace-dotnet/pull/5988
for simplicity