### PR TITLE
Make sure we run all the TFMs on master builds

### DIFF
--- a/tracer/build/_build/Build.Steps.cs
+++ b/tracer/build/_build/Build.Steps.cs
@@ -186,9 +186,21 @@ partial class Build
         (true, false) => new[] { TargetFramework.NET5_0, TargetFramework.NET6_0, TargetFramework.NET8_0, },
     };
 
+    string ReleaseBranchForCurrentVersion() => new Version(Version).Major switch
+    {
+        LatestMajorVersion => "origin/master",
+        var major => $"origin/release/{major}.x",
+    };
+
     bool RequiresThoroughTesting()
     {
-        var baseBranch = string.IsNullOrEmpty(TargetBranch) ? "origin/master" : $"origin/{TargetBranch}";
+        var baseBranch = string.IsNullOrEmpty(TargetBranch) ? ReleaseBranchForCurrentVersion() : $"origin/{TargetBranch}";
+        if (IsGitBaseBranch(baseBranch))
+        {
+            // do a full run on the main branch
+            return true;
+        }
+
         var gitChangedFiles = GetGitChangedFiles(baseBranch);
         var integrationChangedFiles = TargetFrameworks
             .SelectMany(tfm => new[]

--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -64,7 +64,7 @@ partial class Build : NukeBuild
 
                 void GenerateConditionVariableBasedOnGitChange(string variableName, string[] filters, string[] exclusionFilters)
                 {
-                    var baseBranch = string.IsNullOrEmpty(TargetBranch) ? "origin/master" : $"origin/{TargetBranch}";
+                    var baseBranch = string.IsNullOrEmpty(TargetBranch) ? ReleaseBranchForCurrentVersion() : $"origin/{TargetBranch}";
                     bool isChanged;
                     var forceExplorationTestsWithVariableName = $"force_exploration_tests_with_{variableName}";
 

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -58,6 +58,9 @@ partial class Build : NukeBuild
     [Parameter("Is the build running on Alpine linux? Default is 'false'")]
     readonly bool IsAlpine = false;
 
+    [Parameter("The current latest tracer version")]
+    const int LatestMajorVersion = 3;
+
     [Parameter("The current version of the source and build")]
     readonly string Version = "3.3.0";
 


### PR DESCRIPTION
## Summary of changes

Update `RequiresThoroughTesting()` to return `true` when we're running on master or release/2.x

## Reason for change

We should be doing thorough testing on the main branches. I thought we were. I don't quite understand how we're _not_

## Implementation details

Check to see if we're _on_ the main branch for the verison, and if so, do the thorough testing

## Test coverage

Can't really test this properly until we merge it...

## Other details

I sure hope this doesn't reveal more issues :awkward: