### PR TITLE
[Profiler] Make sure Watcher thread is started before Sampler thread

### DIFF
--- a/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
+++ b/profiler/src/ProfilerEngine/Datadog.Profiler.Native/StackSamplerLoopManager.h
@@ -105,9 +105,9 @@ private:
     inline bool GetUpdateIsThreadSafeForStackSampleCollection(ManagedThreadInfo* pThreadInfo, bool* pIsStatusChanged);
     static inline bool ShouldCollectThread(std::uint64_t threadAggPeriodDeadlockCount, std::uint64_t globalAggPeriodDeadlockCount) ;
 
-    void RunStackSampling();
+    void InitializeSampler();
 
-    void RunWatcher();
+    void RunWatcherAndSampler();
     void ShutdownWatcher();
 
     void WatcherLoop();


### PR DESCRIPTION
## Summary of changes

Ensure Watcher thread is started before Sampler thread.

## Reason for change

We got a customer report where the app was hanged. 
The Sampler thread interrupted the Main thread (because it might have executed managed code at some point or a bug in the CLR ¯\\\_(ツ)\_/¯) and that thread was holding at least 3 locks (the loadlibrary one, one shared between `RtlLookupFunctionEntry` and `RtlInvertedFunctionTable` and one between `LdrpXXX` functions).
The Sampler thread interrupted the Main thread while it was holding those locks. The Sampler thread called `RtlLookupFunctionEntry` function and was blocked on the lock (the one taken by `RtlInvertedFunctionTable`).
We noticed that the Watcher thread was blocked on `LdrpDrainWorkQueue` (lock taken by a call to one the `LdrpXX`  called by the Main thread)

## Implementation details

Start the sampler thread iff the Watcher thread has started.

## Test coverage

## Other details
<!-- Fixes #{issue} -->

<!--  ⚠️ Note: where possible, please obtain 2 approvals prior to merging. Unless CODEOWNERS specifies otherwise, for external teams it is typically best to have one review from a team member, and one review from apm-dotnet. Trivial changes do not require 2 reviews. -->
