### PR TITLE
[ASM] Capabilities reporting against WAF versions.

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Waf/RCMCapabilitiesHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/RCMCapabilitiesHelper.cs
@@ -19,11 +19,11 @@ internal static class RCMCapabilitiesHelper
 
     private static readonly Dictionary<BigInteger, Version> _CapabilitiesVersion = new Dictionary<BigInteger, Version>()
     {
-        { RcmCapabilitiesIndices.AsmRaspSqli, new Version(2, 54) },
-        { RcmCapabilitiesIndices.AsmRaspLfi, new Version(2, 51) },
-        { RcmCapabilitiesIndices.AsmRaspSsrf, new Version(2, 51) },
-        { RcmCapabilitiesIndices.AsmRaspShi, new Version(3, 2) },
-        { RcmCapabilitiesIndices.AsmExclusionData, new Version(3, 2) },
+        { RcmCapabilitiesIndices.AsmRaspSqli, new Version(1, 18) },
+        { RcmCapabilitiesIndices.AsmRaspLfi, new Version(1, 17) },
+        { RcmCapabilitiesIndices.AsmRaspSsrf, new Version(1, 17) },
+        { RcmCapabilitiesIndices.AsmRaspShi, new Version(1, 19) },
+        { RcmCapabilitiesIndices.AsmExclusionData, new Version(1, 19) },
     };
 
     internal static bool WafSupportsCapability(BigInteger capability, string? wafVersion)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/RCMCapabilitiesHelperTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/RCMCapabilitiesHelperTests.cs
@@ -15,15 +15,15 @@ namespace Datadog.Trace.Security.Unit.Tests
         public static TheoryData<string, BigInteger, bool> RcmCapabilitiesTestCases()
         => new TheoryData<string, BigInteger, bool>
         {
-                    { "2.54", RcmCapabilitiesIndices.AsmRaspSqli, true },
-                    { "2.53", RcmCapabilitiesIndices.AsmRaspSqli, false },
-                    { "2.51", RcmCapabilitiesIndices.AsmRaspLfi, true },
-                    { "2.50", RcmCapabilitiesIndices.AsmRaspLfi, false },
-                    { "2.51", RcmCapabilitiesIndices.AsmRaspSsrf, true },
-                    { "2.50", RcmCapabilitiesIndices.AsmRaspSsrf, false },
-                    { "3.2", RcmCapabilitiesIndices.AsmRaspShi, true },
-                    { "3.1", RcmCapabilitiesIndices.AsmRaspShi, false },
-                    { "3.2", RcmCapabilitiesIndices.AsmExclusionData, true },
+                    { "1.19.1", RcmCapabilitiesIndices.AsmRaspSqli, true },
+                    { "1.12.3", RcmCapabilitiesIndices.AsmRaspSqli, false },
+                    { "1.19", RcmCapabilitiesIndices.AsmRaspLfi, true },
+                    { "1.16", RcmCapabilitiesIndices.AsmRaspLfi, false },
+                    { "1.17", RcmCapabilitiesIndices.AsmRaspSsrf, true },
+                    { "1.0.50", RcmCapabilitiesIndices.AsmRaspSsrf, false },
+                    { "1.19", RcmCapabilitiesIndices.AsmRaspShi, true },
+                    { "1.18", RcmCapabilitiesIndices.AsmRaspShi, false },
+                    { "1.19", RcmCapabilitiesIndices.AsmExclusionData, true },
                     { null, RcmCapabilitiesIndices.AsmExclusionData, false },
                     { "INVALID", RcmCapabilitiesIndices.AsmExclusionData, false },
         };


### PR DESCRIPTION
## Summary of changes

The capability reporter was comparing WAF versions against tracer versions. This should be fixed.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
