### PR TITLE
Fix 2.x smoke test and installer tests

### DIFF
--- a/.azure-pipelines/steps/run-snapshot-test.yml
+++ b/.azure-pipelines/steps/run-snapshot-test.yml
@@ -97,7 +97,7 @@ steps:
 - ${{ if eq(parameters.isLinux, true) }}:
   - bash: |
       echo "Verifying snapshot session (fail on mis-match)"
-      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --w '\nGetting a 400 means there is a diff in snapshots. You can diff the files with the artifacts generated. You can also run the tests locally. Follow the doc in /docs/development/CI/RunSmokeTestsLocally\n' --fail "http://localhost:8126$(VERIFY_ENDPOINT)"
+      ${{ parameters.dockerComposePath }} -f $(COMPOSE_PATH) -p ddtrace_$(Build.BuildNumber) exec -T $(TEST_AGENT_TARGET) $(CURL_COMMAND) --fail-with-body "http://localhost:8126$(VERIFY_ENDPOINT)"
     displayName: check snapshots
     env:
       DD_LOGGER_DD_API_KEY: ${{ parameters.apiKey }}

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -163,6 +163,7 @@ variables:
   DD_LOGGER_DD_TAGS: test.configuration.job:$(System.JobDisplayName)
   DD_LOGGER_ENABLED: true
   DD_COLLECTOR_CPU_USAGE: true
+  ToolVersion: 2.58.1
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:
@@ -4885,6 +4886,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
           nuget-smoke-tests
@@ -4902,6 +4904,7 @@ stages:
         docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
@@ -4969,6 +4972,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           dotnet-tool-nuget-smoke-tests
       env:
         dockerTag: $(dockerTag)
@@ -5037,6 +5041,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           dotnet-tool-smoke-tests
       env:
         dockerTag: $(dockerTag)
@@ -5114,6 +5119,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg INSTALL_CMD="$(installCmd)" \
           dotnet-tool-self-instrument-smoke-tests
       env:
@@ -5343,6 +5349,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
           nuget-smoke-tests
@@ -5361,6 +5368,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
           nuget-dddotnet-smoke-tests
@@ -5426,6 +5434,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           dotnet-tool-smoke-tests
       env:
         dockerTag: $(dockerTag)
@@ -5501,6 +5510,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           nuget-smoke-tests.windows
@@ -5521,6 +5531,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           nuget-dddotnet-smoke-tests.windows
@@ -5595,6 +5606,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
           dotnet-tool-smoke-tests.windows
       env:
@@ -5906,7 +5918,7 @@ stages:
           failOnStderr: true
 
         - script: |
-            dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --add-source $(smokeTestAppDir)/artifacts/.
+            dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --add-source $(smokeTestAppDir)/artifacts/. --version $(ToolVersion)
           displayName: Install tracer
 
         - script: |

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4643,12 +4643,9 @@ stages:
 
       - script: |
           # force using a commit just before https://github.com/DataDog/system-tests/pull/2962, which was adapted for v3 
-          mkdir system-tests
+          git clone https://github.com/DataDog/system-tests.git
           cd system-tests
-          git init
-          git remote add origin https://github.com/DataDog/system-tests.git
-          git fetch --depth 1 origin 3415a681860ef3c2e9376aae4befc791431e94d2
-          git checkout FETCH_HEAD
+          git reset 3415a681860ef3c2e9376aae4befc791431e94d2 --hard
           cd ..
         displayName: Get system tests repo
 

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4641,7 +4641,15 @@ stages:
             versionSpec: '3.12'
         displayName: Install python 3.12
 
-      - script: git clone --depth 1 https://github.com/DataDog/system-tests.git
+      - script: |
+          # force using a commit just before https://github.com/DataDog/system-tests/pull/2962, which was adapted for v3 
+          mkdir system-tests
+          cd system-tests
+          git init
+          git remote add origin https://github.com/DataDog/system-tests.git
+          git fetch --depth 1 origin 3415a681860ef3c2e9376aae4befc791431e94d2
+          git checkout FETCH_HEAD
+          cd ..
         displayName: Get system tests repo
 
       - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4939,8 +4939,8 @@ stages:
         command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_nuget_smoke_tests_linux
-#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [generate_variables, merge_commit_id]
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -4969,11 +4969,6 @@ stages:
       inputs:
         artifact: runner-dotnet-tool
         path: $(smokeTestAppDir)/artifacts
