### PR TITLE
Version Bump to 2.59.0

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -163,7 +163,7 @@ variables:
   DD_LOGGER_DD_TAGS: test.configuration.job:$(System.JobDisplayName)
   DD_LOGGER_ENABLED: true
   DD_COLLECTOR_CPU_USAGE: true
-  ToolVersion: 2.58.1
+  ToolVersion: 2.59.0
 
 # Declare the datadog agent as a resource to be used as a pipeline service
 resources:

--- a/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Linux.ApiWrapper/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.Linux.ApiWrapper" VERSION 2.58.1)
+project("Datadog.Linux.ApiWrapper" VERSION 2.59.0)
 
 # ******************************************************
 # Compiler options

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Project definition
 # ******************************************************
 
-project("Datadog.Profiler.Native.Linux" VERSION 2.58.1)
+project("Datadog.Profiler.Native.Linux" VERSION 2.59.0)
 
 option(RUN_ASAN "Build with Clang Undefined-Behavior Sanitizer" OFF)
 option(RUN_UBSAN "Build with Clang Undefined-Behavior Sanitizer" OFF)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Windows/Resource.rc
@@ -62,8 +62,8 @@ END
 
 // ------- version info -------------------------------------------------------
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION             2,58,1,0
-PRODUCTVERSION          2,58,1,0
+FILEVERSION             2,59,0,0
+PRODUCTVERSION          2,59,0,0
 FILEFLAGSMASK           VS_FF_PRERELEASE
 FILEOS                  VOS_NT
 FILETYPE                VFT_DLL
@@ -74,12 +74,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog"
             VALUE "FileDescription", "Continuous Profiler for .NET Applications"
-            VALUE "FileVersion", "2.58.1.0"
+            VALUE "FileVersion", "2.59.0.0"
             VALUE "InternalName", "Native Profiler Engine"
             VALUE "LegalCopyright", "(c) Datadog 2020-2022"
             VALUE "OriginalFilename", "Datadog.Profiler.Native.dll"
             VALUE "ProductName", "Continuous Profiler for .NET Applications"
-            VALUE "ProductVersion", "2.58.1.0"
+            VALUE "ProductVersion", "2.59.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/dd_profiler_version.h
@@ -3,4 +3,4 @@
 
 #pragma once
 
-constexpr auto PROFILER_VERSION = "2.58.1";
+constexpr auto PROFILER_VERSION = "2.59.0";

--- a/profiler/src/ProfilerEngine/ProductVersion.props
+++ b/profiler/src/ProfilerEngine/ProductVersion.props
@@ -5,7 +5,7 @@
 
   <!-- * * * * * * * * * * * INPUTS. Update this section EVERY time the component is shipped/released! * * * * * * * * * * *                -->
   <PropertyGroup>
-    <ProductVersion>2.58.1</ProductVersion>
+    <ProductVersion>2.59.0</ProductVersion>
   </PropertyGroup>
   <!-- * * * * * * * * * * * END OF INPUTS.  * * * * * * * * * * *                                                                          -->
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # Project definition
 # ******************************************************
 
-project("Datadog.Trace.ClrProfiler.Native" VERSION 2.58.1)
+project("Datadog.Trace.ClrProfiler.Native" VERSION 2.59.0)
 
 # ******************************************************
 # Environment detection

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/Resource.rc
@@ -57,8 +57,8 @@ VS_VERSION_INFO VERSIONINFO
 #else
  FILEFLAGS 0x0L
 #endif
- FILEVERSION             2,58,1,0
- PRODUCTVERSION          2,58,1,0
+ FILEVERSION             2,59,0,0
+ PRODUCTVERSION          2,59,0,0
  FILEOS                  VOS_NT
  FILETYPE                VFT_DLL
 BEGIN
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog"
             VALUE "FileDescription", "Native loader for Datadog .NET APM"
-            VALUE "FileVersion", "2.58.1.0"
+            VALUE "FileVersion", "2.59.0.0"
             VALUE "InternalName", "Native loader"
             VALUE "LegalCopyright", "(c) Datadog 2020-2022"
             VALUE "OriginalFilename", "Datadog.Trace.ClrProfiler.Native.dll"
             VALUE "ProductName", "Native loader for Datadog .NET APM"
-            VALUE "ProductVersion", "2.58.1.0"
+            VALUE "ProductVersion", "2.59.0.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/shared/src/msi-installer/WindowsInstaller.wixproj
+++ b/shared/src/msi-installer/WindowsInstaller.wixproj
@@ -17,9 +17,9 @@
     <IntermediateOutputPath>obj\$(Configuration)\$(Platform)\</IntermediateOutputPath>
     <SuppressPdbOutput>True</SuppressPdbOutput>
     <DefineSolutionProperties>false</DefineSolutionProperties>
