### PR TITLE
[Dynamic Instrumentation] DEBUG-2256 Do not create ProbeProcessor when LiveDebugger isn't fully initialized

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeExpressionsProcessor.cs
@@ -38,6 +38,12 @@ namespace Datadog.Trace.Debugger.Expressions
 
         internal void AddProbeProcessor(ProbeDefinition probe)
         {
+            if (LiveDebugger.Instance?.IsInitialized == false)
+            {
+                Log.Error("Failed to create probe processor for probe: {Id}", probe.Id);
+                throw new Exception("AddProbeProcessor can be called only when LiveDebugger is initialized");
+            }
+
             try
             {
                 _processors.AddOrUpdate(

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -47,7 +47,6 @@ namespace Datadog.Trace.Debugger
         private readonly ConfigurationUpdater _configurationUpdater;
         private readonly IDogStatsd _dogStats;
         private readonly object _instanceLock = new();
-        private bool _isInitialized;
         private bool _isRcmAvailable;
 
         private LiveDebugger(
@@ -87,6 +86,8 @@ namespace Datadog.Trace.Debugger
         }
 
         public static LiveDebugger Instance { get; private set; }
+        
+        public bool IsInitialized { get; private set; }
 
         public string ServiceName { get; }
 
@@ -132,7 +133,7 @@ namespace Datadog.Trace.Debugger
                     return;
                 }
 
-                _isInitialized = true;
+                IsInitialized = true;
             }
 
             try
@@ -153,7 +154,7 @@ namespace Datadog.Trace.Debugger
 
             bool CanInitialize()
             {
-                if (_isInitialized)
+                if (IsInitialized)
                 {
                     return false;
                 }

--- a/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
+++ b/tracer/src/Datadog.Trace/Debugger/LiveDebugger.cs
@@ -86,7 +86,7 @@ namespace Datadog.Trace.Debugger
         }
 
         public static LiveDebugger Instance { get; private set; }
-        
+
         public bool IsInitialized { get; private set; }
 
         public string ServiceName { get; }


### PR DESCRIPTION
## Summary of changes
ProbeProcessor can be inialized from various places and it do a low of work. If the LiveDebugger isn't fully initialized, it useless to create it. This PR verify this.
