### PR TITLE
Fix subtle WCF bug

### DIFF
--- a/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
+++ b/tracer/src/Datadog.Trace/ClrProfiler/AutoInstrumentation/Wcf/WcfCommon.cs
@@ -63,8 +63,10 @@ namespace Datadog.Trace.ClrProfiler.AutoInstrumentation.Wcf
                 WebHeadersCollection? headers = null;
 
                 IDictionary<string, object?>? requestProperties = requestMessage.Properties;
-                if (requestProperties?.TryGetValue("httpRequest", out var httpRequestProperty) ?? false
-                    && httpRequestProperty.GetType().FullName.Equals(HttpRequestMessagePropertyTypeName, StringComparison.OrdinalIgnoreCase))
+                if (requestProperties is not null
+                 && requestProperties.TryGetValue("httpRequest", out var httpRequestProperty)
+                 && httpRequestProperty?.GetType().FullName != null
+                 && httpRequestProperty.GetType().FullName!.Equals(HttpRequestMessagePropertyTypeName, StringComparison.OrdinalIgnoreCase))
                 {
                     var httpRequestPropertyProxy = httpRequestProperty.DuckCast<HttpRequestMessagePropertyStruct>();
                     var webHeaderCollection = httpRequestPropertyProxy.Headers;


### PR DESCRIPTION
## Summary of changes

Fix the precedence bug

## Reason for change

The order of precedence is wrong with the use of `?? false`, so the second condition is never checked

![image](https://github.com/user-attachments/assets/87f60037-972f-47b9-a2b8-936691178089)

## Implementation details

Make the null check explicit

## Test coverage

Meh, this seems like a tricky case to check so YOLO?
