### PR TITLE
[ASM] RASP: add telemetry tag for shell injection

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -28,6 +28,7 @@ internal static class RaspModule
         AddressesConstants.FileAccess => RaspRuleType.Lfi,
         AddressesConstants.UrlAccess => RaspRuleType.Ssrf,
         AddressesConstants.DBStatement => RaspRuleType.SQlI,
+        AddressesConstants.ShellInjection => RaspRuleType.CommandInjection,
         _ => null,
     };
 

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class RaspRuleTypeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 3;
+    public const int Length = 4;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType"/> value.
@@ -33,6 +33,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi => "waf_version;rule_type:lfi",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf => "waf_version;rule_type:ssrf",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI => "waf_version;rule_type:sql_injection",
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection => "waf_version;rule_type:command_injection",
             _ => value.ToString(),
         };
 
@@ -49,6 +50,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI,
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection,
         };
 
     /// <summary>
@@ -65,6 +67,7 @@ internal static partial class RaspRuleTypeExtensions
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI),
+            nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection),
         };
 
     /// <summary>
@@ -81,5 +84,6 @@ internal static partial class RaspRuleTypeExtensions
             "waf_version;rule_type:lfi",
             "waf_version;rule_type:ssrf",
             "waf_version;rule_type:sql_injection",
+            "waf_version;rule_type:command_injection",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net461/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 560;
+    private const int CountLength = 563;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -563,18 +563,21 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 509
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.rule.match, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 512
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.timeout, index = 514
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // instrum.user_auth.missing_user_id, index = 515
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // instrum.user_auth.missing_user_id, index = 518
             new(new[] { "framework:aspnetcore_identity" }),
             new(new[] { "framework:unknown" }),
-            // executed.source, index = 517
+            // executed.source, index = 520
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -589,9 +592,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 531
+            // executed.propagation, index = 534
             new(null),
-            // executed.sink, index = 532
+            // executed.sink, index = 535
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -619,7 +622,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 559
+            // request.tainted, index = 562
             new(null),
         };
 
@@ -629,7 +632,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 4, 4, 4, 2, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -833,41 +836,41 @@ internal partial class MetricsTelemetryCollector
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 509 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 512 + (int)tag;
+        var index = 514 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
     {
-        var index = 515 + (int)tag;
+        var index = 518 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 517 + (int)tag;
+        var index = 520 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[531], increment);
+        Interlocked.Add(ref _buffer.Count[534], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 532 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[559], increment);
+        Interlocked.Add(ref _buffer.Count[562], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class RaspRuleTypeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 3;
+    public const int Length = 4;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType"/> value.
@@ -33,6 +33,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi => "waf_version;rule_type:lfi",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf => "waf_version;rule_type:ssrf",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI => "waf_version;rule_type:sql_injection",
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection => "waf_version;rule_type:command_injection",
             _ => value.ToString(),
         };
 
@@ -49,6 +50,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI,
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection,
         };
 
     /// <summary>
@@ -65,6 +67,7 @@ internal static partial class RaspRuleTypeExtensions
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI),
+            nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection),
         };
 
     /// <summary>
@@ -81,5 +84,6 @@ internal static partial class RaspRuleTypeExtensions
             "waf_version;rule_type:lfi",
             "waf_version;rule_type:ssrf",
             "waf_version;rule_type:sql_injection",
+            "waf_version;rule_type:command_injection",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/net6.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 560;
+    private const int CountLength = 563;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -563,18 +563,21 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 509
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.rule.match, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 512
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.timeout, index = 514
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // instrum.user_auth.missing_user_id, index = 515
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // instrum.user_auth.missing_user_id, index = 518
             new(new[] { "framework:aspnetcore_identity" }),
             new(new[] { "framework:unknown" }),
-            // executed.source, index = 517
+            // executed.source, index = 520
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -589,9 +592,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 531
+            // executed.propagation, index = 534
             new(null),
-            // executed.sink, index = 532
+            // executed.sink, index = 535
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -619,7 +622,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 559
+            // request.tainted, index = 562
             new(null),
         };
 