-        buildType: 'specific'
-        project: 'dd-trace-dotnet'
-        definition: 54
-        buildVersionToDownload: 'specific'
-        pipelineId: 163463
 
     - script: |
         mkdir -p tracer/build_data/snapshots
@@ -5866,8 +5861,8 @@ stages:
       displayName: CheckSmokeTestsForErrors
 
 - stage: dotnet_tool_nuget_smoke_tests_macos
-#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [generate_variables, merge_commit_id]
+  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -5902,11 +5897,6 @@ stages:
           inputs:
             artifact: runner-dotnet-tool
             path: $(smokeTestAppDir)/artifacts
-            buildType: 'specific'
-            project: 'dd-trace-dotnet'
-            definition: 54
-            buildVersionToDownload: 'specific'
-            pipelineId: 163463
 
         - script: |
             mkdir -p tracer/build_data/snapshots

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4641,12 +4641,8 @@ stages:
             versionSpec: '3.12'
         displayName: Install python 3.12
 
-      - script: |
-          # force using a commit just before https://github.com/DataDog/system-tests/pull/2962, which was adapted for v3 
-          git clone https://github.com/DataDog/system-tests.git
-          cd system-tests
-          git reset 3415a681860ef3c2e9376aae4befc791431e94d2 --hard
-          cd ..
+      # force using a branch just before https://github.com/DataDog/system-tests/pull/2962, which adapted the system tests for v3 
+      - script: git clone --branch andrew/release/2.x --depth 1 https://github.com/DataDog/system-tests.git
         displayName: Get system tests repo
 
       - task: DownloadPipelineArtifact@2

--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4939,8 +4939,8 @@ stages:
         command: "CheckSmokeTestsForErrors"
 
 - stage: dotnet_tool_nuget_smoke_tests_linux
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
+#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -4969,6 +4969,11 @@ stages:
       inputs:
         artifact: runner-dotnet-tool
         path: $(smokeTestAppDir)/artifacts
+        buildType: 'specific'
+        project: 'dd-trace-dotnet'
+        definition: 54
+        buildVersionToDownload: 'specific'
+        pipelineId: 163463
 
     - script: |
         mkdir -p tracer/build_data/snapshots
@@ -5861,8 +5866,8 @@ stages:
       displayName: CheckSmokeTestsForErrors
 
 - stage: dotnet_tool_nuget_smoke_tests_macos
-  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
-  dependsOn: [dotnet_tool, generate_variables, merge_commit_id]
+#  condition: and(succeeded(), eq(variables['isBenchmarksOnlyBuild'], 'False'), or(eq(variables.isMainOrReleaseBranch, 'true'), eq(variables.run_all_installer_tests, 'true')))
+  dependsOn: [generate_variables, merge_commit_id]
   variables:
     targetShaId: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.sha']]
     targetBranch: $[ stageDependencies.merge_commit_id.fetch.outputs['set_sha.branch']]
@@ -5897,6 +5902,11 @@ stages:
           inputs:
             artifact: runner-dotnet-tool
             path: $(smokeTestAppDir)/artifacts
+            buildType: 'specific'
+            project: 'dd-trace-dotnet'
+            definition: 54
+            buildVersionToDownload: 'specific'
+            pipelineId: 163463
 
         - script: |
             mkdir -p tracer/build_data/snapshots

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -115,6 +115,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
       # - RELATIVE_PROFILER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-windows-nuget-tester
     volumes:
@@ -135,6 +136,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
       # - RELATIVE_PROFILER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-windows-nuget-tester
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -895,6 +895,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
         # - RELATIVE_PROFILER_PATH=
         # - RELATIVE_API_WRAPPER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-nuget-tester
@@ -917,6 +918,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
         # - RELATIVE_PROFILER_PATH=
         # - RELATIVE_API_WRAPPER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-nuget-tester
@@ -939,6 +941,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-tester
     volumes:
     - ./:/project
