### PR TITLE
[ASM] Update fingerprint rules

### DIFF
--- a/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
@@ -15,7 +15,6 @@ namespace Datadog.Trace.AppSec.AttackerFingerprint;
 internal static class AttackerFingerprintHelper
 {
     private static readonly IDatadogLogger Log = DatadogLogging.GetLoggerFor(typeof(AttackerFingerprintHelper));
-    private static readonly Dictionary<string, object> _fingerprintRequest = new() { { AddressesConstants.WafContextProcessor, new Dictionary<string, object> { { "fingerprint", true } } } };
     private static bool _warningLogged = false;
 
     public static void AddSpanTags(Span span, IResult result)

--- a/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
+++ b/tracer/src/Datadog.Trace/AppSec/AttackerFingerprint/AttackerFingerprintHelper.cs
@@ -18,9 +18,9 @@ internal static class AttackerFingerprintHelper
     private static readonly Dictionary<string, object> _fingerprintRequest = new() { { AddressesConstants.WafContextProcessor, new Dictionary<string, object> { { "fingerprint", true } } } };
     private static bool _warningLogged = false;
 
-    public static void AddSpanTags(Span span)
+    public static void AddSpanTags(Span span, IResult result)
     {
-        if (span.IsFinished || span.Type != SpanTypes.Web)
+        if (result?.FingerprintDerivatives is null || span.IsFinished || span.Type != SpanTypes.Web)
         {
             return;
         }
@@ -33,8 +33,7 @@ internal static class AttackerFingerprintHelper
             return;
         }
 
-        var result = securityCoordinator.RunWaf(_fingerprintRequest);
-        AddSpanTags(result?.FingerprintDerivatives, span);
+        AddSpanTags(result.FingerprintDerivatives, span);
     }
 
     private static void AddSpanTags(Dictionary<string, object?>? fingerPrintDerivatives, ISpan span)

--- a/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
+++ b/tracer/src/Datadog.Trace/AppSec/Coordinator/SecurityCoordinator.Reporter.cs
@@ -132,7 +132,7 @@ internal readonly partial struct SecurityCoordinator
                 traceContext.AddWafSecurityEvents(result.Data);
             }
 
-            AttackerFingerprintHelper.AddSpanTags(_localRootSpan);
+            AttackerFingerprintHelper.AddSpanTags(_localRootSpan, result);
 
             var clientIp = _localRootSpan.GetTag(Tags.HttpClientIp);
             if (!string.IsNullOrEmpty(clientIp))

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/rasp-rule-set.json
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/rasp-rule-set.json
@@ -16,22 +16,23 @@
   ],
   "processors": [
     {
-      "id": "processor-001",
+      "id": "http-endpoint-fingerprint",
       "generator": "http_endpoint_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -62,26 +63,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-002",
+      "id": "http-header-fingerprint",
       "generator": "http_header_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -97,26 +99,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-003",
+      "id": "http-network-fingerprint",
       "generator": "http_network_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -132,26 +135,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-004",
+      "id": "session-fingerprint",
       "generator": "session_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -177,7 +181,7 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     }
   ],
@@ -455,6 +459,35 @@
         "stack_trace",
         "block"
       ]