@@ -629,7 +632,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 4, 4, 4, 2, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -833,41 +836,41 @@ internal partial class MetricsTelemetryCollector
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 509 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 512 + (int)tag;
+        var index = 514 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
     {
-        var index = 515 + (int)tag;
+        var index = 518 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 517 + (int)tag;
+        var index = 520 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[531], increment);
+        Interlocked.Add(ref _buffer.Count[534], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 532 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[559], increment);
+        Interlocked.Add(ref _buffer.Count[562], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class RaspRuleTypeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 3;
+    public const int Length = 4;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType"/> value.
@@ -33,6 +33,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi => "waf_version;rule_type:lfi",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf => "waf_version;rule_type:ssrf",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI => "waf_version;rule_type:sql_injection",
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection => "waf_version;rule_type:command_injection",
             _ => value.ToString(),
         };
 
@@ -49,6 +50,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI,
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection,
         };
 
     /// <summary>
@@ -65,6 +67,7 @@ internal static partial class RaspRuleTypeExtensions
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI),
+            nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection),
         };
 
     /// <summary>
@@ -81,5 +84,6 @@ internal static partial class RaspRuleTypeExtensions
             "waf_version;rule_type:lfi",
             "waf_version;rule_type:ssrf",
             "waf_version;rule_type:sql_injection",
+            "waf_version;rule_type:command_injection",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netcoreapp3.1/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 560;
+    private const int CountLength = 563;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -563,18 +563,21 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 509
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.rule.match, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 512
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.timeout, index = 514
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // instrum.user_auth.missing_user_id, index = 515
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // instrum.user_auth.missing_user_id, index = 518
             new(new[] { "framework:aspnetcore_identity" }),
             new(new[] { "framework:unknown" }),
-            // executed.source, index = 517
+            // executed.source, index = 520
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -589,9 +592,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 531
+            // executed.propagation, index = 534
             new(null),
-            // executed.sink, index = 532
+            // executed.sink, index = 535
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -619,7 +622,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 559
+            // request.tainted, index = 562
             new(null),
         };
 
@@ -629,7 +632,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 4, 4, 4, 2, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -833,41 +836,41 @@ internal partial class MetricsTelemetryCollector
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 509 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 512 + (int)tag;
+        var index = 514 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
     {
-        var index = 515 + (int)tag;
+        var index = 518 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 517 + (int)tag;
+        var index = 520 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[531], increment);
+        Interlocked.Add(ref _buffer.Count[534], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 532 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[559], increment);
+        Interlocked.Add(ref _buffer.Count[562], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/EnumExtensionsGenerator/RaspRuleTypeExtensions_EnumExtensions.g.cs
@@ -17,7 +17,7 @@ internal static partial class RaspRuleTypeExtensions
     /// The number of members in the enum.
     /// This is a non-distinct count of defined names.
     /// </summary>
-    public const int Length = 3;
+    public const int Length = 4;
 
     /// <summary>
     /// Returns the string representation of the <see cref="Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType"/> value.
@@ -33,6 +33,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi => "waf_version;rule_type:lfi",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf => "waf_version;rule_type:ssrf",
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI => "waf_version;rule_type:sql_injection",
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection => "waf_version;rule_type:command_injection",
             _ => value.ToString(),
         };
 
@@ -49,6 +50,7 @@ internal static partial class RaspRuleTypeExtensions
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf,
             Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI,
+            Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection,
         };
 
     /// <summary>
@@ -65,6 +67,7 @@ internal static partial class RaspRuleTypeExtensions
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Lfi),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.Ssrf),
             nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.SQlI),
+            nameof(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType.CommandInjection),
         };
 
     /// <summary>
@@ -81,5 +84,6 @@ internal static partial class RaspRuleTypeExtensions
             "waf_version;rule_type:lfi",
             "waf_version;rule_type:ssrf",
             "waf_version;rule_type:sql_injection",
+            "waf_version;rule_type:command_injection",
         };
 }

--- a/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
+++ b/tracer/src/Datadog.Trace/Generated/netstandard2.0/Datadog.Trace.SourceGenerators/TelemetryMetricGenerator/MetricsTelemetryCollector_Count.g.cs
@@ -11,7 +11,7 @@ using System.Threading;
 namespace Datadog.Trace.Telemetry;
 internal partial class MetricsTelemetryCollector
 {
-    private const int CountLength = 560;
+    private const int CountLength = 563;
 
     /// <summary>
     /// Creates the buffer for the <see cref="Datadog.Trace.Telemetry.Metrics.Count" /> values.
@@ -563,18 +563,21 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.rule.match, index = 509
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.rule.match, index = 510
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // rasp.timeout, index = 512
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // rasp.timeout, index = 514
             new(new[] { "waf_version", "rule_type:lfi" }),
             new(new[] { "waf_version", "rule_type:ssrf" }),
             new(new[] { "waf_version", "rule_type:sql_injection" }),
-            // instrum.user_auth.missing_user_id, index = 515
+            new(new[] { "waf_version", "rule_type:command_injection" }),
+            // instrum.user_auth.missing_user_id, index = 518
             new(new[] { "framework:aspnetcore_identity" }),
             new(new[] { "framework:unknown" }),
-            // executed.source, index = 517
+            // executed.source, index = 520
             new(new[] { "source_type:http.request.body" }),
             new(new[] { "source_type:http.request.path" }),
             new(new[] { "source_type:http.request.parameter.name" }),
@@ -589,9 +592,9 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "source_type:http.request.uri" }),
             new(new[] { "source_type:grpc.request.body" }),
             new(new[] { "source_type:sql.row.value" }),
