### PR TITLE
Fix the trace pipeline stage

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6456,14 +6456,26 @@ stages:
 
     steps:
     - template: steps/install-latest-dotnet-sdk.yml
+
+    - bash: dotnet tool install dd-trace --global --prerelease
+      displayName: "Install dd-trace"
+      retryCountOnTaskFailure: 2
+
     - bash: |
-        dotnet run $(Build.BuildId)
+        mkdir -p $(Build.SourcesDirectory)/artifacts/build_data
+        dotnet build
+        dd-trace run --set-env "DD_TRACE_LOG_DIRECTORY=$(Build.SourcesDirectory)/artifacts/build_data" -- dotnet run --no-restore --no-build -- $(Build.BuildId)
         exit $?
       displayName: "Run"
       workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"
 
     - bash: sleep 20
       displayName: Wait 20 seconds to agent flush before finishing pipeline
+
+    - publish: $(Build.SourcesDirectory)/artifacts/build_data
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
 
 - stage: notify_slack_on_failures
   condition: >


### PR DESCRIPTION
## Summary of changes

Fixes the `trace-pipeline` stage

## Reason for change

We broke it in v3 because it uses manual-only instrumentation 🙈 

## Implementation details

Install and use the latest `dd-trace` tool from nuget.org. The trace pipeline installs the latest `Datadog.Trace` NuGet package, so by installing the latest `dd-trace` we're matching package versions correctly here too, so no need to thread the version through explicitly I think.

## Test coverage

Before 🙁 
![image](https://github.com/user-attachments/assets/ee0cbea0-c277-4c8a-a125-3baabf539a12)

[After](https://ddstaging.datadoghq.com/apm/services/consolidated-pipeline/operations/ci_run/resources) 😃
 
![image](https://github.com/user-attachments/assets/6ee5080d-0c4e-4f58-9ee4-6822204639b1)


## Other details

The `release/2.x` branch pipeline isn't broken, so this doesn't need backporting