### PR TITLE
[Crashtracking] Add registry key to installer

### DIFF
--- a/shared/src/msi-installer/Product.wxs
+++ b/shared/src/msi-installer/Product.wxs
@@ -129,9 +129,9 @@
         <RegistryKey Root="HKLM" Key="Software\$(var.Company)\$(var.ProductName)">
           <RegistryValue Type="string" Name="InstallPath" Value="[INSTALLFOLDER]" Action="write"/>
         </RegistryKey>
-          <RegistryKey Root="HKLM" Key="Software\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules">
-              <RegistryValue Type="integer" Name="[INSTALLFOLDER.win_x64]Datadog.Trace.ClrProfiler.Native.dll" Value="1" Action="write"/>
-          </RegistryKey>
+        <RegistryKey Root="HKLM" Key="Software\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules">
+          <RegistryValue Type="integer" Name="[INSTALLFOLDER.win_x64]Datadog.Trace.ClrProfiler.Native.dll" Value="1" Action="write"/>
+        </RegistryKey>
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/shared/src/msi-installer/Product.wxs
+++ b/shared/src/msi-installer/Product.wxs
@@ -129,6 +129,9 @@
         <RegistryKey Root="HKLM" Key="Software\$(var.Company)\$(var.ProductName)">
           <RegistryValue Type="string" Name="InstallPath" Value="[INSTALLFOLDER]" Action="write"/>
         </RegistryKey>
+          <RegistryKey Root="HKLM" Key="Software\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules">
+              <RegistryValue Type="integer" Name="[INSTALLFOLDER.win_x64]Datadog.Trace.ClrProfiler.Native.dll" Value="1" Action="write"/>
+          </RegistryKey>
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
## Summary of changes

Register `Datadog.Trace.ClrProfiler.Native.dll` in the `HKLM\Software\Microsoft\Windows\Windows Error Reporting\RuntimeExceptionHelperModules` key.

## Reason for change

This is needed by crashtracking.
If the value is absent, the tracer will create it in HKCU (the instrumented application is unlikely to have permission to write to HKLM). However, registering the crash handler in HKCU is only supported in somewhat versions of Windows (since Windows 10 2004). So we should rely on HKLM whenever possible.

## Other details

Depends on https://github.com/DataDog/dd-trace-dotnet/pull/6088
