### PR TITLE
[Profiler] Disable `timer_create`-based CPU profiler when required

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.cpp
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include "CpuProfilerDisableScope.h"
+
+#include "ManagedThreadInfo.h"
+
+#include <sys/syscall.h>
+#include <unistd.h>
+
+CpuProfilerDisableScope::CpuProfilerDisableScope(ManagedThreadInfo* threadInfo)
+    : _timerId{-1}, _oldValue{0}
+{
+    if (threadInfo == nullptr) [[unlikely]]
+        return;
+
+    _timerId = threadInfo->GetTimerId();
+
+    if (_timerId != -1)
+    {
+        struct itimerspec ts;
+        ts.it_interval.tv_sec = 0;
+        ts.it_interval.tv_nsec = 0;
+        ts.it_value = ts.it_interval;
+        // disarm the timer so this is not accounted for the managed thread cpu usage
+        syscall(__NR_timer_settime, _timerId, 0, &ts, &_oldValue);
+    }
+}
+
+CpuProfilerDisableScope::~CpuProfilerDisableScope()
+{
+   if (_timerId != -1)
+   {
+       // re-arm the timer
+       syscall(__NR_timer_settime, _timerId, 0, &_oldValue, nullptr);
+   }
+}

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.cpp
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 CpuProfilerDisableScope::CpuProfilerDisableScope(ManagedThreadInfo* threadInfo)
-    : _timerId{-1}, _oldValue{0}
+    : _timerId{-1}, _oldPeriod{0}
 {
     if (threadInfo == nullptr) [[unlikely]]
         return;
@@ -23,7 +23,7 @@ CpuProfilerDisableScope::CpuProfilerDisableScope(ManagedThreadInfo* threadInfo)
         ts.it_interval.tv_nsec = 0;
         ts.it_value = ts.it_interval;
         // disarm the timer so this is not accounted for the managed thread cpu usage
-        syscall(__NR_timer_settime, _timerId, 0, &ts, &_oldValue);
+        syscall(__NR_timer_settime, _timerId, 0, &ts, &_oldPeriod);
     }
 }
 
@@ -32,6 +32,6 @@ CpuProfilerDisableScope::~CpuProfilerDisableScope()
    if (_timerId != -1)
    {
        // re-arm the timer
-       syscall(__NR_timer_settime, _timerId, 0, &_oldValue, nullptr);
+       syscall(__NR_timer_settime, _timerId, 0, &_oldPeriod, nullptr);
    }
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.h
@@ -12,6 +12,11 @@ public:
     explicit CpuProfilerDisableScope(ManagedThreadInfo* threadInfo);
     ~CpuProfilerDisableScope();
 
+    CpuProfilerDisableScope(CpuProfilerDisableScope const&) = delete;
+    CpuProfilerDisableScope& operator=(CpuProfilerDisableScope const&) = delete;
+    CpuProfilerDisableScope(CpuProfilerDisableScope&&) = delete;
+    CpuProfilerDisableScope operator=(CpuProfilerDisableScope&&) = delete;
+
 private:
     std::int32_t _timerId;
     struct itimerspec _oldValue;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.h
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+
+#include <cstdint>
+#include <time.h>
+
+struct ManagedThreadInfo;
+
+struct CpuProfilerDisableScope
+{
+public:
+    explicit CpuProfilerDisableScope(ManagedThreadInfo* threadInfo);
+    ~CpuProfilerDisableScope();
+
+private:
+    std::int32_t _timerId;
+    struct itimerspec _oldValue;
+};

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CpuProfilerDisableScope.h
@@ -19,5 +19,5 @@ public:
 
 private:
     std::int32_t _timerId;
-    struct itimerspec _oldValue;
+    struct itimerspec _oldPeriod;
 };

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/LinuxStackFramesCollector.cpp
@@ -13,6 +13,7 @@
 #include <unordered_map>
 
 #include "CallstackProvider.h"
+#include "CpuProfilerDisableScope.h"
 #include "IConfiguration.h"
 #include "Log.h"
 #include "ManagedThreadInfo.h"
@@ -124,7 +125,7 @@ StackSnapshotResultBuffer* LinuxStackFramesCollector::CollectStackSampleImplemen
         // Disable timer_create-based CPU profiler if needed
         // When scope goes out of scope, the CPU profiler will be reenabled for
         // pThreadInfo thread
