### PR TITLE
[ASM]Fix InvalidOperationException in httpContext.Items

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6562,14 +6562,26 @@ stages:
 
     steps:
     - template: steps/install-latest-dotnet-sdk.yml
+
+    - bash: dotnet tool install dd-trace --global --prerelease
+      displayName: "Install dd-trace"
+      retryCountOnTaskFailure: 2
+
     - bash: |
-        dotnet run $(Build.BuildId)
+        mkdir -p $(Build.SourcesDirectory)/artifacts/build_data
+        dotnet build
+        dd-trace run --set-env "DD_TRACE_LOG_DIRECTORY=$(Build.SourcesDirectory)/artifacts/build_data" -- dotnet run --no-restore --no-build -- $(Build.BuildId)
         exit $?
       displayName: "Run"
       workingDirectory: "$(Build.SourcesDirectory)/tracer/tools/PipelineMonitor"
 
     - bash: sleep 20
       displayName: Wait 20 seconds to agent flush before finishing pipeline
+
+    - publish: $(Build.SourcesDirectory)/artifacts/build_data
+      artifact: _$(System.StageName)_$(Agent.JobName)_logs_$(System.JobAttempt)
+      condition: succeededOrFailed()
+      continueOnError: true
 
 - stage: notify_slack_on_failures
   condition: >

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -149,7 +149,18 @@ internal readonly partial struct SecurityCoordinator
 
         public override HttpContext Context { get; }
 
-        internal override bool IsBlocked => Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out _) is true;
+        internal override bool IsBlocked
+        {
+            get
+            {
+                if (Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out var value))
+                {
+                    return value is bool boolValue && boolValue;
+                }
+
+                return false;
+            }
+        }
 
         internal override int StatusCode => Context.Response.StatusCode;
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -149,7 +149,18 @@ internal readonly partial struct SecurityCoordinator
 
         public override HttpContext Context { get; }
 
-        internal override bool IsBlocked => Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out _);
+        internal override bool IsBlocked
+        {
+            get
+            {
+                if (Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out var value))
+                {
+                    return value is bool boolValue && boolValue;
+                }
+
+                return false;
+            }
+        }
 
         internal override int StatusCode => Context.Response.StatusCode;
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -149,18 +149,7 @@ internal readonly partial struct SecurityCoordinator
 
         public override HttpContext Context { get; }
 
-        internal override bool IsBlocked
-        {
-            get
-            {
-                if (Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out var value))
-                {
-                    return value is bool boolValue && boolValue;
-                }
-
-                return false;
-            }
-        }
+        internal override bool IsBlocked => Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out _) is true;
 
         internal override int StatusCode => Context.Response.StatusCode;
 

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Core.cs
@@ -149,7 +149,7 @@ internal readonly partial struct SecurityCoordinator
 
         public override HttpContext Context { get; }
 
-        internal override bool IsBlocked => Context.Items[BlockingAction.BlockDefaultActionName] is true;
+        internal override bool IsBlocked => Context.Items.TryGetValue(BlockingAction.BlockDefaultActionName, out _) is true;
 
         internal override int StatusCode => Context.Response.StatusCode;
 

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/HttpTransportTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/HttpTransportTests.cs
@@ -1,0 +1,46 @@
+// <copyright file="HttpTransportTests.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Web;
+using FluentAssertions;
+#if NETCOREAPP
+using Microsoft.AspNetCore.Http;
+#endif
+using Moq;
+using Xunit;
+using static Datadog.Trace.AppSec.Coordinator.SecurityCoordinator;
+
+namespace Datadog.Trace.Security.Unit.Tests;
+
+public class HttpTransportTests
+{
+    [Fact]
+    public void Given_http_transport()
+    {
+        // Arrange
+        var httpContext = CreateContext();
+        var transport = new HttpTransport(httpContext);
+        transport.IsBlocked.Should().BeFalse();
+        transport.MarkBlocked();
+        transport.IsBlocked.Should().BeTrue();
+    }
+
+    private HttpContext CreateContext()
+    {
+#if NETCOREAPP
+        var contextMock = new Mock<HttpContext>();
+        contextMock.SetupGet(c => c.Items).Returns(new Dictionary<object, object>());
+        return contextMock.Object;
+#else
+        var request = new HttpRequest("file", "http://localhost/benchmarks", "data=param");
+        var response = new HttpResponse(new StringWriter());
+        var context = new HttpContext(request, response);
+        return context;
+#endif
+    }
+}


### PR DESCRIPTION
## Summary of changes

This PR fixes the InvalidOperationException that is thrown in the ASM code.
Some logs can be found [here](https://app.datadoghq.com/logs?query=source%3Adotnet%20%2AAppsec%2A%20%40tracer_version%3A3%2A%20%2AInvalidOperationException%2A%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AgAAAZHXAWGCGYxJ7AAAAAAAAAAYAAAAAEFaSFhBV0dDQUFBQmh4MUdySmhmTkFBQQAAACQAAAAAMDE5MWQ3MDctMWNiYS00NDgwLWJhODQtZWY5YTk4NmQ4YzFk&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1720177260603&to_ts=1720782060603&live=true).

This error can happen only in netcore versions of the framework. When we access httpcontext.Items, the exception is thrown if the key is not found. httpcontext.Items is defined as a IDictionary<object, object>. Usually, it will be a Microsoft.AspNetCore.Http.ItemsDictionary, which does not throw an exception when trying to retrieve a key that is not stored, but other custom implementations such as Dictionary<object, object> will throw it. It seems that in one customer, we are receiving a context in which Items is a Dictionary.

This might be due to custom middlewares, third party extensions, use of custom http contexts, etc.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
