### PR TITLE
[IAST] Remove safe origin ranges

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -125,7 +125,6 @@ src/Datadog.Trace/DiagnosticListeners/RouteEndpoint.cs
 src/Datadog.Trace/DogStatsd/NoOpStatsd.cs
 src/Datadog.Trace/DogStatsd/StatsdExtensions.cs
 src/Datadog.Trace/DogStatsd/TracerMetricNames.cs
-src/Datadog.Trace/ExtensionMethods/ArrayExtensions.cs
 src/Datadog.Trace/ExtensionMethods/DictionaryExtensions.cs
 src/Datadog.Trace/ExtensionMethods/DoubleExtensions.cs
 src/Datadog.Trace/ExtensionMethods/MessagePackBinaryExtensions.cs

--- a/tracer/src/Datadog.Trace/ExtensionMethods/ArrayExtensions.cs
+++ b/tracer/src/Datadog.Trace/ExtensionMethods/ArrayExtensions.cs
@@ -3,12 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+#nullable enable
+
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Datadog.Trace.ExtensionMethods
 {
     internal static class ArrayExtensions
     {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T[] Concat<T>(this T[] array, params T[] newElements)
         {
             var destination = new T[array.Length + newElements.Length];
@@ -17,6 +21,13 @@ namespace Datadog.Trace.ExtensionMethods
             Array.Copy(newElements, 0, destination, array.Length, newElements.Length);
 
             return destination;
+        }
+
+        // We want to clash with Linq Contains method
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Contains<T>(this T[] array, T value)
+        {
+            return Array.IndexOf(array, value) >= 0;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/GlobalUsings.cs
+++ b/tracer/src/Datadog.Trace/GlobalUsings.cs
@@ -10,3 +10,5 @@ global using ThrowHelper = Datadog.Trace.Util.ThrowHelper;
 #if NETFRAMEWORK || NETSTANDARD2_0
 global using Datadog.Trace.VendoredMicrosoftCode.System;
 #endif
+
+global using Datadog.Trace.ExtensionMethods;

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -60,7 +60,7 @@ internal static partial class IastModule
     private static readonly Func<TaintedObject, bool> Always = (x) => true;
     private static readonly DbRecordManager DbRecords = new DbRecordManager(IastSettings);
     private static bool _showTimeoutExceptionError = true;
-    private static SourceType[] _dbSources = [SourceType.SqlRowValue];
+    private static readonly SourceType[] _dbSources = [SourceType.SqlRowValue];
 
     internal static void LogTimeoutError(RegexMatchTimeoutException err)
     {

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -60,6 +60,7 @@ internal static partial class IastModule
     private static readonly Func<TaintedObject, bool> Always = (x) => true;
     private static readonly DbRecordManager DbRecords = new DbRecordManager(IastSettings);
     private static bool _showTimeoutExceptionError = true;
+    private static SourceType[] _dbSources = [SourceType.SqlRowValue];
 
     internal static void LogTimeoutError(RegexMatchTimeoutException err)
     {
@@ -72,29 +73,6 @@ internal static partial class IastModule
         {
             Log.Debug(err, "IAST Regex timed out when trying to match value against pattern {Pattern}.", err.Pattern);
         }
-    }
-
-    internal static bool NoDbSource(TaintedObject tainted)
-    {
-        // Reject any vuln with all ranges coming from a db source
-        try
-        {
-            foreach (var range in tainted.Ranges)
-            {
-                if (range.Source?.Origin != SourceType.SqlRowValue)
-                {
-                    return true;
-                }
-           }
-
-            return false;
-        }
-        catch (Exception err)
-        {
-            Log.Error(err, "Error while checking for non Database tainted origins.");
-        }
-
-        return true;
     }
 
     internal static string? OnUnvalidatedRedirect(string? evidence)
@@ -176,7 +154,7 @@ internal static partial class IastModule
             }
 
             OnExecutedSinkTelemetry(IastInstrumentedSinks.TrustBoundaryViolation);
-            return GetScope(name, IntegrationId.TrustBoundaryViolation, VulnerabilityTypeName.TrustBoundaryViolation, OperationNameTrustBoundaryViolation, NoDbSource);
+            return GetScope(name, IntegrationId.TrustBoundaryViolation, VulnerabilityTypeName.TrustBoundaryViolation, OperationNameTrustBoundaryViolation, taintValidator: Always, safeSources: _dbSources);
         }
         catch (Exception ex)
         {
@@ -195,7 +173,7 @@ internal static partial class IastModule
             }
 
             OnExecutedSinkTelemetry(IastInstrumentedSinks.LdapInjection);
-            return GetScope(evidence, IntegrationId.Ldap, VulnerabilityTypeName.LdapInjection, OperationNameLdapInjection, NoDbSource);
+            return GetScope(evidence, IntegrationId.Ldap, VulnerabilityTypeName.LdapInjection, OperationNameLdapInjection, taintValidator: Always, safeSources: _dbSources);
         }
         catch (Exception ex)
         {
@@ -214,7 +192,7 @@ internal static partial class IastModule
         try
         {
             OnExecutedSinkTelemetry(IastInstrumentedSinks.Ssrf);
-            return GetScope(evidence, IntegrationId.Ssrf, VulnerabilityTypeName.Ssrf, OperationNameSsrf, NoDbSource, exclusionSecureMarks: SecureMarks.Ssrf);
+            return GetScope(evidence, IntegrationId.Ssrf, VulnerabilityTypeName.Ssrf, OperationNameSsrf, taintValidator: Always, safeSources: _dbSources, exclusionSecureMarks: SecureMarks.Ssrf);
         }
         catch (Exception ex)
         {
@@ -252,7 +230,7 @@ internal static partial class IastModule
         try
         {
             OnExecutedSinkTelemetry(IastInstrumentedSinks.PathTraversal);
-            return GetScope(evidence, IntegrationId.PathTraversal, VulnerabilityTypeName.PathTraversal, OperationNamePathTraversal, NoDbSource);
+            return GetScope(evidence, IntegrationId.PathTraversal, VulnerabilityTypeName.PathTraversal, OperationNamePathTraversal, taintValidator: Always, safeSources: _dbSources);
         }
         catch (Exception ex)
         {
@@ -310,7 +288,7 @@ internal static partial class IastModule
         {
             OnExecutedSinkTelemetry(IastInstrumentedSinks.CommandInjection);
             var evidence = BuildCommandInjectionEvidence(file, argumentLine, argumentList);
-            return string.IsNullOrEmpty(evidence) ? IastModuleResponse.Empty : GetScope(evidence, integrationId, VulnerabilityTypeName.CommandInjection, OperationNameCommandInjection, NoDbSource);
+            return string.IsNullOrEmpty(evidence) ? IastModuleResponse.Empty : GetScope(evidence, integrationId, VulnerabilityTypeName.CommandInjection, OperationNameCommandInjection, taintValidator: Always, safeSources: _dbSources);
         }
         catch (Exception ex)
         {
@@ -324,7 +302,7 @@ internal static partial class IastModule
         try
         {
             OnExecutedSinkTelemetry(IastInstrumentedSinks.ReflectionInjection);
-            return GetScope(param, integrationId, VulnerabilityTypeName.ReflectionInjection, OperationNameReflectionInjection, NoDbSource);
+            return GetScope(param, integrationId, VulnerabilityTypeName.ReflectionInjection, OperationNameReflectionInjection, taintValidator: Always, safeSources: _dbSources);
         }
         catch (Exception ex)
         {
@@ -616,7 +594,17 @@ internal static partial class IastModule
         return isRequest && traceContext?.IastRequestContext?.AddVulnerabilitiesAllowed() == true;
     }
 
-    private static IastModuleResponse GetScope(string evidenceValue, IntegrationId integrationId, string vulnerabilityType, string operationName, Func<TaintedObject, bool>? taintValidator = null, bool addLocation = true, int? hash = null, StackTrace? externalStack = null, SecureMarks exclusionSecureMarks = SecureMarks.None)
+    private static IastModuleResponse GetScope(
+        string evidenceValue,
+        IntegrationId integrationId,
+        string vulnerabilityType,
+        string operationName,
+        Func<TaintedObject, bool>? taintValidator = null,
+        bool addLocation = true,
+        int? hash = null,
+        StackTrace? externalStack = null,
+        SecureMarks exclusionSecureMarks = SecureMarks.None,
+        SourceType[]? safeSources = null)
     {
         var tracer = Tracer.Instance;
         if (!IastSettings.Enabled || !tracer.Settings.IsIntegrationEnabled(integrationId))
@@ -653,10 +641,17 @@ internal static partial class IastModule
             }
         }
 
-        // Contains at least one range that is not safe (when analyzing a vulnerability that can have secure marks)
-        if (exclusionSecureMarks != SecureMarks.None && !Ranges.ContainsUnsafeRange(tainted?.Ranges))
+        var ranges = tainted?.Ranges;
+        if (ranges is not null)
         {
-            return IastModuleResponse.Empty;
+            var unsafeRanges = Ranges.GetUnsafeRanges(ranges, exclusionSecureMarks, safeSources);
+            if (unsafeRanges is null || unsafeRanges.Length == 0)
+            {
+                return IastModuleResponse.Empty;
+            }
+
+            // Contains at least one range that is not safe (when analyzing a vulnerability that can have secure marks)
+            ranges = unsafeRanges;
         }
 
         var location = addLocation ? GetLocation(externalStack, currentSpan) : null;
@@ -665,10 +660,9 @@ internal static partial class IastModule
             return IastModuleResponse.Empty;
         }
 
-        var unsafeRanges = Ranges.UnsafeRanges(tainted?.Ranges, exclusionSecureMarks);
         var vulnerability = (hash is null) ?
-            new Vulnerability(vulnerabilityType, location, new Evidence(evidenceValue, unsafeRanges), integrationId) :
-            new Vulnerability(vulnerabilityType, (int)hash, location, new Evidence(evidenceValue, unsafeRanges), integrationId);
+            new Vulnerability(vulnerabilityType, location, new Evidence(evidenceValue, ranges), integrationId) :
+            new Vulnerability(vulnerabilityType, (int)hash, location, new Evidence(evidenceValue, ranges), integrationId);
 
         if (!IastSettings.DeduplicationEnabled || HashBasedDeduplication.Instance.Add(vulnerability))
         {
@@ -801,7 +795,7 @@ internal static partial class IastModule
 
         var evidence = StringAspects.Concat(headerName, HeaderInjectionEvidenceSeparator, headerValue);
         var hash = ("HEADER_INJECTION:" + headerName).GetStaticHashCode();
-        GetScope(evidence, integrationId, VulnerabilityTypeName.HeaderInjection, OperationNameHeaderInjection, NoDbSource, false, hash);
+        GetScope(evidence, integrationId, VulnerabilityTypeName.HeaderInjection, OperationNameHeaderInjection, taintValidator: Always, safeSources: _dbSources, addLocation: false, hash: hash);
     }
 
     internal static IastModuleResponse OnXpathInjection(string xpath)
@@ -814,7 +808,7 @@ internal static partial class IastModule
         try
         {
             OnExecutedSinkTelemetry(IastInstrumentedSinks.XPathInjection);
-            return GetScope(xpath, IntegrationId.XpathInjection, VulnerabilityTypeName.XPathInjection, OperationNameXPathInjection, NoDbSource);
+            return GetScope(xpath, IntegrationId.XpathInjection, VulnerabilityTypeName.XPathInjection, OperationNameXPathInjection, taintValidator: Always, safeSources: _dbSources);
         }
         catch (Exception ex)
         {
@@ -844,8 +838,8 @@ internal static partial class IastModule
             return;
         }
 
-        // We use the same secure marks as XSS
-        GetScope(messageDuck.Body, IntegrationId.EmailHtmlInjection, VulnerabilityTypeName.EmailHtmlInjection, OperationNameEmailHtmlInjection, taintValidator: NoDbSource, exclusionSecureMarks: SecureMarks.Xss);
+        // We use the same secure marks as XSS, but excluding db sources
+        GetScope(messageDuck.Body, IntegrationId.EmailHtmlInjection, VulnerabilityTypeName.EmailHtmlInjection, OperationNameEmailHtmlInjection, taintValidator: Always, safeSources: _dbSources, exclusionSecureMarks: SecureMarks.Xss);
     }
 
     internal static void RegisterDbRecord(object instance)

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -59,8 +59,8 @@ internal static partial class IastModule
     private static readonly Lazy<EvidenceRedactor?> EvidenceRedactorLazy = new Lazy<EvidenceRedactor?>(() => CreateRedactor(IastSettings));
     private static readonly Func<TaintedObject, bool> Always = (x) => true;
     private static readonly DbRecordManager DbRecords = new DbRecordManager(IastSettings);
-    private static bool _showTimeoutExceptionError = true;
     private static readonly SourceType[] _dbSources = [SourceType.SqlRowValue];
+    private static bool _showTimeoutExceptionError = true;
 
     internal static void LogTimeoutError(RegexMatchTimeoutException err)
     {

--- a/tracer/src/Datadog.Trace/Iast/Range.cs
+++ b/tracer/src/Datadog.Trace/Iast/Range.cs
@@ -8,7 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Datadog.Trace.Iast;
 
@@ -57,11 +57,19 @@ internal readonly struct Range : IComparable<Range>
         return this.Start.CompareTo(other.Start);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool IsSecure(SecureMarks marks, SourceType[]? safeSources)
+    {
+        return IsMarked(marks) || IsSafeSource(safeSources);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsMarked(SecureMarks marks)
     {
         return (SecureMarks & marks) != NotMarked;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsSafeSource(SourceType[]? safeSources)
     {
         if (safeSources is null || Source is null)
@@ -69,15 +77,7 @@ internal readonly struct Range : IComparable<Range>
             return false;
         }
 
-        foreach (var source in safeSources)
-        {
-            if (Source.Origin == source)
-            {
-                return true;
-            }
-        }
-
-        return false
+        return safeSources.Contains(Source.Origin);
     }
 
     internal bool IsBefore(Range? range)

--- a/tracer/src/Datadog.Trace/Iast/Range.cs
+++ b/tracer/src/Datadog.Trace/Iast/Range.cs
@@ -69,7 +69,15 @@ internal readonly struct Range : IComparable<Range>
             return false;
         }
 
-        return safeSources.Contains(Source.Origin);
+        foreach (var source in safeSources)
+        {
+            if (Source.Origin == source)
+            {
+                return true;
+            }
+        }
+
+        return false
     }
 
     internal bool IsBefore(Range? range)

--- a/tracer/src/Datadog.Trace/Iast/Range.cs
+++ b/tracer/src/Datadog.Trace/Iast/Range.cs
@@ -8,6 +8,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 namespace Datadog.Trace.Iast;
 
@@ -59,6 +60,16 @@ internal readonly struct Range : IComparable<Range>
     public bool IsMarked(SecureMarks marks)
     {
         return (SecureMarks & marks) != NotMarked;
+    }
+
+    public bool IsSafeSource(SourceType[]? safeSources)
+    {
+        if (safeSources is null || Source is null)
+        {
+            return false;
+        }
+
+        return safeSources.Contains(Source.Origin);
     }
 
     internal bool IsBefore(Range? range)

--- a/tracer/src/Datadog.Trace/Iast/Ranges.cs
+++ b/tracer/src/Datadog.Trace/Iast/Ranges.cs
@@ -214,54 +214,35 @@ internal static class Ranges
             return ranges;
         }
 
-        bool existsSecureRanges = false;
+        int insecureCount = 0;
         for (int x = 0; x < ranges.Length; x++)
         {
             var range = ranges[x];
-            if (range.IsMarked(safeMarks) || range.IsSafeSource(safeSources))
+            if (!range.IsSecure(safeMarks, safeSources))
             {
-                existsSecureRanges = true;
-                break;
+                insecureCount++;
             }
         }
 
-        if (!existsSecureRanges)
+        if (insecureCount == ranges.Length)
         {
-            // This is made in order to avoid unnecesary allocations (most common situation)
+            // This is made in order to avoid unnecessary allocations (most common situation)
             return ranges;
         }
 
-        List<Range> insecureRanges = new List<Range>(ranges.Length);
+        Range[] insecureRanges = new Range[insecureCount];
+        int i = 0;
         for (int x = 0; x < ranges.Length; x++)
         {
             var range = ranges[x];
-            if (range.IsMarked(safeMarks) || range.IsSafeSource(safeSources))
+            if (!range.IsSecure(safeMarks, safeSources))
             {
-                continue;
-            }
-
-            insecureRanges.Add(range);
-        }
-
-        return insecureRanges.ToArray();
-    }
-
-    internal static bool ContainsUnsafeRange(IEnumerable<Range>? ranges)
-    {
-        if (ranges is null)
-        {
-            return false;
-        }
-
-        foreach (var range in ranges)
-        {
-            if (range.SecureMarks == SecureMarks.None)
-            {
-                return true;
+                insecureRanges[i] = range;
+                i++;
             }
         }
 
-        return false;
+        return insecureRanges;
     }
 
     /// <summary>

