### PR TITLE
Stop using current_path in the native loader

### DIFF
--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -80,9 +80,6 @@ namespace datadog::shared::nativeloader
         fs::path configFolder = fs::path(configFilePath).remove_filename();
         Log::Debug("DynamicDispatcherImpl::LoadConfiguration: Config Folder: ", configFolder);
 
-        // Set the current path to the configuration folder (to allow relative paths)
-        fs::current_path(configFolder);
-
         const auto isRunningOnAlpine = IsRunningOnAlpine();
         const auto currentOsArch = GetCurrentOsArch(isRunningOnAlpine);
 

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -126,6 +126,8 @@ namespace datadog::shared::nativeloader
                         // (current_path)
                         std::string absoluteFilepathValue = (configFolder / filepathValue).string();
                         Log::Debug("DynamicDispatcherImpl::LoadConfiguration: [", type, "] Loading: ", filepathValue, " [AbsolutePath=", absoluteFilepathValue,"] (", currentOsArch, ")" );
+                        
+                        ec.clear();
                         if (fs::exists(absoluteFilepathValue, ec))
                         {
                             Log::Debug("[", type, "] Creating a new DynamicInstance object");
@@ -158,8 +160,17 @@ namespace datadog::shared::nativeloader
                         }
                         else
                         {
-                            Log::Warn("DynamicDispatcherImpl::LoadConfiguration: [", type, "] Dynamic library for '", absoluteFilepathValue,
-                                 "' cannot be loaded, file doesn't exist.");
+                            if (ec)
+                            {
+                                Log::Warn("DynamicDispatcherImpl::LoadConfiguration: [", type, "] Dynamic library for '", absoluteFilepathValue,
+                                    "' cannot be loaded, error code: ", ec.value(), ", message: ", ec.message());
+                            }
+                            else
+                            {
+
+                                Log::Warn("DynamicDispatcherImpl::LoadConfiguration: [", type, "] Dynamic library for '", absoluteFilepathValue,
+                                    "' cannot be loaded, file doesn't exist.");
+                            }
                         }
                     }
                     else

--- a/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
+++ b/shared/src/Datadog.Trace.ClrProfiler.Native/dynamic_dispatcher.cpp
@@ -80,10 +80,6 @@ namespace datadog::shared::nativeloader
         fs::path configFolder = fs::path(configFilePath).remove_filename();
         Log::Debug("DynamicDispatcherImpl::LoadConfiguration: Config Folder: ", configFolder);
 
-        // Get the current path
-        fs::path oldCurrentPath = fs::current_path();
-        Log::Debug("DynamicDispatcherImpl::LoadConfiguration: Current Path: ", oldCurrentPath);
-
         // Set the current path to the configuration folder (to allow relative paths)
         fs::current_path(configFolder);
 
@@ -128,9 +124,9 @@ namespace datadog::shared::nativeloader
                     {
                         // Convert possible relative paths to absolute paths using the configuration file folder as base
                         // (current_path)
-                        std::string absoluteFilepathValue = fs::absolute(filepathValue).string();
+                        std::string absoluteFilepathValue = (configFolder / filepathValue).string();
                         Log::Debug("DynamicDispatcherImpl::LoadConfiguration: [", type, "] Loading: ", filepathValue, " [AbsolutePath=", absoluteFilepathValue,"] (", currentOsArch, ")" );
-                        if (fs::exists(absoluteFilepathValue))
+                        if (fs::exists(absoluteFilepathValue, ec))
                         {
                             Log::Debug("[", type, "] Creating a new DynamicInstance object");
 
@@ -182,9 +178,6 @@ namespace datadog::shared::nativeloader
             }
         }
         t.close();
-
-        // Set the current path to the original one
-        fs::current_path(oldCurrentPath);
     }
 
     HRESULT DynamicDispatcherImpl::LoadClassFactory(REFIID riid)


### PR DESCRIPTION
## Summary of changes

Stop changing the current path in the native loader.

## Reason for change

We've received crash reports caused by `fs::current_path`. It's unclear why it threw (apparently it can happen for instance if the current path is too long), but it doesn't look like we actually need it anyway (it was needed for `fs::absolute` but we can replace it by directly appending the relative path to the base path).

## Implementation details

After removing the call to `current_path`, there is a risk that whatever caused it to fail would cause `fs::exist` to fail as well, so I replaced the call with the overload that doesn't throw.

## Test coverage

Many tests already rely on the native loader.