### PR TITLE
[ASM] Add new capabilities for RC

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Numerics;
 using System.Threading;
 using Datadog.Trace.Agent.DiscoveryService;
 using Datadog.Trace.AppSec.Rcm;
@@ -34,7 +35,6 @@ namespace Datadog.Trace.AppSec
     internal class Security : IDatadogSecurity, IDisposable
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor<Security>();
-
         private static Security? _instance;
         private static bool _globalInstanceInitialized;
         private static object _globalInstanceLock = new();
@@ -498,9 +498,19 @@ namespace Datadog.Trace.AppSec
             rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomRules, _noLocalRules);
             rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomBlockingResponse, _noLocalRules);
             rcm.SetCapability(RcmCapabilitiesIndices.AsmTrustedIps, _noLocalRules);
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspLfi, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspLfi));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspSsrf, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspSsrf));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspShi, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspShi));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspSqli, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspSqli));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmExclusionData, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmExclusionData));
             // follows a different pattern to rest of ASM remote config, if available it's the RC value
             // that takes precedence. This follows what other products do.
             rcm.SetCapability(RcmCapabilitiesIndices.AsmAutoUserInstrumentationMode, true);
+        }
+
+        private bool WafSupportsCapability(BigInteger capability)
+        {
+            return RCMCapabilitiesHelper.WafSupportsCapability(capability, _waf?.Version);
         }
 
         private void InitWafAndInstrumentations(bool configurationFromRcm = false)

--- a/tracer/src/Datadog.Trace/AppSec/Security.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Security.cs
@@ -498,10 +498,10 @@ namespace Datadog.Trace.AppSec
             rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomRules, _noLocalRules);
             rcm.SetCapability(RcmCapabilitiesIndices.AsmCustomBlockingResponse, _noLocalRules);
             rcm.SetCapability(RcmCapabilitiesIndices.AsmTrustedIps, _noLocalRules);
-            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspLfi, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspLfi));
-            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspSsrf, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspSsrf));
-            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspShi, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspShi));
-            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspSqli, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspSqli));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspLfi, _settings.RaspEnabled && _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspLfi));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspSsrf, _settings.RaspEnabled && _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspSsrf));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspShi, _settings.RaspEnabled && _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspShi));
+            rcm.SetCapability(RcmCapabilitiesIndices.AsmRaspSqli, _settings.RaspEnabled && _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmRaspSqli));
             rcm.SetCapability(RcmCapabilitiesIndices.AsmExclusionData, _noLocalRules && WafSupportsCapability(RcmCapabilitiesIndices.AsmExclusionData));
             // follows a different pattern to rest of ASM remote config, if available it's the RC value
             // that takes precedence. This follows what other products do.

--- a/tracer/src/Datadog.Trace/AppSec/Waf/RCMCapabilitiesHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/RCMCapabilitiesHelper.cs
@@ -1,0 +1,53 @@
+// <copyright file="RCMCapabilitiesHelper.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using Datadog.Trace.Logging;
+using Datadog.Trace.RemoteConfigurationManagement;
+
+#nullable enable
+
+namespace Datadog.Trace.AppSec.Waf;
+
+internal static class RCMCapabilitiesHelper
+{
+    private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(RCMCapabilitiesHelper));
+
+    private static readonly Dictionary<BigInteger, Version> _CapabilitiesVersion = new Dictionary<BigInteger, Version>()
+    {
+        { RcmCapabilitiesIndices.AsmRaspSqli, new Version(2, 54) },
+        { RcmCapabilitiesIndices.AsmRaspLfi, new Version(2, 51) },
+        { RcmCapabilitiesIndices.AsmRaspSsrf, new Version(2, 51) },
+        { RcmCapabilitiesIndices.AsmRaspShi, new Version(3, 2) },
+        { RcmCapabilitiesIndices.AsmExclusionData, new Version(3, 2) },
+    };
+
+    internal static bool WafSupportsCapability(BigInteger capability, string? wafVersion)
+    {
+        var currentVersion = wafVersion;
+
+        if (string.IsNullOrWhiteSpace(currentVersion))
+        {
+            return false;
+        }
+
+        if (_CapabilitiesVersion.TryGetValue(capability, out var version))
+        {
+            try
+            {
+                return Version.Parse(currentVersion) >= version;
+            }
+            catch
+            {
+                Log.Warning("Failed to parse WAF version {WafVersion}", currentVersion);
+                return false;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RCMCapabilitiesHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RCMCapabilitiesHelperTests.cs
@@ -1,0 +1,39 @@
+// <copyright file="RCMCapabilitiesHelperTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System.Numerics;
+using Datadog.Trace.AppSec.Waf;
+using Datadog.Trace.RemoteConfigurationManagement;
+using Xunit;
+
+namespace Datadog.Trace.Security.Unit.Tests
+{
+    public class RCMCapabilitiesHelperTests
+    {
+        public static TheoryData<string, BigInteger, bool> RcmCapabilitiesTestCases()
+        => new TheoryData<string, BigInteger, bool>
+        {
+                    { "2.54", RcmCapabilitiesIndices.AsmRaspSqli, true },
+                    { "2.53", RcmCapabilitiesIndices.AsmRaspSqli, false },
+                    { "2.51", RcmCapabilitiesIndices.AsmRaspLfi, true },
+                    { "2.50", RcmCapabilitiesIndices.AsmRaspLfi, false },
+                    { "2.51", RcmCapabilitiesIndices.AsmRaspSsrf, true },
+                    { "2.50", RcmCapabilitiesIndices.AsmRaspSsrf, false },
+                    { "3.2", RcmCapabilitiesIndices.AsmRaspShi, true },
+                    { "3.1", RcmCapabilitiesIndices.AsmRaspShi, false },
+                    { "3.2", RcmCapabilitiesIndices.AsmExclusionData, true },
+                    { null, RcmCapabilitiesIndices.AsmExclusionData, false },
+                    { "INVALID", RcmCapabilitiesIndices.AsmExclusionData, false },
+        };
+
+        [Theory]
+        [MemberData(nameof(RcmCapabilitiesTestCases))]
+
+        public void GivenAWafVersion_WhenAskedForRCMCapability_ResultIsCorrect(string wafVersion, BigInteger capability, bool result)
+        {
+            Assert.Equal(result, RCMCapabilitiesHelper.WafSupportsCapability(capability, wafVersion));
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

This PR adds a capabilities helper to manage the ASM RC capabilities. The capabilities for suspicious attacker blocking and RASP have been added.

In a next PR, the required WAF versions for other capabilities will be added.

## Reason for change

We should report that we support these capabilities.

## Implementation details

## Test coverage

Unit tests have been added.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
