### PR TITLE
[backport][serverless] trigger consolidated pipeline on tags (#6052 => v2)

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -9,7 +9,6 @@ trigger:
       - hotfix/*
     exclude:
       - refs/pull/*/head
-      - refs/tags/*
   paths:
     exclude:
       - .azure-pipelines/noop-pipeline.yml


### PR DESCRIPTION
## Summary of changes

Removes exclusion of pipeline trigger for tags.

## Reason for change

Serverless requires a build on a tag in order to have a production ready pipeline to use.

## Implementation details

n/a

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
