### PR TITLE
[Crashtracking] Remove exception types that are too broad

### DIFF
--- a/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
+++ b/tracer/src/Datadog.Trace.Tools.dd_dotnet/CreatedumpCommand.cs
@@ -517,8 +517,6 @@ internal class CreatedumpCommand : Command
             var suspiciousExceptionTypes = new[]
             {
                 "System.InvalidProgramException",
-                "System.Security.VerificationException",
-                "System.MissingMethodException",
                 "System.MissingFieldException",
                 "System.MissingMemberException",
                 "System.BadImageFormatException",


### PR DESCRIPTION
## Summary of changes

Remove `System.MissingMethodException` and `System.Security.VerificationException` from the suspicious exception types.

## Reason for change

They're too broad and are going to cause false-negatives. A crash report will still be generated if one of those exceptions cause a crash *and* we're in the callstack.
