### PR TITLE
Diagnostic tool: Check if DD_INJECTION_ENABLED contains profiler

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Checks/ProcessBasicCheck.cs
@@ -270,8 +270,8 @@ namespace Datadog.Trace.Tools.dd_dotnet.Checks
                 }
                 else
                 {
-                    isContinuousProfilerEnabled = process.EnvironmentVariables.TryGetValue("DD_INJECTION_ENABLED", out var _);
-                    if (isContinuousProfilerEnabled)
+                    if (process.EnvironmentVariables.TryGetValue("DD_INJECTION_ENABLED", out var injectionEnabled)
+                        && injectionEnabled.Contains("profiler", StringComparison.OrdinalIgnoreCase))
                     {
                         Utils.WriteInfo(ContinuousProfilerSsiDeployed);
                     }


### PR DESCRIPTION
## Summary of changes

In the diagnostic tool, we consider that the profiler should be loaded whenever `DD_INJECTION_ENABLED`. While that might be true (?), the profiler shouldn't be _enabled_, so instead look specifically for the value `profiler`.

## Reason for change

This causes failures in the CI in the SSI run.
