### PR TITLE
[IAST] Calculate method full name on demand always

### DIFF
--- a/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/dataflow_il_analysis.cpp
@@ -666,7 +666,7 @@ namespace iast
     WSTRING GetMemberName(ILRewriter* body, mdToken token)
     {
         auto memberRef = body->GetMethodInfo()->GetModuleInfo()->GetMemberRefInfo(token);
-        WSTRING memberName = memberRef != nullptr ? memberRef->GetFullNameWithReturnType() : WStr("Unknown");
+        WSTRING memberName = memberRef != nullptr ? memberRef->GetFullyQualifiedName() : WStr("Unknown");
         return memberName;
     }
     std::string GetString(ILRewriter* body, mdString token)

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.cpp
@@ -91,19 +91,7 @@ namespace iast
         return _name;
     }
 
-    WSTRING& MemberRefInfo::GetFullName()
-    {
-        if (_fullName.size() == 0)
-        {
-            CSGuard lock(&_module->_cs);
-            if (_fullName.size() == 0)
-            {
-                _fullName = BuildFullName();
-            }
-        }
-        return _fullName;
-    }
-    WSTRING MemberRefInfo::BuildFullName()
+    WSTRING MemberRefInfo::GetFullName()
     {
         auto fullName = GetTypeName() + WStr("::") + _name;
         auto signature = GetSignature();
@@ -113,9 +101,9 @@ namespace iast
         }
         return fullName;
     }
-    WSTRING MemberRefInfo::GetFullNameWithReturnType()
+    WSTRING MemberRefInfo::GetFullyQualifiedName()
     {
-        auto res = GetFullName();
+        WSTRING res = GetFullName();
         auto signature = GetSignature();
         if (signature != nullptr)
         {
@@ -236,9 +224,8 @@ namespace iast
             _name = methodName;
         }
         _allowRestoreOnSecondJit = GetRestoreOnSecondJitConfigValue();
-        _fullName = BuildFullName(); // Avoid the lock in the constructor
 
-        _isExcluded = _module->_dataflow->IsMethodExcluded(_fullName);
+        _isExcluded = _module->_dataflow->IsMethodExcluded(GetFullName());
         if (!_isExcluded && _module->_dataflow->HasMethodAttributeExclusions())
         {
             for (auto methodAttribute : GetCustomAttributes())

--- a/tracer/src/Datadog.Tracer.Native/iast/method_info.h
+++ b/tracer/src/Datadog.Tracer.Native/iast/method_info.h
@@ -38,7 +38,6 @@ namespace iast
     protected:
         ModuleInfo* _module = nullptr;
         WSTRING _name = EmptyWStr;
-        WSTRING _fullName = EmptyWStr;
 
         mdTypeDef _typeDef = 0;
         TypeInfo* _typeInfo = nullptr;
@@ -47,8 +46,6 @@ namespace iast
         SignatureInfo* _pSignature = nullptr;
         PCCOR_SIGNATURE _pSig = nullptr;
         ULONG _nSig = 0;
-
-        WSTRING BuildFullName();
     public:
         mdMemberRef GetMemberId();
 
@@ -57,8 +54,8 @@ namespace iast
 
         ModuleInfo* GetModuleInfo();
         WSTRING& GetName();
-        WSTRING& GetFullName();
-        WSTRING GetFullNameWithReturnType();
+        WSTRING GetFullName();
+        WSTRING GetFullyQualifiedName();
         WSTRING& GetTypeName();
         virtual SignatureInfo* GetSignature();
         ULONG GetParameterCount();


### PR DESCRIPTION
## Summary of changes
Stop caching method's fullname in MethodInfo and calculate it on demand

## Reason for change
FullName caching could led to race conditions, and uses memory. It is only used on method creation for exclusion decision, on debug traces and when instrumentation fails, so there's no need for caching it, freeing up memory in the process.

## Implementation details
Remove `_fullName` member in `MethodReference `class and calculate it always when calling `GetFullName()`

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