--- a/tracer/src/Datadog.Trace/Iast/Ranges.cs
+++ b/tracer/src/Datadog.Trace/Iast/Ranges.cs
@@ -207,7 +207,7 @@ internal static class Ranges
         return newRanges.ToArray();
     }
 
-    internal static Range[]? GetUnsafeRanges(Range[] ranges, SecureMarks safeMarks, SourceType[]? safeSources)
+    internal static Range[] GetUnsafeRanges(Range[] ranges, SecureMarks safeMarks, SourceType[]? safeSources)
     {
         if (safeMarks == SecureMarks.None && safeSources is null)
         {
@@ -228,6 +228,10 @@ internal static class Ranges
         {
             // This is made in order to avoid unnecessary allocations (most common situation)
             return ranges;
+        }
+        else if (insecureCount == 0)
+        {
+            return [];
         }
 
         Range[] insecureRanges = new Range[insecureCount];

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/IAST/Tainted/VulnerabilityMarksTests.cs
@@ -3,7 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
 
+using System.Linq;
 using Datadog.Trace.Iast;
+using FluentAssertions;
 using Xunit;
 
 namespace Datadog.Trace.Security.Unit.Tests.IAST.Tainted;
@@ -31,6 +33,55 @@ public class VulnerabilityMarksTests
         foreach (var range in newRanges)
         {
             Assert.Equal(SecureMarks.Xss, range.SecureMarks);
+        }
+    }
+
+    [Theory]
+    [InlineData((byte)SecureMarks.None, null, 14)]
+    [InlineData((byte)SecureMarks.Ssrf, null, 7)]
+    [InlineData((byte)SecureMarks.Xss, null, 8)]
+    [InlineData((byte)SecureMarks.Xss | (byte)SecureMarks.Ssrf, null, 5)]
+    [InlineData((byte)SecureMarks.None, new byte[] { (byte)SourceType.SqlRowValue }, 11)]
+    [InlineData((byte)SecureMarks.None, new byte[] { (byte)SourceType.RequestBody }, 11)]
+    [InlineData((byte)SecureMarks.None, new byte[] { (byte)SourceType.SqlRowValue, (byte)SourceType.RequestBody }, 8)]
+    [InlineData((byte)SecureMarks.Xss, new byte[] { (byte)SourceType.SqlRowValue }, 6)]
+    public void GivenRanges_WhenFiltered_SecureRangesAreRemoved(byte secureMarks, byte[] secureOrigins, int expectedRangeCount)
+    {
+        var marks = (SecureMarks)secureMarks;
+        var origins = secureOrigins?.Select(o => (SourceType)o).ToArray();
+
+        Source request = new Source(SourceType.RequestQuery, "request", null);
+        Source sqlRow = new Source(SourceType.SqlRowValue, "sql", null);
+        Source body = new Source(SourceType.RequestBody, "body", null);
+        Range[] ranges =
+        [
+            new Range(2, 4),
+            new Range(12, 2, request),
+            new Range(14, 2, request, SecureMarks.Xss),
+            new Range(16, 2, request, SecureMarks.Xss | SecureMarks.Ssrf),
+            new Range(18, 2, sqlRow),
+            new Range(20, 2, sqlRow, SecureMarks.Ssrf),
+            new Range(22, 2, sqlRow, SecureMarks.Xss | SecureMarks.Ssrf),
+            new Range(24, 2, body),
+            new Range(26, 2, body, SecureMarks.Ssrf),
+            new Range(28, 2, body, SecureMarks.Xss | SecureMarks.Ssrf),
+            new Range(30, 1),
+            new Range(32, 2, null, SecureMarks.Ssrf),
+            new Range(34, 2, null, SecureMarks.Xss),
+            new Range(36, 2, null, SecureMarks.Xss | SecureMarks.Ssrf)
+        ];
+
+        var newRanges = Ranges.GetUnsafeRanges(ranges, marks, origins);
+        newRanges.Should().NotBeNull();
+        newRanges.Length.Should().Be(expectedRangeCount);
+
+        foreach (var range in newRanges)
+        {
+            (range.SecureMarks & marks).Should().Be(SecureMarks.None);
+            if (range.Source is not null && secureOrigins is not null)
+            {
+                origins.Contains(range.Source.Origin).Should().BeFalse();
+            }
         }
     }
 }

