### PR TITLE
[Crashtracking] Fix the handling of COMPlus_DbgMiniDumpName (#5980 -> v2)

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/functions_to_wrap.c
@@ -181,6 +181,7 @@ static const char* datadogCrashMarker = "datadog_crashtracking";
 #define COMPlus_DbgEnableMiniDump "COMPlus_DbgEnableMiniDump"
 #define DOTNET_DbgMiniDumpName "DOTNET_DbgMiniDumpName"
 #define COMPlus_DbgMiniDumpName "COMPlus_DbgMiniDumpName"
+#define DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME "DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME"
 
 __attribute__((constructor))
 void initLibrary(void)
@@ -196,6 +197,16 @@ void initLibrary(void)
             // Early nope
             return;
         }
+    }
+
+    // Bash provides its own version of the getenv/setenv functions
+    // Fetch the original ones and use those instead
+    char *(*real_getenv)(const char *) = (char *(*)(const char *))dlsym(RTLD_NEXT, "getenv");
+    int (*real_setenv)(const char *, const char *, int) = (int (*)(const char *, const char *, int))dlsym(RTLD_NEXT, "setenv");
+
+    if (real_getenv == NULL || real_setenv == NULL)
+    {
+        return;
     }
 
     // If crashtracking is enabled, check the value of DOTNET_DbgEnableMiniDump
@@ -279,17 +290,17 @@ void initLibrary(void)
 
     if (crashHandler != NULL && crashHandler[0] != '\0')
     {
-        char* enableMiniDump = getenv(DOTNET_DbgEnableMiniDump);
+        char* enableMiniDump = real_getenv(DOTNET_DbgEnableMiniDump);
 
         if (enableMiniDump == NULL)
         {
-            enableMiniDump = getenv(COMPlus_DbgEnableMiniDump);
+            enableMiniDump = real_getenv(COMPlus_DbgEnableMiniDump);
         }
 
         if (enableMiniDump != NULL && enableMiniDump[0] == '1')
         {
-            // If DOTNET_DbgEnableMiniDump is set, the crash handler should call createdump when done
-            char* passthrough = getenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH);
+            // Passthrough is expected by dd-dotnet to know whether it should forward the call to createdump
+            char* passthrough = real_getenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH);
 
             if (passthrough == NULL || passthrough[0] == '\0')
             {
@@ -298,25 +309,40 @@ void initLibrary(void)
                 //  - dotnet run sets DOTNET_DbgEnableMiniDump=1
                 //  - dotnet then launches the target app
                 //  - the target app thinks DOTNET_DbgEnableMiniDump has been set by the user and enables passthrough
-                setenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH, "1", 1);
+                real_setenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH, "1", 1);
             }
         }
         else
         {
             // If DOTNET_DbgEnableMiniDump is not set, we set it so that the crash handler is called,
             // but we instruct it to not call createdump afterwards
-            setenv(COMPlus_DbgEnableMiniDump, "1", 1);
-            setenv(DOTNET_DbgEnableMiniDump, "1", 1);
-            setenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH, "0", 1);
+            real_setenv(COMPlus_DbgEnableMiniDump, "1", 1);
+            real_setenv(DOTNET_DbgEnableMiniDump, "1", 1);
+            real_setenv(DD_INTERNAL_CRASHTRACKING_PASSTHROUGH, "0", 1);
         }
 
-        originalMiniDumpName = getenv(DOTNET_DbgMiniDumpName);
-        if (originalMiniDumpName == NULL)
+        originalMiniDumpName = real_getenv(DOTNET_DbgMiniDumpName);
+
+        if (originalMiniDumpName == NULL || strncmp(originalMiniDumpName, datadogCrashMarker, strlen(datadogCrashMarker)) == 0)
         {
-            originalMiniDumpName = getenv(COMPlus_DbgMiniDumpName);
+            originalMiniDumpName = real_getenv(COMPlus_DbgMiniDumpName);
         }
-        setenv(COMPlus_DbgMiniDumpName, datadogCrashMarker, 1);
-        setenv(DOTNET_DbgMiniDumpName, datadogCrashMarker, 1);
+
+        if (originalMiniDumpName != NULL && strncmp(originalMiniDumpName, datadogCrashMarker, strlen(datadogCrashMarker)) == 0)
+        {
+            // If LD_PRELOAD was set in the parent process, then we replaced COMPlus_DbgMiniDumpName with datadogCrashMarker and lost the original value
+            // We use DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME to retrieve it
+            originalMiniDumpName = real_getenv(DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME);
+        }
+
+        if (originalMiniDumpName != NULL && originalMiniDumpName[0] != '\0')
+        {
+            // Save the original value in DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME so that child processes can retrieve it
+            real_setenv(DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME, originalMiniDumpName, 1);
+        }
+
+        real_setenv(COMPlus_DbgMiniDumpName, datadogCrashMarker, 1);
+        real_setenv(DOTNET_DbgMiniDumpName, datadogCrashMarker, 1);
     }
 }
 

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/ConsoleTestHelper.cs
@@ -49,12 +49,16 @@ public abstract class ConsoleTestHelper : ToolTestHelper
         return (executable, args);
     }
 
