### PR TITLE
[ASM] Fix one flakiness in rcm asm data integration tests and simplify some asm rcm code

### DIFF
--- a/tracer/missing-nullability-files.csv
+++ b/tracer/missing-nullability-files.csv
@@ -270,7 +270,6 @@ src/Datadog.Trace/Agent/Transports/MimeTypes.cs
 src/Datadog.Trace/Agent/Transports/SocketHandlerRequestFactory.cs
 src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Core.cs
 src/Datadog.Trace/AppSec/Concurrency/ReaderWriterLock.Framework.cs
-src/Datadog.Trace/AppSec/Waf/IWaf.cs
 src/Datadog.Trace/AppSec/Waf/WafConstants.cs
 src/Datadog.Trace/AppSec/Waf/WafReturnCode.cs
 src/Datadog.Trace/Ci/Agent/ApmAgentWriter.cs

--- a/tracer/src/Datadog.Trace/AppSec/Rcm/AsmDdProduct.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/AsmDdProduct.cs
@@ -40,18 +40,9 @@ internal class AsmDdProduct : IAsmConfigUpdater
 
     public void ProcessRemovals(ConfigurationStatus configurationStatus, List<RemoteConfigurationPath> removedConfigsForThisProduct)
     {
-        var oneRemoved = false;
         foreach (var removedConfig in removedConfigsForThisProduct)
         {
-            oneRemoved |= configurationStatus.RulesByFile.Remove(removedConfig.Path);
-        }
-
-        if (configurationStatus.RulesByFile.Count == 0)
-        {
-            configurationStatus.IncomingUpdateState.FallbackToEmbeddedRuleset();
-        }
-        else if (oneRemoved)
-        {
+            configurationStatus.RulesByFile.Remove(removedConfig.Path);
             configurationStatus.IncomingUpdateState.WafKeysToApply.Add(ConfigurationStatus.WafRulesKey);
         }
     }

--- a/tracer/src/Datadog.Trace/AppSec/Rcm/Models/AsmDd/RuleSet.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Rcm/Models/AsmDd/RuleSet.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RuleSet.cs" company="Datadog">
+// <copyright file="RuleSet.cs" company="Datadog">
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
@@ -22,13 +22,22 @@ internal class RuleSet
     [JsonProperty("processors")]
     internal JToken? Processors { get; set; }
 
+    [JsonProperty("actions")]
+    internal JToken? Actions { get; set; }
+
     [JsonProperty("scanners")]
     internal JToken? Scanners { get; set; }
 
-    public JToken? All { get; set; }
+    [JsonProperty("exclusions")]
+    internal JToken? Exclusions { get; set; }
+
+    [JsonProperty("custom_rules")]
+    internal JToken? CustomRules { get; set; }
 
     public static RuleSet From(JToken result)
     {
+        // can rules from rc contains exclusions and custom rules?
+
         var ruleset = new RuleSet
         {
             Version = result["version"]?.ToString(),
@@ -36,7 +45,9 @@ internal class RuleSet
             Rules = result["rules"],
             Processors = result["processors"],
             Scanners = result["scanners"],
-            All = result
+            Actions = result["actions"],
+            Exclusions = result["exclusions"],
+            CustomRules = result["custom_rules"]
         };
         return ruleset;
     }
@@ -49,27 +60,37 @@ internal class RuleSet
     {
         if (Rules != null)
         {
-            dictionary.Add("rules", Rules);
+            dictionary["rules"] = Rules;
         }
 
         if (Metadata != null)
         {
-            dictionary.Add("metadata", Metadata);
+            dictionary["metadata"] = Metadata;
         }
 
         if (Version != null)
         {
-            dictionary.Add("version", Version);
+            dictionary["version"] = Version;
         }
 
         if (Processors != null)
         {
-            dictionary.Add("processors", Processors);
+            dictionary["processors"] = Processors;
         }
 
         if (Scanners != null)
         {
-            dictionary.Add("scanners", Scanners);
+            dictionary["scanners"] = Scanners;
+        }
+
+        if (Exclusions is not null)
+        {
+            dictionary["exclusions"] = Exclusions;
+        }
+
+        if (CustomRules is not null)
+        {
+            dictionary["custom_rules"] = CustomRules;
         }
     }
 }

--- a/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/IWaf.cs
@@ -2,7 +2,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2 License.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2017 Datadog, Inc.
 // </copyright>
-
+#nullable enable
 using System;
 using Datadog.Trace.AppSec.Rcm;
 using Datadog.Trace.AppSec.Waf.NativeBindings;