-    <OutputName>datadog-dotnet-apm-2.58.1-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
+    <OutputName>datadog-dotnet-apm-2.59.0-$(Platform)</OutputName> <!-- -The regex recognizes this line -->
     <MonitoringHomeDirectory Condition="'$(MonitoringHomeDirectory)' == ''">$(MSBuildThisFileDirectory)..\..\bin\monitoring-home</MonitoringHomeDirectory>
-    <DefineConstants>InstallerVersion=2.58.1;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
+    <DefineConstants>InstallerVersion=2.59.0;MonitoringHomeDirectory=$(MonitoringHomeDirectory);</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DefineConstants>$(DefineConstants);Debug</DefineConstants>

--- a/shared/src/native-src/version.h
+++ b/shared/src/native-src/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-constexpr auto PROFILER_VERSION = "2.58.1";
+constexpr auto PROFILER_VERSION = "2.59.0";

--- a/tracer/build/_build/Build.cs
+++ b/tracer/build/_build/Build.cs
@@ -59,7 +59,7 @@ partial class Build : NukeBuild
     readonly bool IsAlpine = false;
 
     [Parameter("The current version of the source and build")]
-    readonly string Version = "2.58.1";
+    readonly string Version = "2.59.0";
 
     [Parameter("Whether the current build version is a prerelease(for packaging purposes)")]
     readonly bool IsPrerelease = false;

