### PR TITLE
Add explicit permissions to all workflows (#5728 => v2)

### DIFF
--- a/.github/workflows/auto-trigger-aas-release.yml
+++ b/.github/workflows/auto-trigger-aas-release.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   trigger_aas_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # read secrets
 
     steps:
       - name: Trigger AAS release

--- a/.github/workflows/auto_add_vnext_milestone_to_pr.yml
+++ b/.github/workflows/auto_add_vnext_milestone_to_pr.yml
@@ -12,6 +12,10 @@ jobs:
   add_to_milestone:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Version Bump]') == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # need to modify existing PR
+      issues: write # need to potentially create a new milestone
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/auto_bump_test_package_versions.yml
+++ b/.github/workflows/auto_bump_test_package_versions.yml
@@ -11,6 +11,10 @@ jobs:
   bump_package_versions:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || startsWith(github.event.pull_request.head.ref, 'dependabot/nuget/tracer/dependabot/') == true
     runs-on: windows-latest
+    permissions:
+      actions: read # read secrets
+      contents: write # Creates a branch
+      pull-requests: write # Creates a PR
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -7,6 +7,9 @@ jobs:
   check-snapshots:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # need to add a comment to a PR
 
     steps:
       - name: Checkout

--- a/.github/workflows/auto_code_freeze_block_pr.yml
+++ b/.github/workflows/auto_code_freeze_block_pr.yml
@@ -6,6 +6,10 @@ on:
 jobs:
   check_for_code_freeze:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read # need to read milestones
+      statuses: write # add a commit status check
 
     steps:
     - uses: octokit/request-action@v2.x

--- a/.github/workflows/auto_create_version_bump_pr.yml
+++ b/.github/workflows/auto_create_version_bump_pr.yml
@@ -13,6 +13,10 @@ jobs:
     
     if: endsWith(github.event.release.tag_name, '.0') || endsWith(github.event.release.tag_name, '.0-prerelease')
     runs-on: windows-latest
+    permissions:
+      contents: write # Creates a branch
+      pull-requests: write # Creates a PR
+      issues: write # Closes milestones
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/auto_deploy_aas_test_apps.yml
+++ b/.github/workflows/auto_deploy_aas_test_apps.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   deploy_aas_test_apps:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # read secrets
+      issues: read # Read milestones milestones
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -7,6 +7,10 @@ jobs:
   add-labels:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # Update labels on PRs (might not be necessary, but we call the UpdateIssue API so...)
+      pull-requests: write # Update labels on PRs
 
     steps:
       - name: Checkout

--- a/.github/workflows/auto_update_benchmark_branches.yml
+++ b/.github/workflows/auto_update_benchmark_branches.yml
@@ -11,6 +11,8 @@ jobs:
       startsWith(github.event.release.tag_name, 'v2.')
       && !endsWith(github.event.release.tag_name, '-prerelease')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Creates and deletes branches
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/code_freeze_end.yml
+++ b/.github/workflows/code_freeze_end.yml
@@ -11,6 +11,11 @@ jobs:
       github.event_name == 'workflow_dispatch' 
       || (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'closed')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # Fetches PRs
+      issues: write # Opens milestones
+      statuses: write # add a commit status check
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/code_freeze_start.yml
+++ b/.github/workflows/code_freeze_start.yml
@@ -11,6 +11,12 @@ jobs:
       github.event_name == 'workflow_dispatch' || 
       (github.event.milestone.title == 'Code Freeze' && github.event.milestone.state == 'open')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # read secrets
+      pull-requests: read # Fetches PRs
+      issues: write # Opens milestones
+      statuses: write # add a commit status check
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/create-system-test-docker-base-images.yml
+++ b/.github/workflows/create-system-test-docker-base-images.yml
@@ -19,6 +19,10 @@ on:
 jobs:
   build-and-publish-base-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # read secrets
+      packages: write # pushing to ghcr.io
     env:
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"
     steps:

--- a/.github/workflows/create_draft_release.yml
+++ b/.github/workflows/create_draft_release.yml
@@ -13,6 +13,10 @@ on:
 jobs:
   create_draft_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # create release
+      actions: read # read secrets
+      issues: write # change milestones 
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       AZURE_DEVOPS_TOKEN: "${{ secrets.AZURE_DEVOPS_TOKEN }}"

--- a/.github/workflows/create_hotfix_branch.yml
+++ b/.github/workflows/create_hotfix_branch.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   bump_version:
     runs-on: windows-latest
+    permissions:
+      contents: write # Push branches
+      issues: write # change milestones 
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       NewVersion: "${{ github.event.inputs.version }}"

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -5,6 +5,10 @@ jobs:
   check-quality:
     runs-on: ubuntu-latest
     name: Datadog Static Analyzer
+    permissions:
+      actions: read # read secrets
+      contents: read
+      statuses: write # add status checks (?) 
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/force_manual_version_bump.yml
+++ b/.github/workflows/force_manual_version_bump.yml
@@ -14,6 +14,10 @@ on:
 jobs:
   bump_version:
     runs-on: windows-latest
+    permissions:
+      contents: write # Creates a branch
+      pull-requests: write # Creates a PR
+      issues: write # Closes milestones
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       NewVersion: "${{ github.event.inputs.version }}"

--- a/.github/workflows/generate_package_versions.yml
+++ b/.github/workflows/generate_package_versions.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   generate_package_versions:
     runs-on: windows-latest
+    permissions:
+      contents: write # Pushes to a branch
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/override_version_bump_pr_checks.yml
+++ b/.github/workflows/override_version_bump_pr_checks.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   override_checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      statuses: write # Update status checks
 
     steps:
       - name: Fail if branch is not version-bump PR or bot PR

--- a/.github/workflows/verify_app_trimming_changes_are_persisted.yml
+++ b/.github/workflows/verify_app_trimming_changes_are_persisted.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   verify_app_trimming_descriptor_generator:
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/verify_files_without_nullability.yml
+++ b/.github/workflows/verify_files_without_nullability.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   verify_files_without_nullability:
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/verify_integrations_map_added.yml
+++ b/.github/workflows/verify_integrations_map_added.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   bump_package_versions:
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/verify_source_generated_changes_are_persisted.yml
+++ b/.github/workflows/verify_source_generated_changes_are_persisted.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   verify_source_generators:
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Support longpaths

--- a/.github/workflows/verify_span_metadata_markdown_is_updated.yml
+++ b/.github/workflows/verify_span_metadata_markdown_is_updated.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   verify_span_metadata:
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Support longpaths


### PR DESCRIPTION
## Summary of changes

- Adds explicit permissions to all workflows

## Reason for change

It's a best practice to explicitly specify required permissions for all workflows, and soon we'll have to

## Implementation details

Worked through each workflow, trying to work out what it does and what permissions it needs

## Test coverage

I wish

## Other details

Please don't just 🙈 approve this, it needs 👀 because it has the potential to break at critical times otherwise! The workflows that run as part of standard PRs should be fine, but anything that's rare/release specific needs properly understanding

Fixes VULN-8204

## Summary of changes

## Reason for change

## Implementation details

## Test coverage

## Other details
Backport of https://github.com/DataDog/dd-trace-dotnet/pull/5728
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
