### PR TITLE
[Profiler] Download profiler debug symbols for integration tests

### DIFF
--- a/.azure-pipelines/ultimate-pipeline.yml
+++ b/.azure-pipelines/ultimate-pipeline.yml
@@ -2658,6 +2658,12 @@ stages:
         artifact: linux-monitoring-home-$(artifactSuffix)
         path: $(monitoringHome)
 
+    - task: DownloadPipelineArtifact@2
+      displayName: Download linux debug symbols
+      inputs:
+        artifact: linux-profiler-symbols-$(artifactSuffix)
+        path: $(monitoringHome)
+
     # when we build samples separately, we could run this step and the docker-compose one below in //
     # (currently the docker-compose step relies on serverless samples)
     - template: steps/run-in-docker.yml


### PR DESCRIPTION
## Summary of changes

Download profiler debug symbols for integration tests jobs.
## Reason for change
When a test takes too much time, the profiler test infrastructure calls gdb to collect all threads callstack and print it in the console. (and generate a coredump)
Since binaries are stripped, the callstack are difficult to read. For the jobs that runs on CentOS 7, we cannot create a new image and install gdb (and tools) because of deprecation and mainly because all the CentOS 7 packages are gone.

## Implementation details
Download the profiler native debug symbols when setting up the tests.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