@@ -14,11 +14,11 @@ namespace Datadog.Trace.AppSec.Waf
     {
         public string Version { get; }
 
-        public IContext CreateContext();
+        public IContext? CreateContext();
 
         internal unsafe WafReturnCode Run(IntPtr contextHandle, DdwafObjectStruct* rawPersistentData, DdwafObjectStruct* rawEphemeralData, ref DdwafResultStruct retNative, ulong timeoutMicroSeconds);
 
-        UpdateResult UpdateWafFromConfigurationStatus(ConfigurationStatus configurationStatus);
+        UpdateResult UpdateWafFromConfigurationStatus(ConfigurationStatus configurationStatus, string? staticRulesFilePath = null);
 
         public string[] GetKnownAddresses();
 

--- a/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/Initialization/WafConfigurator.cs
@@ -82,6 +82,13 @@ namespace Datadog.Trace.AppSec.Waf.Initialization
             return File.OpenRead(rulesFile);
         }
 
+        /// <summary>
+        /// Deserialize rules for the waf as Jtoken
+        /// If null is passed, will deserialize embedded rule file in the app
+        /// If a path is given but file isn't found, it won't fallback on the embedded rule file
+        /// </summary>
+        /// <param name="rulesFilePath">if null, will fallback on embedded rules file</param>
+        /// <returns>the rules, might be null if file not found</returns>
         internal static JToken? DeserializeEmbeddedOrStaticRules(string? rulesFilePath)
         {
             JToken root;

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitResult.cs
@@ -10,7 +10,6 @@ using Datadog.Trace.AppSec.Waf.NativeBindings;
 using Datadog.Trace.AppSec.WafEncoding;
 using Datadog.Trace.Logging;
 using Datadog.Trace.Vendors.Newtonsoft.Json;
-using Datadog.Trace.Vendors.Newtonsoft.Json.Linq;
 
 namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
 {
@@ -18,7 +17,7 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
     {
         private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(InitResult));
 
-        private InitResult(ushort failedToLoadRules, ushort loadedRules, string ruleFileVersion, IReadOnlyDictionary<string, object> errors, JToken? embeddedRules = null, bool unusableRuleFile = false, IntPtr? wafHandle = null, WafLibraryInvoker? wafLibraryInvoker = null, IEncoder? encoder = null, bool shouldEnableWaf = true, bool incompatibleWaf = false)
+        private InitResult(ushort failedToLoadRules, ushort loadedRules, string ruleFileVersion, IReadOnlyDictionary<string, object> errors, bool unusableRuleFile = false, IntPtr? wafHandle = null, WafLibraryInvoker? wafLibraryInvoker = null, IEncoder? encoder = null, bool shouldEnableWaf = true, bool incompatibleWaf = false)
         {
             HasErrors = errors.Count > 0;
             Errors = errors;

--- a/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitResult.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Waf/ReturnTypes.Managed/InitResult.cs
@@ -22,7 +22,6 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
         {
             HasErrors = errors.Count > 0;
             Errors = errors;
-            EmbeddedRules = embeddedRules;
             FailedToLoadRules = failedToLoadRules;
             LoadedRules = loadedRules;
             RuleFileVersion = ruleFileVersion;
@@ -54,8 +53,6 @@ namespace Datadog.Trace.AppSec.Waf.ReturnTypes.Managed
         internal ushort LoadedRules { get; }
 
         internal IReadOnlyDictionary<string, object> Errors { get; }
-
-        public JToken? EmbeddedRules { get; set; }
 
         internal string ErrorMessage { get; }
 

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
@@ -151,6 +151,14 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             request.CachedTargetFiles.Should().HaveCount(3);
             var spanAfterAsmDeactivated = await SendRequestsAsync(agent, url);
 
+            // we have to send first asm features = true, because asm_data won't be taken into account as rcm subscriptions to asm_data have been removed when turning off the waf. and then, later on, send, separately the asm data. That's the trade off of not subscribing to asm_data and asm when appsec is turned off
+            request = await agent.SetupRcmAndWait(
+                          Output,
+                          [
+                              (new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, RcmProducts.AsmFeatures, asmFeaturesFileId)]);
+            request.Should().NotBeNull();
+            request.CachedTargetFiles.Should().HaveCount(1);
+
             request = await agent.SetupRcmAndWait(
                           Output,
                           [
@@ -198,7 +206,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
 
             await agent.SetupRcmAndWait(
                 Output,
-                [(new Payload { RulesData = [new RuleData { Id = "blocked_users", Type = "data_with_expiration", Data = [new Data { Expiration = 5545453532, Value = "user3" }] }] }, RcmProducts.AsmData,  fileId)]);
+                [(new Payload { RulesData = [new RuleData { Id = "blocked_users", Type = "data_with_expiration", Data = [new Data { Expiration = 5545453532, Value = "user3" }] }] }, RcmProducts.AsmData, fileId)]);
             var spanAfterAsmData = await SendRequestsAsync(agent, url);
             var spans = new List<MockSpan>();
             spans.AddRange(spanBeforeAsmData);

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/Rcm/AspNetCore5AsmData.cs
@@ -12,8 +12,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Datadog.Trace.AppSec;
-using Datadog.Trace.AppSec.Rcm;
 using Datadog.Trace.AppSec.Rcm.Models.AsmData;
 using Datadog.Trace.AppSec.Rcm.Models.AsmFeatures;
 using Datadog.Trace.Configuration;
@@ -75,18 +73,17 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             // we want to see the ip here
             var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");
-            var settings = VerifyHelper.GetSpanVerifierSettings(scrubbers: scrubbers, parameters: new object[] { test, sanitisedUrl });
+            var settings = VerifyHelper.GetSpanVerifierSettings(scrubbers: scrubbers, parameters: [test, sanitisedUrl]);
             var spanBeforeAsmData = await SendRequestsAsync(agent, url);
 
             await agent.SetupRcmAndWait(
                 Output,
-                new[]
-                {
-                    ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = MainIp } } } } },
+                [
+                    (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 5545453532, Value = MainIp }] }] },
                      RcmProducts.AsmData, nameof(AspNetCore5AsmDataBlockingRequestIp)),
