### PR TITLE
Fix bug in version bump task

### DIFF
--- a/tracer/build/_build/PrepareRelease/SetAllVersions.cs
+++ b/tracer/build/_build/PrepareRelease/SetAllVersions.cs
@@ -245,8 +245,8 @@ namespace PrepareRelease
 
                 // Pipeline
                 SynchronizeVersion(
-                    ".azure-pipelines/ultimate-pipeline.yml",
-                    text => Regex.Replace(text, $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\"", $"ToolVersion: \"{VersionString(withPrereleasePostfix: true)}\""));
+                    "../.azure-pipelines/ultimate-pipeline.yml",
+                    text => Regex.Replace(text, $"ToolVersion: {VersionPattern(withPrereleasePostfix: true)}", $"ToolVersion: {VersionString(withPrereleasePostfix: true)}"));
 
                 // Nuke build
                 SynchronizeVersion(


### PR DESCRIPTION
## Summary of changes

Fixes a bug in the version-bump path

## Reason for change

The path needs to be relative to the tracer folder (:wat:)

## Implementation details

Fix the path

## Test coverage

Yup, tested the version bump task works as expected

## Other details

Fixed or release/2.x branch in 
- https://github.com/DataDog/dd-trace-dotnet/pull/6021
