### PR TITLE
[Build] Update and fix linux debug symbols artifact

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -4041,55 +4041,73 @@ stages:
           displayName: Download linux profiler Alpine symbols
           inputs:
             artifact: linux-profiler-symbols-linux-musl-x64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
+            path: $(Build.ArtifactStagingDirectory)/symbols
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux profiler x64 symbols
           inputs:
             artifact: linux-profiler-symbols-linux-x64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
+            path: $(Build.ArtifactStagingDirectory)/symbols
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux profiler Arm64 symbols
           inputs:
             artifact: linux-profiler-symbols-linux-arm64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
+            path: $(Build.ArtifactStagingDirectory)/symbols
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux profiler Alpine Arm64 symbols
+          inputs:
+            artifact: linux-profiler-symbols-linux-musl-arm64
+            path: $(Build.ArtifactStagingDirectory)/symbols
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux tracer Alpine symbols
           inputs:
             artifact: linux-tracer-symbols-linux-musl-x64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
+            path: $(Build.ArtifactStagingDirectory)/symbols
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux tracer x64 symbols
           inputs:
             artifact: linux-tracer-symbols-linux-x64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
+            path: $(Build.ArtifactStagingDirectory)/symbols
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux tracer Arm64 symbols
           inputs:
             artifact: linux-tracer-symbols-linux-arm64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
+            path: $(Build.ArtifactStagingDirectory)/symbols
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux tracer Alpine Arm64 symbols
+          inputs:
+            artifact: linux-tracer-symbols-linux-musl-arm64
+            path: $(Build.ArtifactStagingDirectory)/symbols
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux universal libraries linux x64 symbols
           inputs:
             artifact: linux-universal-symbols-linux-x64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64/linux-x64
+            path: $(Build.ArtifactStagingDirectory)/symbols/linux-x64
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux universal libraries linux musl x64 symbols
           inputs:
             artifact: linux-universal-symbols-linux-x64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64/linux-musl-x64
+            path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-x64
 
         - task: DownloadPipelineArtifact@2
           displayName: Download linux universal libraries linux arm64 symbols
           inputs:
             artifact: linux-universal-symbols-linux-arm64
-            path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64/linux-arm64
+            path: $(Build.ArtifactStagingDirectory)/symbols/linux-arm64
+
+        - task: DownloadPipelineArtifact@2
+          displayName: Download linux universal libraries linux musl arm64 symbols
+          inputs:
+            artifact: linux-universal-symbols-linux-arm64
+            path: $(Build.ArtifactStagingDirectory)/symbols/linux-musl-arm64
 
         - task: DownloadPipelineArtifact@2
           displayName: Download dd-dotnet linux-x64 symbols


### PR DESCRIPTION
## Summary of changes

Add the linux Alpine Arm64 debug symbols in the artifact and fix the directory structure.

## Reason for change
- Missing Linux Alpine Arm64 symbols in the artifact
- Currently the folder structure looks like this
![image](https://github.com/user-attachments/assets/d9ff220f-26ff-408f-8578-23689df7fff7)
The intermediate level is useless, so remove it.

## Implementation details
- Download the Linux Alpine Arm64 symbols 
- Add them to the corresponding folder
- Remove useless `linux-x64` (for ex)

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