+    },
+    {
+      "id": "ua0-600-12x",
+      "name": "Arachni",
+      "tags": {
+        "type": "attack_tool",
+        "category": "attack_attempt",
+        "cwe": "200",
+        "capec": "1000/118/169",
+        "tool_name": "Arachni",
+        "confidence": "1"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "inputs": [
+              {
+                "address": "server.request.headers.no_cookies",
+                "key_path": [
+                  "user-agent"
+                ]
+              }
+            ],
+            "regex": "^Arachni\\/v"
+          },
+          "operator": "match_regex"
+        }
+      ],
+      "transformers": []
     },
     {
       "id": "rasp-932-400",

--- a/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.3.0.json
+++ b/tracer/test/Datadog.Trace.Security.IntegrationTests/ruleset.3.0.json
@@ -16,22 +16,23 @@
   ],
   "processors": [
     {
-      "id": "processor-001",
+      "id": "http-endpoint-fingerprint",
       "generator": "http_endpoint_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -62,26 +63,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-002",
+      "id": "http-header-fingerprint",
       "generator": "http_header_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -97,26 +99,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-003",
+      "id": "http-network-fingerprint",
       "generator": "http_network_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -132,26 +135,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-004",
+      "id": "session-fingerprint",
       "generator": "session_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -177,7 +181,7 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     }
   ],

--- a/tracer/test/Datadog.Trace.Security.Unit.Tests/Fingerprint/FingerprintTests.cs
+++ b/tracer/test/Datadog.Trace.Security.Unit.Tests/Fingerprint/FingerprintTests.cs
@@ -16,120 +16,120 @@ namespace Datadog.Trace.Security.Unit.Tests;
 
 public class FingerprintTests : WafLibraryRequiredTest
 {
-    private static List<Dictionary<string, object>> sampleData = new()
+    private static List<List<Dictionary<string, object>>> sampleData = new()
         {
-            new Dictionary<string, object>()
+            new List<Dictionary<string, object>>()
             {
-                { AddressesConstants.RequestUriRaw, "/path/to/resource/?key=" },
-                { AddressesConstants.RequestMethod, "PUT" },
-                { AddressesConstants.RequestQuery, new Dictionary<string, string> { { "key", "value" } } },
-                { AddressesConstants.RequestBody, new Dictionary<string, string> { { "key", "value" } } },
-                { AddressesConstants.RequestHeaderNoCookies, new Dictionary<string, string> { { "user-agent", "Random" }, { "x-forwarded-for", "::1" }, { "custom", "value" } } },
-                { AddressesConstants.RequestCookies, new Dictionary<string, string> { { "name", "albert" }, { "language", "en-GB" }, { "session_id", "ansd0182u2n" } } },
-                { AddressesConstants.UserId, "admin" },
-                { AddressesConstants.UserSessionId, "ansd0182u2n" }
-            },
-            new Dictionary<string, object>()
-            {
-                { "server.request.method", "GET" },
-                { "server.response.status", "200" },
-                { "server.request.uri.raw", "/Iast/GetFileContent?file=/nonexisting.txt" },
-                { "http.client_ip", "::1" },
-                { "server.request.body", new Dictionary<string, string>() },
-                { "server.request.query", new Dictionary<string, string[]> { { "file", new[] { "/nonexisting.txt" } } } },
+                new Dictionary<string, object>
                 {
-                    "server.request.headers.no_cookies", new Dictionary<string, string[]>
-                    {
-                        { "cache-control", new[] { "max-age=0" } },
-                        { "connection", new[] { "keep-alive" } },
-                        { "accept", new[] { "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7" } },
-                        { "accept-encoding", new[] { "gzip , deflate, br, zstd" } },
-                        { "accept-language", new[] { "en,es-ES;q=0.9,es;q=0.8" } },
-                        { "host", new[] { "localhost:5003" } },
-                        { "referer", new[] { "http://localhost:5003/" } },
-                        { "user-agent", new[] { "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" } },
-                        { "sec-ch-ua", new[] { "\"Chromium\";v=\"128\", \"Not;A=Brand\";v=\"24\", \"Google Chrome\";v=\"128\"" } },
-                        { "sec-ch-ua-mobile", new[] { "?0" } },
-                        { "sec-ch-ua-platform", new[] { "\"Windows\"" } },
-                        { "upgrade-insecure-requests", new[] { "1" } },
-                        { "sec-fetch-site", new[] { "same-origin" } },
-                        { "sec-fetch-mode", new[] { "navigate" } },
-                        { "sec-fetch-user", new[] { "?1" } },
-                        { "sec-fetch-dest", new[] { "document" } }
-                    }
-                },
-                {
-                    "server.request.cookies", new Dictionary<string, string[]>
-                    {
-                        { ".AspNetCore.Antiforgery.dInqUVwbgyA", new[] { "CfDJ8DWtaLKARU1BicbVG7iD6w0lxol0VHahrPFrsql7ySzRtc-oxacIBn4biwlminJYcnuU_8hDW60aVfqux98gC6T-ZpAVQ7YK_fdPn6wbqLO4pNe9jQ3jwbhpMqgbl1Ng2nWoam8UexOt4Q0mP8lkADY" } },
-                        { "__AntiXsrfToken", new[] { "6587af0f57a2452185675cb0c830f8ec" } },
-                        { "accountType", new[] { "Personal" } },
-                        { "file", new[] { "value1" } },
-                        { "argumentLine", new[] { "value2" } },
-                        { "SecureKey", new[] { "SecureValue" } },
-                        { "SameSiteKey", new[] { "SameSiteValue" } },
-                        { "AllVulnerabilitiesCookieKey", new[] { "AllVulnerabilitiesCookieValue&SameSite=None" } },
-                        { "NoSameSiteKeyDefault", new[] { "NoSameSiteValueDefault" } },
-                        { "NoSameSiteKeyNone", new[] { "NoSameSiteValueNOne&SameSite=None" } },
-                        { "NoSameSiteKey", new[] { "NoSameSiteValue" } },
-                        { "NoSameSiteKeyLax", new[] { "NoSameSiteValueLax" } },
-                        { "NoSameSiteKeyDef", new[] { "NoSameSiteValueDef" } },
-                        { "insecureKey", new[] { "insecureValue" } },
-                        { ".AspNetCore.Correlation.oidc.xxxxxxxxxxxxxxxxxxx", new[] { "ExcludedCookieVulnValue" } },
-                        { "NoHttpOnlyKey", new[] { "NoHttpOnlyValue" } },
-                        { ".AspNetCore.Antiforgery.PEOLKb2zqCM", new[] { "CfDJ8N8HgaU-AuxItWDrE6uHmv5Nx2auCU2Nz4wPtc65npv5lxXup6TheS5Af5OxeI4p-F8qu4m3bqB9ngwMMNLTksq3J4rDOfDleYwS0ZO6sus4UQwJj9PXsX_tmEjSjvyHBQSyj0erEIC206XNFDz7oi8" } },
-                        { ".AspNetCore.Antiforgery.dv9Y7hx5lOY", new[] { "CfDJ8N8HgaU-AuxItWDrE6uHmv5vbQjBTneuzffR0UWgwEbiUtb6cQDjp8VEQ9JVGvqF_BW0M85B3spAuysW_rY5tFQ6R-pNAnwJnAvoO-zwxA7Fx6mepz2G7BFXjnEpeHkew7ARSyoryR12nYpD1tNU9S8" } },
-                        { ".AspNetCore.Antiforgery.jE_SavyZJRU", new[] { "CfDJ8N8HgaU-AuxItWDrE6uHmv7NfxQhx1lE8BOs9z5BaqShFHv9a4xh3pg5gA40Yqo3uy4gFtk_oTW_aPSfpppytPKAdb-oYYt6FX5ajDN21C9yAIF3Ob8xBGGbBBoXKVXGE4g0AEan5HaSlUk2WxdY0PY" } },
-                        { ".AspNetCore.Session", new[] { "CfDJ8L/VJqbgbZ9AmItcsJeWhzGYBGDf0hQBOKYF9PXBQb+iCK/LWVuiTTVjmvN2NiKjtG08fe/7iqy/UwEmjtIf4RSZbvaAtdx5IjYu8J3t51dfons7ldcMWlvVu0hFrlB0aPuIiu25BAD1A4CXFuIfDIp+U3C/eCaHU9EJNLdKDh3c" } },
-                        { "umb_installId", new[] { "9a334af1-788e-473d-ae5c-ed64edc39f3a" } },
-                        { "SafeCookieKey", new[] { "SafeCookieValue&SameSite=Strict" } },
-                        { "UnsafeEmptyCookie", new[] { "SameSite=None" } }
-                    }
+                    { AddressesConstants.RequestUriRaw, "/path/to/resource/?key=" },
+                    { AddressesConstants.RequestMethod, "PUT" },
+                    { AddressesConstants.RequestQuery, new Dictionary<string, string> { { "key", "value" } } },
+                    { AddressesConstants.RequestBody, new Dictionary<string, string> { { "key", "value" } } },
+                    { AddressesConstants.RequestHeaderNoCookies, new Dictionary<string, string> { { "user-agent", "Arachni/v1.5.1" }, { "x-forwarded-for", "::1" }, { "custom", "value" } } },
+                    { AddressesConstants.RequestCookies, new Dictionary<string, string> { { "name", "albert" }, { "language", "en-GB" }, { "session_id", "ansd0182u2n" } } },
+                    { AddressesConstants.UserId, "admin" },
+                    { AddressesConstants.UserSessionId, "ansd0182u2n" }
                 }
             },
-            new Dictionary<string, object>()
+            new List<Dictionary<string, object>>()
             {
-                { AddressesConstants.RequestUriRaw, "/path/to/resource.php" },
-                { AddressesConstants.RequestMethod, "GET" },
-                { AddressesConstants.RequestQuery, new Dictionary<string, string> { { "name", "datadog" }, { "index", "295" } } },
-                { AddressesConstants.RequestBody, new Dictionary<string, string>() },
-                { AddressesConstants.RequestHeaderNoCookies, new Dictionary<string, object> { { "user-agent", new string[] { "Arachni", "other" } }, { "x-forwarded-for", "1.2.3.4" }, { "Accept-Language", "en_UK" }, { "X-Custom-Header", "42" } } },
-                { AddressesConstants.RequestCookies, new Dictionary<string, string> { { "Expires ", "tomorrow" }, { "SessionToken", "12asd8ahjsd91j289" } } },
-                { AddressesConstants.UserId, "non-admin" }
+                new Dictionary<string, object>()
+                {
+                    { "server.request.method", "GET" },
+                    { "server.response.status", "200" },
+                    { "server.request.uri.raw", "/Iast/GetFileContent?file=/nonexisting.txt" },
+                    { "http.client_ip", "::1" },
+                    { "server.request.body", new Dictionary<string, string>() },
+                    { "server.request.query", new Dictionary<string, string[]> { { "file", new[] { "/nonexisting.txt" } } } },
+                    {
+                        "server.request.headers.no_cookies", new Dictionary<string, string[]>
+                        {
+                            { "cache-control", new[] { "max-age=0" } },
+                            { "connection", new[] { "keep-alive" } },
+                            { "accept", new[] { "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7" } },
+                            { "accept-encoding", new[] { "gzip , deflate, br, zstd" } },
+                            { "accept-language", new[] { "en,es-ES;q=0.9,es;q=0.8" } },
+                            { "host", new[] { "localhost:5003" } },
+                            { "referer", new[] { "http://localhost:5003/" } },
+                            { "user-agent", new[] { "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36" } },
+                            { "sec-ch-ua", new[] { "\"Chromium\";v=\"128\", \"Not;A=Brand\";v=\"24\", \"Google Chrome\";v=\"128\"" } },
+                            { "sec-ch-ua-mobile", new[] { "?0" } },
+                            { "sec-ch-ua-platform", new[] { "\"Windows\"" } },
+                            { "upgrade-insecure-requests", new[] { "1" } },
+                            { "sec-fetch-site", new[] { "same-origin" } },
+                            { "sec-fetch-mode", new[] { "navigate" } },
+                            { "sec-fetch-user", new[] { "?1" } },
+                            { "sec-fetch-dest", new[] { "document" } }
+                        }
+                    },
+                    {
+                        "server.request.cookies", new Dictionary<string, string[]>
+                        {
+                            { ".AspNetCore.Antiforgery.dInqUVwbgyA", new[] { "CfDJ8DWtaLKARU1BicbVG7iD6w0lxol0VHahrPFrsql7ySzRtc-oxacIBn4biwlminJYcnuU_8hDW60aVfqux98gC6T-ZpAVQ7YK_fdPn6wbqLO4pNe9jQ3jwbhpMqgbl1Ng2nWoam8UexOt4Q0mP8lkADY" } },
+                            { "__AntiXsrfToken", new[] { "6587af0f57a2452185675cb0c830f8ec" } },
+                            { "accountType", new[] { "Personal" } },
+                            { "file", new[] { "value1" } },
+                            { "argumentLine", new[] { "value2" } },
+                            { "SecureKey", new[] { "SecureValue" } },
+                            { "SameSiteKey", new[] { "SameSiteValue" } },
+                            { "AllVulnerabilitiesCookieKey", new[] { "AllVulnerabilitiesCookieValue&SameSite=None" } },
+                            { "NoSameSiteKeyDefault", new[] { "NoSameSiteValueDefault" } },
+                            { "NoSameSiteKeyNone", new[] { "NoSameSiteValueNOne&SameSite=None" } },
+                            { "NoSameSiteKey", new[] { "NoSameSiteValue" } },
+                            { "NoSameSiteKeyLax", new[] { "NoSameSiteValueLax" } },
+                            { "NoSameSiteKeyDef", new[] { "NoSameSiteValueDef" } },
+                            { "insecureKey", new[] { "insecureValue" } },
+                            { ".AspNetCore.Correlation.oidc.xxxxxxxxxxxxxxxxxxx", new[] { "ExcludedCookieVulnValue" } },
+                            { "NoHttpOnlyKey", new[] { "NoHttpOnlyValue" } },
+                            { ".AspNetCore.Antiforgery.PEOLKb2zqCM", new[] { "CfDJ8N8HgaU-AuxItWDrE6uHmv5Nx2auCU2Nz4wPtc65npv5lxXup6TheS5Af5OxeI4p-F8qu4m3bqB9ngwMMNLTksq3J4rDOfDleYwS0ZO6sus4UQwJj9PXsX_tmEjSjvyHBQSyj0erEIC206XNFDz7oi8" } },
+                            { ".AspNetCore.Antiforgery.dv9Y7hx5lOY", new[] { "CfDJ8N8HgaU-AuxItWDrE6uHmv5vbQjBTneuzffR0UWgwEbiUtb6cQDjp8VEQ9JVGvqF_BW0M85B3spAuysW_rY5tFQ6R-pNAnwJnAvoO-zwxA7Fx6mepz2G7BFXjnEpeHkew7ARSyoryR12nYpD1tNU9S8" } },
+                            { ".AspNetCore.Antiforgery.jE_SavyZJRU", new[] { "CfDJ8N8HgaU-AuxItWDrE6uHmv7NfxQhx1lE8BOs9z5BaqShFHv9a4xh3pg5gA40Yqo3uy4gFtk_oTW_aPSfpppytPKAdb-oYYt6FX5ajDN21C9yAIF3Ob8xBGGbBBoXKVXGE4g0AEan5HaSlUk2WxdY0PY" } },
+                            { ".AspNetCore.Session", new[] { "CfDJ8L/VJqbgbZ9AmItcsJeWhzGYBGDf0hQBOKYF9PXBQb+iCK/LWVuiTTVjmvN2NiKjtG08fe/7iqy/UwEmjtIf4RSZbvaAtdx5IjYu8J3t51dfons7ldcMWlvVu0hFrlB0aPuIiu25BAD1A4CXFuIfDIp+U3C/eCaHU9EJNLdKDh3c" } },
+                            { "umb_installId", new[] { "9a334af1-788e-473d-ae5c-ed64edc39f3a" } },
+                            { "SafeCookieKey", new[] { "SafeCookieValue&SameSite=Strict" } },
+                            { "UnsafeEmptyCookie", new[] { "SameSite=None" } }
+                        }
+                    }
+                },
+                new Dictionary<string, object>()
+                {
+                     { AddressesConstants.FileAccess, "/nonexisting.txt" }
+                }
+            },
+            new List<Dictionary<string, object>>()
+            {
+                new Dictionary<string, object>()
+                {
+                    { AddressesConstants.RequestUriRaw, "/path/to/resource.php" },
+                    { AddressesConstants.RequestMethod, "GET" },
+                    { AddressesConstants.RequestQuery, new Dictionary<string, string> { { "name", "datadog" }, { "index", "295" } } },
+                    { AddressesConstants.RequestBody, new Dictionary<string, string>() },
+                    { AddressesConstants.RequestHeaderNoCookies, new Dictionary<string, object> { { "user-agent", new string[] { "Arachni/v1.5.1" } }, { "x-forwarded-for", "1.2.3.4" }, { "Accept-Language", "en_UK" }, { "X-Custom-Header", "42" } } },
+                    { AddressesConstants.RequestCookies, new Dictionary<string, string> { { "Expires ", "tomorrow" }, { "SessionToken", "12asd8ahjsd91j289" } } },
+                    { AddressesConstants.UserId, "non-admin" }
+                }
             }
         };
 
     [Theory]
-    [InlineData(0, 4, true)]
-    [InlineData(1, 3, true)]
-    [InlineData(2, 3, true)]
-    [InlineData(0, 4, false)]
-    [InlineData(1, 3, false)]
-    [InlineData(2, 3, false)]
-    public void GivenAFingerprintRequest_WhenRunWAF_FingerprintIsGenerated(int testIndex, int resultingHeaders, bool singleCall)
+    [InlineData(0, 4)]
+    [InlineData(1, 3)]
+    [InlineData(2, 3)]
+    public void GivenAFingerprintRequest_WhenRunWAF_FingerprintIsGenerated(int testIndex, int resultingHeaders)
     {
         var ruleFile = "rasp-rule-set.json";
         var context = InitWaf(true, ruleFile, new Dictionary<string, object>(), out var waf);
-        Dictionary<string, object> args;
+        List<Dictionary<string, object>> args;
 
-        if (singleCall)
+        args = sampleData[testIndex];
+        IResult result = null;
+        foreach (var data in args)
         {
-            args = new Dictionary<string, object>(sampleData[testIndex])
-            {
-                { AddressesConstants.WafContextProcessor, new Dictionary<string, object> { { "fingerprint", true } } }
-            };
-        }
-        else
-        {
-            args = new Dictionary<string, object>(sampleData[testIndex]);
-            _ = context.Run(args, TimeoutMicroSeconds);
-            args = new Dictionary<string, object>()
-            {
-                { AddressesConstants.WafContextProcessor, new Dictionary<string, object> { { "fingerprint", true } } }
-            };
+            result = context.Run(data, TimeoutMicroSeconds);
+            result.Timeout.Should().BeFalse("Timeout should be false");
         }
 
-        var result = context.Run(args, TimeoutMicroSeconds);
         result.FingerprintDerivatives.Count.Should().Be(resultingHeaders);
     }
 

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore2/rasp-rule-set.json
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore2/rasp-rule-set.json
@@ -16,22 +16,23 @@
   ],
   "processors": [
     {
-      "id": "processor-001",
+      "id": "http-endpoint-fingerprint",
       "generator": "http_endpoint_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -62,26 +63,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-002",
+      "id": "http-header-fingerprint",
       "generator": "http_header_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -97,26 +99,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-003",
+      "id": "http-network-fingerprint",
       "generator": "http_network_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -132,26 +135,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-004",
+      "id": "session-fingerprint",
       "generator": "session_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -177,7 +181,7 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     }
   ],
@@ -454,6 +458,56 @@
       "on_match": [
         "stack_trace",
         "block"
+      ]
+    },
+    {
+      "id": "rasp-932-400",
+      "name": "New exploit",
+      "enabled": true,
+      "tags": {
+        "type": "new_injection",
+        "category": "vulnerability_trigger",
+        "cwe": "77",
+        "capec": "1000/152/248/88",
+        "confidence": "0",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.sys.shell.cmd"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+
+              {
+                "address": "graphql.server.resolver"
+              }
+            ]
+          },
+          "operator": "new_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
       ]
     }
   ]

