### PR TITLE
[ASM] Change stack trim proportion

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -173,7 +173,7 @@ internal static class RaspModule
 
     private static void SendStack(Span rootSpan, string id)
     {
-        var stack = StackReporter.GetStack(Security.Instance.Settings.MaxStackTraceDepth, id);
+        var stack = StackReporter.GetStack(Security.Instance.Settings.MaxStackTraceDepth, Security.Instance.Settings.MaxStackTraceDepthTopPercent, id);
 
         if (stack is not null)
         {

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
@@ -15,9 +15,9 @@ internal static class StackReporter
 {
     private const string _language = "dotnet";
 
-    public static Dictionary<string, object>? GetStack(int maxStackTraceDepth, string id, StackFrame[]? stackFrames = null)
+    public static Dictionary<string, object>? GetStack(int maxStackTraceDepth, int topPercent, string id, StackFrame[]? stackFrames = null)
     {
-        var frames = GetFrames(maxStackTraceDepth, stackFrames ?? new StackTrace(true).GetFrames());
+        var frames = GetFrames(maxStackTraceDepth, topPercent, stackFrames ?? new StackTrace(true).GetFrames());
 
         if (frames is null || frames.Count == 0)
         {
@@ -27,7 +27,7 @@ internal static class StackReporter
         return MetaStructHelper.StackTraceInfoToDictionary(null, _language, id, null, frames);
     }
 
-    private static List<Dictionary<string, object>> GetFrames(int maxStackTraceDepth, StackFrame?[] frames)
+    private static List<Dictionary<string, object>> GetFrames(int maxStackTraceDepth, int topPercent, StackFrame?[] frames)
     {
         var allValidFrames = new List<Dictionary<string, object>>(frames.Length);
         int counter = 0;
@@ -57,13 +57,16 @@ internal static class StackReporter
         // Determine if we need to trim the stack
         if (maxStackTraceDepth > 0 && allValidFrames.Count > maxStackTraceDepth)
         {
-            int topCount = Math.Max(1, (int)(0.75 * (double)maxStackTraceDepth));
+            int topCount = Math.Max(1, (int)((double)topPercent * (double)maxStackTraceDepth / 100.0));
             int bottomCount = maxStackTraceDepth - topCount;
             var trimmedStackFrames = new List<Dictionary<string, object>>(maxStackTraceDepth);
-            // Add the top 75% frames
+            // Add the top pecent frames
             trimmedStackFrames.AddRange(allValidFrames.GetRange(0, topCount));
-            // Add the bottom 25% frames
-            trimmedStackFrames.AddRange(allValidFrames.GetRange(allValidFrames.Count - bottomCount, bottomCount));
+            // Add the bottom percent frames
+            if (bottomCount > 0)
+            {
+                trimmedStackFrames.AddRange(allValidFrames.GetRange(allValidFrames.Count - bottomCount, bottomCount));
+            }
 
             return trimmedStackFrames;
         }

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
@@ -57,12 +57,12 @@ internal static class StackReporter
         // Determine if we need to trim the stack
         if (maxStackTraceDepth > 0 && allValidFrames.Count > maxStackTraceDepth)
         {
-            int topCount = Math.Max(1, (int)(0.25 * maxStackTraceDepth));
+            int topCount = Math.Max(1, (int)(0.75 * (double)maxStackTraceDepth));
             int bottomCount = maxStackTraceDepth - topCount;
             var trimmedStackFrames = new List<Dictionary<string, object>>(maxStackTraceDepth);
-            // Add the top 25% frames
+            // Add the top 75% frames
             trimmedStackFrames.AddRange(allValidFrames.GetRange(0, topCount));
-            // Add the bottom 75% frames
+            // Add the bottom 25% frames
             trimmedStackFrames.AddRange(allValidFrames.GetRange(allValidFrames.Count - bottomCount, bottomCount));
 
             return trimmedStackFrames;

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/StackReporter.cs
@@ -60,7 +60,7 @@ internal static class StackReporter
             int topCount = Math.Max(1, (int)((double)topPercent * (double)maxStackTraceDepth / 100.0));
             int bottomCount = maxStackTraceDepth - topCount;
             var trimmedStackFrames = new List<Dictionary<string, object>>(maxStackTraceDepth);
-            // Add the top pecent frames
+            // Add the top percent frames
             trimmedStackFrames.AddRange(allValidFrames.GetRange(0, topCount));
             // Add the bottom percent frames
             if (bottomCount > 0)

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -150,6 +150,11 @@ namespace Datadog.Trace.AppSec
                                   .AsInt32(defaultValue: 32, validator: val => val >= 1)
                                   .Value;
 
+            MaxStackTraceDepthTopPercent = config
+                                  .WithKeys(ConfigurationKeys.AppSec.MaxStackTraceDepthTopPercent)
+                                  .AsInt32(defaultValue: 75, validator: val => val >= 0 && val <= 100)
+                                  .Value;
+
             WafDebugEnabled = config
                              .WithKeys(ConfigurationKeys.AppSec.WafDebugEnabled)
                              .AsBool(defaultValue: false);
@@ -184,6 +189,8 @@ namespace Datadog.Trace.AppSec
         public int MaxStackTraces { get; }
 
         public int MaxStackTraceDepth { get; }
+
+        public int MaxStackTraceDepthTopPercent { get; }
 
         /// <summary>
         /// Gets keys indicating the optional custom appsec headers the user wants to send.

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -71,6 +71,11 @@ namespace Datadog.Trace.Configuration
             internal const string MaxStackTraceDepth = "DD_APPSEC_MAX_STACK_TRACE_DEPTH";
 
             /// <summary>
+            /// with a default value of 75, defines the percentage of frames taken from the top of the stack when trimming. Min 0, Max 100
+            /// </summary>
+            internal const string MaxStackTraceDepthTopPercent = "DD_APPSEC_MAX_STACK_TRACE_DEPTH_TOP_PERCENT";
+
+            /// <summary>
             /// The regex that will be used to obfuscate possible sensitive data in keys that are highlighted WAF as potentially malicious
             /// </summary>
             internal const string ObfuscationParameterKeyRegex = "DD_APPSEC_OBFUSCATION_PARAMETER_KEY_REGEXP";

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/StackReporterTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/StackReporterTests.cs
@@ -33,7 +33,7 @@ public class StackReporterTests
     }
 
     [Fact]
-    public void GivenMultipleFrames_WhenMaxDepthIsSet_ThenReturnsTop25AndBottom75Percent()
+    public void GivenMultipleFrames_WhenMaxDepthIsSet_ThenReturnsTop75AndBottom25Percent()
     {
         int maxStackTraceDepth = 2;
         var mockFrames = CreateStackForTests(4);
@@ -49,7 +49,7 @@ public class StackReporterTests
     }
 
     [Fact]
-    public void GivenMultipleFrames_WhenMaxDepthIsSetTo4_ThenReturnsTop25AndBottom75Percent()
+    public void GivenMultipleFrames_WhenMaxDepthIsSetTo4_ThenReturnsTop75AndBottom25Percent()
     {
         int maxStackTraceDepth = 4;
         var mockFrames = CreateStackForTests(40);
@@ -61,8 +61,8 @@ public class StackReporterTests
         Assert.NotNull(frames);
         Assert.Equal(maxStackTraceDepth, frames.Count);
         Assert.Equal("file1.cs", frames[0]["file"]);
-        Assert.Equal("file38.cs", frames[1]["file"]);
-        Assert.Equal("file39.cs", frames[2]["file"]);
+        Assert.Equal("file2.cs", frames[1]["file"]);
+        Assert.Equal("file3.cs", frames[2]["file"]);
         Assert.Equal("file40.cs", frames[3]["file"]);
     }
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/StackReporterTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RASP/StackReporterTests.cs
@@ -20,7 +20,7 @@ public class StackReporterTests
     {
         int maxStackTraceDepth = 10;
         var mockFrames = CreateStackForTests(2);
-        var result = StackReporter.GetStack(maxStackTraceDepth, "test", mockFrames);
+        var result = StackReporter.GetStack(maxStackTraceDepth, 100, "test", mockFrames);
 
         Assert.NotNull(result);
         Assert.True(result.ContainsKey("frames"));
@@ -37,7 +37,7 @@ public class StackReporterTests
     {
         int maxStackTraceDepth = 2;
         var mockFrames = CreateStackForTests(4);
-        var result = StackReporter.GetStack(maxStackTraceDepth, "test", mockFrames);
+        var result = StackReporter.GetStack(maxStackTraceDepth, 75, "test", mockFrames);
         Assert.NotNull(result);
         Assert.True(result.ContainsKey("frames"));
 
@@ -53,7 +53,7 @@ public class StackReporterTests
     {
         int maxStackTraceDepth = 4;
         var mockFrames = CreateStackForTests(40);
-        var result = StackReporter.GetStack(maxStackTraceDepth, "test", mockFrames);
+        var result = StackReporter.GetStack(maxStackTraceDepth, 75, "test", mockFrames);
         Assert.NotNull(result);
         Assert.True(result.ContainsKey("frames"));
 
@@ -71,7 +71,7 @@ public class StackReporterTests
     {
         var mockFrames = CreateStackForTests(40);
 
-        var result = StackReporter.GetStack(0, "test", mockFrames);
+        var result = StackReporter.GetStack(0, 0, "test", mockFrames);
         Assert.NotNull(result);
         Assert.True(result.ContainsKey("frames"));
 
@@ -82,7 +82,7 @@ public class StackReporterTests
     public void GivenNoStackFrames_WhenGetStackIsCalled_ThenReturnsNull()
     {
         StackFrame[] mockFrames = [];
-        var result = StackReporter.GetStack(5, "test", mockFrames);
+        var result = StackReporter.GetStack(5, 100, "test", mockFrames);
         Assert.Null(result);
     }
 

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -431,6 +431,7 @@
   "DD_APPSEC_STACK_TRACE_ENABLED": "appsec_stack_trace_enabled",
   "DD_APPSEC_MAX_STACK_TRACES": "appsec_max_stack_traces",
   "DD_APPSEC_MAX_STACK_TRACE_DEPTH": "appsec_max_stack_trace_depth",
+  "DD_APPSEC_MAX_STACK_TRACE_DEPTH_TOP_PERCENT": "appsec_max_stack_trace_depth_top_percent",
   "DD_APPSEC_SCA_ENABLED": "appsec_sca_enabled",
   "DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE": "appsec_auto_user_instrumentation_mode",
   "DD_EXPERIMENTAL_APPSEC_USE_UNSAFE_ENCODER": "appsec_use_unsafe_encoder",


### PR DESCRIPTION
## Summary of changes
Right now, when reporting a stack, we trim the stack, providing 25% of the max count from the upper frames and 75% from the bottom. As discussed with other library teams, this has proven to add poor information, being much more valuable the upper frames then the lower ones.
Make this proportion configurable by an envvar

## Reason for change
Trimmed stacks submitted to backend with IAST vulnerabilities or RASP blocking events, when trimmed, add poor information to the client

## Implementation details
Added an env var to tell how many top frames will be retrieved in proportion.

## Test coverage
Unit tests.

## Other details
[dd-go PR](https://github.com/DataDog/dd-go/pull/149284)

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