-        auto scope = pThreadInfo->DisableCpuProfiler();
+        auto scope = CpuProfilerDisableScope(pThreadInfo);
 
         _plibrariesInfo->UpdateCache();
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -10,6 +10,7 @@
 #include "IAllocationsListener.h"
 #include "IContentionListener.h"
 #include "Log.h"
+#include "ManagedThreadInfo.h"
 #include "OpSysTools.h"
 
 
@@ -63,6 +64,15 @@ void ClrEventsParser::ParseEvent(
     LPCBYTE eventData
     )
 {
+    auto pThreadInfo = ManagedThreadInfo::CurrentThreadInfo;
+
+    // Disable timer_create-based CPU profiler if needed
+    // When scope goes out of scope, the CPU profiler will be reenabled for
+    // pThreadInfo thread
+    auto scope = pThreadInfo != nullptr ?
+                    pThreadInfo->DisableCpuProfiler() :
+                    ManagedThreadInfo::CpuTimeDisableScope(nullptr);
+
     if (KEYWORD_GC == (keywords & KEYWORD_GC))
     {
         ParseGcEvent(timestamp, id, version, cbEventData, eventData);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -64,6 +64,7 @@ void ClrEventsParser::ParseEvent(
     LPCBYTE eventData
     )
 {
+#ifdef LINUX
     auto pThreadInfo = ManagedThreadInfo::CurrentThreadInfo;
 
     // Disable timer_create-based CPU profiler if needed
@@ -72,6 +73,7 @@ void ClrEventsParser::ParseEvent(
     auto scope = pThreadInfo != nullptr ?
                     pThreadInfo->DisableCpuProfiler() :
                     ManagedThreadInfo::CpuTimeDisableScope(nullptr);
+#endif
 
     if (KEYWORD_GC == (keywords & KEYWORD_GC))
     {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "CpuProfilerDisableScope.h"
 #include "IAllocationsListener.h"
 #include "IContentionListener.h"
 #include "Log.h"
@@ -70,9 +71,7 @@ void ClrEventsParser::ParseEvent(
     // Disable timer_create-based CPU profiler if needed
     // When scope goes out of scope, the CPU profiler will be reenabled for
     // pThreadInfo thread
-    auto scope = pThreadInfo != nullptr ?
-                    pThreadInfo->DisableCpuProfiler() :
-                    ManagedThreadInfo::CpuProfilerDisableScope(nullptr);
+    auto scope = CpuProfilerDisableScope(pThreadInfo.get());
 #endif
 
     if (KEYWORD_GC == (keywords & KEYWORD_GC))

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -72,7 +72,7 @@ void ClrEventsParser::ParseEvent(
     // pThreadInfo thread
     auto scope = pThreadInfo != nullptr ?
                     pThreadInfo->DisableCpuProfiler() :
-                    ManagedThreadInfo::CpuTimeDisableScope(nullptr);
+                    ManagedThreadInfo::CpuProfilerDisableScope(nullptr);
 #endif
 
     if (KEYWORD_GC == (keywords & KEYWORD_GC))

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ClrEventsParser.cpp
@@ -7,7 +7,9 @@
 #include <iostream>
 #include <sstream>
 
+#ifdef LINUX
 #include "CpuProfilerDisableScope.h"
+#endif
 #include "IAllocationsListener.h"
 #include "IContentionListener.h"
 #include "Log.h"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -27,7 +27,9 @@
 #include "ClrLifetime.h"
 #include "Configuration.h"
 #include "ContentionProvider.h"
+#ifdef LINUX
 #include "CpuProfilerDisableScope.h"
+#endif
 #include "CpuTimeProvider.h"
 #include "DebugInfoStore.h"
 #include "EnabledProfilers.h"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -27,6 +27,7 @@
 #include "ClrLifetime.h"
 #include "Configuration.h"
 #include "ContentionProvider.h"
+#include "CpuProfilerDisableScope.h"
 #include "CpuTimeProvider.h"
 #include "DebugInfoStore.h"
 #include "EnabledProfilers.h"
@@ -1810,9 +1811,7 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ExceptionThrown(ObjectID thrownOb
         // pThreadInfo thread
 
         auto pThreadInfo = ManagedThreadInfo::CurrentThreadInfo;
-        auto scope = __builtin_expect(pThreadInfo != nullptr, 1) ?
-                        pThreadInfo->DisableCpuProfiler() :
-                        ManagedThreadInfo::CpuProfilerDisableScope(nullptr);
+        auto scope = CpuProfilerDisableScope(pThreadInfo.get());
 #endif
         _pExceptionsProvider->OnExceptionThrown(thrownObjectId);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1805,11 +1805,14 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ExceptionThrown(ObjectID thrownOb
     if (_pConfiguration->IsExceptionProfilingEnabled() && _pSsiManager->IsProfilerStarted())
     {
 #ifdef LINUX
+        // Disable timer_create-based CPU profiler if needed
+        // When scope goes out of scope, the CPU profiler will be reenabled for
+        // pThreadInfo thread
 
         auto pThreadInfo = ManagedThreadInfo::CurrentThreadInfo;
         auto scope = __builtin_expect(pThreadInfo != nullptr, 1) ?
                         pThreadInfo->DisableCpuProfiler() :
-                        ManagedThreadInfo::CpuTimeDisableScope(nullptr);
+                        ManagedThreadInfo::CpuProfilerDisableScope(nullptr);
 #endif
         _pExceptionsProvider->OnExceptionThrown(thrownObjectId);
     }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CorProfilerCallback.cpp
@@ -1804,6 +1804,13 @@ HRESULT STDMETHODCALLTYPE CorProfilerCallback::ExceptionThrown(ObjectID thrownOb
 
     if (_pConfiguration->IsExceptionProfilingEnabled() && _pSsiManager->IsProfilerStarted())
     {
+#ifdef LINUX
+
+        auto pThreadInfo = ManagedThreadInfo::CurrentThreadInfo;
+        auto scope = __builtin_expect(pThreadInfo != nullptr, 1) ?
+                        pThreadInfo->DisableCpuProfiler() :
+                        ManagedThreadInfo::CpuTimeDisableScope(nullptr);
+#endif
         _pExceptionsProvider->OnExceptionThrown(thrownObjectId);
     }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -108,10 +108,10 @@ public:
     inline std::pair<std::uint64_t, std::uint64_t> GetTracingContext() const;
 
 #ifdef LINUX
-    struct CpuTimeDisableScope
+    struct CpuProfilerDisableScope
     {
     public:
-        explicit CpuTimeDisableScope(ManagedThreadInfo* threadInfo)
+        explicit CpuProfilerDisableScope(ManagedThreadInfo* threadInfo)
             : _timerId{-1}, _oldValue{0}
         {
             if (threadInfo == nullptr)
@@ -129,10 +129,11 @@ public:
             }
         }
 
-        ~CpuTimeDisableScope()
+        ~CpuProfilerDisableScope()
         {
             if (_timerId != -1)
             {
+                // re-arm the timer
                 syscall(__NR_timer_settime, _timerId, 0, &_oldValue, nullptr);
             }
         }
@@ -141,9 +142,9 @@ public:
         struct itimerspec _oldValue;
     };
 
-    CpuTimeDisableScope DisableCpuProfiler()
+    CpuProfilerDisableScope DisableCpuProfiler()
     {
-        return CpuTimeDisableScope(this);
+        return CpuProfilerDisableScope(this);
     }
 #endif
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ManagedThreadInfo.h
@@ -19,6 +19,10 @@
 #include <shared_mutex>
 #include <utility>
 
+#ifdef LINUX
+#include <sys/syscall.h>
+#endif
+
 static constexpr int32_t MinFieldAlignRequirement = 8;
 static constexpr int32_t FieldAlignRequirement = (MinFieldAlignRequirement >= alignof(std::uint64_t)) ? MinFieldAlignRequirement : alignof(std::uint64_t);
 


### PR DESCRIPTION
## Summary of changes

Disable `timer_create`-based profiler when a managed thread is executing profiler library code.

## Reason for change

If an exception is thrown (or contention...) , the CPU consumed to do `profiler work` is accounted to the managed thread.
We would like to remove this time to be removed from it to have an accurate view of managed execution (at less biased).

## Implementation details

- create a `CpuProfilerDisableScope` struct that will dis-arm the timer when entering the ctor, and re-arm the timer when entering the dtor.
- Create `CpuProfilerDisableScope` instance for the current managed thread only where profiler might have a significant impact on the managed thread CPU consumption.
## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
