### PR TITLE
Fix SSI tests for profiler integration tests

### DIFF
--- a/profiler/test/Datadog.Profiler.IntegrationTests/SingleStepInstrumentation/SingleStepInstrumentationTest.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/SingleStepInstrumentation/SingleStepInstrumentationTest.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using Datadog.Profiler.IntegrationTests.Helpers;
+using Datadog.Profiler.IntegrationTests.Xunit;
 using FluentAssertions;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -16,6 +17,7 @@ using Xunit.Abstractions;
 
 namespace Datadog.Profiler.IntegrationTests.SingleStepInstrumentation
 {
+    [EnvironmentRestorerAttribute(EnvironmentVariables.SsiDeployed)]
     public class SingleStepInstrumentationTest
     {
         private readonly ITestOutputHelper _output;

--- a/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/EnvironmentRestorerAttribute.cs
+++ b/profiler/test/Datadog.Profiler.IntegrationTests/Xunit/EnvironmentRestorerAttribute.cs
@@ -1,0 +1,44 @@
+// <copyright file="EnvironmentRestorerAttribute.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace Datadog.Profiler.IntegrationTests.Xunit;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class EnvironmentRestorerAttribute : BeforeAfterTestAttribute
+{
+    private readonly string[] _variables;
+    private readonly Dictionary<string, string> _originalVariables;
+
+    public EnvironmentRestorerAttribute(params string[] args)
+    {
+        _variables = args;
+        _originalVariables = new(args.Length);
+    }
+
+    public override void Before(MethodInfo methodUnderTest)
+    {
+        foreach (var variable in _variables)
+        {
+            _originalVariables[variable] = Environment.GetEnvironmentVariable(variable);
+            // clear variable
+            Environment.SetEnvironmentVariable(variable, null);
+        }
+
+        base.Before(methodUnderTest);
+    }
+
+    public override void After(MethodInfo methodUnderTest)
+    {
+        foreach (var variable in _originalVariables)
+        {
+            Environment.SetEnvironmentVariable(variable.Key, variable.Value);
+        }
+    }
+}


### PR DESCRIPTION
## Summary of changes

Fix profiler integration tests in the SSI run

## Reason for change

#5240 changed the behaviour of the profiler in the presence of SSI variables. We have a scheduled run on master that specifically sets the variables. This breaks the profiler integration tests that depend on those variables.

## Implementation details

Add an "environment restorer" attribute, which mirrors the one we use in the tracing integration tests. Ensures that the SSI tests are working in their expected environment

## Test coverage

This is the test, but did [a dedicated run too](https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=163728&view=results), and it works

## Other details

Related to #6014