### PR TITLE
Fix gitlab build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,9 +20,8 @@ build:
       - $CI_COMMIT_TAG # We don't need to build/publish when building a release tag
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  before_script:
+  pre_get_sources_script:
     - git config --system core.longpaths true
-    - New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts-out) { remove-item -recurse -force artifacts-out }
@@ -51,9 +50,8 @@ publish:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies:
     - build
-  before_script:
+  pre_get_sources_script:
     - git config --system core.longpaths true
-    - New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   script:
     - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
     - $resultjson = $result | convertfrom-json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   before_script:
     - git config --system core.longpaths true
+    - New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts-out) { remove-item -recurse -force artifacts-out }
@@ -52,6 +53,7 @@ publish:
     - build
   before_script:
     - git config --system core.longpaths true
+    - New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   script:
     - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
     - $resultjson = $result | convertfrom-json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,8 @@ build:
       - $CI_COMMIT_TAG # We don't need to build/publish when building a release tag
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
+  before_script:
+    - git config --system core.longpaths true
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts-out) { remove-item -recurse -force artifacts-out }
@@ -48,6 +50,8 @@ publish:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies:
     - build
+  before_script:
+    - git config --system core.longpaths true
   script:
     - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
     - $resultjson = $result | convertfrom-json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,9 @@ build:
       - $CI_COMMIT_TAG # We don't need to build/publish when building a release tag
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
-  pre_get_sources_script:
-    - git config --system core.longpaths true
+  hooks:
+    pre_get_sources_script:
+      - git config --system core.longpaths true
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts-out) { remove-item -recurse -force artifacts-out }
@@ -50,8 +51,9 @@ publish:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies:
     - build
-  pre_get_sources_script:
-    - git config --system core.longpaths true
+  hooks:
+    pre_get_sources_script:
+      - git config --system core.longpaths true
   script:
     - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
     - $resultjson = $result | convertfrom-json


### PR DESCRIPTION
## Summary of changes

Enables longpath support on the gitlab Windows jobs

## Reason for change

We moved the location of the repo in GitLab, which increased the path length, and we hit long path issues

## Implementation details

Make the runner set `git config --system core.longpaths true` - it's [a crazy olde time restriction](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell), so realistically everyone should have this anyway

## Test coverage

The build works, so it's fixed!

## Other details
We could shorten the paths to work around it, but it's just another accident waiting to happen. This is not the first time 🙈 

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
