### PR TITLE
[CI Visibility] Fix code coverage enabled tag behavior

### DIFF
--- a/tracer/src/Datadog.Trace/Ci/TestSession.cs
+++ b/tracer/src/Datadog.Trace/Ci/TestSession.cs
@@ -533,7 +533,6 @@ public sealed class TestSession
             CIVisibility.Log.Information("TestSession.ReceiveMessage (code coverage): {Value}", codeCoverageMessage.Value);
 
             // Adds the global code coverage percentage to the session
-            SetTag(CodeCoverageTags.Enabled, "true");
             SetTag(CodeCoverageTags.PercentageOfTotalLines, codeCoverageMessage.Value);
         }
     }

--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Testing/DotnetTest/DotnetCommon.cs
@@ -155,7 +155,6 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Testing.DotnetTest
                     {
                         if (TryGetCoveragePercentageFromXml(extCodeCoverageFilePath, out var coveragePercentage))
                         {
-                            session.SetTag(CodeCoverageTags.Enabled, "true");
                             session.SetTag(CodeCoverageTags.PercentageOfTotalLines, coveragePercentage);
                         }
                         else

--- a/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
+++ b/tracer/test/Datadog.Trace.Tools.Runner.IntegrationTests/CiRunCommandTests.cs
@@ -118,7 +118,7 @@ namespace Datadog.Trace.Tools.Runner.IntegrationTests
             environmentVariables.Should().NotBeNull();
 
             testSession.Should().NotBeNull();
-            testSession.Meta.Should().Contain(new KeyValuePair<string, string>(CodeCoverageTags.Enabled, "true"));
+            testSession.Meta.Should().NotContain(new KeyValuePair<string, string>(CodeCoverageTags.Enabled, "true"));
             testSession.Metrics.Should().Contain(new KeyValuePair<string, double>(CodeCoverageTags.PercentageOfTotalLines, 83.33));
         }
     }


### PR DESCRIPTION
## Summary of changes

This PR fixes the current behavior of the `test.code_coverage.enabled` tag to only set it to true when Intelligent Test Runner is enabled and collecting coverage data per test

## Reason for change

.NET implementation was setting this value also on global code coverage reporting, being different to other tracers implementations

## Implementation details

Remove the set tag when reporting the global code coverage from third party libraries.

## Test coverage

Updated the code coverage reporting test to check we don't set the tag anymore.

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
