### PR TITLE
Fix installer tests (#5994 => main)

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -172,6 +172,7 @@ variables:
   DD_COLLECTOR_CPU_USAGE: true
   # If we're doing an SSI run, set the indicator, the rest need to be set in the stage
   IS_SSI_RUN: $[ or(eq(variables['Build.CronSchedule.DisplayName'], 'Daily SSI Run'), eq(variables['force_ssi_run'], 'true')) ]
+  ToolVersion: 2.58.1
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:
@@ -5147,6 +5148,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
           nuget-smoke-tests
@@ -5164,6 +5166,7 @@ stages:
         docker-compose -p $(DockerComposeProjectName) build \
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
@@ -5231,6 +5234,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           dotnet-tool-nuget-smoke-tests
       env:
         dockerTag: $(dockerTag)
@@ -5299,6 +5303,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           dotnet-tool-smoke-tests
       env:
         dockerTag: $(dockerTag)
@@ -5376,6 +5381,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg INSTALL_CMD="$(installCmd)" \
           dotnet-tool-self-instrument-smoke-tests
       env:
@@ -5605,6 +5611,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
           nuget-smoke-tests
@@ -5623,6 +5630,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           --build-arg RELATIVE_APIWRAPPER_PATH="$(relativeApiWrapperPath)" \
           nuget-dddotnet-smoke-tests
@@ -5688,6 +5696,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           dotnet-tool-smoke-tests
       env:
         dockerTag: $(dockerTag)
@@ -5763,6 +5772,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           nuget-smoke-tests.windows
@@ -5783,6 +5793,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
           --build-arg RELATIVE_PROFILER_PATH="$(relativeProfilerPath)" \
           nuget-dddotnet-smoke-tests.windows
@@ -5857,6 +5868,7 @@ stages:
           --build-arg DOTNETSDK_VERSION=$(dotnetCoreSdkLatestVersionShort) \
           --build-arg RUNTIME_IMAGE=$(runtimeImage) \
           --build-arg PUBLISH_FRAMEWORK=$(publishFramework) \
+          --build-arg TOOL_VERSION=$(ToolVersion) \
           --build-arg CHANNEL_32_BIT="$(channel32Bit)" \
           dotnet-tool-smoke-tests.windows
       env:
@@ -6165,7 +6177,7 @@ stages:
           failOnStderr: true
 
         - script: |
-            dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --add-source $(smokeTestAppDir)/artifacts/. --prerelease
+            dotnet tool install dd-trace --tool-path $(smokeTestAppDir)/publish --add-source $(smokeTestAppDir)/artifacts/. --version $(ToolVersion) --prerelease
           displayName: Install tracer
 
         - script: |

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -115,6 +115,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
       # - RELATIVE_PROFILER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-windows-nuget-tester
     volumes:
@@ -135,6 +136,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
       # - RELATIVE_PROFILER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-windows-nuget-tester
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -903,6 +903,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
         # - RELATIVE_PROFILER_PATH=
         # - RELATIVE_API_WRAPPER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-nuget-tester
@@ -925,6 +926,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
         # - RELATIVE_PROFILER_PATH=
         # - RELATIVE_API_WRAPPER_PATH=
     image: dd-trace-dotnet/${dockerTag:-not-set}-nuget-tester
@@ -947,6 +949,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-tester
     volumes:
     - ./:/project
@@ -988,6 +991,7 @@ services:
         # - DOTNETSDK_VERSION=
         # - RUNTIME_IMAGE=
         # - PUBLISH_FRAMEWORK=
+        # - TOOL_VERSION=
     image: dd-trace-dotnet/${dockerTag:-not-set}-dotnet-tool-nuget-tester
     volumes:
     - ./:/project

--- a/tracer/build/_build/Build.GitHub.cs
+++ b/tracer/build/_build/Build.GitHub.cs
@@ -424,6 +424,7 @@ partial class Build
         {
             var expectedFileChanges = new List<string>
             {
+                ".azure-pipelines/ultimate-pipeline.yml",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc",
                 "profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h",

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -243,6 +243,11 @@ namespace PrepareRelease
             {
                 Console.WriteLine($"Updating source version instances to {VersionString()}");
 
+                // Pipeline
+                SynchronizeVersion(
+                    ".azure-pipelines/ultimate-pipeline.yml",
+                    text => Regex.Replace(text, $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\"", $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\""));
+
                 // Nuke build
                 SynchronizeVersion(
                     "build/_build/Build.cs",

--- a/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.dotnet-tool.nuget.dockerfile
@@ -19,10 +19,11 @@ WORKDIR /app
 COPY --from=builder /src/artifacts /app/install
 
 ARG INSTALL_CMD
+ARG TOOL_VERSION
 RUN mkdir -p /opt/datadog \
     && mkdir -p /var/log/datadog \
     && mkdir -p /tool \
-    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. \
+    && dotnet tool install dd-trace --tool-path /tool --add-source /app/install/. --version $TOOL_VERSION \
     && rm -rf /app/install
 
 # Set the optional env vars

--- a/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dd-dotnet.dockerfile
@@ -8,14 +8,12 @@ FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
-# do an initial restore
-RUN dotnet restore "AspNetCoreSmokeTest.csproj"
-
-# install the package
-RUN dotnet add package "Datadog.Trace.Bundle" --source /src/artifacts --prerelease
-
+ARG TOOL_VERSION
 ARG PUBLISH_FRAMEWORK
-RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet nuget add source /src/artifacts \
+    && dotnet add package "Datadog.Trace.Bundle" --version $TOOL_VERSION --prerelease \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
 FROM $RUNTIME_IMAGE AS publish
 

--- a/tracer/build/_build/docker/smoke.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.nuget.dockerfile
@@ -8,14 +8,12 @@ FROM mcr.microsoft.com/dotnet/sdk:$DOTNETSDK_VERSION as builder
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
-# do an initial restore
-RUN dotnet restore "AspNetCoreSmokeTest.csproj"
-
-# install the package
-RUN dotnet add package "Datadog.Trace.Bundle" --source /src/artifacts --prerelease
-
+ARG TOOL_VERSION
 ARG PUBLISH_FRAMEWORK
-RUN dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
+RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
+    && dotnet nuget add source /src/artifacts \
+    && dotnet add package "Datadog.Trace.Bundle" --version $TOOL_VERSION --prerelease \
+    && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework $PUBLISH_FRAMEWORK -o /src/publish
 
 FROM $RUNTIME_IMAGE AS publish
 

--- a/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dd-dotnet.dockerfile
@@ -12,9 +12,10 @@ WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
 ARG PUBLISH_FRAMEWORK
+ARG TOOL_VERSION
 RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
     && dotnet nuget add source "c:\src\artifacts" \
-    && dotnet add package "Datadog.Trace.Bundle" --prerelease \
+    && dotnet add package "Datadog.Trace.Bundle" --version %TOOL_VERSION% --prerelease \
     && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o "c:\src\publish"
 
 FROM $RUNTIME_IMAGE AS publish-msi

--- a/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
+++ b/tracer/build/_build/docker/smoke.windows.nuget.dockerfile
@@ -11,10 +11,11 @@ USER ContainerAdministrator
 WORKDIR /src
 COPY ./test/test-applications/regression/AspNetCoreSmokeTest/ .
 
+ARG TOOL_VERSION
 ARG PUBLISH_FRAMEWORK
 RUN dotnet restore "AspNetCoreSmokeTest.csproj" \
     && dotnet nuget add source "c:\src\artifacts" \
-    && dotnet add package "Datadog.Trace.Bundle" --prerelease \
+    && dotnet add package "Datadog.Trace.Bundle" --version %TOOL_VERSION% --prerelease \
     && dotnet publish "AspNetCoreSmokeTest.csproj" -c Release --framework %PUBLISH_FRAMEWORK% -o "c:\src\publish"
 
 FROM $RUNTIME_IMAGE AS publish-msi


### PR DESCRIPTION
## Summary of changes

- Fix nuget/dd-trace installer tests in 2.x branch

## Reason for change

The code we were using to install the "local" builds of the NuGet packages added the local source. However the dotnet restore was looking in both the local and nuget.org sources, and installing the highest version it found. That worked fine until we released 3.2.0 publicly and expect to install 2.59.0 of the local build.

## Implementation details

Install an explicit version of the tracer. As this version is never in the public nuget.org source but _is_ in the local source, it uses that.

> In https://github.com/DataDog/dd-trace-dotnet/pull/5989 I tried a different approach but it just didn't work.

Having to thread the version through everywhere is kinda horrible, but is the only thing I could find that works.

## Test coverage

Will run a full installer test 

## Other details

The whole approach should be rewritten to be managed by Nuke tbh, if we ever find time

This PR is a "forward port" of 
- https://github.com/DataDog/dd-trace-dotnet/pull/5994

(the issue was exhibited on the 2.x branch, so this is preemptive for the future)
