### PR TITLE
[Tracing] Update parsing validation for OTEL_SDK_DISABLED

### DIFF
--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -365,8 +365,8 @@ namespace Datadog.Trace.Configuration
             var otelActivityListenerEnabled = config
                                              .WithKeys(ConfigurationKeys.OpenTelemetry.SdkDisabled)
                                              .AsBoolResult(
-                                                  value => string.Equals(value, "true", StringComparison.OrdinalIgnoreCase)
-                                                               ? ParsingResult<bool>.Success(result: false)
+                                                  value => bool.TryParse(value, out var result)
+                                                               ? ParsingResult<bool>.Success(!result)
                                                                : ParsingResult<bool>.Failure());
             IsActivityListenerEnabled = config
                                        .WithKeys(ConfigurationKeys.FeatureFlags.OpenTelemetryEnabled, "DD_TRACE_ACTIVITY_LISTENER_ENABLED")


### PR DESCRIPTION
## Summary of changes
Consider both "true" and "false" valid values for the OTEL_SDK_DISABLED in terms of our metric reporting

## Reason for change
This change is motivated by enforcing standardized behaviors in our tracers in our system-tests

## Implementation details

## Test coverage


## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