-    protected async Task<ProcessHelper> StartConsole(EnvironmentHelper environmentHelper, bool enableProfiler, string args, params (string Key, string Value)[] environmentVariables)
+    protected Task<ProcessHelper> StartConsole(EnvironmentHelper environmentHelper, bool enableProfiler, string args, params (string Key, string Value)[] environmentVariables)
     {
         var (executable, baseArgs) = PrepareSampleApp(environmentHelper);
-
         args = $"{baseArgs} {args}";
 
+        return StartConsole(executable, args, environmentHelper, enableProfiler, environmentVariables);
+    }
+
+    protected async Task<ProcessHelper> StartConsole(string executable, string args, EnvironmentHelper environmentHelper, bool enableProfiler, params (string Key, string Value)[] environmentVariables)
+    {
         var processStart = new ProcessStartInfo(executable, args) { UseShellExecute = false, RedirectStandardError = true, RedirectStandardOutput = true };
 
         MockTracerAgent? agent = null;

--- a/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.dd_dotnet.ArtifactTests/CreatedumpTests.cs
@@ -24,7 +24,7 @@ namespace Datadog.Trace.Tools.dd_dotnet.ArtifactTests;
 
 public class CreatedumpTests : ConsoleTestHelper
 {
-    private const string CreatedumpExpectedOutput = "Writing minidump";
+    private const string CreatedumpExpectedOutput = "Writing minidump with heap to file /dev/null";
     private const string CrashReportExpectedOutput = "The crash may have been caused by automatic instrumentation";
 
     public CreatedumpTests(ITestOutputHelper output)
@@ -92,6 +92,41 @@ public class CreatedumpTests : ConsoleTestHelper
         {
             helper.StandardOutput.Should().NotContain(CreatedumpExpectedOutput);
         }
+    }
+
+    [SkippableFact]
+    public async Task BashScript()
+    {
+        // This tests the case when an app is called through a bash script
+        // This scenario has unique challenges because:
+        //   - The COMPlus_DbgMiniDumpName environment variable that we override is then inherited by the child
+        //   - Bash overrides the getenv/setenv functions, which cause some unexpected behaviors
+
+        SkipOn.Platform(SkipOn.PlatformValue.Windows);
+        SkipOn.Platform(SkipOn.PlatformValue.MacOs);
+
+        using var reportFile = new TemporaryFile();
+
+        (string, string)[] environment = [LdPreloadConfig, .. CreatedumpConfig, CrashReportConfig(reportFile)];
+
+        var (executable, args) = PrepareSampleApp(EnvironmentHelper);
+
+        var bashScript = $"#!/bin/bash\n{executable} {args} crash-datadog\n";
+        using var bashFile = new TemporaryFile();
+        bashFile.SetContent(bashScript);
+
+        using var helper = await StartConsole("/bin/bash", bashFile.Path, EnvironmentHelper, false, environment);
+
+        await helper.Task;
+
+        using var assertionScope = new AssertionScope();
+        assertionScope.AddReportable("stdout", helper.StandardOutput);
+        assertionScope.AddReportable("stderr", helper.ErrorOutput);
+
+        helper.StandardOutput.Should().Contain(CrashReportExpectedOutput);
+        File.Exists(reportFile.Path).Should().BeTrue();
+
+        helper.StandardOutput.Should().Contain(CreatedumpExpectedOutput);
     }
 
     [SkippableTheory]
@@ -482,6 +517,8 @@ public class CreatedumpTests : ConsoleTestHelper
         public string Url => $"file:/{Path}";
 
         public string GetContent() => File.ReadAllText(Path);
+
+        public void SetContent(string content) => File.WriteAllText(Path, content);
 
         public void Dispose()
         {


### PR DESCRIPTION
## Summary of changes

To distinguish the case when createdump is called because of a crash vs a call from `dotnet-dump`, we store a dummy value in `COMPlus_DbgMiniDumpName`:
https://github.com/DataDog/dd-trace-dotnet/pull/5852

However, this becomes a problem when the process spawns a child process, as it inherits the dummy `COMPlus_DbgMiniDumpName` and we lose the original value.

To get around that, this PR saves the original value in `DD_INTERNAL_CRASHTRACKING_MINIDUMPNAME` so the children can retrieve it.

## Reason for change

This prevents the crash dump to be generated when launching the app from a bash script when `LD_PRELOAD` is set globally.

## Implementation details

We discovered that bash provides its own version of the `getenv`/`setenv` functions, which leads to some unexpected behavior. To get around that, we use `dlsym` to fetch the original libc functions.

## Test coverage

Added a test with a sample app launched from a bash script.

## Other details

Backport of #5980