### PR TITLE
[IAST] Avoid lock in method ctor.

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -98,16 +98,20 @@ namespace iast
             CSGuard lock(&_module->_cs);
             if (_fullName.size() == 0)
             {
-                auto fullName = GetTypeName() + WStr("::") + _name;
-                auto signature = GetSignature();
-                if (signature != nullptr)
-                {
-                    fullName = signature->CharacterizeMember(fullName);
-                }
-                _fullName = fullName;
+                _fullName = BuildFullName();
             }
         }
         return _fullName;
+    }
+    WSTRING MemberRefInfo::BuildFullName()
+    {
+        auto fullName = GetTypeName() + WStr("::") + _name;
+        auto signature = GetSignature();
+        if (signature != nullptr)
+        {
+            fullName = signature->CharacterizeMember(fullName);
+        }
+        return fullName;
     }
     WSTRING MemberRefInfo::GetFullNameWithReturnType()
     {
@@ -232,8 +236,9 @@ namespace iast
             _name = methodName;
         }
         _allowRestoreOnSecondJit = GetRestoreOnSecondJitConfigValue();
+        _fullName = BuildFullName(); // Avoid the lock in the constructor
 
-        _isExcluded = _module->_dataflow->IsMethodExcluded(GetFullName());
+        _isExcluded = _module->_dataflow->IsMethodExcluded(_fullName);
         if (!_isExcluded && _module->_dataflow->HasMethodAttributeExclusions())
         {
             for (auto methodAttribute : GetCustomAttributes())

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.h
@@ -48,6 +48,7 @@ namespace iast
         PCCOR_SIGNATURE _pSig = nullptr;
         ULONG _nSig = 0;
 
+        WSTRING BuildFullName();
     public:
         mdMemberRef GetMemberId();
 


### PR DESCRIPTION
## Summary of changes
Avoid a unneeded lock in the `MethodInfo` constructor when calculating full name

## Reason for change
All methods need to calculate their full name in order to determine if they are excluded from dataflow. FullName calculation is lazy, and thus, protected by a mutex. This was moved to the constructor in a previous refactor, but the mutext kept bein taken, and there's no need for that

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