-            // executed.propagation, index = 531
+            // executed.propagation, index = 534
             new(null),
-            // executed.sink, index = 532
+            // executed.sink, index = 535
             new(new[] { "vulnerability_type:none" }),
             new(new[] { "vulnerability_type:weak_cipher" }),
             new(new[] { "vulnerability_type:weak_hash" }),
@@ -619,7 +622,7 @@ internal partial class MetricsTelemetryCollector
             new(new[] { "vulnerability_type:directory_listing_leak" }),
             new(new[] { "vulnerability_type:session_timeout" }),
             new(new[] { "vulnerability_type:email_html_injection" }),
-            // request.tainted, index = 559
+            // request.tainted, index = 562
             new(null),
         };
 
@@ -629,7 +632,7 @@ internal partial class MetricsTelemetryCollector
     /// It is equal to the cardinality of the tag combinations (or 1 if there are no tags)
     /// </summary>
     private static int[] CountEntryCounts { get; }
-        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 3, 3, 3, 2, 14, 1, 27, 1, };
+        = new int[]{ 4, 76, 1, 3, 4, 2, 2, 4, 1, 1, 1, 22, 3, 2, 4, 4, 1, 22, 3, 90, 90, 2, 44, 6, 1, 1, 76, 1, 22, 3, 1, 1, 5, 3, 4, 4, 4, 2, 14, 1, 27, 1, };
 
     public void RecordCountLogCreated(Datadog.Trace.Telemetry.Metrics.MetricTags.LogLevel tag, int increment = 1)
     {
@@ -833,41 +836,41 @@ internal partial class MetricsTelemetryCollector
 
     public void RecordCountRaspRuleMatch(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 509 + (int)tag;
+        var index = 510 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountRaspTimeout(Datadog.Trace.Telemetry.Metrics.MetricTags.RaspRuleType tag, int increment = 1)
     {
-        var index = 512 + (int)tag;
+        var index = 514 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountMissingUserId(Datadog.Trace.Telemetry.Metrics.MetricTags.AuthenticationFramework tag, int increment = 1)
     {
-        var index = 515 + (int)tag;
+        var index = 518 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedSources(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSources tag, int increment = 1)
     {
-        var index = 517 + (int)tag;
+        var index = 520 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastExecutedPropagations(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[531], increment);
+        Interlocked.Add(ref _buffer.Count[534], increment);
     }
 
     public void RecordCountIastExecutedSinks(Datadog.Trace.Telemetry.Metrics.MetricTags.IastInstrumentedSinks tag, int increment = 1)
     {
-        var index = 532 + (int)tag;
+        var index = 535 + (int)tag;
         Interlocked.Add(ref _buffer.Count[index], increment);
     }
 
     public void RecordCountIastRequestTainted(int increment = 1)
     {
-        Interlocked.Add(ref _buffer.Count[559], increment);
+        Interlocked.Add(ref _buffer.Count[562], increment);
     }
 }

--- a/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
+++ b/tracer/src/Datadog.Trace/Telemetry/Metrics/MetricTags.cs
@@ -284,6 +284,7 @@ internal static class MetricTags
         [Description("waf_version;rule_type:lfi")] Lfi = 0,
         [Description("waf_version;rule_type:ssrf")] Ssrf = 1,
         [Description("waf_version;rule_type:sql_injection")] SQlI = 2,
+        [Description("waf_version;rule_type:command_injection")] CommandInjection = 3,
     }
 
     public enum TruncationReason


### PR DESCRIPTION
## Summary of changes

The RASP shell injection telemetry tag was not defined, so telemetry was not being sent.

## Reason for change

Fix the RASP telemetry for shell injection.

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
