### PR TITLE
Add ability to disable additional `ADO.NET` Command Types

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AdoNet/DbScopeFactory.cs
@@ -170,7 +170,7 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     return true;
                 default:
                     string commandTypeName = commandTypeFullName.Substring(commandTypeFullName.LastIndexOf(".", StringComparison.Ordinal) + 1);
-                    if (commandTypeName == "InterceptableDbCommand" || commandTypeName == "ProfiledDbCommand")
+                    if (IsDisabledCommandType(commandTypeName))
                     {
                         integrationId = null;
                         dbType = null;
@@ -196,6 +196,31 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet
                     };
                     return true;
             }
+        }
+
+        internal static bool IsDisabledCommandType(string commandTypeName)
+        {
+            if (string.IsNullOrEmpty(commandTypeName))
+            {
+                return false;
+            }
+
+            var disabledTypes = Tracer.Instance.Settings.DisabledAdoNetCommandTypes;
+
+            if (disabledTypes is null || disabledTypes.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var disabledType in disabledTypes)
+            {
+                if (string.Equals(disabledType, commandTypeName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static class Cache<TCommand>

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.cs
@@ -464,6 +464,14 @@ namespace Datadog.Trace.Configuration
         public const string RemoveClientServiceNamesEnabled = "DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED";
 
         /// <summary>
+        /// Configuration key for the comma-separated list of user disabled
+        /// ADO.NET CommandType names that should not have Span created for them.
+        /// <para>"InterceptableDbCommand" and "ProfiledDbCommand" are always disabled by default.</para>
+        /// </summary>
+        /// <seealso cref="TracerSettings.DisabledAdoNetCommandTypes"/>
+        public const string DisabledAdoNetCommandTypes = "DD_TRACE_DISABLED_ADONET_COMMAND_TYPES";
+
+        /// <summary>
         /// String constants for CI Visibility configuration keys.
         /// </summary>
         public static class CIVisibility

--- a/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ImmutableTracerSettings.cs
@@ -185,6 +185,7 @@ namespace Datadog.Trace.Configuration
             }
 
             DbmPropagationMode = settings.DbmPropagationMode;
+            DisabledAdoNetCommandTypes = settings.DisabledAdoNetCommandTypes;
 
             // We need to take a snapshot of the config telemetry for the tracer settings,
             // but we can't send it to the static collector, as this settings object may never be "activated"
@@ -637,6 +638,11 @@ namespace Datadog.Trace.Configuration
            || IsRunningMiniAgentInAzureFunctions
            || IsRunningInGCPFunctions
            || LambdaMetadata.IsRunningInLambda);
+
+        /// <summary>
+        /// Gets the disabled ADO.NET Command Types that won't have spans generated for them.
+        /// </summary>
+        internal HashSet<string> DisabledAdoNetCommandTypes { get; }
 
         /// <summary>
         /// Create a <see cref="ImmutableTracerSettings"/> populated from the default sources

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -495,6 +495,20 @@ namespace Datadog.Trace.Configuration
                                        .WithKeys(ConfigurationKeys.FeatureFlags.CommandsCollectionEnabled)
                                        .AsBool(false);
 
+            var defaultDisabledAdoNetCommandTypes = new string[] { "InterceptableDbCommand", "ProfiledDbCommand" };
+            var userDisabledAdoNetCommandTypes = config.WithKeys(ConfigurationKeys.DisabledAdoNetCommandTypes).AsString();
+
+            if (string.IsNullOrEmpty(userDisabledAdoNetCommandTypes))
+            {
+                DisabledAdoNetCommandTypes = new HashSet<string>(defaultDisabledAdoNetCommandTypes, StringComparer.OrdinalIgnoreCase);
+            }
+            else
+            {
+                var userSplit = TrimSplitString(userDisabledAdoNetCommandTypes, commaSeparator);
+                DisabledAdoNetCommandTypes = new HashSet<string>(userSplit, StringComparer.OrdinalIgnoreCase);
+                DisabledAdoNetCommandTypes.UnionWith(defaultDisabledAdoNetCommandTypes);
+            }
+
             // we "enrich" with these values which aren't _strictly_ configuration, but which we want to track as we tracked them in v1
             telemetry.Record(ConfigTelemetryData.NativeTracerVersion, Instrumentation.GetNativeTracerVersion(), recordValue: true, ConfigurationOrigins.Default);
             telemetry.Record(ConfigTelemetryData.FullTrustAppDomain, value: AppDomain.CurrentDomain.IsFullyTrusted, ConfigurationOrigins.Default);
@@ -1039,6 +1053,11 @@ namespace Datadog.Trace.Configuration
         /// Gets the metadata schema version
         /// </summary>
         internal SchemaVersion MetadataSchemaVersion { get; }
+
+        /// <summary>
+        /// Gets the disabled ADO.NET Command Types that won't have spans generated for them.
+        /// </summary>
+        internal HashSet<string> DisabledAdoNetCommandTypes { get; }
 
         /// <summary>
         /// Create a <see cref="TracerSettings"/> populated from the default sources

--- a/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
+++ b/tracer/src/Datadog.Trace/Configuration/TracerSettings.cs
@@ -498,15 +498,12 @@ namespace Datadog.Trace.Configuration
             var defaultDisabledAdoNetCommandTypes = new string[] { "InterceptableDbCommand", "ProfiledDbCommand" };
             var userDisabledAdoNetCommandTypes = config.WithKeys(ConfigurationKeys.DisabledAdoNetCommandTypes).AsString();
 
-            if (string.IsNullOrEmpty(userDisabledAdoNetCommandTypes))
-            {
-                DisabledAdoNetCommandTypes = new HashSet<string>(defaultDisabledAdoNetCommandTypes, StringComparer.OrdinalIgnoreCase);
-            }
-            else
+            DisabledAdoNetCommandTypes = new HashSet<string>(defaultDisabledAdoNetCommandTypes, StringComparer.OrdinalIgnoreCase);
+
+            if (!string.IsNullOrEmpty(userDisabledAdoNetCommandTypes))
             {
                 var userSplit = TrimSplitString(userDisabledAdoNetCommandTypes, commaSeparator);
-                DisabledAdoNetCommandTypes = new HashSet<string>(userSplit, StringComparer.OrdinalIgnoreCase);
-                DisabledAdoNetCommandTypes.UnionWith(defaultDisabledAdoNetCommandTypes);
+                DisabledAdoNetCommandTypes.UnionWith(userSplit);
             }
 
             // we "enrich" with these values which aren't _strictly_ configuration, but which we want to track as we tracked them in v1

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -20,6 +20,8 @@ using DbType = Datadog.Trace.ClrProfiler.AutoInstrumentation.AdoNet.DbType;
 
 namespace Datadog.Trace.ClrProfiler.Managed.Tests
 {
+    [Collection("DbScopeFactoryTests")]
+    [TracerRestorer]
     public class DbScopeFactoryTests
     {
         private const string DbmCommandText = "SELECT 1";
@@ -269,6 +271,26 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             Assert.False(result2);
             Assert.False(actualIntegrationId2.HasValue);
             Assert.Null(actualDbType2);
+        }
+
+        [Fact]
+        internal void TryGetIntegrationDetails_FailsForKnownCommandTypes_AndUserDefined()
+        {
+            Tracer.Configure(TracerSettings.Create(new Dictionary<string, object> { { ConfigurationKeys.DisabledAdoNetCommandTypes, "SomeFakeDbCommand" } }));
+            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", out var actualIntegrationId, out var actualDbType);
+            Assert.False(result);
+            Assert.False(actualIntegrationId.HasValue);
+            Assert.Null(actualDbType);
+
+            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", out var actualIntegrationId2, out var actualDbType2);
+            Assert.False(result2);
+            Assert.False(actualIntegrationId2.HasValue);
+            Assert.Null(actualDbType2);
+
+            bool result3 = DbScopeFactory.TryGetIntegrationDetails("SomeFakeDbCommand", out var actualIntegrationId3, out var actualDbType3);
+            Assert.False(result3);
+            Assert.False(actualIntegrationId3.HasValue);
+            Assert.Null(actualDbType3);
         }
 
         [Theory]

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -253,7 +253,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var command = (IDbCommand)Activator.CreateInstance(commandType)!;
             command.CommandText = DbmCommandText;
 
-            bool result = DbScopeFactory.TryGetIntegrationDetails(command.GetType().FullName, tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
+            bool result = DbScopeFactory.TryGetIntegrationDetails(command.GetType().FullName, out var actualIntegrationId, out var actualDbType);
             Assert.True(result);
             Assert.Equal(expectedIntegrationName, actualIntegrationId.ToString());
             Assert.Equal(expectedDbType, actualDbType);
@@ -262,12 +262,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [Fact]
         internal void TryGetIntegrationDetails_FailsForKnownCommandType()
         {
-            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
+            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", out var actualIntegrationId, out var actualDbType);
             Assert.False(result);
             Assert.False(actualIntegrationId.HasValue);
             Assert.Null(actualDbType);
 
-            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", tracer: Tracer.Instance, out var actualIntegrationId2, out var actualDbType2);
+            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", out var actualIntegrationId2, out var actualDbType2);
             Assert.False(result2);
             Assert.False(actualIntegrationId2.HasValue);
             Assert.Null(actualDbType2);
@@ -277,17 +277,17 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         internal void TryGetIntegrationDetails_FailsForKnownCommandTypes_AndUserDefined()
         {
             Tracer.Configure(TracerSettings.Create(new Dictionary<string, object> { { ConfigurationKeys.DisabledAdoNetCommandTypes, "SomeFakeDbCommand" } }));
-            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
+            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", out var actualIntegrationId, out var actualDbType);
             Assert.False(result);
             Assert.False(actualIntegrationId.HasValue);
             Assert.Null(actualDbType);
 
-            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", tracer: Tracer.Instance, out var actualIntegrationId2, out var actualDbType2);
+            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", out var actualIntegrationId2, out var actualDbType2);
             Assert.False(result2);
             Assert.False(actualIntegrationId2.HasValue);
             Assert.Null(actualDbType2);
 
-            bool result3 = DbScopeFactory.TryGetIntegrationDetails("SomeFakeDbCommand", tracer: Tracer.Instance, out var actualIntegrationId3, out var actualDbType3);
+            bool result3 = DbScopeFactory.TryGetIntegrationDetails("SomeFakeDbCommand", out var actualIntegrationId3, out var actualDbType3);
             Assert.False(result3);
             Assert.False(actualIntegrationId3.HasValue);
             Assert.Null(actualDbType3);
@@ -304,7 +304,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("Custom.DB.Command", "AdoNet", "db")]
         internal void TryGetIntegrationDetails_CustomCommandType(string commandTypeFullName, string integrationId, string expectedDbType)
         {
-            DbScopeFactory.TryGetIntegrationDetails(commandTypeFullName, tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
+            DbScopeFactory.TryGetIntegrationDetails(commandTypeFullName, out var actualIntegrationId, out var actualDbType);
             Assert.Equal(integrationId, actualIntegrationId?.ToString());
             Assert.Equal(expectedDbType, actualDbType);
         }

--- a/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
+++ b/tracer/test/Datadog.Trace.ClrProfiler.Managed.Tests/DbScopeFactoryTests.cs
@@ -253,7 +253,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
             var command = (IDbCommand)Activator.CreateInstance(commandType)!;
             command.CommandText = DbmCommandText;
 
-            bool result = DbScopeFactory.TryGetIntegrationDetails(command.GetType().FullName, out var actualIntegrationId, out var actualDbType);
+            bool result = DbScopeFactory.TryGetIntegrationDetails(command.GetType().FullName, tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
             Assert.True(result);
             Assert.Equal(expectedIntegrationName, actualIntegrationId.ToString());
             Assert.Equal(expectedDbType, actualDbType);
@@ -262,12 +262,12 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [Fact]
         internal void TryGetIntegrationDetails_FailsForKnownCommandType()
         {
-            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", out var actualIntegrationId, out var actualDbType);
+            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
             Assert.False(result);
             Assert.False(actualIntegrationId.HasValue);
             Assert.Null(actualDbType);
 
-            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", out var actualIntegrationId2, out var actualDbType2);
+            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", tracer: Tracer.Instance, out var actualIntegrationId2, out var actualDbType2);
             Assert.False(result2);
             Assert.False(actualIntegrationId2.HasValue);
             Assert.Null(actualDbType2);
@@ -277,17 +277,17 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         internal void TryGetIntegrationDetails_FailsForKnownCommandTypes_AndUserDefined()
         {
             Tracer.Configure(TracerSettings.Create(new Dictionary<string, object> { { ConfigurationKeys.DisabledAdoNetCommandTypes, "SomeFakeDbCommand" } }));
-            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", out var actualIntegrationId, out var actualDbType);
+            bool result = DbScopeFactory.TryGetIntegrationDetails("InterceptableDbCommand", tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
             Assert.False(result);
             Assert.False(actualIntegrationId.HasValue);
             Assert.Null(actualDbType);
 
-            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", out var actualIntegrationId2, out var actualDbType2);
+            bool result2 = DbScopeFactory.TryGetIntegrationDetails("ProfiledDbCommand", tracer: Tracer.Instance, out var actualIntegrationId2, out var actualDbType2);
             Assert.False(result2);
             Assert.False(actualIntegrationId2.HasValue);
             Assert.Null(actualDbType2);
 
-            bool result3 = DbScopeFactory.TryGetIntegrationDetails("SomeFakeDbCommand", out var actualIntegrationId3, out var actualDbType3);
+            bool result3 = DbScopeFactory.TryGetIntegrationDetails("SomeFakeDbCommand", tracer: Tracer.Instance, out var actualIntegrationId3, out var actualDbType3);
             Assert.False(result3);
             Assert.False(actualIntegrationId3.HasValue);
             Assert.Null(actualDbType3);
@@ -304,7 +304,7 @@ namespace Datadog.Trace.ClrProfiler.Managed.Tests
         [InlineData("Custom.DB.Command", "AdoNet", "db")]
         internal void TryGetIntegrationDetails_CustomCommandType(string commandTypeFullName, string integrationId, string expectedDbType)
         {
-            DbScopeFactory.TryGetIntegrationDetails(commandTypeFullName, out var actualIntegrationId, out var actualDbType);
+            DbScopeFactory.TryGetIntegrationDetails(commandTypeFullName, tracer: Tracer.Instance, out var actualIntegrationId, out var actualDbType);
             Assert.Equal(integrationId, actualIntegrationId?.ToString());
             Assert.Equal(expectedDbType, actualDbType);
         }

--- a/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
+++ b/tracer/test/Datadog.Trace.Tests/Telemetry/config_norm_rules.json
@@ -530,6 +530,7 @@
   "DD_IAST_DB_ROWS_TO_TAINT": "iast_db_rows_to_taint",
   "DD_IAST_COOKIE_FILTER_PATTERN": "iast_cookie_filter_pattern",
   "DD_TRACE_STARTUP_LOGS": "trace_startup_logs_enabled",
+  "DD_TRACE_DISABLED_ADONET_COMMAND_TYPES": "trace_disabled_adonet_command_types",
   "DD_MAX_LOGFILE_SIZE": "trace_log_file_max_size",
   "DD_TRACE_LOGGING_RATE": "trace_log_rate",
   "DD_TRACE_LOG_PATH": "trace_log_path",

--- a/tracer/test/snapshots/FakeCommandTests_v0.verified.txt
+++ b/tracer/test/snapshots/FakeCommandTests_v0.verified.txt
@@ -1,0 +1,1913 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_22,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_24,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_26,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_28,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_29,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_30,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_31,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_32,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_33,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_34,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_35,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_36,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_37,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_38,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_39,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_40,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_41,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_42,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_47,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_48,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_49,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_50,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_51,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_52,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_53,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_54,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_55,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_56,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_57,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_58,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_59,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_60,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_61,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_63,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_64,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_65,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_66,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_67,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_68,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_69,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_70,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_71,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_72,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_73,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_74,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_75,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_76,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_77,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_78,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_79,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_80,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_81,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_82,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_83,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_84,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_85,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_86,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_87,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_88,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_89,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_90,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_91,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_92,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_93,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_94,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_95,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_96,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_97,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_98,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_99,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_100,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_101,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_102,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_103,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_104,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_105,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand-fake,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      span.kind: client
+    },
+    Metrics: {
+      _dd.top_level: 1.0
+    }
+  }
+]

--- a/tracer/test/snapshots/FakeCommandTests_v0.verified.txt
+++ b/tracer/test/snapshots/FakeCommandTests_v0.verified.txt
@@ -1,4 +1,4 @@
-[
+﻿[
   {
     TraceId: Id_1,
     SpanId: Id_2,
@@ -14,7 +14,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -35,7 +36,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -56,7 +58,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -77,7 +80,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -98,7 +102,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -119,7 +124,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -140,7 +146,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -161,7 +168,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -182,7 +190,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -203,7 +212,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -224,7 +234,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -245,7 +256,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -266,7 +278,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -287,7 +300,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -308,7 +322,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -329,7 +344,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -350,7 +366,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -371,7 +388,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -392,7 +410,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -413,7 +432,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -434,7 +454,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -455,7 +476,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -476,7 +498,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -497,7 +520,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -518,7 +542,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -539,7 +564,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -560,7 +586,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -581,7 +608,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -602,7 +630,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -623,7 +652,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -644,7 +674,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -665,7 +696,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -686,7 +718,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -707,7 +740,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -728,7 +762,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -749,7 +784,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -770,7 +806,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -791,7 +828,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -812,7 +850,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -833,7 +872,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -854,7 +894,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -875,7 +916,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -896,7 +938,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -917,7 +960,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -938,7 +982,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -959,7 +1004,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -980,7 +1026,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1001,7 +1048,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1022,7 +1070,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1043,7 +1092,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1064,7 +1114,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1085,7 +1136,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1106,7 +1158,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1127,7 +1180,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1148,7 +1202,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1169,7 +1224,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1190,7 +1246,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1211,7 +1268,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1232,7 +1290,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1253,7 +1312,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1274,7 +1334,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1295,7 +1356,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1316,7 +1378,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1337,7 +1400,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1358,7 +1422,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1379,7 +1444,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1400,7 +1466,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1421,7 +1488,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1442,7 +1510,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1463,7 +1532,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1484,7 +1554,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1505,7 +1576,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1526,7 +1598,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1547,7 +1620,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1568,7 +1642,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1589,7 +1664,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1610,7 +1686,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1631,7 +1708,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1652,7 +1730,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1673,7 +1752,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1694,7 +1774,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1715,7 +1796,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1736,7 +1818,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1757,7 +1840,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1778,7 +1862,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1799,7 +1884,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1820,7 +1906,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1841,7 +1928,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1862,7 +1950,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1883,7 +1972,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0
@@ -1904,7 +1994,8 @@
       env: integration_tests,
       language: dotnet,
       runtime-id: Guid_1,
-      span.kind: client
+      span.kind: client,
+      _dd.base_service: Samples.FakeDbCommand
     },
     Metrics: {
       _dd.top_level: 1.0

--- a/tracer/test/snapshots/FakeCommandTests_v0_disabledFakeCommand.verified.txt
+++ b/tracer/test/snapshots/FakeCommandTests_v0_disabledFakeCommand.verified.txt
@@ -1,0 +1,281 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: RunAllAsync<TCommand>,
+    Resource: RunAllAsync<TCommand>,
+    Service: Samples.FakeDbCommand,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: command,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: command,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: command,
+    Resource: IDbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: command,
+    Resource: IDbCommandGenericConstraint<FakeCommand>,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: command,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: command,
+    Resource: IDbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: command,
+    Resource: IDbCommandGenericConstraint<FakeCommand>-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: sync,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: async,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: async-with-cancellation,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: sync,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: async,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: async-with-cancellation,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: sync,
+    Resource: IDbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_5,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: sync,
+    Resource: IDbCommandGenericConstraint<FakeCommand>,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_6,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: sync,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_7,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_19,
+    Name: async,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_7,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: async-with-cancellation,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_7,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_21,
+    Name: sync,
+    Resource: IDbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_8,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_22,
+    Name: sync,
+    Resource: IDbCommandGenericConstraint<FakeCommand>-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_9,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  }
+]

--- a/tracer/test/snapshots/FakeCommandTests_v1.verified.txt
+++ b/tracer/test/snapshots/FakeCommandTests_v1.verified.txt
@@ -1,0 +1,1822 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_22,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_24,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_26,
+    Name: fake.query,
+    Resource: DELETE FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_28,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_29,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_30,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_31,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_32,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_33,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_34,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_35,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_36,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_37,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_38,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_39,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_40,
+    Name: fake.query,
+    Resource: DROP TABLE IF EXISTS [FakeDbCommand-Test-GUID]; CREATE TABLE [FakeDbCommand-Test-GUID] (Id int PRIMARY KEY, Name varchar(100));,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_41,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_42,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_43,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_44,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_45,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_46,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_47,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_48,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_49,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_50,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_51,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_52,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_53,
+    Name: fake.query,
+    Resource: INSERT INTO [FakeDbCommand-Test-GUID] (Id, Name) VALUES (@Id, @Name);,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_54,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_55,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_56,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_57,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_58,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_59,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_60,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_61,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_62,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_63,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_64,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_65,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_66,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_67,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_68,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_69,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_70,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_71,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_72,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_73,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_74,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_75,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_76,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_77,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_78,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_79,
+    Name: fake.query,
+    Resource: SELECT * FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_80,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_81,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_82,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_83,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_84,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_85,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_86,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_87,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_88,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_89,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_90,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_91,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_92,
+    Name: fake.query,
+    Resource: SELECT Name FROM [FakeDbCommand-Test-GUID] WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_93,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_3,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_94,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_5,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_95,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_7,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_96,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_9,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_97,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_11,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_98,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_13,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_99,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_15,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_100,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_17,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_101,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_19,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_102,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_21,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_103,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_23,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_104,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_25,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_105,
+    Name: fake.query,
+    Resource: UPDATE [FakeDbCommand-Test-GUID] SET Name=@Name WHERE Id=@Id;,
+    Service: Samples.FakeDbCommand,
+    Type: sql,
+    ParentId: Id_27,
+    Tags: {
+      component: AdoNet,
+      db.name: fake,
+      db.type: fake,
+      env: integration_tests,
+      language: dotnet,
+      peer.service: fake,
+      span.kind: client,
+      version: 1.0.0,
+      _dd.peer.service.source: db.name
+    }
+  }
+]

--- a/tracer/test/snapshots/FakeCommandTests_v1_disabledFakeCommand.verified.txt
+++ b/tracer/test/snapshots/FakeCommandTests_v1_disabledFakeCommand.verified.txt
@@ -1,0 +1,281 @@
+[
+  {
+    TraceId: Id_1,
+    SpanId: Id_2,
+    Name: RunAllAsync<TCommand>,
+    Resource: RunAllAsync<TCommand>,
+    Service: Samples.FakeDbCommand,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      runtime-id: Guid_1,
+      version: 1.0.0
+    },
+    Metrics: {
+      process_id: 0,
+      _dd.top_level: 1.0,
+      _dd.tracer_kr: 1.0,
+      _sampling_priority_v1: 1.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_3,
+    Name: command,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_4,
+    Name: command,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_5,
+    Name: command,
+    Resource: IDbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_6,
+    Name: command,
+    Resource: IDbCommandGenericConstraint<FakeCommand>,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_7,
+    Name: command,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_8,
+    Name: command,
+    Resource: IDbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_9,
+    Name: command,
+    Resource: IDbCommandGenericConstraint<FakeCommand>-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_2,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_10,
+    Name: sync,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_11,
+    Name: async,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_12,
+    Name: async-with-cancellation,
+    Resource: FakeCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_3,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_13,
+    Name: sync,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_14,
+    Name: async,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_15,
+    Name: async-with-cancellation,
+    Resource: DbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_4,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_16,
+    Name: sync,
+    Resource: IDbCommand,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_5,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_17,
+    Name: sync,
+    Resource: IDbCommandGenericConstraint<FakeCommand>,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_6,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_18,
+    Name: sync,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_7,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_19,
+    Name: async,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_7,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_20,
+    Name: async-with-cancellation,
+    Resource: DbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_7,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_21,
+    Name: sync,
+    Resource: IDbCommand-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_8,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  },
+  {
+    TraceId: Id_1,
+    SpanId: Id_22,
+    Name: sync,
+    Resource: IDbCommandGenericConstraint<FakeCommand>-netstandard,
+    Service: Samples.FakeDbCommand,
+    ParentId: Id_9,
+    Tags: {
+      env: integration_tests,
+      language: dotnet,
+      version: 1.0.0
+    }
+  }
+]


### PR DESCRIPTION
## Summary of changes

Allows users to configure _additionally_ `ADO.NET` `DbCommand`s to be disabled so they won't have a Span created from them.

## Reason for change

Since we instrument basically _any_ `DbCommand` in `ADO.NET` this can lead to unwanted/duplicate Spans that customers have little control over. This allows for a comma-separated list of command type names that the .NET Tracer will not create a Span for if they encounter it.

## Implementation details

Adds new Environment Variable `DD_TRACE_DISABLED_ADONET_COMMAND_TYPES` that accepts a comma-separated `string` of `ADO.NET` Command Type names that the Tracer will not create a Span for.

For example (some pseudo-code here):

Assuming we have a custom `DbCommand` `FooDbCommand` that we don't want Spans for ->

```csharp
public class FooDbCommand : DbCommand
{
    ... class contents here
}
```

We'd need to set `DD_TRACE_DISABLED_ADONET_COMMAND_TYPES` to ->

```
DD_TRACE_DISABLED_ADONET_COMMAND_TYPES="FooDbCommand"
```

## Test coverage

- Extended current `DbScopeFactoryTests` to add new value.
- Extended `FakeCommandTests` to include disabling of `FakeCommand`
- Snapshotted those tests as well.

## Other details

Merge the dd-go PR when this PR is merged: https://github.com/DataDog/dd-go/pull/150493

Backported to 2.x in https://github.com/DataDog/dd-trace-dotnet/pull/6054
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
