### PR TITLE
Move IDM up in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -150,7 +150,10 @@ docker-compose.serverless.yml                                      @DataDog/trac
 /tracer/test/test-applications/integrations/Samples.MSTestTests/  @DataDog/ci-app-libraries-dotnet
 /tracer/test/test-applications/integrations/Samples.MSTestTests2/  @DataDog/ci-app-libraries-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs  @DataDog/ci-app-libraries-dotnet
-
+/tracer/test/snapshots/MsTestV2* @DataDog/ci-app-libraries-dotnet
+/tracer/test/snapshots/NUnit* @DataDog/ci-app-libraries-dotnet
+/tracer/test/snapshots/XUnit* @DataDog/ci-app-libraries-dotnet
+/tracer/test/snapshots/Selenium* @DataDog/ci-app-libraries-dotnet
 # Common Files
 Datadog.Trace.Trimming.xml                @DataDog/apm-dotnet
 Directory.Build.props                     @DataDog/apm-dotnet

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,76 +11,6 @@
 # IDM
 /tracer/test/test-applications/integrations/                                                            @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 
-# CI
-/tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
-/tracer/src/Datadog.Trace/PDBs/MethodSymbolResolver.cs        @DataDog/ci-app-libraries-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/  @DataDog/ci-app-libraries-dotnet
-/tracer/test/test-applications/integrations/Samples.XUnitTests/  @DataDog/ci-app-libraries-dotnet
-/tracer/test/test-applications/integrations/Samples.NUnitTests/  @DataDog/ci-app-libraries-dotnet
-/tracer/test/test-applications/integrations/Samples.MSTestTests/  @DataDog/ci-app-libraries-dotnet
-/tracer/test/test-applications/integrations/Samples.MSTestTests2/  @DataDog/ci-app-libraries-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs  @DataDog/ci-app-libraries-dotnet
-
-# ASM
-/tracer/src/Datadog.Trace/AppSec/         @DataDog/asm-dotnet
-/tracer/src/Datadog.Tracer.Native/iast/    @DataDog/asm-dotnet
-/tracer/test/test-applications/security/   @DataDog/asm-dotnet
-/tracer/test/Datadog.Trace.Security.IntegrationTests/ @DataDog/asm-dotnet
-/tracer/test/Datadog.Trace.Security.Unit.Tests/       @DataDog/asm-dotnet
-/tracer/test/snapshots/Security*          @DataDog/asm-dotnet
-/tracer/test/snapshots/Iast*          	@DataDog/asm-dotnet
-/tracer/test/snapshots/Rasp*          	@DataDog/asm-dotnet
-/tracer/src/Datadog.Trace/Iast/           @DataDog/asm-dotnet
-AspectsDefinitions.g.cs 				@DataDog/asm-dotnet
-/tracer/test/test-applications/integrations/Samples.InstrumentedTests/ @DataDog/asm-dotnet
-/tracer/src/Datadog.Trace/Tags.AppSec.cs @DataDog/asm-dotnet
-/tracer/test/benchmarks/Benchmarks.Trace/Asm/   @DataDog/asm-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CryptographyAlgorithm/  @DataDog/asm-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/HashAlgorithm/  @DataDog/asm-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/  @DataDog/asm-dotnet
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/StackTraceLeak/  @DataDog/asm-dotnet
-/tracer/test/test-applications/integrations/Samples.ProcessStart  @DataDog/asm-dotnet
-
-# Profiler
-/profiler/                                @DataDog/profiling-dotnet
-.github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
-/tracer/src/Datadog.Trace/ContinuousProfiler/ @DataDog/profiling-dotnet @DataDog/tracing-dotnet
-/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ @DataDog/profiling-dotnet @DataDog/tracing-dotnet
-
-# Debugger
-/tracer/src/Datadog.Trace/Debugger/        @DataDog/debugger-dotnet
-/tracer/test/Datadog.Trace.Tests/Debugger/ @DataDog/debugger-dotnet
-/tracer/src/Datadog.Trace/PDBs/            @DataDog/debugger-dotnet
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/ @DataDog/debugger-dotnet
-/tracer/test/test-applications/debugger/   @DataDog/debugger-dotnet
-debugger_*.cpp                             @DataDog/debugger-dotnet
-debugger_*.h                               @DataDog/debugger-dotnet
-/tracer/test/Datadog.Trace.Tests/Debugger  @DataDog/debugger-dotnet
-/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ @DataDog/debugger-dotnet
-tracer/src/Datadog.InstrumentedAssemblyGenerator/ @DataDog/debugger-dotnet
-tracer/src/Datadog.InstrumentedAssemblyVerification/ @DataDog/debugger-dotnet
-fault_tolerant_*.cpp                       @DataDog/debugger-dotnet
-fault_tolerant_*.h                         @DataDog/debugger-dotnet
-/tracer/src/Datadog.Trace/FaultTolerant/   @DataDog/debugger-dotnet
-/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs   @DataDog/debugger-dotnet
-Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
-
-# Serverless
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/   @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/       @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/test-applications/azure-functions/                    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/test-applications/integrations/Samples.AWS.Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
-/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/        @DataDog/tracing-dotnet  @DataDog/serverless-aws
-docker-compose.serverless.yml                                      @DataDog/tracing-dotnet  @DataDog/serverless-aws
-
-# Shared code we could move to the root folder
-/tracer/build/                            @DataDog/apm-dotnet
-
-# IDM (note @DataDog/tracing-dotnet may be removed at a later date)
-
 ## DBM and DSM
 /tracer/src/Datadog.Trace/DatabaseMonitoring/                                                           @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
 /tracer/src/Datadog.Trace/DataStreamsMonitoring/                                                        @DataDog/apm-idm-dotnet  @DataDog/tracing-dotnet
