### PR TITLE
Disable debugger exploration tests

### DIFF
--- a/tracer/build/_build/Build.VariableGenerations.cs
+++ b/tracer/build/_build/Build.VariableGenerations.cs
@@ -324,10 +324,11 @@ partial class Build : NukeBuild
                     useCases.Add(global::ExplorationTestUseCase.Tracer.ToString());
                 }
 
-                if (isDebuggerChanged)
-                {
-                    useCases.Add(global::ExplorationTestUseCase.Debugger.ToString());
-                }
+                // Debugger exploration tests are currently all broken, so disabling
+                // if (isDebuggerChanged)
+                // {
+                //     useCases.Add(global::ExplorationTestUseCase.Debugger.ToString());
+                // }
 
                 if (isProfilerChanged)
                 {


### PR DESCRIPTION
## Summary of changes

Disables the debugger exploration tests

## Reason for change

They're all completely broken

## Implementation details

Disable the tests until debugger team can look into them

## Test coverage

This is the test