--- a/tracer/test/snapshots/Iast.DatabaseSourceInjection.AspNetCore5.Mixed.verified.txt
+++ b/tracer/test/snapshots/Iast.DatabaseSourceInjection.AspNetCore5.Mixed.verified.txt
@@ -42,11 +42,7 @@
             "source": 0
           },
           {
-            "value": "<script language='javascript' type='text/javascript'>alert('Stored XSS attack');</script>",
-            "source": 1
-          },
-          {
-            "value": ":443/api/v1/test/123/?param1=pone&param2=ptwo#fragment1=fone&fragment2=ftwo"
+            "value": "<script language='javascript' type='text/javascript'>alert('Stored XSS attack');</script>:443/api/v1/test/123/?param1=pone&param2=ptwo#fragment1=fone&fragment2=ftwo"
           }
         ]
       }
@@ -57,11 +53,6 @@
       "origin": "http.request.parameter",
       "name": "host",
       "value": "localhost"
-    },
-    {
-      "origin": "sql.row.value",
-      "name": "Details",
-      "value": "<script language='javascript' type='text/javascript'>alert('Stored XSS attack');</script>"
     }
   ]
 }


### PR DESCRIPTION
## Summary of changes
Remove ranges from safe origins from vulnerability evidence

## Reason for change
Until now, only ranges marked with a secure mark were removed from evidence, but ranges from safe sources (like database values in non XSS or SQLi injections) were being sent.

SecureMarks are marks added to a range that indicates that it has been sanitized (and thus, secured) for that vulnerability.
In the same manner, there some origins that do not apply to certain vulnerabilities, like database values not applying in injection but XSS and SQLi. So in these cases, those ranges should be removed from the evidence.

## Implementation details
Filter ranges by source as well as by secure marks

## Test coverage
Unit and integration tests

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
