### PR TITLE
Remove warning about non-serializable test data

### DIFF
--- a/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMetaStructTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Agent/MessagePack/SpanMetaStructTests.cs
@@ -103,7 +103,7 @@ public class SpanMetaStructTests
             }
        };
 
-    [MemberData(nameof(Data))]
+    [MemberData(nameof(Data), DisableDiscoveryEnumeration = true)]
     [Theory]
     public static void GivenAEncodedSpanWithMetaStruct_WhenDecoding_ThenMetaStructIsCorrectlyDecoded(List<Tuple<string, object?>> dataToEncode)
     {

--- a/tracer/test/Datadog.Trace.Tests/Tagging/ActivityTagsTests.cs
+++ b/tracer/test/Datadog.Trace.Tests/Tagging/ActivityTagsTests.cs
@@ -70,7 +70,7 @@ public class ActivityTagsTests
     // TODO what about an array of object that contains string and numeric objects?
 
     [Theory]
-    [MemberData(nameof(TagData))]
+    [MemberData(nameof(TagData), DisableDiscoveryEnumeration = true)]
     public void Tags_ShouldBe_PlacedInMetricsOrMeta(string tagKey, object tagValue, TagKind expectedTagKind)
     {
         var activityMock = new Mock<IActivity5>();
@@ -97,7 +97,7 @@ public class ActivityTagsTests
     }
 
     [Theory]
-    [MemberData(nameof(ArrayTagData))]
+    [MemberData(nameof(ArrayTagData), DisableDiscoveryEnumeration = true)]
     public void ArrayedTags_ShouldBe_PlacedInMeta(string tagKey, object tagValue, TagKind expectedTagKind, Dictionary<string, object> expectedTagValues)
     {
         var activityMock = new Mock<IActivity5>();


### PR DESCRIPTION
## Summary of changes

Removes warnings about non-serializable test data

## Reason for change

Warnings about `Non-serializable data ('System.Object[]')`.

## Implementation details

Ignored them by setting `DisableDiscoveryEnumeration = true` on `MemberData`.

## Test coverage

Ran tests locally, warning gone.

## Other details

Maybe I could've changed them to have serializable test data 🤷 
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