-                    (new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 1545453532, Value = MainIp } } } } },
+                    (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 1545453532, Value = MainIp }] }] },
                      RcmProducts.AsmData, nameof(AspNetCore5AsmDataBlockingRequestIp) + "2"),
-                });
+                ]);
 
             var spanAfterAsmData = await SendRequestsAsync(agent, url);
             var spans = new List<MockSpan>();
@@ -113,11 +110,11 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
             // we want to see the ip here
             var scrubbers = VerifyHelper.SpanScrubbers.Where(s => s.RegexPattern.ToString() != @"http.client_ip: (.)*(?=,)");
-            var settings = VerifyHelper.GetSpanVerifierSettings(scrubbers: scrubbers, parameters: new object[] { test, sanitisedUrl });
+            var settings = VerifyHelper.GetSpanVerifierSettings(scrubbers: scrubbers, parameters: [test, sanitisedUrl]);
             var spanBeforeAsmData = await SendRequestsAsync(agent, url);
             var asmFeaturesFileId = nameof(AspNetCore5AsmDataSecurityEnabledBlockingRequestIpOneClick);
 
-            var request = await agent.SetupRcmAndWait(Output, new[] { ((object)new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, RcmProducts.AsmFeatures, asmFeaturesFileId) });
+            var request = await agent.SetupRcmAndWait(Output, [(new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, RcmProducts.AsmFeatures, asmFeaturesFileId)]);
             request.Should().NotBeNull();
             request.CachedTargetFiles.Should().HaveCount(1);
             var spanAfterAsmActivated = await SendRequestsAsync(agent, url);
@@ -127,13 +124,12 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
 
             request = await agent.SetupRcmAndWait(
                           Output,
-                          new[]
-                          {
-                              ((object)new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, RcmProducts.AsmFeatures, asmFeaturesFileId),
-                              (new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = MainIp }, new Data { Expiration = null, Value = "123.1.1.1" } } } } }, RcmProducts.AsmData, fileId),
-                              ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 1545453532, Value = MainIp } } } } }, RcmProducts.AsmData,
+                          [
+                              (new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, RcmProducts.AsmFeatures, asmFeaturesFileId),
+                              (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 5545453532, Value = MainIp }, new Data { Expiration = null, Value = "123.1.1.1" }] }] }, RcmProducts.AsmData, fileId),
+                              (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 1545453532, Value = MainIp }] }] }, RcmProducts.AsmData,
                                fileId2)
-                          });
+                          ]);
             request.Should().NotBeNull();
             request.CachedTargetFiles.Should().HaveCount(3);
             request.CachedTargetFiles.Any(c => c.Path.Contains(fileId)).Should().BeTrue();
@@ -143,28 +139,26 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
 
             request = await agent.SetupRcmAndWait(
                           Output,
-                          new[]
-                          {
-                              ((object)new AsmFeatures { Asm = new AsmFeature { Enabled = false } }, RcmProducts.AsmFeatures,
+                          [
+                              (new AsmFeatures { Asm = new AsmFeature { Enabled = false } }, RcmProducts.AsmFeatures,
                                 asmFeaturesFileId),
-                              (new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = MainIp }, new Data { Expiration = null, Value = "123.1.1.1" } } } } },
+                              (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 5545453532, Value = MainIp }, new Data { Expiration = null, Value = "123.1.1.1" }] }] },
                                RcmProducts.AsmData, fileId),