@@ -980,6 +983,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-nuget-tester
     volumes:
     - ./:/project

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -424,6 +424,7 @@ partial class Build
         {
             var expectedFileChanges = new List<string>
             {
+                ".azure-pipelines/ultimate-pipeline.yml",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h",

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -243,6 +243,11 @@ namespace PrepareRelease
             {
                 Console.WriteLine($"Updating source version instances to {VersionString()}");
 
+                // Pipeline
+                SynchronizeVersion(
+                    ".azure-pipelines/ultimate-pipeline.yml",
+                    text => Regex.Replace(text, $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\"", $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\""));
+
                 // Nuke build
                 SynchronizeVersion(
                     "build/_build/Build.cs",

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -19,10 +19,11 @@ WORKDIR /app
 COPY --from=builder /src/artifacts /app/install
 
 ARG INSTALL_CMD
+ARG TOOL_VERSION
 RUN mkdir -p /opt/datadog \
     && mkdir -p /var/log/datadog \
     && mkdir -p /tool \
-    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. \
+    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. --version $TOOL_VERSION \
     && rm -rf /app/install
 
 # Set the optional env vars

--- a/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
@@ -8,14 +8,12 @@ FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
-# do an initial restore
-RUN dotnet restore "AspNetCoreSmokeTest.csproj"
-
-# install the package
-RUN dotnet add package "Datadog.Trace.Bundle" --source /src/artifacts
-
+ARG TOOL_VERSION
 ARG PUBLISH_FRAMEWORK
-RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet nuget add source /src/artifacts \
+    && dotnet add package "Datadog.Trace.Bundle" --version $TOOL_VERSION \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
 FROM $RUNTIME_IMAGE AS publish
 

--- a/tracer/build/_build/docker/smoke.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dockerfile
@@ -8,14 +8,12 @@ FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
-# do an initial restore
-RUN dotnet restore "AspNetCoreSmokeTest.csproj"
-
-# install the package
-RUN dotnet add package "Datadog.Trace.Bundle" --source /src/artifacts
-
+ARG TOOL_VERSION
 ARG PUBLISH_FRAMEWORK
-RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet nuget add source /src/artifacts \
+    && dotnet add package "Datadog.Trace.Bundle" --version $TOOL_VERSION \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
 FROM $RUNTIME_IMAGE AS publish
 

--- a/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
@@ -12,9 +12,10 @@ WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
 ARG PUBLISH_FRAMEWORK
+ARG TOOL_VERSION
 RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
     && dotnet nuget add source "c:\src\artifacts" \
-    && dotnet add package "Datadog.Trace.Bundle" \
+    && dotnet add package "Datadog.Trace.Bundle" --version %TOOL_VERSION% \
     && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o "c:\src\publish"
 
 FROM $RUNTIME_IMAGE AS publish-msi

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -11,10 +11,11 @@ USER ContainerAdministrator
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
+ARG TOOL_VERSION
 ARG PUBLISH_FRAMEWORK
 RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
     && dotnet nuget add source "c:\src\artifacts" \
-    && dotnet add package "Datadog.Trace.Bundle" \
+    && dotnet add package "Datadog.Trace.Bundle" --version %TOOL_VERSION% \
     && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o "c:\src\publish"
 
 FROM $RUNTIME_IMAGE AS publish-msi


### PR DESCRIPTION
## Summary of changes

- Fix nuget/dd-trace installer tests in 2.x branch
- Pin system tests in 2.x branch

## Reason for change

The code we were using to install the "local" builds of the NuGet packages added the local source. However the dotnet restore was looking in both the local and nuget.org sources, and installing the highest version it found. That worked fine until we released 3.2.0 publicly and expect to install 2.59.0 of the local build.

For system-tests, we had to change how things work to support v3 (https://github.com/DataDog/system-tests/pull/2962), but unfortunately that breaks for v2.

## Implementation details

Install an explicit version of the tracer. As this version is never in the public nuget.org source but _is_ in the local source, it uses that.

> In https://github.com/DataDog/dd-trace-dotnet/pull/5989 I tried a different approach but it just didn't work.

For system tests, just pinning to the specific commit prior to the v3 PR being merged. 

Having to thread the version through everywhere is kinda horrible, but is the only thing I could find that works.

## Test coverage

Running [a full installer run here](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=163526&view=results)

## Other details

The whole approach should be rewritten to be managed by Nuke tbh, if we ever find time

This PR also contains a backport of 
- https://github.com/DataDog/dd-trace-dotnet/pull/5988
for simplicity

Supersedes
- https://github.com/DataDog/dd-trace-dotnet/pull/5989