### PR TITLE
[Profiler] Fix duplicated lifecycle telemetry

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/TelemetryMetricsWorker.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/TelemetryMetricsWorker.cpp
@@ -173,10 +173,10 @@ bool TelemetryMetricsWorker::Start(
     }
 
     // start the worker
-    // NOTE: builder is consummed after the call so no need to drop it
+    // NOTE: builder is consumed after the call so no need to drop it
     // TODO: we need to update libdatadog to avoid taking the ownership of the builder
     //       and explicitly drop it in all cases
-    result = ddog_telemetry_builder_run(builder, &_impl->_pHandle);
+    result = ddog_telemetry_builder_run_metric_logs(builder, &_impl->_pHandle); // don't send lifecycle telemetry
     if (result.tag == DDOG_OPTION_ERROR_SOME_ERROR)
     {
         auto error = make_error(result);


### PR DESCRIPTION
## Summary of changes
Avoid sending application lifecycle telemetry 

## Reason for change
The Tracer is already sending these application lifecycle telemetry events

## Implementation details
Use a different API from libdatadog telemetry

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
