### PR TITLE
Bump timeit to 0.1.21

### DIFF
--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net462.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net462.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net462.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net462.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net60.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net60.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net60.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net60.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net80.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net80.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net80.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.net80.json
@@ -1,0 +1,46 @@
+{
+  "enableDatadog": true,
+  "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.net80.json",
+  "warmUpCount": 5,
+  "count": 50,
+  "scenarios": [
+    {
+      "name": "Baseline",
+      "environmentVariables": {
+        "CORECLR_ENABLE_PROFILING": "0",
+        "COR_ENABLE_PROFILING": "0"
+      }
+    },
+    {
+      "name": "CallTarget\u002BInlining\u002BNGEN"
+    }
+  ],
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.FakeDbCommand.dll no-wait",
+  "processTimeout": 15,
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.FakeDbCommand\\release_net8.0",
+  "environmentVariables": {
+    "CORECLR_ENABLE_PROFILING": "1",
+    "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "CORECLR_PROFILER_PATH_32": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "CORECLR_PROFILER_PATH_ARM64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-ARM64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "DD_DOTNET_TRACER_HOME": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home",
+    "COR_ENABLE_PROFILING": "1",
+    "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "COR_PROFILER_PATH_32": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "COR_PROFILER_PATH_ARM64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-ARM64\\Datadog.Trace.ClrProfiler.Native.dll"
+  },
+  "pathValidations": [
+    "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+    "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+  ],
+  "tags": {
+    "runtime.architecture": "x64",
+    "runtime.name": ".NET Core",
+    "runtime.version": "8.0",
+    "benchmark.job.runtime.name": ".NET 8.0",
+    "benchmark.job.runtime.moniker": "net8.0"
+  }
+}

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.netcoreapp31.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.netcoreapp31.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.FakeDbCommand/Samples.FakeDbCommand.windows.netcoreapp31.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.FakeDbCommand.windows.netcoreapp31.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -23,8 +23,3 @@ echo *********************
 echo .NET Core 6.0
 echo *********************
 dotnet timeit Samples.FakeDbCommand.windows.net60.json
-
-echo *********************
-echo .NET Core 8.0
-echo *********************
-dotnet timeit Samples.FakeDbCommand.windows.net80.json

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.FakeDbCommand.windows.net60.json DEL /F results_Samples
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.1.19
+dotnet tool update -g timeitsharp --version 0.1.21
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
+++ b/tracer/build/timeit/Samples.FakeDbCommand/run.cmd
@@ -2,6 +2,7 @@
 IF EXIST results_Samples.FakeDbCommand.windows.net462.json DEL /F results_Samples.FakeDbCommand.windows.net462.json
 IF EXIST results_Samples.FakeDbCommand.windows.netcoreapp31.json DEL /F results_Samples.FakeDbCommand.windows.netcoreapp31.json
 IF EXIST results_Samples.FakeDbCommand.windows.net60.json DEL /F results_Samples.FakeDbCommand.windows.net60.json
+IF EXIST results_Samples.FakeDbCommand.windows.net80.json DEL /F results_Samples.FakeDbCommand.windows.net80.json
 
 echo *********************
 echo Installing timeitsharp
@@ -22,3 +23,8 @@ echo *********************
 echo .NET Core 6.0
 echo *********************
 dotnet timeit Samples.FakeDbCommand.windows.net60.json
+
+echo *********************
+echo .NET Core 8.0
+echo *********************
+dotnet timeit Samples.FakeDbCommand.windows.net80.json

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net462.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net462.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net462.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net462.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net60.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net60.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net60.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net60.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net80.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -1,0 +1,46 @@
+{
+  "enableDatadog": true,
+  "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net80.json",
+  "warmUpCount": 5,
+  "count": 50,
+  "scenarios": [
+    {
+      "name": "Baseline",
+      "environmentVariables": {
+        "CORECLR_ENABLE_PROFILING": "0",
+        "COR_ENABLE_PROFILING": "0"
+      }
+    },
+    {
+      "name": "CallTarget\u002BInlining\u002BNGEN"
+    }
+  ],
+  "processName": "dotnet",
+  "processArguments": ".\\Samples.HttpMessageHandler.dll",
+  "processTimeout": 15,
+  "workingDirectory": "$(CWD)\\..\\..\\..\\..\\artifacts\\bin\\Samples.HttpMessageHandler\\release_net8.0",
+  "environmentVariables": {
+    "CORECLR_ENABLE_PROFILING": "1",
+    "CORECLR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "CORECLR_PROFILER_PATH_32": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+    "CORECLR_PROFILER_PATH_64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "CORECLR_PROFILER_PATH_ARM64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-ARM64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "DD_DOTNET_TRACER_HOME": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home",
+    "COR_ENABLE_PROFILING": "1",
+    "COR_PROFILER": "{846F5F1C-F9AE-4B07-969E-05C26BC060D8}",
+    "COR_PROFILER_PATH_32": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+    "COR_PROFILER_PATH_64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll",
+    "COR_PROFILER_PATH_ARM64": "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-ARM64\\Datadog.Trace.ClrProfiler.Native.dll"
+  },
+  "pathValidations": [
+    "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x86\\Datadog.Trace.ClrProfiler.Native.dll",
+    "$(CWD)\\..\\..\\..\\..\\shared\\bin\\monitoring-home\\win-x64\\Datadog.Trace.ClrProfiler.Native.dll"
+  ],
+  "tags": {
+    "runtime.architecture": "x64",
+    "runtime.name": ".NET Core",
+    "runtime.version": "8.0",
+    "benchmark.job.runtime.name": ".NET 8.0",
+    "benchmark.job.runtime.moniker": "net8.0"
+  }
+}

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net80.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.net80.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.net80.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -3,6 +3,24 @@
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.netcoreapp31.json",
   "warmUpCount": 5,
   "count": 60,
