### PR TITLE
[IAST] Change filtered cookie vuln hash

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -375,7 +375,7 @@ internal static partial class IastModule
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static int GetCookieHash(string vulnerability, string cookieName, bool isFiltered)
     {
-        return (vulnerability.ToString() + ":" + (isFiltered ? "Filtered" : cookieName)).GetStaticHashCode();
+        return (isFiltered ? ("FILTERED_" + vulnerability) : (vulnerability + ":" + cookieName)).GetStaticHashCode();
     }
 
     public static IastModuleResponse OnInsecureCookie(IntegrationId integrationId, string cookieName, bool isFiltered)

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/HashTests.cs
@@ -64,4 +64,16 @@ public class HashTests
         var hashCode = vulnerability.GetHashCode();
         Assert.Equal(expectedHash, hashCode);
     }
+
+    [Theory]
+    [InlineData(VulnerabilityTypeName.InsecureCookie, "AspNetCoreRateLimit.RateLimitProcessor", false, -304624042)]
+    [InlineData(VulnerabilityTypeName.InsecureCookie, "AspNetCoreRateLimit.RateLimitProcessor", true, 990913114)]
+    [InlineData(VulnerabilityTypeName.InsecureCookie, "AspNetCore.Views_Iast_ReflectedXss+<<ExecuteAsync>b__8_1>d", true, 990913114)]
+    [InlineData(VulnerabilityTypeName.NoSameSiteCookie, "AspNetCore.Views_Iast_ReflectedXss+<<ExecuteAsync>b__8_1>d", false, 1003850134)]
+    [InlineData(VulnerabilityTypeName.NoSameSiteCookie, "AspNetCore.Views_Iast_ReflectedXss+<<ExecuteAsync>b__8_1>d", true, -636226626)]
+    [InlineData(VulnerabilityTypeName.NoSameSiteCookie, "AspNetCoreRateLimit.RateLimitProcessor", true, -636226626)]
+    public void GivenACookie_WhenCalculatedHash_ValueIsExpected(string vulnName, string cookieName, bool isFiltered, int hash)
+    {
+        IastModule.GetCookieHash(vulnName, cookieName, isFiltered).Should().Be(hash);
+    }
 }

--- a/tracer/test/snapshots/Iast.AspNetCore5.enableIast=True.path =_Iast_AllVulnerabilitiesCookie.verified.txt
+++ b/tracer/test/snapshots/Iast.AspNetCore5.enableIast=True.path =_Iast_AllVulnerabilitiesCookie.verified.txt
@@ -47,63 +47,63 @@
     },
     {
       "type": "NO_SAMESITE_COOKIE",
-      "hash": -1837181716,
+      "hash": -636226626,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.0"
       }
     },
     {
       "type": "NO_HTTPONLY_COOKIE",
-      "hash": 1990393425,
+      "hash": -60481650,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.0"
       }
     },
     {
       "type": "INSECURE_COOKIE",
-      "hash": 1170867602,
+      "hash": 990913114,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.0"
       }
     },
     {
       "type": "NO_SAMESITE_COOKIE",
-      "hash": -1837181716,
+      "hash": -636226626,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.1"
       }
     },
     {
       "type": "NO_HTTPONLY_COOKIE",
-      "hash": 1990393425,
+      "hash": -60481650,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.1"
       }
     },
     {
       "type": "INSECURE_COOKIE",
-      "hash": 1170867602,
+      "hash": 990913114,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.1"
       }
     },
     {
       "type": "NO_SAMESITE_COOKIE",
-      "hash": -1837181716,
+      "hash": -636226626,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.2"
       }
     },
     {
       "type": "NO_HTTPONLY_COOKIE",
-      "hash": 1990393425,
+      "hash": -60481650,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.2"
       }
     },
     {
       "type": "INSECURE_COOKIE",
-      "hash": 1170867602,
+      "hash": 990913114,
       "evidence": {
         "value": "LongCookie.abcdefghijklmnopqrstuvwxyz0123456789.2"
       }


### PR DESCRIPTION
## Summary of changes
Update [RFC](https://docs.google.com/document/d/1LLilcVkA1godL5sXuEoMlPFTT-hEF-8f-seGnx_CIvc/edit) changes in filtered cookie calculation

## Reason for change
Previous option could collide with a cookie named `Filtered`

## Implementation details
Changed the hash calculation to `FILTERED_VULN` instead of `VULN:Filtered`

## Test coverage
Added unit test

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
