### PR TITLE
Add `ddprs` to DBM injected comment + fix `dddbs`

### DIFF
--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -21,6 +21,7 @@ namespace Datadog.Trace.DatabaseMonitoring
     {
         private const string SqlCommentSpanService = "dddbs";
         private const string SqlCommentRootService = "ddps";
+        private const string SqlCommentPeerService = "ddprs";
         private const string SqlCommentDbName = "dddb";
         private const string SqlCommentOuthost = "ddh";
         private const string SqlCommentVersion = "ddpv";
@@ -41,6 +42,12 @@ namespace Datadog.Trace.DatabaseMonitoring
                 var propagatorStringBuilder = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
                 var dddbs = span.Context.ServiceNameInternal;
                 propagatorStringBuilder.Append(DbmPrefix).Append(Uri.EscapeDataString(dddbs)).Append('\'');
+
+                if (span.Tags is SqlV1Tags { PeerServiceSource: "peer.service" } sqlTags)
+                {
+                    var ddprs = sqlTags.PeerService;
+                    propagatorStringBuilder.Append(',').Append(SqlCommentPeerService).Append("='").Append(Uri.EscapeDataString(ddprs)).Append('\'');
+                }
 
                 if (span.Context.TraceContext?.Environment is { } envTag)
                 {

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -39,7 +39,7 @@ namespace Datadog.Trace.DatabaseMonitoring
                 (propagationStyle is DbmPropagationLevel.Service or DbmPropagationLevel.Full))
             {
                 var propagatorStringBuilder = StringBuilderCache.Acquire(StringBuilderCache.MaxBuilderSize);
-                var dddbs = (span.Tags is SqlV1Tags sqlTags) ? sqlTags.PeerService : span.Context.ServiceNameInternal;
+                var dddbs = span.Context.ServiceNameInternal;
                 propagatorStringBuilder.Append(DbmPrefix).Append(Uri.EscapeDataString(dddbs)).Append('\'');
 
                 if (span.Context.TraceContext?.Environment is { } envTag)

--- a/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
+++ b/tracer/src/Datadog.Trace/DatabaseMonitoring/DatabaseMonitoringPropagator.cs
@@ -43,9 +43,24 @@ namespace Datadog.Trace.DatabaseMonitoring
                 var dddbs = span.Context.ServiceNameInternal;
                 propagatorStringBuilder.Append(DbmPrefix).Append(Uri.EscapeDataString(dddbs)).Append('\'');
 
-                if (span.Tags is SqlV1Tags { PeerServiceSource: "peer.service" } sqlTags)
+                string? ddprs = null;
+                if (span.Tags is SqlV1Tags sqlTags)
                 {
-                    var ddprs = sqlTags.PeerService;
+                    if (sqlTags.PeerServiceSource == "peer.service")
+                    {
+                        ddprs = sqlTags.PeerService;
+                    }
+                }
+                else
+                {
+                    if (span.Tags.GetTag(Tags.PeerServiceRemappedFrom) != null)
+                    {
+                        ddprs = span.Tags.GetTag(Tags.PeerService);
+                    }
+                }
+
+                if (ddprs != null)
+                {
                     propagatorStringBuilder.Append(',').Append(SqlCommentPeerService).Append("='").Append(Uri.EscapeDataString(ddprs)).Append('\'');
                 }
 

--- a/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
@@ -110,7 +110,7 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             var integrationId = IntegrationId.Npgsql;
             var samplingPriority = SamplingPriority.AutoReject;
             var dbServiceName = "Test.Service-postgres";
-            var expectedComment = "/*dddbs='dbname',ddps='Test.Service',dddb='MyDatabase',ddh='MyHost'*/";
+            var expectedComment = $"/*dddbs='{dbServiceName}',ddps='Test.Service',dddb='MyDatabase',ddh='MyHost'*/";
             var traceParentInjected = false;
             var dbName = "dbname";
 

--- a/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
@@ -184,7 +184,8 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
             sqlTags.SetTag(Tags.PeerServiceRemappedFrom, "old_value");
             sqlTags.SetTag(Tags.PeerService, peerService);
 
-            var span = _v1Tracer.StartSpan("db.query", sqlTags, serviceName: "myServiceName");
+            var tracer = version == SchemaVersion.V1 ? _v1Tracer : _v0Tracer;
+            var span = tracer.StartSpan("db.query", sqlTags, serviceName: "myServiceName");
 
             var returnedComment = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, "Test.Service", "MyDatabase", "MyHost", span, IntegrationId.Npgsql, out var traceParentInjectedValue);
 

--- a/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/DatabaseMonitoring/DatabaseMonitoringPropagatorTests.cs
@@ -104,6 +104,25 @@ namespace Datadog.Trace.Tests.DatabaseMonitoring
         }
 
         [Fact]
+        public void PeerServiceInjected()
+        {
+            var dbmPropagationLevel = DbmPropagationLevel.Service;
+            var traceParentInjected = false;
+            var peerService = "myPeerService";
+            var dbName = "myDbName";
+
+            var sqlTags = new SqlV1Tags { DbName = dbName };
+            sqlTags.SetTag(Tags.PeerService, peerService);
+
+            var span = _v1Tracer.StartSpan("db.query", sqlTags, serviceName: "myServiceName");
+
+            var returnedComment = DatabaseMonitoringPropagator.PropagateDataViaComment(dbmPropagationLevel, "Test.Service", "MyDatabase", "MyHost", span, IntegrationId.Npgsql, out var traceParentInjectedValue);
+
+            traceParentInjectedValue.Should().Be(traceParentInjected);
+            returnedComment.Should().Be("/*dddbs='myServiceName',ddprs='myPeerService',ddps='Test.Service',dddb='MyDatabase',ddh='MyHost'*/");
+        }
+
+        [Fact]
         public void ExpectedCommentInjectedV1()
         {
             var dbmPropagationLevel = DbmPropagationLevel.Service;


### PR DESCRIPTION
## Summary of changes

- add `ddprs` (peer service) to the comment injected by DBM, contains the peer service value only if set explicitely
- revert the behavior introduced in #4619, as per spec, peer service is not supposed to override `dddbs`.

## Reason for change

spec: https://docs.google.com/document/d/1Cg9RLydNzK1BTf3EFaEC4NlQtvAO-_rDdPLSO8HgDCs
slack thread: https://dd.slack.com/archives/C02U25426A1/p1727254455343209

## Implementation details

By taking the value of `ServiceNameInternal` from the span, dddbs will have either the service name of the calling service or the name of the DB depending on how fake services are configured.

The SQL tags V1 record if a peer service override was set
https://github.com/DataDog/dd-trace-dotnet/blob/40c8f59154c71dcce502c740304b9ef281f5c355/tracer/src/Datadog.Trace/Tagging/SqlTags.cs#L57-L58
so I'm using that to know if I should use the `PeerService` value (because it always has a value, it falls back to the DB type or the outhost if peer service is not set).
https://github.com/DataDog/dd-trace-dotnet/blob/40c8f59154c71dcce502c740304b9ef281f5c355/tracer/src/Datadog.Trace/Tagging/SqlTags.cs#L48

For V0, I'm relying on the fact that the old value is saved when peer service is set. Not sure if I could just always use peer service in that case ?
https://github.com/DataDog/dd-trace-dotnet/blob/4bafc78fa25382fefb03fa4e052905ca371d1ffa/tracer/src/Datadog.Trace/Configuration/Schema/NamingSchema.cs#L64-L65

## Test coverage

## Other details
JIRA: AIT-10032
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
