### PR TITLE
[ASM] Activate api sec by default

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -6343,7 +6343,7 @@ stages:
             SNAPSHOT_DIR: $(System.DefaultWorkingDirectory)/tracer/build/smoke_test_snapshots
             SNAPSHOT_CI: 1
             # ignoring 'http.client_ip' and 'network.client.ip' because it's set to '::1' here instead of expected '127.0.0.1'
-            SNAPSHOT_IGNORED_ATTRS: span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.git.commit.sha,meta._dd.git.repository_url,meta.http.client_ip,meta.network.client.ip
+            SNAPSHOT_IGNORED_ATTRS: span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.git.commit.sha,meta._dd.git.repository_url,meta.http.client_ip,meta.network.client.ip,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers #api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
 
         - script: |
             # Based on variables set in smoke.dotnet-tool.nuget.dockerfile

--- a/docker-compose.windows.yml
+++ b/docker-compose.windows.yml
@@ -23,7 +23,7 @@ services:
     - "8126:8126"
     environment:
     - SNAPSHOT_CI=1
-    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta.http.client_ip,meta.network.client.ip,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers #api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
 
   smoke-tests.windows:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -871,7 +871,7 @@ services:
     environment:
     - ENABLED_CHECKS=trace_count_header,meta_tracer_version_header,trace_content_length
     - SNAPSHOT_CI=1
-    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id
+    - SNAPSHOT_IGNORED_ATTRS=span_id,trace_id,parent_id,duration,start,metrics.system.pid,meta.runtime-id,metrics.process_id,meta._dd.p.dm,meta._dd.p.tid,meta._dd.parent_id,meta._dd.appsec.s.req.params,meta._dd.appsec.s.res.body,meta._dd.appsec.s.req.headers,meta._dd.appsec.s.res.headers #api-security attrs are unfortunately ignored because gzip compression generates different bytes per platform windows/linux
 
   smoke-tests:
     build:

--- a/tracer/build/smoke_test_snapshots/smoke_test_snapshots.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_snapshots.json
@@ -40,6 +40,10 @@
       "meta": {
         "_dd.appsec.waf.version": "1.19.1",
         "_dd.runtime_family": "dotnet",
+        "_dd.appsec.s.req.params": "H4sIAAAAAAAAA4uuVkrOzyspys/JSS1Ssoq2iNVRSkwuyczPA3NqYwH+CR9jIQAAAA==",
+        "_dd.appsec.s.res.body": "H4sIAAAAAAAAA4u2iAUA8YntnQMAAAA=",
+        "_dd.appsec.s.req.headers": "H4sIAAAAAAAAA4WOMQ6AIBAE/3I1FHaGrxCKixAkQSBwhYbwdzUWNhDqnd1ZWeHkGgl1tDxhNoG40yCklKtSrII3AcTSFAPKuJlCSKYb/zOEtkyQgkfyLjzK7GJ2dI2N36mZ8iVHx/dYev2mbkdocaj9AAAA",
+        "_dd.appsec.s.res.headers": "H4sIAAAAAAAAA4uuVkrOzytJzSvRLaksSFWyio6OtoiN1alWyknNU7IyrI2tjQUAcaAU2yQAAAA=",
         "aspnet_core.endpoint": "AspNetCoreSmokeTest.ValuesController.Get (AspNetCoreSmokeTest)",
         "aspnet_core.route": "api/values",
         "component": "aspnet_core",

--- a/tracer/build/smoke_test_snapshots/smoke_test_snapshots_2_1.json
+++ b/tracer/build/smoke_test_snapshots/smoke_test_snapshots_2_1.json
@@ -40,6 +40,9 @@
       "meta": {
         "_dd.appsec.waf.version": "1.19.1",
         "_dd.runtime_family": "dotnet",
+        "_dd.appsec.s.res.body": "H4sIAAAAAAAAA4u2iAUA8YntnQMAAAA=",
+        "_dd.appsec.s.req.headers": "H4sIAAAAAAAAA4WOMQrAIBDA/uKsQ7fiVw6Ho4oVrIp3Q4v491JcLc4JJNAEVzwcMbITGgB2Y2QT0SWht27kwAWrSzzlt7LIaLNXjJ4WCuFVYkhelRpyDfws/NFVwa7S3+SfdmaarXfzAg6PMlH9AAAA",
+        "_dd.appsec.s.res.headers": "H4sIAAAAAAAAA4uuVkrOzytJzSvRLaksSFWyio6OtoiN1alWyknNU7IyrI2tjQUAcaAU2yQAAAA=",
         "aspnet_core.route": "api/values",
         "component": "aspnet_core",
         "http.client_ip": "127.0.0.1",

--- a/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
+++ b/tracer/src/Datadog.Trace/AppSec/SecuritySettings.cs
@@ -124,7 +124,7 @@ namespace Datadog.Trace.AppSec
             }
 
             ApiSecurityEnabled = config.WithKeys(ConfigurationKeys.AppSec.ApiSecurityEnabled, "DD_EXPERIMENTAL_API_SECURITY_ENABLED")
-                                       .AsBool(false);
+                                       .AsBool(true);
 
             ApiSecuritySampleDelay = config.WithKeys(ConfigurationKeys.AppSec.ApiSecuritySampleDelay)
                                            .AsDouble(30.0, val => val >= 0.0)

--- a/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
+++ b/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.AppSec.cs
@@ -112,7 +112,7 @@ namespace Datadog.Trace.Configuration
             internal const string UserEventsAutoInstrumentationMode = "DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE";
 
             /// <summary>
-            /// Unless set to true or 1, tracers don’t collect schemas. After the experiment, the environment variable will be removed and schema collection will be enabled only when ASM is enabled
+            /// When ASM is enabled, collects in spans endpoints apis schemas analyzed by the waf, default value is true.
             /// </summary>
             internal const string ApiSecurityEnabled = "DD_API_SECURITY_ENABLED";
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetCoreApiSecurity.cs
@@ -35,10 +35,7 @@ public abstract class AspNetCoreApiSecurity : AspNetBase, IClassFixture<AspNetCo
         // necessary as the developer middleware prevents the right blocking response
         EnvironmentHelper.CustomEnvironmentVariables.Add("ASPNETCORE_ENVIRONMENT", "Production");
         SetEnvironmentVariable(ConfigurationKeys.LogDirectory, LogDirectory);
-        if (enableApiSecurity)
-        {
-            EnvironmentHelper.CustomEnvironmentVariables.Add(ConfigurationKeys.AppSec.ApiSecurityEnabled, "true");
-        }
+        SetEnvironmentVariable(ConfigurationKeys.AppSec.ApiSecurityEnabled, enableApiSecurity.ToString());
     }
 
     public override void Dispose()

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetFxWebApiApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetFxWebApiApiSecurity.cs
@@ -34,11 +34,7 @@ public abstract class AspNetFxWebApiApiSecurity : AspNetBase, IClassFixture<IisF
     {
         SetSecurity(true);
         EnvironmentHelper.CustomEnvironmentVariables.Add(ConfigurationKeys.AppSec.Rules, "ApiSecurity\\ruleset-with-block.json");
-
-        if (enableApiSecurity)
-        {
-            EnvironmentHelper.CustomEnvironmentVariables.Add(ConfigurationKeys.AppSec.ApiSecurityEnabled, "true");
-        }
+        SetEnvironmentVariable(ConfigurationKeys.AppSec.ApiSecurityEnabled, enableApiSecurity.ToString());
 
         _iisFixture = iisFixture;
         AddCookies(new Dictionary<string, string> { { "cookie-key", "cookie-value" } });

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetMvc5ApiSecurity.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ApiSecurity/AspNetMvc5ApiSecurity.cs
@@ -47,11 +47,7 @@ public abstract class AspNetMvc5ApiSecurity : AspNetBase, IClassFixture<IisFixtu
     {
         SetSecurity(true);
         EnvironmentHelper.CustomEnvironmentVariables.Add(ConfigurationKeys.AppSec.Rules, "ApiSecurity\\ruleset-with-block.json");
-        if (enableApiSecurity)
-        {
-            EnvironmentHelper.CustomEnvironmentVariables.Add(ConfigurationKeys.AppSec.ApiSecurityEnabled, "true");
-        }
-
+        SetEnvironmentVariable(ConfigurationKeys.AppSec.ApiSecurityEnabled, enableApiSecurity.ToString());
         AddCookies(new Dictionary<string, string> { { "cookie-key", "cookie-value" } });
         _iisFixture = iisIisFixture;
         _testName = "Security." + nameof(AspNetMvc5ApiSecurity) + ".enableApiSecurity=" + enableApiSecurity;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetBase.cs
@@ -83,6 +83,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             _jsonSerializerSettingsOrderProperty = new JsonSerializerSettings { ContractResolver = new OrderedContractResolver() };
 
             _clearMetaStruct = clearMetaStruct;
+            SetEnvironmentVariable(ConfigurationKeys.AppSec.ApiSecurityEnabled, "false");
         }
 
         protected bool IncludeAllHttpSpans { get; set; } = false;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AutoUserEvents.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCore5AutoUserEvents.cs
@@ -8,6 +8,7 @@
 #pragma warning disable SA1649 // File name must match first type name
 
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBare.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
 using Xunit;
 using Xunit.Abstractions;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetCoreBase.cs
@@ -8,8 +8,8 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using Datadog.Trace.AppSec;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.TestHelpers;
-using Datadog.Trace.Vendors.Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/AspNetMvc5.cs
@@ -65,6 +65,7 @@ namespace Datadog.Trace.Security.IntegrationTests
             SetSecurity(enableSecurity);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.Rules, DefaultRuleFile);
             SetEnvironmentVariable(Configuration.ConfigurationKeys.DebugEnabled, "1");
+            SetEnvironmentVariable(Configuration.ConfigurationKeys.AppSec.ApiSecurityEnabled, "false");
 
             _classicMode = classicMode;
             _iisFixture = iisFixture;

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/RcmBase.cs
@@ -25,6 +25,7 @@ public class RcmBase : AspNetBase, IClassFixture<AspNetCoreTestFixture>
         Fixture = fixture;
         EnableSecurity = enableSecurity;
         SetEnvironmentVariable(ConfigurationKeys.Rcm.PollInterval, "0.5");
+        SetEnvironmentVariable(ConfigurationKeys.AppSec.ApiSecurityEnabled, "false");
     }
 
     protected AspNetCoreTestFixture Fixture { get; }


### PR DESCRIPTION
## Summary of changes

Activate api security by default 

## Reason for change

https://docs.google.com/document/d/1BbF-ZQHG9seaaik578WFCb1PEs-SmKq34PHg5sG3q6s/edit#heading=h.d3npy38hknxa

## Implementation details

Had to ignore the tags in the system tests as Gzip bytes results in different values under linux/windows
Maybe future: implement in the test agent some normalization for api security tags.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
