### PR TITLE
Guard from out of memory during probe processing

### DIFF
--- a/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Expressions/ProbeProcessor.cs
@@ -160,7 +160,7 @@ namespace Datadog.Trace.Debugger.Expressions
 
         public bool ShouldProcess(in ProbeData probeData)
         {
-            return HasCondition() || probeData.Sampler.Sample();
+            return HasCondition() || (probeData.Sampler.Sample() && GlobalMemoryCircuitBreaker.Instance.CanAllocate(1024));
         }
 
         public bool Process<TCapture>(ref CaptureInfo<TCapture> info, IDebuggerSnapshotCreator inSnapshotCreator, in ProbeData probeData)

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/IPoolable.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/IPoolable.cs
@@ -1,0 +1,14 @@
+// <copyright file="IPoolable.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+namespace Datadog.Trace.Debugger.Helpers
+{
+    internal interface IPoolable<TSetParameters>
+    {
+        void Set(TSetParameters parameters);
+
+        void Reset();
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryInfoRetriever.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/MemoryInfoRetriever.cs
@@ -1,0 +1,230 @@
+// <copyright file="MemoryInfoRetriever.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace Datadog.Trace.Debugger.Helpers
+{
+    internal static class MemoryInfoRetriever
+    {
+        private const long DEFAULT_MEMORY_THRESHOLD = 1024L * 1024 * 1024; // 1 GB
+        private const double DEFAULT_PERCENTAGE = 0.7;
+
+        public static long GetTotalPhysicalMemory()
+        {
+            if (IsRunningInContainer())
+            {
+                return GetContainerMemoryLimit();
+            }
+            else if (IsWindows())
+            {
+                return GetWindowsTotalPhysicalMemory();
+            }
+            else if (IsLinux())
+            {
+                return GetLinuxTotalPhysicalMemory();
+            }
+            else if (IsMacOS())
+            {
+                return GetMacOSTotalPhysicalMemory();
+            }
+
+            return 0; // Indicates failure to retrieve memory info
+        }
+
+        internal static long GetDynamicMemoryThreshold(double percentageOfPhysicalMemory = DEFAULT_PERCENTAGE)
+        {
+            long totalPhysicalMemory = GetTotalPhysicalMemory();
+
+            if (totalPhysicalMemory > 0)
+            {
+                return (long)(totalPhysicalMemory * percentageOfPhysicalMemory);
+            }
+            else
+            {
+                // Fallback to default values based on the environment
+                if (IsWindows())
+                {
+                    return 2L * 1024 * 1024 * 1024; // 2 GB for Windows
+                }
+                else if (IsLinux())
+                {
+                    return 1024L * 1024 * 1024; // 1 GB for Linux
+                }
+                else if (IsMacOS())
+                {
+                    return 2L * 1024 * 1024 * 1024; // 2 GB for macOS
+                }
+                else
+                {
+                    return DEFAULT_MEMORY_THRESHOLD;
+                }
+            }
+        }
+
+        private static bool IsRunningInContainer()
+        {
+            return File.Exists("/.dockerenv") || File.Exists("/run/.containerenv");
+        }
+
+        private static bool IsWindows()
+        {
+#if NETCOREAPP3_0_OR_GREATER
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+#else
+            return Environment.OSVersion.Platform == PlatformID.Win32NT;
+#endif
+        }
+
+        private static bool IsLinux()
+        {
+#if NETCOREAPP3_0_OR_GREATER
+            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+#else
+            return Environment.OSVersion.Platform == PlatformID.Unix && !IsMacOS();
+#endif
+        }
+
+        private static bool IsMacOS()
+        {
+#if NETCOREAPP3_0_OR_GREATER
+            return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+#else
+            return Environment.OSVersion.Platform == PlatformID.Unix &&
+                   Directory.Exists("/System/Library/CoreServices");
+#endif
+        }
+
+        private static long GetContainerMemoryLimit()
+        {
+            try
+            {
+                string cgroupMemLimitPath = "/sys/fs/cgroup/memory/memory.limit_in_bytes";
+                if (File.Exists(cgroupMemLimitPath))
+                {
+                    string memLimitStr = File.ReadAllText(cgroupMemLimitPath).Trim();
+                    if (long.TryParse(memLimitStr, out long memLimit))
+                    {
+                        return memLimit;
+                    }
+                }
+            }
+            catch
+            {
+                // Silently handle any exceptions
+            }
+
+            return 0; // Indicates failure to retrieve container memory limit
+        }
+
+        private static long GetWindowsTotalPhysicalMemory()
+        {
+            try
+            {
+                var memStatus = new MEMORYSTATUSEX();
+                if (GlobalMemoryStatusEx(memStatus))
+                {
+                    return (long)memStatus.ullTotalPhys;
+                }
+            }
+            catch
+            {
+                // Silently handle any exceptions
+            }
+
+            return 0;
+        }
+
+        private static long GetLinuxTotalPhysicalMemory()
+        {
+            try
+            {
+                string[] lines = File.ReadAllLines("/proc/meminfo");
+                foreach (string line in lines)
+                {
+                    if (line.StartsWith("MemTotal:"))
+                    {
+                        string[] parts = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                        if (parts.Length >= 2 && long.TryParse(parts[1], out long memKb))
+                        {
+                            return memKb * 1024; // Convert KB to bytes
+                        }
+                    }
+                }
+            }
+            catch
+            {
+                // Silently handle any exceptions
+            }
+
+            return 0;
+        }
+
+        private static long GetMacOSTotalPhysicalMemory()
+        {
+            try
+            {
+                var output = ExecuteCommand("sysctl", "-n hw.memsize");
+                if (long.TryParse(output, out long memSize))
+                {
+                    return memSize;
+                }
+            }
+            catch
+            {
+                // Silently handle any exceptions
+            }
+
+            return 0;
+        }
+
+        private static string ExecuteCommand(string command, string arguments)
+        {
+            var process = new System.Diagnostics.Process()
+            {
+                StartInfo = new System.Diagnostics.ProcessStartInfo
+                {
+                    FileName = command,
+                    Arguments = arguments,
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                }
+            };
+            process.Start();
+            string result = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+            return result.Trim();
+        }
+
+        // Windows-specific structures and methods
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        private class MEMORYSTATUSEX
+        {
+            public uint dwLength;
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+            public uint dwMemoryLoad;
+            public ulong ullTotalPhys;
+            public ulong ullAvailPhys;
+            public ulong ullTotalPageFile;
+            public ulong ullAvailPageFile;
+            public ulong ullTotalVirtual;
+            public ulong ullAvailVirtual;
+            public ulong ullAvailExtendedVirtual;
+#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
+
+            public MEMORYSTATUSEX()
+            {
+                dwLength = (uint)Marshal.SizeOf(typeof(MEMORYSTATUSEX));
+            }
+        }
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        static extern bool GlobalMemoryStatusEx([In, Out] MEMORYSTATUSEX lpBuffer);
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/Helpers/ObjectPool.cs
+++ b/tracer/src/Datadog.Trace/Debugger/Helpers/ObjectPool.cs
@@ -1,0 +1,46 @@
+// <copyright file="ObjectPool.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Concurrent;
+
+namespace Datadog.Trace.Debugger.Helpers
+{
+    internal class ObjectPool<T, TSetParameters>
+        where T : class, IPoolable<TSetParameters>, new()
+    {
+        private readonly ConcurrentBag<T> _objects;
+        private readonly Func<T> _objectFactory;
+        private readonly int _maxSize;
+
+        public ObjectPool(Func<T>? objectFactory = null, int maxSize = 100)
+        {
+            _objectFactory = objectFactory ?? (() => new T());
+            _maxSize = maxSize;
+            _objects = new ConcurrentBag<T>();
+        }
+
+        public T Get() => _objects.TryTake(out T item) ? item : _objectFactory();
+
+        public T? Get(TSetParameters parameters)
+        {
+            var item = _objects.TryTake(out var obj) ? obj : _objectFactory();
+            item?.Set(parameters);
+            return item;
+        }
+
+        public void Return(T? item)
+        {
+            item?.Reset();
+            if (item != null && _objects.Count < _maxSize)
+            {
+                _objects.Add(item);
+            }
+        }
+
+        public int Count => _objects.Count;
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/GlobalMemoryCircuitBreaker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/GlobalMemoryCircuitBreaker.cs
@@ -1,0 +1,40 @@
+// <copyright file="GlobalMemoryCircuitBreaker.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+using System;
+using Datadog.Trace.Debugger.Helpers;
+
+namespace Datadog.Trace.Debugger.RateLimiting
+{
+    internal class GlobalMemoryCircuitBreaker
+    {
+        private static readonly Lazy<GlobalMemoryCircuitBreaker> _lazyInstance =
+            new Lazy<GlobalMemoryCircuitBreaker>(() => new GlobalMemoryCircuitBreaker(
+                                                     memoryThreshold: MemoryInfoRetriever.GetDynamicMemoryThreshold(0.5), // 50% of physical memory
+                                                     cooldownPeriod: TimeSpan.FromSeconds(10),
+                                                     allocationThresholdPercentage: 0.1 // 10% default
+                                                 ));
+
+        internal static GlobalMemoryCircuitBreaker Instance => _lazyInstance.Value;
+
+        private readonly MemoryCircuitBreaker _circuitBreaker;
+
+        private GlobalMemoryCircuitBreaker(long memoryThreshold, TimeSpan cooldownPeriod, double allocationThresholdPercentage)
+        {
+            _circuitBreaker = new MemoryCircuitBreaker(memoryThreshold, cooldownPeriod, allocationThresholdPercentage);
+        }
+
+        internal bool CanAllocate(long estimatedAllocationSize = 0)
+        {
+            return _circuitBreaker.CanAllocate(estimatedAllocationSize);
+        }
+
+        internal long GetCurrentMemoryUsage() => _circuitBreaker.GetCurrentMemoryUsage();
+
+        internal long GetMemoryThreshold() => _circuitBreaker.GetMemoryThreshold();
+
+        internal double GetAvailableMemoryPercentage() => _circuitBreaker.GetAvailableMemoryPercentage();
+    }
+}

--- a/tracer/src/Datadog.Trace/Debugger/RateLimiting/MemoryCircuitBreaker.cs
+++ b/tracer/src/Datadog.Trace/Debugger/RateLimiting/MemoryCircuitBreaker.cs
@@ -1,0 +1,67 @@
+// <copyright file="MemoryCircuitBreaker.cs" company="Datadog">
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
+// </copyright>
+#nullable enable
+using System;
+using System.Threading;
+
+namespace Datadog.Trace.Debugger.RateLimiting
+{
+    internal class MemoryCircuitBreaker
+    {
+        private readonly long _memoryThreshold;
+        private readonly TimeSpan _cooldownPeriod;
+        private readonly double _allocationThresholdPercentage;
+        private long _lastTrippedTicks = 0;
+        private long _currentMemoryUsage = 0;
+
+        internal MemoryCircuitBreaker(
+            long memoryThreshold = 1024L * 1024 * 1024, // 1 GB default
+            TimeSpan? cooldownPeriod = null,
+            double allocationThresholdPercentage = 0.05) // 5% default
+        {
+            _memoryThreshold = memoryThreshold;
+            _cooldownPeriod = cooldownPeriod ?? TimeSpan.FromSeconds(10);
+            _allocationThresholdPercentage = allocationThresholdPercentage;
+        }
+
+        public bool CanAllocate(long estimatedAllocationSize = 0)
+        {
+            long currentTicks = DateTime.UtcNow.Ticks;
+            long lastTrippedTicks = Interlocked.Read(ref _lastTrippedTicks);
+
+            if ((new TimeSpan(currentTicks - lastTrippedTicks)) < _cooldownPeriod)
+            {
+                return false;
+            }
+
+            _currentMemoryUsage = GC.GetTotalMemory(false);
+
+            if (_currentMemoryUsage > _memoryThreshold)
+            {
+                Interlocked.Exchange(ref _lastTrippedTicks, currentTicks);
+                return false;
+            }
+
+            if (estimatedAllocationSize > 0)
+            {
+                long availableMemory = _memoryThreshold - _currentMemoryUsage;
+                if (estimatedAllocationSize > availableMemory * _allocationThresholdPercentage)
+                {
+                    Interlocked.Exchange(ref _lastTrippedTicks, currentTicks);
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal long GetCurrentMemoryUsage() => _currentMemoryUsage;
+
+        internal long GetMemoryThreshold() => _memoryThreshold;
+
+        internal double GetAvailableMemoryPercentage() =>
+            (double)(_memoryThreshold - _currentMemoryUsage) / _memoryThreshold * 100;
+    }
+}


### PR DESCRIPTION
## Summary of changes
There are cases that we reach out of memory during snapshot creation and we want to avoid it

## Implementation details
We are using object pool and circuit memory breaker