@@ -152,6 +82,74 @@ docker-compose.serverless.yml                                      @DataDog/trac
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracerFlareTests.cs                             @DataDog/tracing-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TracingIntegrationTest.cs                       @DataDog/tracing-dotnet
 /tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/TransportTests.cs                               @DataDog/tracing-dotnet
+
+# ASM
+/tracer/src/Datadog.Trace/AppSec/         @DataDog/asm-dotnet
+/tracer/src/Datadog.Tracer.Native/iast/    @DataDog/asm-dotnet
+/tracer/test/test-applications/security/   @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.Security.IntegrationTests/ @DataDog/asm-dotnet
+/tracer/test/Datadog.Trace.Security.Unit.Tests/       @DataDog/asm-dotnet
+/tracer/test/snapshots/Security*          @DataDog/asm-dotnet
+/tracer/test/snapshots/Iast*          	@DataDog/asm-dotnet
+/tracer/test/snapshots/Rasp*          	@DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/Iast/           @DataDog/asm-dotnet
+AspectsDefinitions.g.cs 				@DataDog/asm-dotnet
+/tracer/test/test-applications/integrations/Samples.InstrumentedTests/ @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/Tags.AppSec.cs @DataDog/asm-dotnet
+/tracer/test/benchmarks/Benchmarks.Trace/Asm/   @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/CryptographyAlgorithm/  @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/HashAlgorithm/  @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Process/  @DataDog/asm-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/StackTraceLeak/  @DataDog/asm-dotnet
+/tracer/test/test-applications/integrations/Samples.ProcessStart  @DataDog/asm-dotnet
+
+# Profiler
+/profiler/                                @DataDog/profiling-dotnet
+.github/workflows/profiler-pipeline.yml   @DataDog/profiling-dotnet
+/tracer/src/Datadog.Trace/ContinuousProfiler/ @DataDog/profiling-dotnet @DataDog/tracing-dotnet
+/tracer/test/Datadog.Trace.Tests/ContinuousProfiler/ @DataDog/profiling-dotnet @DataDog/tracing-dotnet
+
+# Debugger
+/tracer/src/Datadog.Trace/Debugger/        @DataDog/debugger-dotnet
+/tracer/test/Datadog.Trace.Tests/Debugger/ @DataDog/debugger-dotnet
+/tracer/src/Datadog.Trace/PDBs/            @DataDog/debugger-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/Debugger/ @DataDog/debugger-dotnet
+/tracer/test/test-applications/debugger/   @DataDog/debugger-dotnet
+debugger_*.cpp                             @DataDog/debugger-dotnet
+debugger_*.h                               @DataDog/debugger-dotnet
+/tracer/test/Datadog.Trace.Tests/Debugger  @DataDog/debugger-dotnet
+/tracer/test/Datadog.Trace.Debugger.IntegrationTests/ @DataDog/debugger-dotnet
+tracer/src/Datadog.InstrumentedAssemblyGenerator/ @DataDog/debugger-dotnet
+tracer/src/Datadog.InstrumentedAssemblyVerification/ @DataDog/debugger-dotnet
+fault_tolerant_*.cpp                       @DataDog/debugger-dotnet
+fault_tolerant_*.h                         @DataDog/debugger-dotnet
+/tracer/src/Datadog.Trace/FaultTolerant/   @DataDog/debugger-dotnet
+/tracer/src/Datadog.Trace/Configuration/ConfigurationKeys.Debugger.cs   @DataDog/debugger-dotnet
+Datadog.Trace.Debugger.slnf                @DataDog/debugger-dotnet
+
+# Serverless
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/AWS/SDK/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
+/tracer/src/Datadog.Trace/ClrProfiler/ServerlessInstrumentation/   @DataDog/tracing-dotnet  @DataDog/serverless-aws
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/AWS/       @DataDog/tracing-dotnet  @DataDog/serverless-aws
+/tracer/test/test-applications/azure-functions/                    @DataDog/tracing-dotnet  @DataDog/serverless-aws
+/tracer/test/test-applications/integrations/Samples.AWS.Lambda/    @DataDog/tracing-dotnet  @DataDog/serverless-aws
+/tracer/test/test-applications/integrations/Samples.Amazon.Lambda.RuntimeSupport/        @DataDog/tracing-dotnet  @DataDog/serverless-aws
+docker-compose.serverless.yml                                      @DataDog/tracing-dotnet  @DataDog/serverless-aws
+
+# Shared code we could move to the root folder
+/tracer/build/                            @DataDog/apm-dotnet
+
+# CI
+/tracer/src/Datadog.Trace/Ci/             @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/CI/   @DataDog/ci-app-libraries-dotnet @DataDog/apm-dotnet
+/tracer/src/Datadog.Trace/PDBs/MethodSymbolResolver.cs        @DataDog/ci-app-libraries-dotnet
+/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.XUnitTests/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.NUnitTests/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.MSTestTests/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/test-applications/integrations/Samples.MSTestTests2/  @DataDog/ci-app-libraries-dotnet
+/tracer/test/Datadog.Trace.ClrProfiler.IntegrationTests/SourceCodeIntegrationGitMetadataTests.cs  @DataDog/ci-app-libraries-dotnet
 
 # Common Files
 Datadog.Trace.Trimming.xml                @DataDog/apm-dotnet


### PR DESCRIPTION
## Summary of changes

This will allow all of the others to override IDM more consistently.

## Reason for change

IDM was getting added to all of the CI Visibility PRs and this should address that.

## Implementation details

- Select lines
- `Ctrl + X`
- `Ctrl + V`
- Select lines
- `Ctrl + X`
- `Ctrl + V`
- `Ctrl + S`
- `Ctrl + S`
- `Ctrl + S`

## Test coverage

:shrug:

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
