### PR TITLE
Add serverless sample app link to samples folder

### DIFF
--- a/tracer/samples/ServerlessAWS/README.md
+++ b/tracer/samples/ServerlessAWS/README.md
@@ -1,0 +1,3 @@
+# Serverless on AWS
+
+A full example demonstrating how to use the .NET tracer when building serverless applications on AWS can be found in the [serverless-getting-started](https://github.com/DataDog/serverless-sample-app) repository. This repository contains a full sample application, with deployable examples in [Terraform](https://github.com/DataDog/serverless-sample-app/blob/main/src/dotnet/README.md#terraform), the [AWS CDK](https://github.com/DataDog/serverless-sample-app/blob/main/src/dotnet/README.md#aws-cdk) and the [AWS Serverless Application Model (SAM)](https://github.com/DataDog/serverless-sample-app/blob/main/src/dotnet/README.md#aws-sam).


### PR DESCRIPTION
## Summary of changes
Add a link to the serverless sample app repository to the samples folder.

## Reason for change

The serverless sample app is a new repository demonstrating how to use Datadog for observing serverless applications. It has examples in .NET, using Terraform, SAM, or CDK as IaC framework.

## Implementation details

N/A

## Test coverage

N/A

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
