### PR TITLE
[Profiler][cleanup] Shorten libdatadog helper functions name

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native.Linux/CrashReportingLinux.cpp
@@ -216,7 +216,7 @@ std::vector<StackFrame> CrashReportingLinux::GetThreadFrames(int32_t tid, Resolv
                 stackFrame.method = std::string(methodData.symbolName);
                 hasName = true;
 
-                auto demangleResult = ddog_demangle(libdatadog::FfiHelper::StringToCharSlice(stackFrame.method), DDOG_PROF_DEMANGLE_OPTIONS_COMPLETE);
+                auto demangleResult = ddog_demangle(libdatadog::to_char_slice(stackFrame.method), DDOG_PROF_DEMANGLE_OPTIONS_COMPLETE);
 
                 if (demangleResult.tag == DDOG_PROF_STRING_WRAPPER_RESULT_OK)
                 {

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AgentProxy.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/AgentProxy.hpp
@@ -114,7 +114,7 @@ private:
         auto profileBuffer = encodedProfile->buffer;
         std::string const profile_filename = "auto.pprof";
 
-        ddog_prof_Exporter_File profile{FfiHelper::StringToCharSlice(profile_filename), ddog_Vec_U8_as_slice(&profileBuffer)};
+        ddog_prof_Exporter_File profile{to_char_slice(profile_filename), ddog_Vec_U8_as_slice(&profileBuffer)};
 
         std::vector<ddog_prof_Exporter_File> uncompressed_files;
         uncompressed_files.reserve(1);
@@ -127,7 +127,7 @@ private:
         for (auto& [filename, content] : files)
         {
             ddog_Slice_U8 fileSlice{reinterpret_cast<const uint8_t*>(content.c_str()), content.size()};
-            to_compress_files.push_back({FfiHelper::StringToCharSlice(filename), fileSlice});
+            to_compress_files.push_back({to_char_slice(filename), fileSlice});
         }
 
         ddog_prof_Exporter_Slice_File uncompressed_files_view = {uncompressed_files.data(), uncompressed_files.size()};
@@ -137,7 +137,7 @@ private:
         ddog_CharSlice ffi_metadata{};
         if (!metadata.empty())
         {
-            ffi_metadata = FfiHelper::StringToCharSlice(metadata);
+            ffi_metadata = to_char_slice(metadata);
             pMetadata = &ffi_metadata;
         }
 
@@ -148,7 +148,7 @@ private:
         ddog_CharSlice ffi_info{};
         if (!info.empty())
         {
-            ffi_info = FfiHelper::StringToCharSlice(info);
+            ffi_info = to_char_slice(info);
             pInfo = &ffi_info;
         }
 

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/CrashReporting.cpp
@@ -117,7 +117,7 @@ ULONG CrashReporting::Release()
 
 int32_t CrashReporting::AddTag(const char* key, const char* value)
 {
-    auto result = ddog_crashinfo_add_tag(&_crashInfo, libdatadog::FfiHelper::StringToCharSlice(std::string_view(key)), libdatadog::FfiHelper::StringToCharSlice(std::string_view(value)));
+    auto result = ddog_crashinfo_add_tag(&_crashInfo, libdatadog::to_char_slice(key), libdatadog::to_char_slice(value));
 
     if (result.tag == DDOG_PROF_CRASHTRACKER_RESULT_ERR)
     {
@@ -142,7 +142,7 @@ int32_t CrashReporting::SetSignalInfo(int32_t signal, const char* description)
         signalInfo = std::string(description);
     }
 
-    ddog_crashinfo_set_siginfo(&_crashInfo, { (uint64_t)signal, libdatadog::FfiHelper::StringToCharSlice(signalInfo) });
+    ddog_crashinfo_set_siginfo(&_crashInfo, { (uint64_t)signal, libdatadog::to_char_slice(signalInfo) });
 
     return 0;
 }
@@ -191,7 +191,7 @@ int32_t CrashReporting::ResolveStacks(int32_t crashingThreadId, ResolveManagedCa
                 .colno = { DDOG_PROF_OPTION_U32_NONE_U32, 0},
                 .filename = {nullptr, 0},
                 .lineno = { DDOG_PROF_OPTION_U32_NONE_U32, 0},
-                .name = libdatadog::FfiHelper::StringToCharSlice(strings[i])
+                .name = libdatadog::to_char_slice(strings[i])
             };
 
             auto ip = static_cast<uintptr_t>(frame.ip);
@@ -249,16 +249,16 @@ int32_t CrashReporting::SetMetadata(const char* libraryName, const char* library
     auto vecTags = ddog_Vec_Tag_new();
 
     const ddog_prof_CrashtrackerMetadata metadata = {
-        .profiling_library_name = libdatadog::FfiHelper::StringToCharSlice(std::string_view(libraryName)) ,
-        .profiling_library_version = libdatadog::FfiHelper::StringToCharSlice(std::string_view(libraryVersion)),
-        .family = libdatadog::FfiHelper::StringToCharSlice(std::string_view(family)),
+        .profiling_library_name = libdatadog::to_char_slice(libraryName) ,
+        .profiling_library_version = libdatadog::to_char_slice(libraryVersion),
+        .family = libdatadog::to_char_slice(family),
         .tags = &vecTags
     };
 
     for (int32_t i = 0; i < tagCount; i++)
     {
         auto tag = tags[i];
-        ddog_Vec_Tag_push(&vecTags, libdatadog::FfiHelper::StringToCharSlice(std::string_view(tag.key)), libdatadog::FfiHelper::StringToCharSlice(std::string_view(tag.value)));
+        ddog_Vec_Tag_push(&vecTags, libdatadog::to_char_slice(tag.key), libdatadog::to_char_slice(tag.value));
     }
 
     auto result = ddog_crashinfo_set_metadata(&_crashInfo, metadata);
@@ -295,7 +295,7 @@ int32_t CrashReporting::WriteToFile(const char* url)
 {
     ddog_prof_CrashtrackerConfiguration config{};
 
-    config.endpoint = ddog_Endpoint_file(libdatadog::FfiHelper::StringToCharSlice(std::string_view(url)));
+    config.endpoint = ddog_Endpoint_file(libdatadog::to_char_slice(url));
     config.timeout_secs = 10;
 
     auto result = ddog_crashinfo_upload_to_endpoint(&_crashInfo, config);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExporterBuilder.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/ExporterBuilder.cpp
@@ -58,9 +58,9 @@ std::unique_ptr<libdatadog::AgentProxy> ExporterBuilder::CreateAgentProxy()
     auto endpoint = CreateEndpoint();
 
     auto result = ddog_prof_Exporter_new(
-        FfiHelper::StringToCharSlice(_libraryName),
-        FfiHelper::StringToCharSlice(_libraryVersion),
-        FfiHelper::StringToCharSlice(_languageFamily),
+        to_char_slice(_libraryName),
+        to_char_slice(_libraryVersion),
+        to_char_slice(_languageFamily),
         static_cast<ddog_Vec_Tag*>(*_tags._impl),
         endpoint.inner);
 
@@ -103,10 +103,10 @@ ExporterBuilder::AgentEndpoint ExporterBuilder::CreateEndpoint()
     {
         assert(!_site.empty());
         assert(!_apiKey.empty());
-        return {ddog_prof_Endpoint_agentless(FfiHelper::StringToCharSlice(_site), FfiHelper::StringToCharSlice(_apiKey))};
+        return {ddog_prof_Endpoint_agentless(to_char_slice(_site), to_char_slice(_apiKey))};
     }
 
-    return {ddog_prof_Endpoint_agent(FfiHelper::StringToCharSlice(_url))};
+    return {ddog_prof_Endpoint_agent(to_char_slice(_url))};
 }
 
 std::unique_ptr<Exporter> ExporterBuilder::Build()

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FfiHelper.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FfiHelper.cpp
@@ -14,41 +14,41 @@ extern "C"
 }
 
 namespace libdatadog {
-ddog_ByteSlice FfiHelper::StringToByteSlice(std::string const& str)
+ddog_ByteSlice to_byte_slice(std::string const& str)
 {
     return {(uint8_t*)str.c_str(), str.size()};
 }
 
-ddog_ByteSlice FfiHelper::StringToByteSlice(char const* str)
+ddog_ByteSlice to_byte_slice(char const* str)
 {
     return {(uint8_t*)str, strlen(str)};
 }
 
-ddog_CharSlice FfiHelper::StringToCharSlice(std::string const& str)
+ddog_CharSlice to_char_slice(std::string const& str)
 {
     return {str.data(), str.size()};
 }
 
-ddog_CharSlice FfiHelper::StringToCharSlice(std::string_view str)
+ddog_CharSlice to_char_slice(std::string_view str)
 {
     return {str.data(), str.size()};
 }
 
-ddog_prof_ValueType FfiHelper::CreateValueType(std::string const& type, std::string const& unit)
+ddog_prof_ValueType CreateValueType(std::string const& type, std::string const& unit)
 {
     auto valueType = ddog_prof_ValueType{};
-    valueType.type_ = FfiHelper::StringToCharSlice(type);
-    valueType.unit = FfiHelper::StringToCharSlice(unit);
+    valueType.type_ = to_char_slice(type);
+    valueType.unit = to_char_slice(unit);
     return valueType;
 }
 
-std::string FfiHelper::GetErrorMessage(ddog_Error& error)
+std::string GetErrorMessage(ddog_Error& error)
 {
     auto message = ddog_Error_message(&error);
     return std::string(message.ptr, message.len);
 }
 
-std::string FfiHelper::GetErrorMessage(ddog_MaybeError& error)
+std::string GetErrorMessage(ddog_MaybeError& error)
 {
     return std::string((char*)error.some.message.ptr, error.some.message.len);
 }

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FfiHelper.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/FfiHelper.h
@@ -13,23 +13,16 @@ extern "C"
 }
 
 namespace libdatadog {
-class FfiHelper
+ddog_CharSlice to_char_slice(std::string const& str);
+ddog_CharSlice to_char_slice(std::string_view str);
+constexpr ddog_CharSlice to_char_slice(const char* str)
 {
-public:
-    FfiHelper() = delete;
+    return {str, std::char_traits<char>::length(str)};
+}
+ddog_prof_ValueType CreateValueType(std::string const& type, std::string const& unit);
 
-    static ddog_ByteSlice StringToByteSlice(std::string const& str);
-    static ddog_ByteSlice StringToByteSlice(char const* str);
-    static ddog_CharSlice StringToCharSlice(std::string const& str);
-    static ddog_CharSlice StringToCharSlice(std::string_view str);
-    constexpr static ddog_CharSlice StringToCharSlice(const char* str)
-    {
-        return {str, std::char_traits<char>::length(str)};
-    }
-    static ddog_prof_ValueType CreateValueType(std::string const& type, std::string const& unit);
-    static std::string GetErrorMessage(ddog_Error& error);
-    static std::string GetErrorMessage(ddog_MaybeError& error);
-};
+std::string GetErrorMessage(ddog_Error& error);
+std::string GetErrorMessage(ddog_MaybeError& error);
 
 Success make_error(ddog_Error error);
 Success make_error(std::string error);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Profile.cpp
@@ -41,11 +41,11 @@ libdatadog::Success Profile::Add(std::shared_ptr<Sample> const& sample)
         auto& location = locations[idx];
 
         location.mapping = {};
-        location.mapping.filename = FfiHelper::StringToCharSlice(frame.ModuleName);
-        location.function.filename = FfiHelper::StringToCharSlice(frame.Filename);
+        location.mapping.filename = to_char_slice(frame.ModuleName);
+        location.function.filename = to_char_slice(frame.Filename);
         location.function.start_line = frame.StartLine;
         location.line = frame.StartLine; // For now we only have the start line of the function.
-        location.function.name = FfiHelper::StringToCharSlice(frame.Frame);
+        location.function.name = to_char_slice(frame.Frame);
         location.address = 0; // TODO check if we can get that information in the provider
 
         ++idx;
@@ -95,7 +95,7 @@ libdatadog::Success Profile::Add(std::shared_ptr<Sample> const& sample)
 
 void Profile::SetEndpoint(int64_t traceId, std::string const& endpoint)
 {
-    auto endpointName = FfiHelper::StringToCharSlice(endpoint);
+    auto endpointName = to_char_slice(endpoint);
 
     auto res = ddog_prof_Profile_set_endpoint(*_impl, traceId, endpointName);
     if (res.tag == DDOG_PROF_PROFILE_RESULT_ERR)
@@ -113,7 +113,7 @@ void Profile::SetEndpoint(int64_t traceId, std::string const& endpoint)
 
 void Profile::AddEndpointCount(std::string const& endpoint, int64_t count)
 {
-    auto endpointName = FfiHelper::StringToCharSlice(endpoint);
+    auto endpointName = to_char_slice(endpoint);
 
     auto res = ddog_prof_Profile_add_endpoint_count(*_impl, endpointName, 1);
     if (res.tag == DDOG_PROF_PROFILE_RESULT_ERR)
@@ -133,8 +133,8 @@ libdatadog::Success Profile::AddUpscalingRuleProportional(std::vector<std::uintp
                                                           uint64_t sampled, uint64_t real)
 {
     ddog_prof_Slice_Usize offsets_slice = {offsets.data(), offsets.size()};
-    ddog_CharSlice labelName_slice = FfiHelper::StringToCharSlice(labelName);
-    ddog_CharSlice groupName_slice = FfiHelper::StringToCharSlice(groupName);
+    ddog_CharSlice labelName_slice = to_char_slice(labelName);
+    ddog_CharSlice groupName_slice = to_char_slice(groupName);
 
     auto upscalingRuleAdd = ddog_prof_Profile_add_upscaling_rule_proportional(*_impl, offsets_slice, labelName_slice, groupName_slice, sampled, real);
     if (upscalingRuleAdd.tag == DDOG_PROF_PROFILE_RESULT_ERR)
@@ -160,12 +160,12 @@ libdatadog::profile_unique_ptr CreateProfile(std::vector<SampleValueType> const&
 
     for (auto const& type : valueTypes)
     {
-        samplesTypes.push_back(FfiHelper::CreateValueType(type.Name, type.Unit));
+        samplesTypes.push_back(CreateValueType(type.Name, type.Unit));
     }
 
     struct ddog_prof_Slice_ValueType sample_types = {samplesTypes.data(), samplesTypes.size()};
 
-    auto period_value_type = FfiHelper::CreateValueType(periodType, periodUnit);
+    auto period_value_type = CreateValueType(periodType, periodUnit);
 
     auto period = ddog_prof_Period{};
     period.type_ = period_value_type;

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SuccessImpl.hpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/SuccessImpl.hpp
@@ -21,13 +21,13 @@ namespace libdatadog {
 struct SuccessImpl
 {
     SuccessImpl(ddog_Error error) :
-        SuccessImpl(FfiHelper::GetErrorMessage(error))
+        SuccessImpl(GetErrorMessage(error))
     {
         ddog_Error_drop(&error);
     }
 
     SuccessImpl(ddog_MaybeError error) :
-        SuccessImpl(FfiHelper::GetErrorMessage(error.some))
+        SuccessImpl(GetErrorMessage(error.some))
     {
         assert(error.tag == DDOG_OPTION_ERROR_SOME_ERROR);
         ddog_MaybeError_drop(error);

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Tags.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/Tags.cpp
@@ -43,8 +43,8 @@ Tags& Tags::operator=(Tags&& tags) noexcept
 
 libdatadog::Success Tags::Add(std::string const& name, std::string const& value)
 {
-    auto ffiName = FfiHelper::StringToCharSlice(name);
-    auto ffiValue = FfiHelper::StringToCharSlice(value);
+    auto ffiName = to_char_slice(name);
+    auto ffiValue = to_char_slice(value);
 
     auto pushResult = ddog_Vec_Tag_push(&_impl->_tags, ffiName, ffiValue);
     if (pushResult.tag == DDOG_VEC_TAG_PUSH_RESULT_ERR)

--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/TelemetryMetricsWorker.cpp
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/TelemetryMetricsWorker.cpp
@@ -93,10 +93,10 @@ bool TelemetryMetricsWorker::Start(
     }
 
     ddog_TelemetryWorkerBuilder* builder;
-    auto service = FfiHelper::StringToCharSlice(serviceName);
-    auto lang = FfiHelper::StringToCharSlice(language);
-    auto lang_version = FfiHelper::StringToCharSlice(languageVersion);
-    auto tracer_version = FfiHelper::StringToCharSlice(libraryVersion);
+    auto service = to_char_slice(serviceName);
+    auto lang = to_char_slice(language);
+    auto lang_version = to_char_slice(languageVersion);
+    auto tracer_version = to_char_slice(libraryVersion);
 
     auto result = ddog_telemetry_builder_instantiate(&builder, service, lang, lang_version, tracer_version);
     if (result.tag == DDOG_OPTION_ERROR_SOME_ERROR)
@@ -118,12 +118,12 @@ bool TelemetryMetricsWorker::Start(
 #endif
         std::string pathname = FileHelper::GenerateFilename("telemetry", ".json", serviceName, runtimeId);
         endpointUrl = "file://" + outputDirectory.generic_string() + separator + pathname;
-        endpoint_char = FfiHelper::StringToCharSlice(endpointUrl);
+        endpoint_char = to_char_slice(endpointUrl);
     }
     else
     {
         endpointUrl = agentUrl + TelemetryMetricsEndPoint;
-        endpoint_char = FfiHelper::StringToCharSlice(endpointUrl);
+        endpoint_char = to_char_slice(endpointUrl);
     }
 
     auto* endpoint = ddog_endpoint_from_url(endpoint_char);
@@ -138,7 +138,7 @@ bool TelemetryMetricsWorker::Start(
     }
 
     // other builder configuration
-    auto runtime_id = FfiHelper::StringToCharSlice(runtimeId);
+    auto runtime_id = to_char_slice(runtimeId);
     result = ddog_telemetry_builder_with_str_runtime_id(builder, runtime_id);
     if (result.tag == DDOG_OPTION_ERROR_SOME_ERROR)
     {
@@ -150,7 +150,7 @@ bool TelemetryMetricsWorker::Start(
     // these are optional
     if (!serviceVersion.empty())
     {
-        auto service_version = FfiHelper::StringToCharSlice(serviceVersion);
+        auto service_version = to_char_slice(serviceVersion);
         result = ddog_telemetry_builder_with_str_application_service_version(builder, service_version);
         if (result.tag == DDOG_OPTION_ERROR_SOME_ERROR)
         {
@@ -162,7 +162,7 @@ bool TelemetryMetricsWorker::Start(
 
     if (!environment.empty())
     {
-        auto env = FfiHelper::StringToCharSlice(environment);
+        auto env = to_char_slice(environment);
         result = ddog_telemetry_builder_with_str_application_env(builder, env);
         if (result.tag == DDOG_OPTION_ERROR_SOME_ERROR)
         {
@@ -205,7 +205,7 @@ bool TelemetryMetricsWorker::Start(
                                   {"enablement_choice", enablementTagValue}},
                                  false);
 
-    auto numberOfProfilesMetricName = FfiHelper::StringToCharSlice("ssi_heuristic.number_of_profiles");
+    auto numberOfProfilesMetricName = to_char_slice("ssi_heuristic.number_of_profiles");
 
     _impl->_numberOfProfilesKey = ddog_telemetry_handle_register_metric_context(
         _impl->_pHandle, numberOfProfilesMetricName, DDOG_METRIC_TYPE_COUNT, *static_cast<ddog_Vec_Tag const*>(*tags._impl), true, DDOG_METRIC_NAMESPACE_PROFILERS);
@@ -214,7 +214,7 @@ bool TelemetryMetricsWorker::Start(
                              {"enablement_choice", enablementTagValue}},
                             false);
 
-    auto numberOfRuntimeIdMetricName = FfiHelper::StringToCharSlice("ssi_heuristic.number_of_runtime_id");
+    auto numberOfRuntimeIdMetricName = to_char_slice("ssi_heuristic.number_of_runtime_id");
 
     _impl->_numberOfRuntimeIdKey = ddog_telemetry_handle_register_metric_context(
         _impl->_pHandle, numberOfRuntimeIdMetricName, DDOG_METRIC_TYPE_COUNT, *static_cast<ddog_Vec_Tag const*>(*tags._impl), true, DDOG_METRIC_NAMESPACE_PROFILERS);


### PR DESCRIPTION
## Summary of changes
Shorten `libdatadog` helper functions name

## Reason for change

cleaner and easier to read.

## Implementation details

Use free functions instead of static methods in a static class.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
