### PR TITLE
[Profiler] Fix LinuxDlIteratePhdrDeadlock test (#5963 -> v2)

### DIFF
--- a/profiler/src/Demos/Samples.Computer01/ComputerService.cs
+++ b/profiler/src/Demos/Samples.Computer01/ComputerService.cs
@@ -44,7 +44,9 @@ namespace Samples.Computer01
         private NullThreadNameBugCheck _nullThreadNameBugCheck;
         private MethodsSignature _methodsSignature;
         private SigSegvHandlerExecution _sigsegvHandler;
+#if NETCOREAPP3_0_OR_GREATER
         private LinuxDlIteratePhdrDeadlock _linuxDlIteratePhdrDeadlock;
+#endif
 
 #if NET5_0_OR_GREATER
         private OpenLdapCrash _openldapCrash;
@@ -182,9 +184,11 @@ namespace Samples.Computer01
                     StartStringConcat(parameter);
                     break;
 
+#if NETCOREAPP3_0_OR_GREATER
                 case Scenario.LinuxDlIteratePhdrDeadlock:
                     StartLinuxDlIteratePhdrDeadlock();
                     break;
+#endif
 
                 default:
                     throw new ArgumentOutOfRangeException(nameof(scenario), $"Unsupported scenario #{_scenario}");
@@ -317,9 +321,11 @@ namespace Samples.Computer01
                     StopStringConcat();
                     break;
 
+#if NETCOREAPP3_0_OR_GREATER
                 case Scenario.LinuxDlIteratePhdrDeadlock:
                     StopLinuxDlIteratePhdrDeadlock();
                     break;
+#endif
             }
         }
 
@@ -584,11 +590,13 @@ namespace Samples.Computer01
             _linuxMallockDeadlock.Start();
         }
 
+#if NETCOREAPP3_0_OR_GREATER
         private void StartLinuxDlIteratePhdrDeadlock()
         {
             _linuxDlIteratePhdrDeadlock = new LinuxDlIteratePhdrDeadlock();
             _linuxDlIteratePhdrDeadlock.Start();
         }
+#endif
 
         private void StartMeasureAllocations()
         {
@@ -764,10 +772,12 @@ namespace Samples.Computer01
             _linuxMallockDeadlock.Stop();
         }
 
+#if NETCOREAPP3_0_OR_GREATER
         private void StopLinuxDlIteratePhdrDeadlock()
         {
             _linuxDlIteratePhdrDeadlock.Stop();
         }
+#endif
 
         private void StopMeasureAllocations()
         {


### PR DESCRIPTION
## Summary of changes

Fix `LinuxDlIteratePhdrDeadlock` test.

## Reason for change

The test is randomly failing and not because there is a deadlock, but only because it's not correct. It uses the `dlopen` and `dlclose` from `libdl.so` library, instead of the ones we wrapped in the `Datadog.Linux.ApiWrapper.x64.so` file.

## Implementation details

- Use `NativeLibrary.SetDllImportResolver` to make sure we control how we want to resolve for our `ApiWrapper` library.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

Backporting of #5963

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
