### PR TITLE
[CI Visibility] Avoid failing unfinished tests

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
+++ b/tracer/src/Datadog.Trace/Ci/CIVisibility.cs
@@ -561,7 +561,7 @@ namespace Datadog.Trace.Ci
                     test.SetErrorInfo(exception);
                 }
 
-                test.Close(TestStatus.Fail);
+                test.Close(TestStatus.Skip, null, "Test is being closed due to test session shutdown.");
             }
 
             foreach (var testSuite in TestSuite.ActiveTestSuites)
@@ -591,7 +591,7 @@ namespace Datadog.Trace.Ci
                     testSession.SetErrorInfo(exception);
                 }
 
-                await testSession.CloseAsync(TestStatus.Fail).ConfigureAwait(false);
+                await testSession.CloseAsync(TestStatus.Skip).ConfigureAwait(false);
             }
 
             await FlushAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Summary of changes

This PR changes the current behaviour of failing opened tests when the test process is being shutdown (SIGTERM).
With this change now those tests are marked as "Skipped" with the "test.skip_reason = Test is being closed due to test session shutdown." 

## Reason for change

Current behaviour is causing problem on CI when the job gets cancelled automatically by the CI when a new commit appears, skewing the stats and results of the test sessions. 

## Implementation details

Changes in the method that closes the opened test events.
