### PR TITLE
[IAST] Fix system test weak_cipher system test

### DIFF
--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -695,7 +695,7 @@ internal static partial class IastModule
     {
         stack ??= StackWalker.GetStackTrace();
         var stackFrame = StackWalker.GetFrame(stack);
-        if (stackFrame is null)
+        if (!stackFrame.Valid)
         {
             return null;
         }
@@ -713,7 +713,7 @@ internal static partial class IastModule
             }
         }
 
-        return new Location(stackFrame, stack, stackId, currentSpan?.SpanId);
+        return new Location(stackFrame.Frame, stack, stackId, currentSpan?.SpanId);
     }
 
     private static IastModuleResponse AddVulnerabilityAsSingleSpan(Tracer tracer, IntegrationId integrationId, string operationName, Vulnerability vulnerability)

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -694,8 +694,7 @@ internal static partial class IastModule
     private static Location? GetLocation(StackTrace? stack = null, Span? currentSpan = null)
     {
         stack ??= StackWalker.GetStackTrace();
-        var stackFrame = StackWalker.GetFrame(stack);
-        if (!stackFrame.Valid)
+        if (!StackWalker.TryGetFrame(stack, out var stackFrame))
         {
             return null;
         }
@@ -713,7 +712,7 @@ internal static partial class IastModule
             }
         }
 
-        return new Location(stackFrame.Frame, stack, stackId, currentSpan?.SpanId);
+        return new Location(stackFrame, stack, stackId, currentSpan?.SpanId);
     }
 
     private static IastModuleResponse AddVulnerabilityAsSingleSpan(Tracer tracer, IntegrationId integrationId, string operationName, Vulnerability vulnerability)

--- a/tracer/src/Datadog.Trace/Iast/StackWalker.cs
+++ b/tracer/src/Datadog.Trace/Iast/StackWalker.cs
@@ -52,8 +52,9 @@ internal static class StackWalker
         return new StackTrace(DefaultSkipFrames, true);
     }
 
-    public static (StackFrame? Frame, bool Valid) GetFrame(StackTrace stackTrace)
+    public static bool TryGetFrame(StackTrace stackTrace, out StackFrame? targetFrame)
     {
+        targetFrame = null;
         foreach (var frame in stackTrace.GetFrames())
         {
             var declaringType = frame?.GetMethod()?.DeclaringType;
@@ -62,18 +63,19 @@ internal static class StackWalker
             {
                 if (excludeType == declaringType?.FullName)
                 {
-                    return (null, false);
+                    return false;
                 }
             }
 
             var assembly = declaringType?.Assembly.GetName().Name;
             if (assembly != null && !MustSkipAssembly(assembly))
             {
-                return (frame, true);
+                targetFrame = frame;
+                break;
             }
         }
 
-        return (null, true);
+        return true;
     }
 
     public static bool MustSkipAssembly(string assembly)

--- a/tracer/src/Datadog.Trace/Iast/StackWalker.cs
+++ b/tracer/src/Datadog.Trace/Iast/StackWalker.cs
@@ -52,7 +52,7 @@ internal static class StackWalker
         return new StackTrace(DefaultSkipFrames, true);
     }
 
-    public static StackFrame? GetFrame(StackTrace stackTrace)
+    public static (StackFrame? Frame, bool Valid) GetFrame(StackTrace stackTrace)
     {
         foreach (var frame in stackTrace.GetFrames())
         {
@@ -62,18 +62,18 @@ internal static class StackWalker
             {
                 if (excludeType == declaringType?.FullName)
                 {
-                    return null;
+                    return (null, false);
                 }
             }
 
             var assembly = declaringType?.Assembly.GetName().Name;
             if (assembly != null && !MustSkipAssembly(assembly))
             {
-                return frame;
+                return (frame, true);
             }
         }
 
-        return stackTrace.GetFrame(0);
+        return (null, true);
     }
 
     public static bool MustSkipAssembly(string assembly)

--- a/tracer/src/Datadog.Trace/Iast/StackWalker.cs
+++ b/tracer/src/Datadog.Trace/Iast/StackWalker.cs
@@ -73,7 +73,7 @@ internal static class StackWalker
             }
         }
 
-        return null;
+        return stackTrace.GetFrame(0);
     }
 
     public static bool MustSkipAssembly(string assembly)


### PR DESCRIPTION
## Summary of changes
Return first frame of the stack trace as location if no suitable one was found, but no exclusion either

## Reason for change
System tests for weak cipher were broken due to a rare situation where no location was detected for the vulnerability

## Implementation details
If no excluded frame was found, but the rest were skipped, we are returning the first stack frame

## Test coverage
system tests should pass now

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
