### PR TITLE
Fix gitlab build (#6025 -> v2)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,9 @@ build:
       - $CI_COMMIT_TAG # We don't need to build/publish when building a release tag
   stage: build
   tags: ["runner:windows-docker", "windowsversion:1809"]
+  hooks:
+    pre_get_sources_script:
+      - git config --system core.longpaths true
   script:
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - if (Test-Path artifacts) { remove-item -recurse -force artifacts }
@@ -53,6 +56,9 @@ publish:
   tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies:
     - build
+  hooks:
+    pre_get_sources_script:
+      - git config --system core.longpaths true
   script:
     - $result =  aws sts assume-role --role-arn "arn:aws:iam::486234852809:role/ci-datadog-windows-filter" --role-session-name AWSCLI-Session
     - $resultjson = $result | convertfrom-json


### PR DESCRIPTION
## Summary of changes

Enables longpath support on the gitlab Windows jobs

## Reason for change

We moved the location of the repo in GitLab, which increased the path length, and we hit long path issues

## Implementation details

Make the runner set `git config --system core.longpaths true` - it's [a crazy olde time restriction](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=powershell), so realistically everyone should have this anyway

## Test coverage

The build works, so it's fixed!

## Other details

We could shorten the paths to work around it, but it's just another accident waiting to happen. This is not the first time 🙈 

Backport of #6025