-                              ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 1545453532, Value = MainIp } } } } },
+                              (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 1545453532, Value = MainIp }] }] },
                                RcmProducts.AsmData, fileId2)
-                          });
+                          ]);
             request.Should().NotBeNull();
             request.CachedTargetFiles.Should().HaveCount(3);
             var spanAfterAsmDeactivated = await SendRequestsAsync(agent, url);
 
             request = await agent.SetupRcmAndWait(
                           Output,
-                          new[]
-                          {
-                              ((object)new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, RcmProducts.AsmFeatures, asmFeaturesFileId), (new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = MainIp }, new Data { Expiration = null, Value = "123.1.1.1" } } } } },
-                                  RcmProducts.AsmData, fileId),
-                              ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = new[] { new Data { Expiration = 1545453532, Value = MainIp } } } } },
+                          [
+                              (new AsmFeatures { Asm = new AsmFeature { Enabled = true } }, RcmProducts.AsmFeatures, asmFeaturesFileId),
+                              (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 5545453532, Value = MainIp }, new Data { Expiration = null, Value = "123.1.1.1" }] }] }, RcmProducts.AsmData, fileId),
+                              (new Payload { RulesData = [new RuleData { Id = "blocked_ips", Type = "ip_with_expiration", Data = [new Data { Expiration = 1545453532, Value = MainIp }] }] },
                                RcmProducts.AsmData, fileId2)
-                          });
+                          ]);
             request.Should().NotBeNull();
             request.CachedTargetFiles.Should().HaveCount(3);
             var spanAfterAsmDataReactivated = await SendRequestsAsync(agent, url);
@@ -196,7 +190,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
             await TryStartApp();
             var agent = Fixture.Agent;
             var sanitisedUrl = VerifyHelper.SanitisePathsForVerify(url);
-            var settings = VerifyHelper.GetSpanVerifierSettings(parameters: new object[] { test, sanitisedUrl });
+            var settings = VerifyHelper.GetSpanVerifierSettings(parameters: [test, sanitisedUrl]);
             var spanBeforeAsmData = await SendRequestsAsync(agent, url);
 
             // make sure this is unique if it s going to be run parallel
@@ -204,7 +198,7 @@ namespace Datadog.Trace.Security.IntegrationTests.Rcm
 
             await agent.SetupRcmAndWait(
                 Output,
-                new[] { ((object)new Payload { RulesData = new[] { new RuleData { Id = "blocked_users", Type = "data_with_expiration", Data = new[] { new Data { Expiration = 5545453532, Value = "user3" } } } } }, RcmProducts.AsmData, acknowledgedId: fileId) });
+                [(new Payload { RulesData = [new RuleData { Id = "blocked_users", Type = "data_with_expiration", Data = [new Data { Expiration = 5545453532, Value = "user3" }] }] }, RcmProducts.AsmData,  fileId)]);
             var spanAfterAsmData = await SendRequestsAsync(agent, url);
             var spans = new List<MockSpan>();
             spans.AddRange(spanBeforeAsmData);


### PR DESCRIPTION
## Summary of changes

Problem was: we send asm features.asm.enabled=true at the same time as we sent some asm_data. But, we need to rememeber that when asm is off, there is NO asm_data, asm products rc subscriptions. So we're not expecting these products hence a common warning in the logs like:
> Received config RemoteConfigurationPath { Path = datadog/2/ASM_DATA/AspNetCore5AsmDataSecurityEnabledBlockingRequestIpOneClick8f9d4f72-ea07-478c-ae2f-4cf25117a1e7/config

It was flaky and still working because as soon as asm_features.asm.enabled = true is applied, we apply other configurations that continue to be sent right after (as the mock agent is  setup with these files and will give the same response if unchanged). So most of the time, the 2 rc sets would be applied quickly and the request sent right after would show a security event. 

But, we weren't waiting for the right state, as we were waiting for only one rc response (with asm_features _and_ asm_data together) and we know they can't be applied at the same time (as the asm_data subscription is removed). It's applied right after. That's why, most of the time, it worked. But it shouldn't really work as we should have been waiting for another round of rc polling. So now, we separate both requests.

So conclusion: beware of what subtle flake can turning on/off subscriptions cause. 
We still want to keep behaving the same though, we dont want to have useless products subscriptions if appsec is disabled, even if that means a creation then later an update of the waf.. 

## Reason for change

Simplify some code as well, no need for the fallback to embedded rule set flag, just test if "rules" is in the dictionary, if not add it from the embedded set.
## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
