### PR TITLE
[CI Visibility] Hide running command by default.

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/LegacyCommand.cs
@@ -8,6 +8,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.Parsing;
 using System.Linq;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Util;
 using Spectre.Console;
 
@@ -120,7 +121,10 @@ namespace Datadog.Trace.Tools.Runner
                         }
                     }
 
-                    AnsiConsole.WriteLine("Running: " + cmdLine);
+                    if (GlobalSettings.Instance.DebugEnabledInternal)
+                    {
+                        Console.WriteLine("Running: {0}", cmdLine);
+                    }
 
                     var arguments = args.Length > 1 ? string.Join(' ', args.Skip(1).ToArray()) : null;
 

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCiCommand.cs
@@ -8,6 +8,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
 using Datadog.Trace.Ci.Tags;
+using Datadog.Trace.Configuration;
 using Datadog.Trace.Logging;
 using Spectre.Console;
 
@@ -58,7 +59,10 @@ namespace Datadog.Trace.Tools.Runner
             }
 
             // Run child process
-            AnsiConsole.WriteLine("Running: " + command);
+            if (GlobalSettings.Instance.DebugEnabledInternal)
+            {
+                Console.WriteLine("Running: {0}", command);
+            }
 
             if (initResults.TestSkippingEnabled || Program.CallbackForTests is not null)
             {

--- a/tracer/src/Datadog.Trace.Tools.Runner/RunCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.Runner/RunCommand.cs
@@ -7,6 +7,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Linq;
+using Datadog.Trace.Configuration;
 using Spectre.Console;
 
 namespace Datadog.Trace.Tools.Runner
@@ -41,7 +42,10 @@ namespace Datadog.Trace.Tools.Runner
                 return;
             }
 
-            AnsiConsole.WriteLine("Running: {0} {1}", program, arguments);
+            if (GlobalSettings.Instance.DebugEnabledInternal)
+            {
+                Console.WriteLine("Running: {0} {1}", program, arguments);
+            }
 
             if (Program.CallbackForTests != null)
             {


### PR DESCRIPTION
## Summary of changes

This PR hides the `Running: ...` message from the stdout by default (available if we run it in debug mode). Also changes the method used to output the message from Spectre.Console to Console

## Reason for change

This should fix: https://datadoghq.atlassian.net/browse/APMS-13380

Notes:
- The CI filter is not kicking in probably because the way `AnsiConsole.WriteLine` handles the output, changing it to `Console.WriteLine` should fix the CI filter.
- We don't have an strong reason to print the `Running...` message so we can just leave it for debug mode, hiding the output as default. 

## Implementation details

- Print the message only if DD_TRACE_DEBUG=true
- Change `AnsiConsole.WriteLine` with `Console.WriteLine`