+  "services": [
+    {
+      "name": "Execute",
+      "options": {
+        "onScenarioStart": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\..",
+          "redirectStandardOutput": true
+        },
+        "onExecutionEnd": {
+          "processName": "call",
+          "processArguments": "remove_logs.cmd",
+          "workingDirectory": "$(CWD)\\.."
+        }
+      }
+    }
+  ],
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.netcoreapp31.json",
   "warmUpCount": 5,
-  "count": 60,
+  "count": 80,
   "services": [
     {
       "name": "Execute",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -9,14 +9,14 @@
       "options": {
         "onScenarioStart": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\..",
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
           "processName": "cmd.exe",
-          "processArguments": "/c remove_logs.cmd",
-          "workingDirectory": "$(CWD)\\.."
+          "processArguments": "/c \"..\\remove_logs.cmd\"",
+          "workingDirectory": "$(CWD)"
         }
       }
     }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -8,14 +8,14 @@
       "name": "Execute",
       "options": {
         "onScenarioStart": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\..",
           "redirectStandardOutput": true
         },
         "onExecutionEnd": {
-          "processName": "call",
-          "processArguments": "remove_logs.cmd",
+          "processName": "cmd.exe",
+          "processArguments": "/c remove_logs.cmd",
           "workingDirectory": "$(CWD)\\.."
         }
       }

--- a/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/Samples.HttpMessageHandler.windows.netcoreapp31.json
@@ -2,7 +2,7 @@
   "enableDatadog": true,
   "jsonExporterFilePath": "$(CWD)\\results_Samples.HttpMessageHandler.windows.netcoreapp31.json",
   "warmUpCount": 5,
-  "count": 50,
+  "count": 60,
   "scenarios": [
     {
       "name": "Baseline",

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -6,7 +6,7 @@ IF EXIST results_Samples.HttpMessageHandler.windows.net60.json DEL /F results_Sa
 echo *********************
 echo Installing timeitsharp
 echo *********************
-dotnet tool update -g timeitsharp --version 0.1.19
+dotnet tool update -g timeitsharp --version 0.1.21
 
 echo *********************
 echo .NET Framework 4.6.1

--- a/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
+++ b/tracer/build/timeit/Samples.HttpMessageHandler/run.cmd
@@ -2,6 +2,7 @@
 IF EXIST results_Samples.HttpMessageHandler.windows.net462.json DEL /F results_Samples.HttpMessageHandler.windows.net462.json
 IF EXIST results_Samples.HttpMessageHandler.windows.netcoreapp31.json DEL /F results_Samples.HttpMessageHandler.windows.netcoreapp31.json
 IF EXIST results_Samples.HttpMessageHandler.windows.net60.json DEL /F results_Samples.HttpMessageHandler.windows.net60.json
+IF EXIST results_Samples.HttpMessageHandler.windows.net80.json DEL /F results_Samples.HttpMessageHandler.windows.net80.json
 
 echo *********************
 echo Installing timeitsharp
@@ -22,3 +23,8 @@ echo *********************
 echo .NET Core 6.0
 echo *********************
 dotnet timeit Samples.HttpMessageHandler.windows.net60.json
+
+echo *********************
+echo .NET Core 8.0
+echo *********************
+dotnet timeit Samples.HttpMessageHandler.windows.net80.json

--- a/tracer/build/timeit/remove_logs.cmd
+++ b/tracer/build/timeit/remove_logs.cmd
@@ -1,0 +1,1 @@
+del /S/q "%ProgramData%\Datadog .NET Tracer\logs\*.*"


### PR DESCRIPTION
## Summary of changes

Bumping timeit to version 0.1.21, also adding a script to timeit to remove the logs generated by the tracer before running each scenario.

The PR also bumps the number of iteration to check if we can reduce the error of the metrics.

The PR also adds a new configuration file for net8.0

## Reason for change

On the benchmark dashboard we can see some unexplained bumps on the same commit (increasing duration on startup and thread count) when using the tracer. We are trying to stabilize the values by removing the logs to avoid the rollup logics from the logs on startup.

## Implementation details

The new version of timeit has support for executing commands before any timeit event. We added a new remove_logs.cmd script to run it before each scenario start and after each execution the target process.

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