--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -245,8 +245,8 @@ namespace PrepareRelease
 
                 // Pipeline
                 SynchronizeVersion(
-                    ".azure-pipelines/ultimate-pipeline.yml",
-                    text => Regex.Replace(text, $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\"", $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\""));
+                    "../.azure-pipelines/ultimate-pipeline.yml",
+                    text => Regex.Replace(text, $"ToolVersion: {VersionPattern(withPrereleasePostfix: true)}", $"ToolVersion: {VersionString(withPrereleasePostfix: true)}"));
 
                 // Nuke build
                 SynchronizeVersion(

--- a/tracer/build/artifacts/dd-dotnet.sh
+++ b/tracer/build/artifacts/dd-dotnet.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-TRACER_VERSION="2.58.1"
+TRACER_VERSION="2.59.0"
 
 # Get the directory of the script
 DIR=$(dirname "$(readlink -f "$0")")

--- a/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
+++ b/tracer/src/Datadog.Trace.AspNet/Datadog.Trace.AspNet.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net461</TargetFrameworks>
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 

--- a/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
+++ b/tracer/src/Datadog.Trace.BenchmarkDotNet/Datadog.Trace.BenchmarkDotNet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <Title>Datadog CI Visibility - BenchmarkDotNet</Title>
     <Description>BenchmarkDotNet exporter for Datadog CI Visibility</Description>
     <Nullable>enable</Nullable>

--- a/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
+++ b/tracer/src/Datadog.Trace.Bundle/Datadog.Trace.Bundle.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <Title>Datadog APM Auto-instrumentation Assets</Title>
     <Description>Auto-instrumentation assets for Datadog APM</Description>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Datadog.Trace.ClrProfiler.Managed.Loader.csproj
@@ -6,7 +6,7 @@
     <OutputPath>..\bin\ProfilerResources\</OutputPath>
 
     <!-- NuGet -->
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
 
     <!-- Hide warnings for EOL .NET Core targets (e.g. netcoreapp2.0) -->
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
+++ b/tracer/src/Datadog.Trace.ClrProfiler.Managed.Loader/Startup.cs
@@ -16,7 +16,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Loader
     /// </summary>
     public partial class Startup
     {
-        private const string AssemblyName = "Datadog.Trace, Version=2.58.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb";
+        private const string AssemblyName = "Datadog.Trace, Version=2.59.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb";
         private const string AzureAppServicesKey = "DD_AZURE_APP_SERVICES";
         private const string AasCustomTracingKey = "DD_AAS_ENABLE_CUSTOM_TRACING";
         private const string AasCustomMetricsKey = "DD_AAS_ENABLE_CUSTOM_METRICS";

--- a/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
+++ b/tracer/src/Datadog.Trace.MSBuild/Datadog.Trace.MSBuild.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
   </PropertyGroup>
 
   <!-- For VS testing purposes only, copy all implementation assemblies to the

--- a/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
+++ b/tracer/src/Datadog.Trace.OpenTracing/Datadog.Trace.OpenTracing.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <Title>Datadog APM - OpenTracing</Title>
     <Description>Provides OpenTracing support for Datadog APM</Description>
     <PackageTags>$(PackageTags);OpenTracing</PackageTags>

--- a/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
+++ b/tracer/src/Datadog.Trace.Tools.Runner/Datadog.Trace.Tools.Runner.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <Title>Datadog APM Auto-instrumentation Runner</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <Description>Auto-instrumentation dotnet global tool for Datadog APM</Description>

--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/Datadog.Trace.Tools.dd_dotnet.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <Title>Datadog APM Auto-instrumentation Launcher</Title>
     <Copyright>Copyright 2020 Datadog, Inc.</Copyright>
     <Description>Auto-instrumentation dotnet tool for Datadog APM</Description>

--- a/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.csproj
+++ b/tracer/src/Datadog.Trace.Trimming/Datadog.Trace.Trimming.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <!-- Unconditionally add a prerelease suffix to the package, but keep the rest of the name so we can associate it with the rest of the release -->
     <Version>$(Version)-prerelease</Version>
   </PropertyGroup>

--- a/tracer/src/Datadog.Trace/Datadog.Trace.csproj
+++ b/tracer/src/Datadog.Trace/Datadog.Trace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet -->
-    <Version>2.58.1</Version>
+    <Version>2.59.0</Version>
     <Title>Datadog APM</Title>
     <Description>Instrumentation library for Datadog APM.</Description>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/tracer/src/Datadog.Trace/TracerConstants.cs
+++ b/tracer/src/Datadog.Trace/TracerConstants.cs
@@ -8,7 +8,7 @@ namespace Datadog.Trace
     internal static class TracerConstants
     {
         public const string Language = "dotnet";
-        public const string AssemblyVersion = "2.58.1.0";
-        public const string ThreePartVersion = "2.58.1";
+        public const string AssemblyVersion = "2.59.0.0";
+        public const string ThreePartVersion = "2.59.0";
     }
 }

--- a/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
+++ b/tracer/src/Datadog.Tracer.Native/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 # Project definition
 # ******************************************************
 
-project("Datadog.Tracer.Native" VERSION 2.58.1)
+project("Datadog.Tracer.Native" VERSION 2.59.0)
 
 # ******************************************************
 # Environment detection

--- a/tracer/src/Datadog.Tracer.Native/Resource.rc
+++ b/tracer/src/Datadog.Tracer.Native/Resource.rc
@@ -50,8 +50,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 2,58,1,0
- PRODUCTVERSION 2,58,1,0
+ FILEVERSION 2,59,0,0
+ PRODUCTVERSION 2,59,0,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Datadog, Inc."
             VALUE "FileDescription", "Datadog CLR Profiler"
-            VALUE "FileVersion", "2.58.1.0"
+            VALUE "FileVersion", "2.59.0.0"
             VALUE "InternalName", "Datadog.Tracer.Native.DLL"
             VALUE "LegalCopyright", "Copyright 2017 Datadog, Inc."
             VALUE "OriginalFilename", "Datadog.Tracer.Native.DLL"
             VALUE "ProductName", "Datadog .NET Tracer"
-            VALUE "ProductVersion", "2.58.1"
+            VALUE "ProductVersion", "2.59.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
+++ b/tracer/src/Datadog.Tracer.Native/dd_profiler_constants.h
@@ -93,7 +93,7 @@ const shared::WSTRING system_private_corelib_assemblyName = WStr("System.Private
 const shared::WSTRING datadog_trace_clrprofiler_managed_loader_assemblyName = WStr("Datadog.Trace.ClrProfiler.Managed.Loader");
 
 const shared::WSTRING managed_profiler_full_assembly_version =
-    WStr("Datadog.Trace, Version=2.58.1.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
+    WStr("Datadog.Trace, Version=2.59.0.0, Culture=neutral, PublicKeyToken=def86d061d0d2eeb");
 
 const shared::WSTRING managed_profiler_name = WStr("Datadog.Trace");
 
@@ -140,7 +140,7 @@ const AssemblyProperty managed_profiler_assembly_property = AssemblyProperty(
                   49,  105, 236, 40,  21,  176, 12, 238, 238, 204, 141, 90,  27,  244, 61,  182, 125, 41,  97,  163,
                   233, 190, 161, 57,  127, 4,   62, 192, 116, 145, 112, 150, 73,  37,  47,  85,  101, 183, 86,  197},
     160, 32772, 1)
-        .WithVersion(2, 58, 1, 0);
+        .WithVersion(2, 59, 0, 0);
 
 } // namespace trace
 


### PR DESCRIPTION
## Summary of changes

Bump the version from 2.58.1 -> 2.59.0

## Reason for change

When we released 2.58.0, there was an issue with the SSI artifacts, so we were planning on doing a patch release (#5983). tl;dr; too much stuff happened and time passed, so we should just do a normal release

## Implementation details

Bumped the version, and fixed a bug in the version bump code!

## Test coverage

meh

