### PR TITLE
[ASM] Segregate asm and iast contexts functionality

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -129,7 +129,7 @@ internal readonly partial struct SecurityCoordinator
             var traceContext = _localRootSpan.Context.TraceContext;
             if (result.Data != null)
             {
-                traceContext.AddWafSecurityEvents(result.Data);
+                traceContext.AppSecRequestContext.AddWafSecurityEvents(result.Data);
             }
 
             AttackerFingerprintHelper.AddSpanTags(_localRootSpan);
@@ -194,7 +194,7 @@ internal readonly partial struct SecurityCoordinator
         // We report always, even if there is no match
         if (result.AggregatedTotalRuntimeRasp > 0)
         {
-            localRootSpan.Context.TraceContext.AddRaspSpanMetrics(result.AggregatedTotalRuntimeRasp, result.AggregatedTotalRuntimeWithBindingsRasp, result.Timeout);
+            localRootSpan.Context.TraceContext.AppSecRequestContext.AddRaspSpanMetrics(result.AggregatedTotalRuntimeRasp, result.AggregatedTotalRuntimeWithBindingsRasp, result.Timeout);
         }
     }
 

--- a/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rasp/RaspModule.cs
@@ -177,7 +177,7 @@ internal static class RaspModule
 
         if (stack is not null)
         {
-            rootSpan.Context.TraceContext.AddRaspStackTraceElement(stack, Security.Instance.Settings.MaxStackTraces);
+            rootSpan.Context.TraceContext.AppSecRequestContext.AddRaspStackTrace(stack, Security.Instance.Settings.MaxStackTraces);
         }
     }
 

--- a/tracer/src/Datadog.Trace/Iast/IastModule.cs
+++ b/tracer/src/Datadog.Trace/Iast/IastModule.cs
@@ -702,7 +702,7 @@ internal static partial class IastModule
             }
             else
             {
-                stackId = currentSpan.Context.TraceContext.GetNextVulnerabilityStackTraceId();
+                stackId = currentSpan.Context.TraceContext.IastRequestContext?.GetNextVulnerabilityStackId();
             }
         }
 

--- a/tracer/src/Datadog.Trace/Iast/Location.cs
+++ b/tracer/src/Datadog.Trace/Iast/Location.cs
@@ -83,7 +83,7 @@ internal readonly struct Location
 #pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
             if (stack is not null)
             {
-                span.Context.TraceContext?.AddVulnerabilityStackTraceElement(stack, Security.Instance.Settings.MaxStackTraces);
+                span.Context.TraceContext?.AppSecRequestContext.AddVulnerabilityStackTrace(stack, Security.Instance.Settings.MaxStackTraces);
             }
         }
     }

--- a/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
+++ b/tracer/src/Datadog.Trace/Propagators/DatadogContextPropagator.cs
@@ -33,7 +33,7 @@ namespace Datadog.Trace.Propagators
 
             if (!string.IsNullOrEmpty(context.Origin))
             {
-                carrierSetter.Set(carrier, HttpHeaderNames.Origin, context.Origin);
+                carrierSetter.Set(carrier, HttpHeaderNames.Origin, context.Origin!);
             }
 
             if (context.GetOrMakeSamplingDecision() is { } samplingPriority)


### PR DESCRIPTION
## Summary of changes
As suggested in [this PR comment](https://github.com/DataDog/dd-trace-dotnet/pull/5997#discussion_r1759159497) by @andrewlock , it is better to remove ASM and IAST specific functionality from the `TraceContext `to theis respective contexts.

## Reason for change
Code cleanup

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