--- a/tracer/test/test-applications/security/Samples.Security.AspNetCore5/rasp-rule-set.json
+++ b/tracer/test/test-applications/security/Samples.Security.AspNetCore5/rasp-rule-set.json
@@ -16,22 +16,23 @@
   ],
   "processors": [
     {
-      "id": "processor-001",
+      "id": "http-endpoint-fingerprint",
       "generator": "http_endpoint_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -62,26 +63,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-002",
+      "id": "http-header-fingerprint",
       "generator": "http_header_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -97,26 +99,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-003",
+      "id": "http-network-fingerprint",
       "generator": "http_network_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -132,26 +135,27 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     },
     {
-      "id": "processor-004",
+      "id": "session-fingerprint",
       "generator": "session_fingerprint",
       "conditions": [
         {
-          "operator": "equals",
+          "operator": "exists",
           "parameters": {
             "inputs": [
               {
-                "address": "waf.context.processor",
-                "key_path": [
-                  "fingerprint"
-                ]
+                "address": "waf.context.event"
+              },
+              {
+                "address": "server.business_logic.users.login.failure"
+              },
+              {
+                "address": "server.business_logic.users.login.success"
               }
-            ],
-            "value": true,
-            "type": "boolean"
+            ]
           }
         }
       ],
@@ -177,7 +181,7 @@
           }
         ]
       },
-      "evaluate": true,
+      "evaluate": false,
       "output": true
     }
   ],
@@ -454,6 +458,56 @@
       "on_match": [
         "stack_trace",
         "block"
+      ]
+    },
+    {
+      "id": "rasp-932-400",
+      "name": "New exploit",
+      "enabled": true,
+      "tags": {
+        "type": "new_injection",
+        "category": "vulnerability_trigger",
+        "cwe": "77",
+        "capec": "1000/152/248/88",
+        "confidence": "0",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.sys.shell.cmd"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+
+              {
+                "address": "graphql.server.resolver"
+              }
+            ]
+          },
+          "operator": "new_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
       ]
     }
   ]


### PR DESCRIPTION
## Summary of changes

This PR updates the format of the fingerprint rules as described in the [RFC](https://docs.google.com/document/d/1DivOa9XsCggmZVzMI57vyxH2_EBJ0-qqIkRHm_sEvSs/edit?pli=1#heading=h.88xvn2cvs9dt)

We don't send anymore the  { "fingerprint", true } request to the WAF. Instead, the WAF returns the fingerprints when a match occurs. This way, we save one WAF call.

## Reason for change

## Implementation details

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
