### PR TITLE
Minor CI fixes

### DIFF
--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -2,6 +2,12 @@ name: Auto Block PR on Code Freeze
 
 on:
   pull_request:
+    branches:
+      - 'main'
+      - 'master'
+      - 'release/**'
+      - 'hotfix/**'
+
 
 jobs:
   check_for_code_freeze:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,6 +78,7 @@ publish:
 download-single-step-artifacts:
   stage: package
   image: registry.ddbuild.io/docker:20.10.13-gbi-focal
+  timeout: 45m
   tags: [ "arch:amd64" ]
   needs: []
   rules:

--- a/.gitlab/download-single-step-artifacts.sh
+++ b/.gitlab/download-single-step-artifacts.sh
@@ -46,8 +46,8 @@ echo "Found build with id '$buildId' for commit '$CI_COMMIT_SHA' on branch '$bra
 # Now try to download the ssi artifacts from the build
 artifactsUrl="https://dev.azure.com/datadoghq/dd-trace-dotnet/_apis/build/builds/$buildId/artifacts?api-version=7.1&artifactName=$artifactName"
 
-# Keep trying to get the artifact for 30 minutes
-TIMEOUT=1800
+# Keep trying to get the artifact for 40 minutes
+TIMEOUT=2400
 STARTED=0
 until (( STARTED == TIMEOUT )) || [ ! -z "${downloadUrl}" ] ; do
     echo "Checking for artifacts at '$artifactsUrl'..."


### PR DESCRIPTION
## Summary of changes

- Try to make the code-freeze PR not block
- Try to prevent timeouts in gitlab jobs

## Reason for change

The auto-pass code freeze check [doesn't seem to be working for PRs](https://github.com/DataDog/dd-trace-dotnet/pull/5986) to non-master for some reason.

Also the gitlab job that waits for artifacts to be ready before trying to download frequently times out.

## Implementation details

Try to force the auto-check to work. It should _already_ be working AFAICT based on the docs, so this is a stab in the dark 🤞 

For the gitlab job, wait for longer